### PR TITLE
Explicitely set the default distribution in DistributionInfo.json

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -1,5 +1,6 @@
 {
     "ModernDistributions": {},
+    "Default": "Ubuntu",
     "Distributions": [
         {
             "Name": "Ubuntu",


### PR DESCRIPTION
This solves #12324.

I'll also make a code change to better handle this case, but at least this will fix existing the existing logic on 2.4.4