### PR TITLE
Fix edge cases around .vhd support

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -466,7 +466,7 @@ Arguments for managing Windows Subsystem for Linux:
                 Move the distribution to a new location.
 
             --set-sparse, -s &lt;true|false&gt;
-                Set the vhdx of distro to be sparse, allowing disk space to be automatically reclaimed.
+                Set the VHD of distro to be sparse, allowing disk space to be automatically reclaimed.
 
             --set-default-user &lt;Username&gt;
                 Set the default user of the distribution.
@@ -546,11 +546,11 @@ Arguments for managing distributions in Windows Subsystem for Linux:
                 Specifies the version to use for the new distribution.
 
             --vhd
-                Specifies that the provided file is a .vhdx file, not a tar file.
-                This operation makes a copy of the .vhdx file at the specified install location.
+                Specifies that the provided file is a .vhd or .vhdx file, not a tar file.
+                This operation makes a copy of the VHD file at the specified install location.
 
     --import-in-place &lt;Distro&gt; &lt;FileName&gt;
-        Imports the specified .vhdx file as a new distribution.
+        Imports the specified VHD file as a new distribution.
         This virtual hard disk must be formatted with the ext4 filesystem type.
 
     --list, -l [Options]
@@ -626,7 +626,7 @@ Build time: {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageCustomKernelModulesNotFound" xml:space="preserve">
-    <value>The custom kernel modules vhd in {} was not found: '{}'.</value>
+    <value>The custom kernel modules VHD in {} was not found: '{}'.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageCustomSystemDistroError" xml:space="preserve">
@@ -704,8 +704,13 @@ The system may need to be restarted so the changes can take effect.</value>
      <comment>{Locked="--install "}{Locked="--no-distribution
 "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
-  <data name="MessageRequiresVhdxFileExtension" xml:space="preserve">
-    <value>The specified file must have the .vhdx file extension.</value>
+  <data name="MessageRequiresFileExtension" xml:space="preserve">
+    <value>The specified file must have the {} file extension.</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageRequiresFileExtensions" xml:space="preserve">
+    <value>The specified file must have the {} or {} file extension.</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageVmSwitchNotFound" xml:space="preserve">
     <value>The VmSwitch '{}' was not found. Available switches: {}</value>
@@ -998,7 +1003,7 @@ Falling back to NAT networking.</value>
     <value>See Docs</value>
   </data>
   <data name="MessageVhdInUse" xml:space="preserve">
-    <value>The operation could not be completed because the vhdx is currently in use. To force WSL to stop use: wsl.exe --shutdown</value>
+    <value>The operation could not be completed because the VHD is currently in use. To force WSL to stop use: wsl.exe --shutdown</value>
     <comment>{Locked="--shutdown"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageInvalidBoolean" xml:space="preserve">
@@ -1006,7 +1011,7 @@ Falling back to NAT networking.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageSparseVhdWsl2Only" xml:space="preserve">
-    <value>Sparse vhdx is supported on WSL2 only.</value>
+    <value>Sparse VHD is supported on WSL2 only.</value>
   </data>
   <data name="MessageLocalSystemNotSupported" xml:space="preserve">
     <value>Running WSL as local system is not supported.</value>
@@ -1055,7 +1060,7 @@ Falling back to NAT networking.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessagePassVhdFlag" xml:space="preserve">
-    <value>This looks like a VHDX file. Use --vhd to import a VHDX instead of a tar.</value>
+    <value>This looks like a VHD file. Use --vhd to import a VHD instead of a tar.</value>
     <comment>{Locked="--vhd "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageDistroStoreInstallFailed" xml:space="preserve">
@@ -1107,7 +1112,7 @@ Error code: {}</value>
   </data>
   <data name="MessageSparseVhdDisabled" xml:space="preserve">
     <value>Sparse VHD support is currently disabled due to potential data corruption.
-To force a distribution to use a sparse vhd, please run:
+To force a distribution to use a sparse VHD, please run:
 wsl.exe --manage &lt;DistributionName&gt; --set-sparse true --allow-unsafe</value>
     <comment>{Locked="--manage "}{Locked="--set-sparse "}{Locked="--allow-unsafe"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
@@ -1125,6 +1130,12 @@ See recovery instructions on: https://aka.ms/wsldiskmountrecovery</value>
     <data name="MessageFailedToTranslate" xml:space="preserve">
     <value>Failed to translate '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageImportVhdInvalidArg" xml:space="preserve">
+    <value>Cannot import a VHD from stdin.</value>
+  </data>
+  <data name="MessageExportVhdInvalidArg" xml:space="preserve">
+    <value>Cannot export a VHD to stdout.</value>
   </data>
   <data name="Settings_ErrorTryAgainLater.Text" xml:space="preserve">
     <value>Something went wrong. Try again later.</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1131,12 +1131,6 @@ See recovery instructions on: https://aka.ms/wsldiskmountrecovery</value>
     <value>Failed to translate '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
-  <data name="MessageImportVhdInvalidArg" xml:space="preserve">
-    <value>Cannot import a VHD from stdin.</value>
-  </data>
-  <data name="MessageExportVhdInvalidArg" xml:space="preserve">
-    <value>Cannot export a VHD to stdout.</value>
-  </data>
   <data name="Settings_ErrorTryAgainLater.Text" xml:space="preserve">
     <value>Something went wrong. Try again later.</value>
   </data>

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -275,14 +275,6 @@ int ExportDistribution(_In_ std::wstring_view commandLine)
     }
     else
     {
-        // If exporting to a vhd, ensure the filename ends with the vhdx file extension.
-        if (WI_IsFlagSet(flags, LXSS_EXPORT_DISTRO_FLAGS_VHD) &&
-            !wsl::windows::common::string::IsPathComponentEqual(filePath.extension().native(), wsl::windows::common::wslutil::c_vhdxFileExtension))
-        {
-            wsl::windows::common::wslutil::PrintMessage(wsl::shared::Localization::MessageRequiresVhdxFileExtension());
-            return -1;
-        }
-
         file.reset(CreateFileW(
             filePath.c_str(), GENERIC_WRITE, (FILE_SHARE_READ | FILE_SHARE_DELETE), nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
 
@@ -371,22 +363,10 @@ int ImportDistribution(_In_ std::wstring_view commandLine)
     }
     else
     {
-        bool isVhd = wsl::windows::common::string::IsPathComponentEqual(
-            filePath.extension().native(), wsl::windows::common::wslutil::c_vhdxFileExtension);
-
-        if (WI_IsFlagSet(flags, LXSS_IMPORT_DISTRO_FLAGS_VHD))
+        if (WI_IsFlagClear(flags, LXSS_IMPORT_DISTRO_FLAGS_VHD))
         {
-            // If importing from a vhd, ensure the filename ends with the vhdx file extension.
-            if (!isVhd)
-            {
-                wsl::windows::common::wslutil::PrintMessage(wsl::shared::Localization::MessageRequiresVhdxFileExtension());
-                return -1;
-            }
-        }
-        else
-        {
-            // Fail if we expect a tar, but the file name has the .vhdx extension.
-            if (isVhd)
+            // Fail if expecting a tar, but the file name has the .vhd or .vhdx extension.
+            if (wsl::windows::common::wslutil::IsVhdFile(filePath))
             {
                 wsl::windows::common::wslutil::PrintMessage(wsl::shared::Localization::MessagePassVhdFlag());
                 return -1;

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1155,6 +1155,13 @@ bool wsl::windows::common::wslutil::IsRunningInMsix()
         return false;
     }
 }
+
+bool wsl::windows::common::wslutil::IsVhdFile(_In_ const std::filesystem::path& path)
+{
+    return wsl::windows::common::string::IsPathComponentEqual(path.extension().native(), c_vhdFileExtension) ||
+           wsl::windows::common::string::IsPathComponentEqual(path.extension().native(), c_vhdxFileExtension);
+}
+
 std::vector<DWORD> wsl::windows::common::wslutil::ListRunningProcesses()
 {
     std::vector<DWORD> pids(1024);

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -122,6 +122,8 @@ void InitializeWil();
 
 bool IsRunningInMsix();
 
+bool IsVhdFile(_In_ const std::filesystem::path& path);
+
 bool IsVirtualMachinePlatformInstalled();
 
 std::vector<DWORD> ListRunningProcesses();

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -927,7 +927,7 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     std::filesystem::path newVhdPath = Location;
     RETURN_HR_IF(E_INVALIDARG, newVhdPath.empty());
 
-    newVhdPath /= LXSS_VM_MODE_VHD_NAME;
+    newVhdPath /= distro.VhdFilePath.filename();
 
     auto impersonate = wil::CoImpersonateClient();
 
@@ -952,7 +952,7 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
 
     // Update the registry location
     registration.Write(Property::BasePath, Location);
-    registration.Write(Property::VhdFileName, LXSS_VM_MODE_VHD_NAME);
+    registration.Write(Property::VhdFileName, newVhdPath.filename().c_str());
 
     revert.release();
 
@@ -1077,8 +1077,26 @@ HRESULT LxssUserSessionImpl::ExportDistribution(_In_opt_ LPCGUID DistroGuid, _In
         {
             if (WI_IsFlagSet(Flags, LXSS_EXPORT_DISTRO_FLAGS_VHD))
             {
+                if (GetFileType(FileHandle) != FILE_TYPE_DISK)
+                {
+                    THROW_HR_WITH_USER_ERROR(E_INVALIDARG, wsl::shared::Localization::MessageExportVhdInvalidArg());
+                }
+
                 const wil::unique_handle userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);
                 auto runAsUser = wil::impersonate_token(userToken.get());
+
+                // Ensure the target file has the correct file extension.
+                std::wstring exportPath;
+                THROW_IF_FAILED(wil::GetFinalPathNameByHandleW(FileHandle, exportPath));
+
+                const auto sourceFileExtension = configuration.VhdFilePath.extension().native();
+                const auto targetFileExtension = std::filesystem::path(std::move(exportPath)).extension().native();
+                if (!wsl::windows::common::string::IsPathComponentEqual(sourceFileExtension, targetFileExtension))
+                {
+                    THROW_HR_WITH_USER_ERROR(
+                        WSL_E_EXPORT_FAILED, wsl::shared::Localization::MessageRequiresFileExtension(sourceFileExtension.c_str()));
+                }
+
                 const wil::unique_hfile vhdFile(CreateFileW(
                     configuration.VhdFilePath.c_str(), GENERIC_READ, (FILE_SHARE_READ | FILE_SHARE_DELETE), nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
 
@@ -1258,13 +1276,9 @@ LxssUserSessionImpl::ImportDistributionInplace(_In_ LPCWSTR DistributionName, _I
 
     s_ValidateDistroName(DistributionName);
 
-    // Return an error if the path is not absolute or does not end in the .vhdx file extension.
+    // Return an error if the path is not absolute or does not have a valid VHD file extension.
     const std::filesystem::path path{VhdPath};
-    RETURN_HR_IF(
-        E_INVALIDARG,
-        !path.is_absolute() ||
-            (!wsl::windows::common::string::IsPathComponentEqual(path.extension().native(), wsl::windows::common::wslutil::c_vhdFileExtension) &&
-             !wsl::windows::common::string::IsPathComponentEqual(path.extension().c_str(), wsl::windows::common::wslutil::c_vhdxFileExtension)));
+    RETURN_HR_IF(E_INVALIDARG, !path.is_absolute() || !wsl::windows::common::wslutil::IsVhdFile(path));
 
     const wil::unique_hkey lxssKey = s_OpenLxssUserKey();
     std::lock_guard lock(m_instanceLock);
@@ -1448,6 +1462,30 @@ HRESULT LxssUserSessionImpl::RegisterDistribution(
                 wil::CreateDirectoryDeep(distributionPath.c_str());
             }
 
+            // If importing a vhd, determine if it is a .vhd or .vhdx.
+            std::wstring vhdName{LXSS_VM_MODE_VHD_NAME};
+            if (WI_IsFlagSet(Flags, LXSS_IMPORT_DISTRO_FLAGS_VHD))
+            {
+                if (GetFileType(FileHandle) != FILE_TYPE_DISK)
+                {
+                    THROW_HR_WITH_USER_ERROR(E_INVALIDARG, wsl::shared::Localization::MessageImportVhdInvalidArg());
+                }
+
+                std::wstring pathBuffer;
+                THROW_IF_FAILED(wil::GetFinalPathNameByHandleW(FileHandle, pathBuffer));
+
+                std::filesystem::path vhdPath{std::move(pathBuffer)};
+
+                if (!wsl::windows::common::wslutil::IsVhdFile(vhdPath))
+                {
+                    using namespace wsl::windows::common::wslutil;
+                    THROW_HR_WITH_USER_ERROR(
+                        WSL_E_IMPORT_FAILED, wsl::shared::Localization::MessageRequiresFileExtensions(c_vhdFileExtension, c_vhdxFileExtension));
+                }
+
+                vhdName = vhdPath.filename();
+            }
+
             registration = DistributionRegistration::Create(
                 lxssKey.get(),
                 DistributionId,
@@ -1457,7 +1495,7 @@ HRESULT LxssUserSessionImpl::RegisterDistribution(
                 flags,
                 LX_UID_ROOT,
                 PackageFamilyName,
-                LXSS_VM_MODE_VHD_NAME,
+                vhdName.c_str(),
                 WI_IsFlagClear(Flags, LXSS_IMPORT_DISTRO_FLAGS_NO_OOBE));
 
             configuration = s_GetDistributionConfiguration(registration, DistributionName == nullptr);

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -1090,7 +1090,7 @@ HRESULT LxssUserSessionImpl::ExportDistribution(_In_opt_ LPCGUID DistroGuid, _In
                 THROW_IF_FAILED(wil::GetFinalPathNameByHandleW(FileHandle, exportPath));
 
                 const auto sourceFileExtension = configuration.VhdFilePath.extension().native();
-                const auto targetFileExtension = std::filesystem::path(std::move(exportPath)).extension().native();
+                const auto targetFileExtension = std::filesystem::path(exportPath).extension().native();
                 if (!wsl::windows::common::string::IsPathComponentEqual(sourceFileExtension, targetFileExtension))
                 {
                     THROW_HR_WITH_USER_ERROR(

--- a/src/windows/service/exe/WslCoreFilesystem.cpp
+++ b/src/windows/service/exe/WslCoreFilesystem.cpp
@@ -71,9 +71,7 @@ void wsl::core::filesystem::CreateVhd(_In_ LPCWSTR target, _In_ ULONGLONG maximu
 
 wil::unique_handle wsl::core::filesystem::OpenVhd(_In_ LPCWSTR Path, _In_ VIRTUAL_DISK_ACCESS_MASK Mask)
 {
-    WI_ASSERT(
-        wsl::shared::string::IsEqual(std::filesystem::path{Path}.extension().c_str(), windows::common::wslutil::c_vhdFileExtension, true) ||
-        wsl::shared::string::IsEqual(std::filesystem::path{Path}.extension().c_str(), windows::common::wslutil::c_vhdxFileExtension, true));
+    WI_ASSERT(wsl::windows::common::wslutil::IsVhdFile(std::filesystem::path{Path}));
 
     // N.B. Specifying unknown for device and vendor means the system will determine the type of VHD.
     VIRTUAL_STORAGE_TYPE storageType{};

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -109,7 +109,7 @@ class SimpleTests
             std::format(L"{} {} {} {}", WSL_IMPORT_ARG, tempDistro, vhdDir.wstring(), tar.wstring()).c_str(),
             L"The operation completed successfully. \r\n",
             L"wsl: Sparse VHD support is currently disabled due to potential data corruption.\r\n"
-            L"To force a distribution to use a sparse vhd, please run:\r\n"
+            L"To force a distribution to use a sparse VHD, please run:\r\n"
             L"wsl.exe --manage <DistributionName> --set-sparse true --allow-unsafe\r\n",
             0);
 
@@ -122,7 +122,7 @@ class SimpleTests
         ValidateOutput(
             std::format(L"{} {} {} {}", WSL_MANAGE_ARG, tempDistro, WSL_MANAGE_ARG_SET_SPARSE_OPTION_LONG, L"true").c_str(),
             L"Sparse VHD support is currently disabled due to potential data corruption.\r\n"
-            L"To force a distribution to use a sparse vhd, please run:\r\n"
+            L"To force a distribution to use a sparse VHD, please run:\r\n"
             L"wsl.exe --manage <DistributionName> --set-sparse true --allow-unsafe\r\nError code: Wsl/Service/E_INVALIDARG\r\n",
             L"",
             -1);

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -6329,9 +6329,6 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         auto tempFile = wsl::windows::common::filesystem::TempFile(
             GENERIC_ALL, 0, CREATE_ALWAYS, wsl::windows::common::filesystem::TempFileFlags::None, L"txt");
 
-        auto deleteFile =
-            wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_WIN32_BOOL_FALSE(DeleteFile(tempFile.Path.c_str())); });
-
         tempFile.Handle.reset();
 
         constexpr auto negativeVariationDistro = L"negative-variation-distro";


### PR DESCRIPTION
While experimenting with the new --fixed-vhd support I realized we do not correctly handle all cases where a distro might be stored as a .vhd. This resolves those issues and clarifies usage that we support both .vhd and .vhdx.