### PR TITLE
networking.sh - should run as root.

### DIFF
--- a/diagnostics/networking.sh
+++ b/diagnostics/networking.sh
@@ -1,4 +1,9 @@
 #! /bin/bash
+ if (($(id -u) != 0))
+ then
+     printf "If you see 'ping: socket: Operation not permitted' errors, "
+     printf "run this command as root.\n"
+fi
 
 set -xu
 


### PR DESCRIPTION
If networking.sh is run by a non-root user, "ping: socket: Operation not permitted" may result.  This adds a test & warning.