### PR TITLE
Fix typo in PackageFamilyName for ubuntu-20.04

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -68,7 +68,7 @@
             "Arm64": true,
             "Amd64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_2004.2020.424.0_x64.appx",
             "Arm64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_2004.2020.424.0_ARM64.appx",
-            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu20.04onWindows_79rhkp1fndgs"
+            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu20.04onWindows_79rhkp1fndgsc"
         },
         {
             "Name": "OracleLinux_8_5",


### PR DESCRIPTION
A typo in PackageFamilyName is preventing the installing of ubuntu-20.04.

```
λ wsl --install -d Ubuntu-20.04 --web-download
Downloading: Ubuntu 20.04 LTS
Installing: Ubuntu 20.04 LTS
Ubuntu 20.04 LTS has been installed.
Launching Ubuntu 20.04 LTS...
The group or resource is not in the correct state to perform the requested operation.
Error code: Wsl/InstallDistro/0x8007139f
```

Fixes #9258