### PR TITLE
Add a script to help diagnose networking issue and instructions to run it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,16 @@ Availability  Capabilities  CapabilityDescriptions                              
               {3, 4, 10}    {"Random Access", "Supports Writing", "SMART Notification"}  \\.\PHYSICALDRIVE2  SCSI           TRUE         Fixed hard disk media  ST2000DM001-1ER164          \\.\PHYSICALDRIVE2  1
 ```
 
+#### Networking issues
+
+If the issue is about networking, download [networking.sh](https://github.com/Microsoft/WSL/blob/master/diagnostics/networking.sh), and execute it inside WSL by running:
+
+```
+$ bash ./networking.sh
+```
+
+Once the script execution is completed, include its output on the issue.
+
 <!-- Preserving anchors -->
 <div id="8-detailed-logs"></div>
 <div id="9-networking-logs"></div>

--- a/diagnostics/networking.sh
+++ b/diagnostics/networking.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -xu
+
+# Gather distro & kernel info
+lsb_release -a || cat /etc/issue
+uname -a
+
+# Output adapter & routing configuration
+ip a
+ip route show
+
+# Validate that the gateway is responsive and can route ICMP correctly
+gateway=$(ip route show | awk '/default/ { print $3 }')
+ping -c 4 "$gateway"
+ping -c 4 1.1.1.1
+
+# Validate that the default route is working (won't work if traceroute isn't installed)
+traceroute 1.1.1.1
+
+# Display the DNS configuration
+cat /etc/resolv.conf
+
+# Validate that everything is functionning correctly
+curl -m 5000 -v https://microsoft.com
+


### PR DESCRIPTION
This change introduces a `networking.sh` script for users reporting networking issues to run.

This script outputs WSL's networking state and runs various tests that will help diagnosing networking problems. 