### PR TITLE
CI: Add systemd-networkd-wait-online.service to discouraged systemd units list

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -22,6 +22,7 @@ KNOWN_TAR_FORMATS = {'^XZ compressed data.*': True, '^gzip compressed data.*': T
 
 DISCOURAGED_SYSTEM_UNITS = ['systemd-resolved.service',
                             'systemd-networkd.service',
+                            'systemd-networkd-wait-online.service',
                             'systemd-tmpfiles-setup.service',
                             'systemd-tmpfiles-clean.service',
                             'systemd-tmpfiles-setup-dev-early.service',


### PR DESCRIPTION
This change adds the networkd wait online service to the list of discouraged systemd units.