### PR TITLE
Add information on the optional components in collect-wsl-logs.ps1

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -35,6 +35,7 @@ if (Test-Path $wslconfig)
 
 get-appxpackage MicrosoftCorporationII.WindowsSubsystemforLinux > $folder/appxpackage.txt
 get-acl "C:\ProgramData\Microsoft\Windows\WindowsApps" -ErrorAction Ignore | Format-List > $folder/acl.txt
+Get-WindowsOptionalFeature -Online > $folder/optional-components.txt
 
 wpr.exe -start $LogProfile -filemode 
 


### PR DESCRIPTION
This change add the list of optional components to collect-wsl-logs.ps1, which will help with issues like ##9443