### PR TITLE
Create a separate pipeline for public CI

### DIFF
--- a/.pipelines/wsl-build-pr.yml
+++ b/.pipelines/wsl-build-pr.yml
@@ -1,0 +1,18 @@
+trigger:
+  branches:
+    include:
+    - master
+    - release/*
+
+git:
+  fetchDepth: -1
+  fetchTags: true
+
+stages:
+- template: build-stage.yml@self
+  parameters:
+    isRelease: false
+
+- template: test-stage.yml@self
+  parameters:
+    rs_prerelease_only: true


### PR DESCRIPTION
This change adds a new pipeline .yml for CI. It's not fully functional yet, but needs to be on master before the pipeline can be created 