### PR TITLE
Updated Ubuntu 18.04 and 20.04  distributions info.

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -43,12 +43,12 @@
         {
             "Name": "Ubuntu-20.04",
             "FriendlyName": "Ubuntu 20.04 LTS",
-            "StoreAppId": "9N6SVWS3RX71",
+            "StoreAppId": "9MTTCL66CPXJ",
             "Amd64": true,
             "Arm64": true,
-            "Amd64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_2004.2020.424.0_x64.appx",
-            "Arm64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_2004.2020.424.0_ARM64.appx",
-            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu20.04onWindows_79rhkp1fndgsc"
+            "Amd64PackageUrl":  "TODO",
+            "Arm64PackageUrl":  "TODO",
+            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu20.04LTS_2004.6.16.0_x64__79rhkp1fndgsc"
         },
         {
             "Name": "Ubuntu-22.04",

--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -33,12 +33,12 @@
         {
             "Name": "Ubuntu-18.04",
             "FriendlyName": "Ubuntu 18.04 LTS",
-            "StoreAppId": "9N9TNGVNDL3Q",
+            "StoreAppId": "9PNKSF5ZN4SW",
             "Amd64": true,
             "Arm64": true,
-            "Amd64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_1804.2019.522.0_x64.appx",
-            "Arm64PackageUrl": "https://wsldownload.azureedge.net/Ubuntu_1804.2019.522.0_ARM64.appx",
-            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu18.04onWindows_79rhkp1fndgsc"
+            "Amd64PackageUrl": "TODO",
+            "Arm64PackageUrl": "TODO",
+            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu18.04LTS_1804.6.4.0_x64__79rhkp1fndgsc"
         },
         {
             "Name": "Ubuntu-20.04",


### PR DESCRIPTION
Updates Ubuntu 18.04 and 20.04 to correct Appx. I need help obtaining the URLs to the amd64 and arm64 versions of the appx.

Closes #10162