### PR TITLE
Correctly report corrupted disks when mount() fails with EUCLEAN

### DIFF
--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -59,7 +59,8 @@ WslCoreInstance::WslCoreInstance(
 
     if (result.Result != 0)
     {
-        if (result.Result == EINVAL && result.FailureStep == LxInitCreateInstanceStepMountDisk)
+        // N.B. EUCLEAN (117) can be returned if the disk's journal is corrupted.
+        if ((result.Result == EINVAL || result.Result == 117) && result.FailureStep == LxInitCreateInstanceStepMountDisk)
         {
             THROW_HR(WSL_E_DISK_CORRUPTED);
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the distribution creating logic to consider `EUCLEAN` as a symptom of a corrupted disk, allowing the correct error message to be displayed

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] Closes #13074 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
