### PR TITLE
documentation tag description and examples refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Note that WSL distro's launch in the Windows Console (unless you have taken step
 
 This is your best ways to interact directly with the Windows Subsystem for Linux teams. We will be monitoring and responding to issues as best we can. Please attempt to avoid filing duplicates of open or closed items when possible. Issues may be tagged with with the following labels:
 
-- **bug** – The issue considered to be a bug internally by the dev team. This tag is generally for gaps in implemented (read: intended to be working) WSL behavior. Things marked with **bug** have a corresponding bug in on Microsoft’s internal bug tracking system.
-  - Example: No internet connectivity in Bash [(#5)](https://github.com/Microsoft/WSL/issues/5)
+- **bug** – The issue considered to be a bug internally by the dev team. This tag is generally for gaps in implemented (read: intended to be working) WSL behavior. Things marked with **bug** have a corresponding bug in on Microsoft’s internal bug tracking system. Example: "du -h reports wrong file size on DrvFs" [(#1894)](https://github.com/microsoft/WSL/issues/1894)
 
-- **feature** – Denotes something understood as not working and is not yet implemented.
+- **feature** – Denotes something understood as not working and is not yet implemented. Example: "Cuda can not be installed" [(#327)](https:/github.com/microsoft/WSL/issues/327)
 
 - **fixinbound** / **fixedinNNNN** – The bug or feature request originally submitted has been addressed in whole or in part. Related or ongoing bug or feature gaps should be opened as a new issue submission if one does not already exist.
 
@@ -20,12 +19,13 @@ This is your best ways to interact directly with the Windows Subsystem for Linux
 
 - **need-repro** – The issue submission is missing fields from the issue [template](https://github.com/Microsoft/WSL/blob/master/ISSUE_TEMPLATE.md), cannot be reproduced with the information provided, or is not actionable.
 
-- **discussion** / **question** – Submissions which are not a bug report or feature request.
-  - Example: Windows Subsystem for Linux is not open source [(#178)](https://github.com/Microsoft/WSL/issues/178)
+- **discussion** / **question** – Submissions which are not a bug report or feature request. Example: Windows Subsystem for Linux is not open source [(#178)](https://github.com/Microsoft/WSL/issues/178)
 
 - **bydesign** / **linux-behavior** – Denotes that an issue that is considered working as intended or would behave analogously on a native Linux kernel.
 
-- **console** – The submission should be directed to the [console issue tracker](https://github.com/microsoft/console/issues)
+- **console** – The submission should be directed to the [console issue tracker](https://github.com/microsoft/console/issues).
+
+- **documentation** – The submission should be directed to the [WSL documentation issue tracker](https://github.com/MicrosoftDocs/WSL).
 
 - **wsl2** - The issue relates specifically to WSL 2.
 


### PR DESCRIPTION
- Add description for "documentation" tag.
- Refresh bug and feature tag examples to point at submissions that have an actionable repro