### PR TITLE
package update: update .net runtime to 9.0.6

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="9.0.4" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="9.0.4" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="9.0.4" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="9.0.6" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="9.0.6" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6228" />
   <package id="Microsoft.Taef" version="10.97.250317001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This change updates the .NET runtime to version 9.0.6 in the `packages.config` file.

This resolves https://github.com/microsoft/WSL/security/dependabot/6 and https://github.com/microsoft/WSL/security/dependabot/7
