### PR TITLE
Silence errors if the WSL package isn't installed

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -32,7 +32,7 @@ if (Test-Path $wslconfig)
 }
 
 get-appxpackage MicrosoftCorporationII.WindowsSubsystemforLinux > $folder/appxpackage.txt
-get-acl "C:\ProgramData\Microsoft\Windows\WindowsApps" | Format-List > $folder/acl.txt
+get-acl "C:\ProgramData\Microsoft\Windows\WindowsApps" -ErrorAction Ignore | Format-List > $folder/acl.txt
 
 wpr.exe -start $LogProfile -filemode 
 


### PR DESCRIPTION
Some users have been confused by the errors displayed of `Collect-Wsl-Logs` is executed on a machine where the WSL app isn't installed.

This change silences those errors.