### PR TITLE
Fixing issue template and removing deprecated field

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,7 +1,6 @@
 ---
 name: "WSL - Bug Report"
 description: Report a bug on Windows Subsystem for Linux
-issue_body: true
 body:
 - type: markdown
   attributes:
@@ -71,7 +70,7 @@ body:
   attributes:
     label: Expected Behavior
     description: What were you expecting to see? Include any relevant examples or documentation links.
-    placeholder: If you want to include screenshots, paste them into the markdown editor below the form or follow up with a separate comment. 
+    placeholder: If you want to include screenshots, paste them into the text area or follow up with a separate comment. 
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,5 +1,5 @@
 ---
-name: "WSL Bug Report"
+name: "WSL - Bug Report"
 description: Report a bug on Windows Subsystem for Linux
 issue_body: true
 body:

--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,9 +1,6 @@
 ---
 name: "WSL Bug Report"
 description: Report a bug on Windows Subsystem for Linux
-title: ""
-labels: ""
-assignees: ""
 issue_body: true
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,9 +1,9 @@
 ---
 name: "WSL Bug Report"
 description: Report a bug on Windows Subsystem for Linux
-title: ''
-labels: ''
-assignees: ''
+title: ""
+labels: ""
+assignees: ""
 issue_body: true
 body:
 - type: markdown


### PR DESCRIPTION
Issues Forms apparently no longer like blank values for the title / label / attributes sections, so our template is currently broken. This change patches over that problem (there's an issue already open on the issue forms repo, and I'll monitor that to figure out if there's something different we need to move to). 

There's also a change that was recently made to deprecate issue_body (this controls the text editor at the bottom of the report); text_areas have now been updated to allow content to be added directly, so while I was modifying the template, I fixed this warning. 