### PR TITLE
Add a handy shortcut to collect storage logs

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -11,11 +11,25 @@ Set-StrictMode -Version Latest
 $folder = "WslLogs-" + (Get-Date -Format "yyyy-MM-dd_HH-mm-ss")
 mkdir -p $folder | Out-Null
 
-if ($LogProfile -eq $null)
+if ($LogProfile -eq $null -Or ![System.IO.File]::Exists($LogProfile))
 {
+    if ($LogProfile -eq $null)
+    {
+        $url = "https://raw.githubusercontent.com/microsoft/WSL/master/diagnostics/wsl.wprp"
+    }
+    elseif ($LogProfile -eq "storage")
+    {
+         $url = "https://raw.githubusercontent.com/microsoft/WSL/master/diagnostics/wsl_storage.wprp"
+    }
+    else
+    {
+        Write-Error "Unknown log profile: $LogProfile"
+        exit 1
+    }
+
     $LogProfile = "$folder/wsl.wprp"
     try {
-        Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/WSL/master/diagnostics/wsl.wprp" -OutFile $LogProfile
+        Invoke-WebRequest -UseBasicParsing $url -OutFile $LogProfile
     }
     catch {
         throw


### PR DESCRIPTION
This change adds a handy shortcut to easily collect logs via: 

```
collect-wsl-logs.ps1 -LogProfile storage
```

We can add more profiles in the future 