### PR TITLE
Revert "Update DistributionInfo.json"

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -3,12 +3,12 @@
         {
             "Name": "Ubuntu",
             "FriendlyName": "Ubuntu",
-            "StoreAppId": "9PDXGNCFSCZV",
+            "StoreAppId": "9NBLGGH4MSV6",
             "Amd64": true,
             "Arm64": true,
-            "Amd64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204-221004.AppxBundle",
-            "Arm64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204-221004.AppxBundle",
-            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu_79rhkp1fndgsc"
+            "Amd64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu.2020.424.0_x64.appx",
+            "Arm64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu.2020.424.0_ARM64.appx",
+            "PackageFamilyName": "CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc"
         },
         {
             "Name": "Debian",


### PR DESCRIPTION
The Ubuntu-22.04 app is not ready to be the default. Will sync with Canonical about the issues.
Reverts microsoft/WSL#8966