### PR TITLE
Use the raw link to wsl.wprp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ To collect WSL logs follow these steps:
 
 If creating a Feedback Hub entry isn't possible, then WSL logs need to be captured manually.
 
-To do so, first download [wsl.wprp](https://github.com/microsoft/WSL/blob/master/diagnostics/wsl.wprp), then run in an administrative command prompt:
+To do so, first download [wsl.wprp](https://raw.githubusercontent.com/microsoft/WSL/master/diagnostics/wsl.wprp), then run in an administrative command prompt:
 
 ```
 $ wpr -start wsl.wprp -filemode


### PR DESCRIPTION
This updates the link to `wsl.wprp` to directly point to the raw file instead of the github view of file.

I'm doing this change because some users get confused and download directly from the link (and so they end up downloading github's html instead of the actual file)