### PR TITLE
Fix PackageFamilyName for Ubuntu-20.04 distribution

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -78,7 +78,7 @@
             "Arm64": true,
             "Amd64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_2004.2020.424.0_x64.appx",
             "Arm64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_2004.2020.424.0_ARM64.appx",
-            "PackageFamilyName": "46932SUSE.openSUSELeap42.2_022rs5jcyhyac"
+            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu20.04onWindows_79rhkp1fndgs"
         }
     ]
 }


### PR DESCRIPTION
This change updates DistributionInfo.json to use the correct PackageFamilyName for Ubuntu 20.04