### PR TITLE
Add AOSC OS to modern distributions.

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -138,6 +138,21 @@
                     "Sha256": "9c5804fc58108a138f53ff111961e17217b1cf429f8e5c8365b52062b621e8e5"
                 }
             }
+        ],
+        "AOSCOS": [
+            {
+                "Name": "AOSCOS",
+                "FriendlyName": "AOSC OS",
+                "Default": true,
+                "Amd64Url": {
+                    "Url": "https://releases.aosc.io/os-amd64/wsl/aosc-os_wsl_20250319_amd64.wsl",
+                    "Sha256": "8f507177cf42649e158fdf0da0d1dfb61d57a4b994c1026ec6aa1441eabfb69f"
+                },
+                "Arm64Url": {
+                    "Url": "https://releases.aosc.io/os-arm64/wsl/aosc-os_wsl_20250319_arm64.wsl",
+                    "Sha256": "2bafbcd16ddb20b64e809658834d4b2c9ceb5e54d49b4505adc2f8e68980438a"
+                }
+            }
         ]
     },
     "Default": "Ubuntu",


### PR DESCRIPTION
Hi, I'm a maintainer of AOSC OS, a general purpose Linux distribution that strives to simplify user experience and improve free and open source software for day-to-day productivity.

Our distribution has been available on Microsoft Store for years <https://www.microsoft.com/store/apps/9NMDF21NV65Z>, and we'd like to adopt the modern distribution solution.

The .wsl files are identical to the version I just submitted to the Store for certification, and are generated by our in-house tool <https://github.com/AOSC-Dev/aoscbootstrap/blob/9182de9024ad24c6294233eb4eb58623be66c238/contrib/generate-releases.sh>.

By the way, we also release AppX sideload packages for machines with no Microsoft Store available, however I see that all other distributions have their AppX on Microsoft's server, does Microsoft accept new submissions to that list too?