### PR TITLE
Don't try to download a new distribution if the name is already in use

### DIFF
--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -271,6 +271,15 @@ std::pair<std::wstring, GUID> WslInstall::InstallModernDistribution(
     const std::optional<uint64_t>& vhdSize,
     const bool fixedVhd)
 {
+    wsl::windows::common::SvcComm service;
+
+    // Fail early if the distributions name is already in use.
+    auto result = wil::ResultFromException([&]() {
+        service.GetDistributionId(name.has_value() ? name->c_str() : distribution.Name.c_str(), LXSS_GET_DISTRO_ID_LIST_ALL);
+    });
+
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS), SUCCEEDED(result));
+    LOG_HR_IF(result, result != WSL_E_DISTRO_NOT_FOUND);
 
     const auto downloadInfo = wsl::shared::Arm64 ? distribution.Arm64Url : distribution.Amd64Url;
     THROW_HR_IF(E_UNEXPECTED, !downloadInfo.has_value());
@@ -304,7 +313,6 @@ std::pair<std::wstring, GUID> WslInstall::InstallModernDistribution(
 
     wsl::windows::common::HandleConsoleProgressBar progressBar(file.get(), Localization::MessageImportProgress());
 
-    wsl::windows::common::SvcComm service;
     auto [id, installedName] = service.RegisterDistribution(
         name.has_value() ? name->c_str() : distribution.Name.c_str(),
         version.value_or(LXSS_WSL_VERSION_DEFAULT),


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to validate that the distribution name is not in use before downloading it 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** Link to issue #12950
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Validation Steps Performed

Added test coverage for new code paths
