### PR TITLE
Add WSL Community Telegram channel to Community Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Issues may be closed by the original poster at any time.  We will close issues i
     - https://github.com/ethanhs/WSL-Programs
     - https://github.com/davatron5000/can-i-subsystem-it
 - Awesome WSL: https://github.com/sirredbeard/Awesome-WSL
+- WSL Community Telegram: http://wsl.community/
 - Tips and guides for new bash users: https://github.com/abergs/ubuntuonwindows
 
 ### Troubleshooting:


### PR DESCRIPTION
The WSL Community Telegram channel is the longest-running chat dedicated to WSL and branched from the original series of WSLConf conference series.