### PR TITLE
Adding the regitry values under tcpip6/parameters

### DIFF
--- a/diagnostics/collect-networking-logs.ps1
+++ b/diagnostics/collect-networking-logs.ps1
@@ -255,6 +255,14 @@ try
 }
 catch {}
 
+# Collect the old Tcpip6 registry values - as they can break WSL if DisabledComponents is set to 0xff
+# see https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/configure-ipv6-in-windows
+try
+{
+    Get-Item HKLM:SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters | Out-File -FilePath "$folder/tcpip6_parameters.log" -Append
+}
+catch {}
+
 # Collect the setup and NetSetup log files
 $netSetupPath = "$env:WINDIR/logs/netsetup"
 if (Test-Path $netSetupPath)


### PR DESCRIPTION
Adding the regitry values under tcpip6/parameters to see if users tried to disable ipv6 from the old stack registry keys which is not supported. It has come up a few times with different users.