### PR TITLE
Fix missing null terminator when calling execv() on modprobe

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3383,7 +3383,7 @@ try
             const std::string KernelModulesList = wsl::shared::string::FromSpan(Buffer, EarlyConfig->KernelModulesListOffset);
             for (const auto& Module : wsl::shared::string::Split(KernelModulesList, ','))
             {
-                const char* Argv[] = {MODPROBE_PATH, Module.c_str()};
+                const char* Argv[] = {MODPROBE_PATH, Module.c_str(), nullptr};
                 int Status = -1;
                 auto result = UtilCreateProcessAndWait(MODPROBE_PATH, Argv, &Status);
                 if (result < 0)

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -682,7 +682,7 @@ Return Value:
         // 2. In sometime we probably will replace most of these string constants
         // with std::string anyway.
         execv(File, const_cast<char* const*>(Argv));
-        LOG_ERROR("{} failed with {}", File, errno);
+        LOG_ERROR("execv({}) failed with {}", File, errno);
         exit(-1);
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a bug causing WSL to boot without kernel modules. The root cause of the bug is a missing null terminator in an argv when calling execv() on modprobe. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated the fix on an ARM64 device. 
