### PR TITLE
Distributions: Add Rocky Linux 9 and 10

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -160,6 +160,34 @@
                 }
             }
         ],
+        "RockyLinux": [
+            {
+                "Name": "RockyLinux-9",
+                "FriendlyName": "Rocky Linux 9",
+                "Default": false,
+                "Amd64Url": {
+                    "Url": "https://dl.rockylinux.org/pub/rocky/9.6/images/x86_64/Rocky-9-WSL-Base-9.6-20250531.0.x86_64.wsl",
+                    "Sha256": "9ce7566838dbd4166942d8976c328e03ec05370d9f04006ec4327b61bf04131a"
+                },
+                "Arm64Url": {
+                    "Url": "https://dl.rockylinux.org/pub/rocky/9.6/images/aarch64/Rocky-9-WSL-Base-9.6-20250602.0.aarch64.wsl",
+                    "Sha256": "7ff27a7cddd781641b5990d15282f2a9631d5bbfd80afac6c598f10cd7739bfd"
+                }
+            },
+            {
+                "Name": "RockyLinux-10",
+                "FriendlyName": "Rocky Linux 10",
+                "Default": true,
+                "Amd64Url": {
+                    "Url": "https://dl.rockylinux.org/pub/rocky/10.0/images/x86_64/Rocky-10-WSL-Base-10.0-20250611.0.x86_64.wsl",
+                    "Sha256": "3e84270955361269d2abf53c89da98f17d91b55ff837412ef683a39602b590cb"
+                },
+                "Arm64Url": {
+                    "Url": "https://dl.rockylinux.org/pub/rocky/10.0/images/aarch64/Rocky-10-WSL-Base-10.0-20250611.0.aarch64.wsl",
+                    "Sha256": "c829c988d02fec874480968fe0dbd66b2db023454f183f0b8f13bb94c8bfb4de"
+                }
+            }
+        ],
         "archlinux": [
             {
                 "Name": "archlinux",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR will add Rocky Linux as a new distribution to the DistributionInfo.json list. More specifically the releases of 9.6 and 10.0.
The WSL images are hosted on the main CDN of the project and I made sure with releng that the links should not break in the future, even if the content is moved to the vault.

Further these images are built with KIWI-ng with these recipes: [9](https://git.resf.org/sig_core/rocky-kiwi-descriptions/src/branch/r9/rocky-wsl.xml) and [10](https://git.resf.org/sig_core/rocky-kiwi-descriptions/src/branch/r10/rocky-wsl.xml)

And finally I looked at the PR for Fedora and hopefully checked everything that might be necessary, if there is anything I/we might be able to improve I'm sure going to do so! 🙂
(beside updating the image when we build a new version of course in the future)

Cheers, Lukas

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here
