### PR TITLE
Reduce the soft file descriptor limit to 10240

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1452,10 +1452,11 @@ Return Value:
 
     //
     // Increase the soft and hard limit for number of open file descriptors.
+    // N.B. the soft limit shouldn't be too high. See https://github.com/microsoft/WSL/issues/12985 .
     //
 
     rlimit Limit{};
-    Limit.rlim_cur = 1024 * 1024;
+    Limit.rlim_cur = 1024 * 10;
     Limit.rlim_max = 1024 * 1024;
     if (setrlimit(RLIMIT_NOFILE, &Limit) < 0)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This pull request solves a regression introduced in 2.5.7 causing docker's init.d script to fail to start 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** Link to issue #12985 12985
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

 We have increased the soft file descriptor limit to 1,048,576, and given that the hard file descriptor limit cannot be lower than the soft one (which is what ulimit -Hn 524288 is trying to do), that command fails.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Validated that docker successfully starts 
