### PR TITLE
Ignore special keys when waiting for user input to save the logs

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -40,7 +40,41 @@ Get-WindowsOptionalFeature -Online > $folder/optional-components.txt
 wpr.exe -start $LogProfile -filemode 
 
 Write-Host -NoNewLine -ForegroundColor Green "Log collection is running. Please reproduce the problem and press any key to save the logs."
-$null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown');
+
+$KeysToIgnore =
+      16,  # Shift (left or right)
+      17,  # Ctrl (left or right)
+      18,  # Alt (left or right)
+      20,  # Caps lock
+      91,  # Windows key (left)
+      92,  # Windows key (right)
+      93,  # Menu key
+      144, # Num lock
+      145, # Scroll lock
+      166, # Back
+      167, # Forward
+      168, # Refresh
+      169, # Stop
+      170, # Search
+      171, # Favorites
+      172, # Start/Home
+      173, # Mute
+      174, # Volume Down
+      175, # Volume Up
+      176, # Next Track
+      177, # Previous Track
+      178, # Stop Media
+      179, # Play
+      180, # Mail
+      181, # Select Media
+      182, # Application 1
+      183  # Application 2
+
+$Key = $null
+while ($Key -Eq $null -Or $Key.VirtualKeyCode -Eq $null -Or $KeysToIgnore -Contains $Key.VirtualKeyCode)
+{
+    $Key = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+}
 
 Write-Host "`nSaving logs..."
 


### PR DESCRIPTION
This change adds logic to ignore special keys when prompting for user input to prevent from accidentally stopping the logs on special key combinations like alt-tab.