### PR TITLE
Discard BOM header when parsing the Windows 'hosts' file

### DIFF
--- a/src/windows/common/filesystem.cpp
+++ b/src/windows/common/filesystem.cpp
@@ -881,7 +881,7 @@ std::string wsl::windows::common::filesystem::GetWindowsHosts(const std::filesys
 
     // Discard any BOM header.
     int potentialHeader[] = {Stream.get(), Stream.get(), Stream.get()};
-    if (potentialHeader[0] != 0xEF || potentialHeader[1] !=  0xBB || potentialHeader[2] !=  0xBF)
+    if (potentialHeader[0] != 0xEF || potentialHeader[1] != 0xBB || potentialHeader[2] != 0xBF)
     {
         Stream.seekg(0); // Reset the position to beginning of the file if no BOM header is found.
     }

--- a/src/windows/common/filesystem.cpp
+++ b/src/windows/common/filesystem.cpp
@@ -874,15 +874,17 @@ std::filesystem::path wsl::windows::common::filesystem::GetTempFolderPath(_In_ H
     return GetLocalAppDataPath(userToken) / L"temp";
 }
 
-std::string wsl::windows::common::filesystem::GetWindowsHosts()
+std::string wsl::windows::common::filesystem::GetWindowsHosts(const std::filesystem::path& Path)
 {
-    // Parse the Windows hosts file.
-    std::wstring SystemDirectory;
-    THROW_IF_FAILED(wil::GetSystemDirectoryW(SystemDirectory));
-
-    auto Path = std::filesystem::path(std::move(SystemDirectory)) / L"drivers" / L"etc" / L"hosts";
     std::ifstream Stream(Path.c_str());
     THROW_HR_IF_MSG(E_FAIL, (Stream.bad() || !Stream.is_open()), "errno = %d", errno);
+
+    // Discard any BOM header.
+    int potentialHeader[] = {Stream.get(), Stream.get(), Stream.get()};
+    if (potentialHeader[0] != 0xEF || potentialHeader[1] !=  0xBB || potentialHeader[2] !=  0xBF)
+    {
+        Stream.seekg(0); // Reset the position to beginning of the file if no BOM header is found.
+    }
 
     std::string WindowsHosts;
     std::string Line;

--- a/src/windows/common/filesystem.hpp
+++ b/src/windows/common/filesystem.hpp
@@ -156,7 +156,7 @@ std::filesystem::path GetTempFilename();
 
 std::filesystem::path GetTempFolderPath(_In_ HANDLE userToken);
 
-std::string GetWindowsHosts();
+std::string GetWindowsHosts(const std::filesystem::path& Path);
 
 /// <summary>
 /// Opens a directory handle with read/execute, optionally also write, & full sharing. The path

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -294,7 +294,12 @@ std::vector<gsl::byte> wsl::windows::common::helpers::GenerateConfigurationMessa
         // N.B. failures generating the hosts string are non-fatal.
         try
         {
-            windowsHosts = filesystem::GetWindowsHosts();
+
+            // Parse the Windows hosts file.
+            std::wstring SystemDirectory;
+            THROW_IF_FAILED(wil::GetSystemDirectoryW(SystemDirectory));
+
+            windowsHosts = filesystem::GetWindowsHosts(std::filesystem::path(std::move(SystemDirectory)) / L"drivers" / L"etc" / L"hosts");
         }
         CATCH_LOG()
     }

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -299,7 +299,8 @@ std::vector<gsl::byte> wsl::windows::common::helpers::GenerateConfigurationMessa
             std::wstring SystemDirectory;
             THROW_IF_FAILED(wil::GetSystemDirectoryW(SystemDirectory));
 
-            windowsHosts = filesystem::GetWindowsHosts(std::filesystem::path(std::move(SystemDirectory)) / L"drivers" / L"etc" / L"hosts");
+            windowsHosts =
+                filesystem::GetWindowsHosts(std::filesystem::path(std::move(SystemDirectory)) / L"drivers" / L"etc" / L"hosts");
         }
         CATCH_LOG()
     }

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -5939,6 +5939,9 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
     TEST_METHOD(EtcHostsParsing)
     {
         constexpr auto inputFileName = L"test-etc-hosts.txt";
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { DeleteFile(inputFileName); });
+
         auto validate = [](const std::string& Input, const std::string& ExpectedOutput) {
             wil::unique_handle inputFile{CreateFile(inputFileName, GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, 0, nullptr)};
 
@@ -5952,7 +5955,8 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         validate("127.0.0.1 microsoft.com", "127.0.0.1\tmicrosoft.com\n");
         validate("\xEF\xBB\xBF 127.0.0.1 microsoft.com", "127.0.0.1\tmicrosoft.com\n"); // Validate that BOM headers are ignored.
         validate("#Comment 127.0.0.1 microsoft.com windows.microsoft.com\n#AnotherComment", "");
-        validate("#Comment 127.0.0.1 microsoft.com windows.microsoft.com\n#AnotherComment\n127.0.0.1 wsl.dev", "127.0.0.1\twsl.dev\n");
+        validate(
+            "#Comment 127.0.0.1 microsoft.com windows.microsoft.com\n#AnotherComment\n127.0.0.1 wsl.dev", "127.0.0.1\twsl.dev\n");
     }
 
 }; // namespace UnitTests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

While reviewing some logs, I discovered suspicious characters in the 'WindowsHosts' field. Turns out that the Windows Host file can contain a UTF8 BOM header. If it does, we shouldn't bring it to the Linux /etc/hosts.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #9642 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
