### PR TITLE
Only check GetLastError() if ReadFile returns false

### DIFF
--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1107,12 +1107,16 @@ std::vector<BYTE> wsl::windows::common::wslutil::HashFile(HANDLE file, DWORD Alg
     std::vector<char> buffer(bufferSize);
 
     DWORD readBytes{};
-    while (ReadFile(file, buffer.data(), bufferSize, &readBytes, nullptr) && readBytes > 0)
+    while (true)
     {
+        THROW_IF_WIN32_BOOL_FALSE(ReadFile(file, buffer.data(), bufferSize, &readBytes, nullptr));
+        if (readBytes == 0)
+        {
+            break;
+        }
+
         THROW_IF_WIN32_BOOL_FALSE(CryptHashData(hash.get(), reinterpret_cast<const BYTE*>(buffer.data()), readBytes, 0));
     }
-
-    THROW_IF_WIN32_ERROR(GetLastError());
 
     std::vector<BYTE> fileHash(32);
     DWORD hashSize = static_cast<DWORD>(fileHash.size());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a logic error in the HashFile() method which can cause the method to fail if GetLastError() is set 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

If ReadFile() returns true, we should not check GetLastError()'s return value. 