### PR TITLE
Collect Get-NetUdpEndpoint in networking script to help with SharedAccess DNS proxy failing to start issues

### DIFF
--- a/diagnostics/collect-networking-logs.ps1
+++ b/diagnostics/collect-networking-logs.ps1
@@ -113,6 +113,12 @@ function Collect-WindowsNetworkState {
         Get-VMSwitch | select Name,Id,SwitchType | Out-File -FilePath "$folder/Get-VMSwitch_$ReproStep.log" -Append
     }
     catch {}
+
+    try
+    {
+        Get-NetUdpEndpoint | Out-File -FilePath "$folder/Get-NetUdpEndpoint_$ReproStep.log" -Append
+    }
+    catch {}
 }
 
 $folder = "WslNetworkingLogs-" + (Get-Date -Format "yyyy-MM-dd_HH-mm-ss")


### PR DESCRIPTION
We have seen multiple issues where the SharedAccess DNS proxy fails to start because there is another listener on UDP port 53 on Windows, which leads to WSL failing to start

Collecting this command should help diagnose those issues faster
