### PR TITLE
Update create-change.py and create-release.py to point to the microsoft/WSL repository

### DIFF
--- a/tools/devops/create-change.py
+++ b/tools/devops/create-change.py
@@ -4,7 +4,7 @@ import json
 from git import Repo
 
 COMMITER_EMAIL = 'noreply@microsoft.com'
-REPO = 'microsoft/wsl-staging' # OSSTODO: Replace with microsoft/wsl once fully open source
+REPO = 'microsoft/wsl'
 
 @click.command()
 @click.argument('repo_path', required=True)

--- a/tools/devops/create-release.py
+++ b/tools/devops/create-release.py
@@ -76,8 +76,7 @@ def get_github_pr_message(token: str, message: str) -> str:
                'Authorization': 'Bearer ' + token,
                'X-GitHub-Api-Version': '2022-11-28'}
 
-    # OSSTODO: Update repo once open source
-    response = requests.get(f'https://api.github.com/repos/microsoft/wsl-staging/pulls/{pr_number}', timeout=30, headers=headers)
+    response = requests.get(f'https://api.github.com/repos/microsoft/wsl/pulls/{pr_number}', timeout=30, headers=headers)
     response.raise_for_status()
 
     return response.json()['body'], pr_number


### PR DESCRIPTION
This change updates `create-release.py` and `create-change.py` to point to microsoft/WSL, now that the code has moved to that repository 