### PR TITLE
Switch to using checkboxes for WSL version, and add section for kernel version

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -29,8 +29,6 @@ body:
     options:
       - label: WSL 2
       - label: WSL 1
-  validations:
-    required: true
 
 - type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -21,12 +21,14 @@ body:
   validations:
     required: true
 
-- type: input
+- type: checkboxes
   attributes:
     label: WSL Version
     description: |
       Tell us whether the issue is on WSL 2 and/or WSL 1. You can tell your WSL version by running `wsl -l -v`. 
-    placeholder: "WSL 2"
+    options:
+      - label: WSL 2
+      - label: WSL 1
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Bug Report"
+name: "WSL Bug Report"
 description: Report a bug on Windows Subsystem for Linux
 title: ''
 labels: ''
@@ -29,6 +29,8 @@ body:
     options:
       - label: "WSL 2"
       - label: "WSL 1"
+  validations:
+    required: true
 
 - type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -27,8 +27,8 @@ body:
     description: |
       Tell us whether the issue is on WSL 2 and/or WSL 1. You can tell your WSL version by running `wsl -l -v`. 
     options:
-      - label: WSL 2
-      - label: WSL 1
+      - label: "WSL 2"
+      - label: "WSL 1"
 
 - type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -29,8 +29,16 @@ body:
     options:
       - label: "WSL 2"
       - label: "WSL 1"
+
+- type: input
+  attributes:
+    label: Kernel Version
+    description: |
+      Please tell us what version of the Linux kernel you are using, or if you are using a custom kernel. 
+      You can run `wsl.exe --status` if that command is available to you, or by running `cat /proc/version` in your distro.
+    placeholder: "5.4.72"
   validations:
-    required: true
+    required: false
 
 - type: input
   attributes:


### PR DESCRIPTION
The WSL version can be better expressed using a checkbox feature of the issue template, so this PR makes that change. 

Also, we don't explicitly ask for the kernel version, which we should for completeness, so I added a section for that.