### PR TITLE
Add wsl_devicehost log provider to default log profile

### DIFF
--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -9,6 +9,7 @@
     <EventProvider Id="lxcore_kernel" Name="0CD1C309-0878-4515-83DB-749843B3F5C9"/>
     <EventProvider Id="lxcore_user" Name="D90B9468-67F0-5B3B-42CC-82AC81FFD960"/>
     <EventProvider Id="lxcore_service" Name="B99CDB5A-039C-5046-E672-1A0DE0A40211"/>
+    <EventProvider Id="wsl_devicehost" Name="9d6c7b9e-2581-4d8a-b8c5-b90b4a17094a"/>
     <EventProvider Id="vm_chipset" Name="de9ba731-7f33-4f44-98c9-6cac856b9f83"/>
     <EventProvider Id="vmcompute_dll" Name="AF7FD3A7-B248-460C-A9F5-FEC39EF8468C"/>
     <EventProvider Id="vmcompute" Name="17103E3F-3C6E-4677-BB17-3B267EB5BE57"/>
@@ -58,6 +59,7 @@
             <EventProviderId Value="lxcore_kernel"/>
             <EventProviderId Value="lxcore_user"/>
             <EventProviderId Value="lxcore_service"/>
+            <EventProviderId Value="wsl_devicehost"/>
             <EventProviderId Value="vm_chipset"/>
             <EventProviderId Value="vmcompute_dll"/>
             <EventProviderId Value="vmcompute"/>


### PR DESCRIPTION
This change adds the `wsl_devicehost` log provider to our default log profile. 

This will help diagnose issues like #9481 