### PR TITLE
Fix various issues with WTI

### DIFF
--- a/.github/actions/triage/action.yml
+++ b/.github/actions/triage/action.yml
@@ -39,6 +39,6 @@ runs:
                 $maybe_comment = @("--comment", "${{ inputs.comment }}")
             }
             
-            curl.exe -L https://github.com/OneBlue/wti/releases/download/v0.1.3/wti.exe -o triage/wti.exe
+            curl.exe -L https://github.com/OneBlue/wti/releases/download/v0.1.4/wti.exe -o triage/wti.exe
             
             cd triage && echo -n $message | .\wti.exe --issue ${{ inputs.issue }} --config config.yml --github-token "${{ inputs.token }}" --ignore-tags @maybe_message @maybe_comment 

--- a/triage/config.yml
+++ b/triage/config.yml
@@ -153,10 +153,13 @@ actions:
     - foreach:
         var: user-visible-error
         debug_message: 'Detected user visible error: $error'
+        skip_similar_issues: false
+
         
     - when:
         condition: 'kernel-panic'
         debug_message: 'Found evidence of kernel panic: $kmsg'
+        skip_similar_issues: false
 
     - when: 
         condition: 
@@ -164,44 +167,53 @@ actions:
         user_message: 'The logs show that WSL2 ran out of memory. Try increasing wsl2.memory in .wslconfig and see if that solves the issue.'
         debug_message: 'Found evidence of OOM kill: $oom-error'
         tag: needs-author-feedback
+        skip_similar_issues: true
         
     - when: 
         condition: 
          and: ['vm-failed-to-start', 'hyperv-firmware-expired']
         user_message: 'The logs show that your Hyper-V firmware is expired. Please update your Windows build and see if that solves the issue'
         tag: needs-author-feedback
+        skip_similar_issues: true
+
         
     - when:
         condition:
           and: ['vm-failed-to-start', 'corrupted-initramfs']
         user_message: 'Your WSL installation seems corrupted. Please try to download and install the [latest WSL release](https://github.com/microsoft/WSL/releases/latest)'
         tag: needs-author-feedback
+        skip_similar_issues: true
        
     - when:
         condition:
           and: [{not: 'service-running'}, 'service-disabled-error']
         user_message: 'The logs show that wslservice is disabled. Try to run (elevated command prompt): `sc.exe config wslservice start= demand` and see if that solves the issue'
         tag: needs-author-feedback
-        
+        skip_similar_issues: true
+
     - when:
         condition:
           and: ['vm-failed-to-start', 'hns-fatal-error']
         user_message: 'An HNS error seems to be causing WSL2 to fail to start. Adding network tag'
         debug_message: 'Found HNS error: $error'
         tag: 'network'
-        
+
     - when:
         condition:
           and: ['vm-failed-to-start', 'vmswitch-known-issue']
         user_message: 'Known vmswitch issue found (error: $error). Adding network tag'
         debug_message: 'Found evidence of vmswitch error: $error'
         tag: 'network'
+        skip_similar_issues: true
+
         
     - when: 
         condition: 'ext4-error'
         user_message: 'The logs shows that a disk mount error occured. Try to [follow these repair instructions](https://learn.microsoft.com/en-us/windows/wsl/disk-space#how-to-repair-a-vhd-mounting-error) and see if that solves the issue.'
         debug_message: 'Found evidence of ext4 error: $error'
         tag: 'needs-author-feedback'
+        skip_similar_issues: true
+
 
     - when:
         condition:
@@ -210,3 +222,4 @@ actions:
         user_message: "The log file doesn't contain any WSL traces. Please make sure **that you reproduced the issue while the log collection was running.**"
         debug_message: 'Found no WSL traces in the logs'
         tag: 'needs-author-feedback'
+        skip_similar_issues: false


### PR DESCRIPTION
Behavior changes: 

- The "similar issues" block will only be skipped if WTI has a definite answer (so when `skip_similar_issues` is true) 
- WTI will not try to analyze logs if multiple log files are posted at once 
- If no logs are found in the description, WTI will not look at the comments unless --comments is passed
- wpaexporter is now called with `-tle`, so it won't failed if ETL events have been dropped during trace collection
- If wpaexporter fails, WTI won't incorrectly display the 'No WSL logs found' user message

See: https://github.com/OneBlue/wti/compare/v0.1.3...v0.1.4 
