### PR TITLE
cleanup: add ChildName to UtilCreateChildProcess error message

### DIFF
--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1034,23 +1034,17 @@ try
 
     if (Config.BootCommand.has_value())
     {
-        const int ChildPid =
-            UtilCreateChildProcess("BootCommand", [Command = Config.BootCommand.value(), SavedSignals = g_SavedSignalActions]() {
-                //
-                // Restore default signal dispositions for the child process.
-                //
+        UtilCreateChildProcess("BootCommand", [Command = Config.BootCommand.value(), SavedSignals = g_SavedSignalActions]() {
+            //
+            // Restore default signal dispositions for the child process.
+            //
 
-                THROW_LAST_ERROR_IF(UtilSetSignalHandlers(SavedSignals, false) < 0);
-                THROW_LAST_ERROR_IF(UtilRestoreBlockedSignals() < 0);
+            THROW_LAST_ERROR_IF(UtilSetSignalHandlers(SavedSignals, false) < 0);
+            THROW_LAST_ERROR_IF(UtilRestoreBlockedSignals() < 0);
 
-                execl("/bin/sh", "sh", "-c", Command.c_str(), nullptr);
-                LOG_ERROR("execl() failed, {}", errno);
-            });
-
-        if (ChildPid < 0)
-        {
-            LOG_ERROR("fork failed {}", errno);
-        }
+            execl("/bin/sh", "sh", "-c", Command.c_str(), nullptr);
+            LOG_ERROR("execl() failed, {}", errno);
+        });
     }
 
     return 0;

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -1333,7 +1333,6 @@ try
     if (SessionLeader < 0)
     {
         Result = -1;
-        LOG_ERROR("fork failed for session leader {}", errno);
         goto InitCreateSessionLeaderExit;
     }
 

--- a/src/linux/init/util.h
+++ b/src/linux/init/util.h
@@ -172,7 +172,7 @@ Return Value:
 
     if (ChildPid < 0)
     {
-        LOG_ERROR("{} failed {}", CloneFlags ? "clone" : "fork", errno);
+        LOG_ERROR("{} failed for {} {}", CloneFlags ? "clone" : "fork", ChildName, errno);
         return -1;
     }
     else if (ChildPid > 0)

--- a/src/linux/init/util.h
+++ b/src/linux/init/util.h
@@ -172,7 +172,7 @@ Return Value:
 
     if (ChildPid < 0)
     {
-        LOG_ERROR("{} failed for {} {}", CloneFlags ? "clone" : "fork", ChildName, errno);
+        LOG_ERROR("{} for {} failed {}", CloneFlags ? "clone" : "fork", ChildName, errno);
         return -1;
     }
     else if (ChildPid > 0)


### PR DESCRIPTION
While doing some code auditing, I noticed that the UtilCreateChildProcess logs an error that could use more context about the operation that failed.