### PR TITLE
Fixing the powershell to collect netsetup logs

### DIFF
--- a/diagnostics/collect-networking-logs.ps1
+++ b/diagnostics/collect-networking-logs.ps1
@@ -259,7 +259,7 @@ catch {}
 $netSetupPath = "$env:WINDIR/logs/netsetup"
 if (Test-Path $netSetupPath)
 {
-    Copy-Item $netSetupPath $folder
+    Copy-Item $netSetupPath/* $folder
 }
 
 $setupApiPath = "$env:WINDIR/inf/setupapi.dev.log"


### PR DESCRIPTION
… worked when there were multiple files in the target path, but when there was just a single file it did not work correctly. this is verified to work with both 1 or more files in the netsetup path.