### PR TITLE
Add /etc/os-release to information collected.

### DIFF
--- a/diagnostics/networking.sh
+++ b/diagnostics/networking.sh
@@ -3,7 +3,7 @@
 set -xu
 
 # Gather distro & kernel info
-lsb_release -a || cat /etc/issue
+lsb_release -a || cat /etc/issue /etc/os-release
 uname -a
 
 # Output adapter & routing configuration


### PR DESCRIPTION
If lsb_release is not installed, /etc/issue is output.  However, /etc/issue is a template used by agetty/mingetty to output issue.  On my system, it contains

\S
Kernel \r on an \m

Collect /etc/os-release in addition.