### PR TITLE
Adding the Ubuntu-22.04 LTS app

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -76,8 +76,8 @@
             "StoreAppId": "9PN20MSR04DW",
             "Amd64": true,
             "Arm64": true,
-            "Amd64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204LTS-230109.AppxBundle",
-            "Arm64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204LTS-230109.AppxBundle",
+            "Amd64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204LTS-230117.appx",
+            "Arm64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204LTS-230117_ARM64.appx",
             "PackageFamilyName": "CanonicalGroupLimited.Ubuntu22.04LTS_79rhkp1fndgsc"
         },
         {

--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -71,6 +71,16 @@
             "PackageFamilyName": "CanonicalGroupLimited.Ubuntu20.04onWindows_79rhkp1fndgsc"
         },
         {
+            "Name": "Ubuntu-22.04",
+            "FriendlyName": "Ubuntu 22.04 LTS",
+            "StoreAppId": "9PN20MSR04DW",
+            "Amd64": true,
+            "Arm64": true,
+            "Amd64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204LTS-230109.AppxBundle",
+            "Arm64PackageUrl": "https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2204LTS-230109.AppxBundle",
+            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu22.04LTS_79rhkp1fndgsc"
+        },
+        {
             "Name": "OracleLinux_8_5",
             "FriendlyName": "Oracle Linux 8.5",
             "StoreAppId": "9P06H18WXBVP",


### PR DESCRIPTION
By updating DistributionInfo.json to bring the latest Ubuntu-22.04 app from the store for those who prefer installing with `wsl --install`.