### PR TITLE
Fix wslsettings crash when invoked from wslservice

### DIFF
--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -92,8 +92,7 @@ public:
     [[nodiscard]] wil::unique_handle Launch(_In_opt_ HANDLE UserToken, _In_ bool HideWindow, _In_ bool CreateNoWindow = false) const
     {
         // If a user token was provided, create an environment block from the token.
-        using unique_environment_block = wil::unique_any<LPVOID, decltype(&DestroyEnvironmentBlock), DestroyEnvironmentBlock>;
-        unique_environment_block environmentBlock{nullptr};
+        wsl::windows::common::helpers::unique_environment_block environmentBlock{nullptr};
         if (ARGUMENT_PRESENT(UserToken))
         {
             THROW_LAST_ERROR_IF(!CreateEnvironmentBlock(&environmentBlock, UserToken, false));
@@ -572,6 +571,12 @@ void wsl::windows::common::helpers::LaunchWslSettingsOOBE(_In_ HANDLE UserToken)
     wsl::windows::common::SubProcess process(wslSettingsExePath.c_str(), commandLine);
     process.SetToken(UserToken);
     process.SetShowWindow(SW_SHOW);
+
+    wsl::windows::common::helpers::unique_environment_block environmentBlock{nullptr};
+    THROW_LAST_ERROR_IF(!CreateEnvironmentBlock(&environmentBlock, UserToken, false));
+
+    process.SetEnvironment(environmentBlock.get());
+
     process.Start();
 }
 

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -92,6 +92,8 @@ struct GuidLess
 
 typedef wil::unique_any_handle_null<decltype(&::ClosePseudoConsole), ::ClosePseudoConsole> unique_pseudo_console;
 
+using unique_environment_block = wil::unique_any<LPVOID, decltype(&DestroyEnvironmentBlock), DestroyEnvironmentBlock>;
+
 inline void DeleteProcThreadAttributeList(_In_ PPROC_THREAD_ATTRIBUTE_LIST AttributeList)
 {
     ::DeleteProcThreadAttributeList(AttributeList);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves crash when `wslsettings.exe` is invoked when the first WSL distribution is installed, and the 'Settings' button is clicked

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The root cause of the issue is the way the `wslsettings.exe` process is created. The process is created via `CreateProcess`, with `lpEnvironment` set to NULL.

That cause `wslsettings.exe` to inherit its parent environment, causing `%LOCALAPPDATA%` to be set to `C:\Windows\System32\config\systemprofile\appdata\local`, which causes SHGetKnownFolderPath() to use that path. 

Because we pass `KF_FLAG_CREATE`, SHGetKnownFolderPath() tries to validate that this folder exists, which fails since the process's token doesn't have access to it. 

This causes `E_FAIL` to be thrown, which crashes the wslsettings process

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Validated that this scenario succeeds after loading the correct environment for the user token
