### PR TITLE
Fix language issues in install WSL ps1 script

### DIFF
--- a/triage/install-latest-wsl.ps1
+++ b/triage/install-latest-wsl.ps1
@@ -3,7 +3,7 @@
 # This script downloads and installs the latest version of the WSL MSI package
 
 # Get current language code
-$chcp_num = (chcp) -replace '\D+\(\d+)','$1'
+$chcp_num = (chcp) -replace '[^\d]+(\d+).*','$1'
 
 # Set language to english
 chcp 437

--- a/triage/install-latest-wsl.ps1
+++ b/triage/install-latest-wsl.ps1
@@ -2,6 +2,12 @@
 
 # This script downloads and installs the latest version of the WSL MSI package
 
+# Get current language code
+$chcp_num = (chcp) -replace '\D+\(\d+)','$1'
+
+# Set language to english
+chcp 437
+
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
@@ -48,3 +54,6 @@ if ($exitCode -Ne 0)
 Write-Host 'Installation complete'
 
 Remove-Item $target -Force
+
+# Restore original language
+chcp $chcp_num


### PR DESCRIPTION
https://github.com/microsoft/WSL/issues/12282#issuecomment-2480894130 The install-latest-wsl.ps1 script cannot parse the operating "System Type" '$systeminfo = & systeminfo | findstr /C:"System Type"' due to language problems. In the Chinese interface environment, "System Type" is the Chinese "系统类型".