### PR TITLE
Reformat the distro validation script

### DIFF
--- a/distributions/validate.py
+++ b/distributions/validate.py
@@ -1,62 +1,74 @@
-import requests
 import json
+import requests
 import sys
-from urllib.request import urlretrieve
-from xml.etree import ElementTree
 import tempfile
 import zipfile
+from urllib.request import urlretrieve
+from xml.etree import ElementTree
+
 
 def download_and_get_manifest(url: str):
-    print(f'Downloading {url}')
+    print(f"Downloading {url}")
 
     filename, _ = urlretrieve(url)
     with zipfile.ZipFile(filename) as archive:
         try:
-            with archive.open('AppxManifest.xml') as manifest:
+            with archive.open("AppxManifest.xml") as manifest:
                 return ElementTree.fromstring(manifest.read())
         except KeyError:
             # In the case of a bundle
-            with archive.open('AppxMetadata/AppxBundleManifest.xml') as manifest:
+            with archive.open("AppxMetadata/AppxBundleManifest.xml") as manifest:
                 return ElementTree.fromstring(manifest.read())
+
 
 def validate_package_url(url: str, family_name: str, platform: str):
     manifest = download_and_get_manifest(url)
-    identity = manifest.find('.//{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Identity')
+    identity = manifest.find(
+        ".//{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Identity"
+    )
 
     if identity is not None:
         # Check the architecture if the package isn't bundled
-        assert platform == identity.attrib['ProcessorArchitecture']
+        assert platform == identity.attrib["ProcessorArchitecture"]
     else:
         # Only check the package name for bundles
-        identity =  manifest.find('.//{http://schemas.microsoft.com/appx/2013/bundle}Identity')
+        identity = manifest.find(
+            ".//{http://schemas.microsoft.com/appx/2013/bundle}Identity"
+        )
 
-    assert identity.attrib['Name'] in family_name
+    assert identity.attrib["Name"] in family_name
+
 
 def validate_distro(distro: dict):
-    if distro['Amd64PackageUrl'] is not None:
-        validate_package_url(distro['Amd64PackageUrl'], distro['PackageFamilyName'], 'x64')
+    if distro["Amd64PackageUrl"] is not None:
+        validate_package_url(
+            distro["Amd64PackageUrl"], distro["PackageFamilyName"], "x64"
+        )
 
-    if distro['Arm64PackageUrl'] is not None:
-        validate_package_url(distro['Arm64PackageUrl'], distro['PackageFamilyName'], 'arm64')
+    if distro["Arm64PackageUrl"] is not None:
+        validate_package_url(
+            distro["Arm64PackageUrl"], distro["PackageFamilyName"], "arm64"
+        )
 
-def is_unique(collection: list):
+
+def is_unique(collection: list) -> bool:
     unique_list = set(collection)
     return len(collection) == len(unique_list)
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(f'Usage: {sys.argv[0]} /path/to/file', file=sys.stderr)
+        print(f"Usage: {sys.argv[0]} /path/to/file", file=sys.stderr)
         exit(1)
 
     with open(sys.argv[1]) as fd:
         content = json.loads(fd.read())
 
-    distros = content['Distributions']
-    assert is_unique([e.get('StoreAppId') for e in distros if e])
-    assert is_unique([e.get('Name') for e in distros if e])
+    distros = content["Distributions"]
+    assert is_unique([e.get("StoreAppId") for e in distros if e])
+    assert is_unique([e.get("Name") for e in distros if e])
 
-    for e in content['Distributions']:
+    for e in content["Distributions"]:
         validate_distro(e)
 
     print("All checks completed successfully")


### PR DESCRIPTION
I reformatted the distribution validation script with [black](https://github.com/psf/black), reordered imports alphabetically (and left the unused be) and added a missing return-type annotation.