### PR TITLE
Fix failing WinGet publish action

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -18,15 +18,13 @@ jobs:
           $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
           $wingetRelevantAssetx64 = $assets | Where-Object { $_.name -like '*x64.msi' } | Select-Object -First 1
           $wingetRelevantAssetARM64 = $assets | Where-Object { $_.name -like '*arm64.msi' } | Select-Object -First 1
-          $wingetRelevantAssetMSIX = $assets | Where-Object { $_.name -like '*.msixbundle' } | Select-Object -First 1
           
           $version = "${{ github.event.release.tag_name }}"
 
           $wingetx64URL = $wingetRelevantAssetx64.browser_download_url
           $wingetARM64URL = $wingetRelevantAssetARM64.browser_download_url
-          $wingetMSIXURL = $wingetRelevantAssetMSIX.browser_download_url
 
           $wingetPackageId = "Microsoft.WSL"
 
           & curl.exe -JLO https://aka.ms/wingetcreate/latest
-          & .\wingetcreate.exe update $wingetPackageId -s -v $version -u "$wingetx64URL|x64" "$wingetARM64URL|arm64" "$wingetMSIXURL" -t "${{ secrets.WINGET_TOKEN }}"
+          & .\wingetcreate.exe update $wingetPackageId -s -v $version -u "$wingetx64URL|x64" "$wingetARM64URL|arm64" -t "${{ secrets.WINGET_TOKEN }}"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -26,7 +26,7 @@ jobs:
           $wingetARM64URL = $wingetRelevantAssetARM64.browser_download_url
           $wingetMSIXURL = $wingetRelevantAssetMSIX.browser_download_url
 
-          $wingetPackage = "Microsoft.WSL"
+          $wingetPackageId = "Microsoft.WSL"
 
           & curl.exe -JLO https://aka.ms/wingetcreate/latest
-          & .\wingetcreate.exe update $wingetPackage -s -v $version -u "$wingetx64URL|x64" "$wingetARM64URL|arm64" "$wingetMSIXURL|x64" "$wingetMSIXURL|arm64" -t "${{ secrets.WINGET_TOKEN }}"
+          & .\wingetcreate.exe update $wingetPackageId -s -v $version -u "$wingetx64URL|x64" "$wingetARM64URL|arm64" "$wingetMSIXURL" -t "${{ secrets.WINGET_TOKEN }}"


### PR DESCRIPTION
## Summary of the Pull Request

WinGet publish action would fail previously because the base manifest at winget-pkgs didn't contain the MSIX installers, and wingetcreate expects the number of installers specified in the command to be the same as that in the latest manifest. The MSIX installers were added in the latest manifest in https://github.com/microsoft/winget-pkgs/pull/258400. Also, the MSIXBundle URL only needs to be specified once (not per architecture) as wingetcreate will parse all the architectures present within the bundle and create those nodes automatically. Specifying it multiple times will fail with an error.

Fixes the failing runs seen in https://github.com/microsoft/WSL/actions/workflows/winget.yml

## Validation Steps Performed

To validate, you can run a wingetcreate command with old installer URLs and a dummy version (omitting the -s / --submit flag to prevent opening a PR like I did in examples below) to test the behavior

This command fails as it specifies the MSIXBundle URL multiple times with arch overrides

```
wingetcreate update Microsoft.WSL --version 10.0.0 --urls "https://github.com/microsoft/WSL/releases/download/2.5.4/wsl.2.5.4.0.x64.msi|x64" "https://github.com/microsoft/WSL/releases/download/2.5.4/wsl.2.5.4.0.arm64.msi|arm64" "https://github.com/microsoft/WSL/releases/download/2.5.4/Microsoft.WSL_2.5.4.0_x64_ARM64.msixbundle|x64" "https://github.com/microsoft/WSL/releases/download/2.5.4/Microsoft.WSL_2.5.4.0_x64_ARM64.msixbundle|arm64"
```

This command succeeds where MSIXBundle is only specified once

```
wingetcreate update Microsoft.WSL --version 10.0.0 --urls "https://github.com/microsoft/WSL/releases/download/2.5.4/wsl.2.5.4.0.x64.msi|x64" "https://github.com/microsoft/WSL/releases/download/2.5.4/wsl.2.5.4.0.arm64.msi|arm64" "https://github.com/microsoft/WSL/releases/download/2.5.4/Microsoft.WSL_2.5.4.0_x64_ARM64.msixbundle"
```

