### PR TITLE
 Fix SyntaxError in `validate-modern.py` due to unescaped newline in f-string

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -154,10 +154,12 @@ def report_status_on_pr(manifest: str):
         return output
 
     for line, text in errors.items():
-        print(f'::error file={manifest},line={line}::Error: {format_list(text).replace('\n', '%0A')}')
+        escaped = format_list(text).replace('\n', '%0A')
+        print(f'::error file={manifest},line={line}::Error: {escaped}')
 
     for line, text in warnings.items():
-        print(f'::warning file={manifest},line={line}::Warning: {format_list(text).replace('\n', '%0A')}')
+        escaped = format_list(text).replace('\n', '%0A')
+        print(f'::warning file={manifest},line={line}::Warning: {escaped}')
 
 
 def read_config_keys(config: configparser.ConfigParser) -> dict:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** Link to issue #12976 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This PR pre-processes the escaped output before formatting it in the f-string. The updated code:
```bash
escaped = format_list(text).replace('\n', '%0A')
print(f'::error file={manifest},line={line}::Error: {escaped}')
```
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
It works find locally.
```bash
$ python validate-modern.py --tar gentoo_20250525.wsl
Found valid keys in "./etc/wsl-distribution.conf": ['oobe.command', 'oobe.defaultname', 'shortcut.enabled', 'shortcut.icon']
Found valid keys in "./etc/wsl.conf": []
```
