### PR TITLE
The README file in this repo has a bad link - [404:NotFound]

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is your best ways to interact directly with the Windows Subsystem for Linux
 
 - **duplicate** – The submission is substantially duplicative of an existing issue, and/or has the same underlying cause.
 
-- **need-repro** – The issue submission is missing fields from the issue [template](https://github.com/Microsoft/WSL/blob/master/ISSUE_TEMPLATE.md), cannot be reproduced with the information provided, or is not actionable.
+- **need-repro** – The issue submission is missing fields from the issue [template](https://github.com/microsoft/WSL/tree/master/.github/ISSUE_TEMPLATE), cannot be reproduced with the information provided, or is not actionable.
 
 - **discussion** / **question** – Submissions which are not a bug report or feature request. Example: Windows Subsystem for Linux is not open source [(#178)](https://github.com/Microsoft/WSL/issues/178)
 


### PR DESCRIPTION
The README file in this repo has a bad link - [404:NotFound]
“template”
Status code [404:NotFound] - Link: https://github.com/Microsoft/WSL/blob/master/ISSUE_TEMPLATE.md

Issue #6232

Is this new link correct to the folder or should it go to one of bug_report.md or feature_request.md??