### PR TITLE
collect-networking-logs.ps1: collect Windows NLM state and Linux ip rules

### DIFF
--- a/diagnostics/collect-networking-logs.ps1
+++ b/diagnostics/collect-networking-logs.ps1
@@ -22,6 +22,12 @@ function Collect-WindowsNetworkState {
 
     try
     {
+        & netsh nlm query all $folder/nlmquery_"$ReproStep".log
+    }
+    catch {}
+
+    try
+    {
         Get-NetIPConfiguration -All -Detailed | Out-File -FilePath "$folder/Get-NetIPConfiguration_$ReproStep.log" -Append
     }
     catch {}

--- a/diagnostics/networking.sh
+++ b/diagnostics/networking.sh
@@ -10,6 +10,7 @@ ip a
 ip route show table all
 ip neighbor
 ip link
+ip rule show
 
 # We only print whether the HTTP proxy variables are set or not, as their content might contain secrets such as usernames, passwords.
 if [ -z ${http_proxy+x} ]; then echo "http_proxy is unset"; else echo "http_proxy is set"; fi


### PR DESCRIPTION
Collect NLM state
Collect Linux ip rules (policy based routing) - for example in mirrored mode those are used for loopback traffic, we need to capture them to confirm they are as expected