### PR TITLE
Add new script for WSL networking diagnostics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,32 @@ Availability  Capabilities  CapabilityDescriptions                              
 
 #### Networking issues
 
-If the issue is about networking, run [networking.bat](https://github.com/Microsoft/WSL/blob/master/diagnostics/networking.bat) in an administrative command prompt:
+Install tcpdump in your WSL distribution using the following commands.
+Note: This might not work if WSL has Internet connectivity issues.
+
+```
+# sudo apt-get update
+# sudo apt-get -y install tcpdump
+```
+
+Run [networking_diagnostics.bat](https://github.com/Microsoft/WSL/blob/master/diagnostics/networking_diagnostics.bat) in an administrative command prompt:
+
+```
+$ git clone https://github.com/microsoft/WSL --depth=1 %tmp%\WSL
+$ cd %tmp%\WSL\diagnostics
+$ networking_diagnostics.bat
+```
+
+Note:
+If tcpdump is installed, the script will open 2 more shells, one of which will ask for your sudo password.
+If tcpdump is not installed, only 1 additional shell will be opened
+Wait for those shells to be opened before reproducing the issue
+
+After reproducing the issue, in the shell that asked for your sudo password, hit Ctrl + C. In the other shells, press any key.
+
+Collect `WslNetworkingLogs.zip`
+
+Run [networking.bat](https://github.com/Microsoft/WSL/blob/master/diagnostics/networking.bat) in an administrative command prompt:
 
 ```
 $ git clone https://github.com/microsoft/WSL --depth=1 %tmp%\WSL

--- a/diagnostics/networking_diagnostics.bat
+++ b/diagnostics/networking_diagnostics.bat
@@ -1,0 +1,18 @@
+powershell invoke-expression 'cmd /c start powershell -Command { .\collect-wsl-logs.ps1 }'
+wsl.exe tr -d "\r" ^| bash < ./networking.sh > wsl_network_configuration_before.log
+powershell Get-NetRoute > get_netroute.log
+powershell invoke-expression 'cmd /c start powershell -Command { "wsl.exe sudo tcpdump -n -i any > tcpdump.log" }'
+
+wpr -start .\wsl_networking.wprp -filemode -instanceName wpr_networking
+pktmon start -c --flags 0x1A
+netsh wfp capture start
+
+pause
+
+netsh wfp capture stop
+pktmon stop
+wpr -stop wsl_networking.etl -instanceName wpr_networking
+
+wsl.exe tr -d "\r" ^| bash < ./networking.sh > wsl_network_configuration_after.log
+
+echo "Finished log collection"

--- a/diagnostics/networking_diagnostics.bat
+++ b/diagnostics/networking_diagnostics.bat
@@ -1,6 +1,12 @@
+set networking_folder=".\networking_logs"
+set neworking_logs_zip=".\WslNetworkingLogs.zip"
+
+mkdir %networking_folder%
+
+wsl.exe tr -d "\r" ^| bash < ./networking.sh > %networking_folder%\wsl_network_configuration_before.log
+powershell Get-NetRoute > %networking_folder%\get_netroute.log
+
 powershell invoke-expression 'cmd /c start powershell -Command { .\collect-wsl-logs.ps1 }'
-wsl.exe tr -d "\r" ^| bash < ./networking.sh > wsl_network_configuration_before.log
-powershell Get-NetRoute > get_netroute.log
 powershell invoke-expression 'cmd /c start powershell -Command { "wsl.exe sudo tcpdump -n -i any > tcpdump.log" }'
 
 wpr -start .\wsl_networking.wprp -filemode -instanceName wpr_networking
@@ -9,10 +15,23 @@ netsh wfp capture start
 
 pause
 
+:: allow some time for the user to stop logs in all the spawned shells
+:: (particularly the shell running collect-wsl-logs.ps1 will take a bit to stop)
+timeout 20
+
 netsh wfp capture stop
 pktmon stop
-wpr -stop wsl_networking.etl -instanceName wpr_networking
+wpr -stop %networking_folder%\wsl_networking.etl -instanceName wpr_networking
 
-wsl.exe tr -d "\r" ^| bash < ./networking.sh > wsl_network_configuration_after.log
+wsl.exe tr -d "\r" ^| bash < ./networking.sh > %networking_folder%\wsl_network_configuration_after.log
+
+move tcpdump.log %networking_folder%
+move PktMon.etl %networking_folder%
+move wfpdiag.cab %networking_folder%
+move "*zip" %networking_folder%
+
+powershell Compress-Archive -Path %networking_folder% -DestinationPath %neworking_logs_zip%
+
+rmdir /s /q %networking_folder%
 
 echo "Finished log collection"


### PR DESCRIPTION
The script collects the regular WSL logs (using collect-wsl-logs.ps1).

In addition, it collects:
traces from networking providers (wsl_networking.wprp)
tcpdump from the container
pktmon logs
WFP logs
host routes
It runs the networking.sh scripts before and after repro and collects it's output
