### PR TITLE
Add logic to capture the content of HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinSock2

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -22,9 +22,10 @@ if ($LogProfile -eq $null)
     }
 }
 
-reg.exe export HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Lxss $folder/HKCU.reg
-reg.exe export HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Lxss $folder/HKLM.reg
-reg.exe export HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\P9NP $folder/P9NP.reg
+reg.exe export HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Lxss $folder/HKCU.txt
+reg.exe export HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Lxss $folder/HKLM.txt
+reg.exe export HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\P9NP $folder/P9NP.txt
+reg.exe export HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinSock2 $folder/Winsock2.txt
 
 $wslconfig = "$env:USERPROFILE/.wslconfig"
 if (Test-Path $wslconfig)


### PR DESCRIPTION
This adds logic to capture `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinSock2` . 
This change also changes the extensions of the registry files to `.txt` so double clicking on it doesn't try to import them