### PR TITLE
Use github.sha as the reference commit hash in the modern distributio…

### DIFF
--- a/.github/workflows/modern-distributions.yml
+++ b/.github/workflows/modern-distributions.yml
@@ -30,5 +30,5 @@ jobs:
             --manifest distributions/DistributionInfo.json \
             --github-token '${{ secrets.GITHUB_TOKEN }}' \
             --github-pr '${{ github.event.pull_request.number }}' \
-            --github-commit '${{ github.event.pull_request.merge_commit_sha }}'
+            --github-commit '${{ github.sha }}'
           shell: bash


### PR DESCRIPTION
This should resolve the CI issues in https://github.com/microsoft/WSL/pull/12321 