### PR TITLE
simplify windows build number directions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ Please fill out the items below.
 # Environment
 
 ```none
-Windows build number: [run `[Environment]::OSVersion` for powershell, or `ver` for cmd]
+Windows build number: [run `cmd.exe /c ver`]
 Your Distribution version: [On Debian or Ubuntu run `lsb_release -r` in WSL]
 Whether the issue is on WSL 2 and/or WSL 1: [run `cat /proc/version` in WSL]
 ```


### PR DESCRIPTION
The current `[Environment]::OSVersion` guidance on providing the build number for does not yield the `Rev` component. It is always '`0`'. That mostly hasn't mattered, but with the advent of the WSL2 backport to 1903 and and 1909 via KB updates, it can be difficult to tell what version of `wsl.exe` submitters are running. Windows Terminal defaults to Powershell these days, so more users are ending up using that as their Windows shell.

Expedient solution is to just tell everyone to run `cmd.exe /c ver` regardless of what shell they're running.