### PR TITLE
Collect BCD configuration during log collection

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -36,6 +36,7 @@ if (Test-Path $wslconfig)
 get-appxpackage MicrosoftCorporationII.WindowsSubsystemforLinux > $folder/appxpackage.txt
 get-acl "C:\ProgramData\Microsoft\Windows\WindowsApps" -ErrorAction Ignore | Format-List > $folder/acl.txt
 Get-WindowsOptionalFeature -Online > $folder/optional-components.txt
+bcdedit.exe > $folder/bcdedit.txt
 
 $wprOutputLog = "$folder/wpr.txt"
 


### PR DESCRIPTION
This change adds logic to capture bcedit output during log collection.

This change will make it easier to diagnose issues like [this one](https://github.com/microsoft/WSL/issues/10467)