### PR TITLE
Make the post import distribution checks less strict

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -2620,7 +2620,7 @@ void PostProcessImportedDistribution(wsl::shared::MessageWriter<LX_MINI_INIT_IMP
 
     Message->ValidDistribution = false;
 
-    for (auto* path : {"/etc", "/bin/sh", "/etc/wsl-distribution.conf"})
+    for (auto* path : {"/etc", "/bin/sh"})
     {
         if (access(path, F_OK) >= 0)
         {

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -2618,17 +2618,20 @@ void PostProcessImportedDistribution(wsl::shared::MessageWriter<LX_MINI_INIT_IMP
     THROW_LAST_ERROR_IF(chdir(ExtractedPath) < 0);
     THROW_LAST_ERROR_IF(chroot(".") < 0);
 
-    for (auto* path : {"/etc", "/bin/sh"})
+    Message->ValidDistribution = false;
+
+    for (auto* path : {"/etc", "/bin/sh", "/etc/wsl-distribution.conf"})
     {
-        if (access(path, F_OK) < 0)
+        if (access(path, F_OK) >= 0)
         {
-            LOG_ERROR("Failed to access {} {}", path, errno);
-            Message->ValidDistribution = false;
-            return;
+            Message->ValidDistribution = true;
         }
     }
 
-    Message->ValidDistribution = true;
+    if (!Message->ValidDistribution)
+    {
+        return;
+    }
 
     auto [flavor, version] = UtilReadFlavorAndVersion("/etc/os-release");
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -5855,7 +5855,7 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             // VERIFY_ARE_EQUAL(err, L"");
         }
 
-        // Validate that tars containg "/etc/wsl-distribution.conf" are accepted.
+        // Validate that tars containing /etc, but not /bin/sh are accepted.
         if (LxsstuVmMode())
         {
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { LxsstuLaunchWsl(L"--unregister empty-distro"); });

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -5860,6 +5860,9 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         {
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { LxsstuLaunchWsl(L"--unregister empty-distro"); });
 
+            DistroFileChange conf(L"/etc/wsl.conf", false);
+            conf.SetContent(L"");
+
             auto [out, err] = LxsstuLaunchWslAndCaptureOutput(
                 L"tar cf - /etc/wsl.conf | wsl.exe --install --from-file - --name empty-distro --no-launch "
                 L"--version 2");

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -5858,13 +5858,10 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         // Validate that tars containg "/etc/wsl-distribution.conf" are accepted.
         if (LxsstuVmMode())
         {
-            DistroFileChange wslDistributionConf(L"/etc/wsl-distribution.conf", false);
-            wslDistributionConf.SetContent(L"");
-
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { LxsstuLaunchWsl(L"--unregister empty-distro"); });
 
             auto [out, err] = LxsstuLaunchWslAndCaptureOutput(
-                L"tar cf - /etc/wsl-distribution.conf | wsl.exe --install --from-file - --name empty-distro --no-launch "
+                L"tar cf - /etc/wsl.conf | wsl.exe --install --from-file - --name empty-distro --no-launch "
                 L"--version 2");
         }
     }

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -5854,6 +5854,19 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             // TODO: Uncomment once SetVersionDebug is removed from the tests .wslconfig.
             // VERIFY_ARE_EQUAL(err, L"");
         }
+
+        // Validate that tars containg "/etc/wsl-distribution.conf" are accepted.
+        if (LxsstuVmMode())
+        {
+            DistroFileChange wslDistributionConf(L"/etc/wsl-distribution.conf", false);
+            wslDistributionConf.SetContent(L"");
+
+            auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { LxsstuLaunchWsl(L"--unregister empty-distro"); });
+
+            auto [out, err] = LxsstuLaunchWslAndCaptureOutput(
+                L"tar cf - /etc/wsl-distribution.conf | wsl.exe --install --from-file - --name empty-distro --no-launch "
+                L"--version 2");
+        }
     }
 
     TEST_METHOD(ImportExportStdout)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change allows distributions to be imported, even if they don't have a /bin/sh, as long as they have at least `/etc`.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** Link to issue #13006
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
 
This change solves docker failing to register a distribution if it doesn't provide `/bin/sh`. See #13006 for details. 

## Validation Steps Performed

Added test coverage for this scenario
