### PR TITLE
Remove directories after the OverlayFs test completes

### DIFF
--- a/test/linux/unit_tests/overlayfs.c
+++ b/test/linux/unit_tests/overlayfs.c
@@ -170,6 +170,18 @@ int OverlayFsTestEntry(int Argc, char* Argv[])
     LxtCheckResult(LxtRunVariations(&Args, g_LxtVariations, LXT_COUNT_OF(g_LxtVariations)));
 
 ErrorExit:
+
+    char DeleteCmd[128];
+
+    for (int Index = 0; Index < LXT_COUNT_OF(g_OvFsTestDirs); ++Index)
+    {
+        sprintf(DeleteCmd, "rm -rf %s", g_OvFsTestDirs[Index]);
+        if (system(DeleteCmd) < 0)
+        {
+            LxtLogError("Failed to delete %s", g_OvFsTestDirs[Index]);
+        }
+    }
+
     LxtUninitialize();
     return !LXT_SUCCESS(Result);
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This test adds logic to make sure that the OverlayFs test case doesn't leave folders behind. These folders seem to be causing issues in further test cases 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
