### PR TITLE
Don't try to create invalid file names if the distribution download url contains parameters

### DIFF
--- a/src/windows/common/Distribution.cpp
+++ b/src/windows/common/Distribution.cpp
@@ -285,7 +285,8 @@ void wsl::windows::common::distribution::LegacyInstallViaGithub(const Distributi
 
     wslutil::PrintMessage(Localization::MessageDownloading(distro.FriendlyName.c_str()), stdout);
 
-    const auto downloadPath = wslutil::DownloadFile(*downloadUrl);
+    // Note: The appx extensions is required for the installation to succeed.
+    const auto downloadPath = wslutil::DownloadFile(*downloadUrl, distro.Name + L".appx");
     auto deleteFile =
         wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] { THROW_IF_WIN32_BOOL_FALSE(DeleteFileW(downloadPath.c_str())); });
 

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -300,7 +300,7 @@ std::pair<std::wstring, GUID> WslInstall::InstallModernDistribution(
     else
     {
         PrintMessage(Localization::MessageDownloading(distribution.FriendlyName.c_str()), stdout);
-        installPath = DownloadFile(downloadInfo->Url);
+        installPath = DownloadFile(downloadInfo->Url, distribution.Name + L".wsl");
         fileDownloaded = true;
     }
 

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -82,7 +82,7 @@ std::wstring ConstructPipePath(_In_ std::wstring_view PipeName);
 
 GUID CreateV5Uuid(const GUID& namespaceGuid, const std::span<const std::byte> name);
 
-std::wstring DownloadFile(std::wstring_view Url, std::wstring Filename = L"");
+std::wstring DownloadFile(std::wstring_view Url, std::wstring Filename);
 
 [[nodiscard]] HANDLE DuplicateHandleFromCallingProcess(_In_ HANDLE handleInTarget);
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -5232,6 +5232,46 @@ Error code: Wsl/InstallDistro/E_UNEXPECTED\r\n",
 Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
                 L"");
         }
+
+        // Validate that url parameters are correctly handled.
+        {
+            constexpr auto tarEndpoint = L"http://127.0.0.1:6667/";
+
+            UniqueWebServer fileServer(tarEndpoint, std::filesystem::path(g_testDistroPath));
+
+            wil::unique_handle tarHandle{CreateFile(g_testDistroPath.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr)};
+            VERIFY_IS_TRUE(!!tarHandle);
+
+            auto manifest = std::format(
+                R"({{
+    "ModernDistributions": {{
+        "test": [
+            {{
+                "Name": "test-url-download",
+                "FriendlyName": "FriendlyName",
+                "Default": true,
+                "Amd64Url": {{
+                    "Url": "{}/distro.tar?foo=bar&key=value",
+                    "Sha256": "{}"
+                }}
+            }}
+        ]
+    }}}})",
+                tarEndpoint,
+                tarHash);
+
+            auto restore = SetManifest(manifest);
+
+            auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { UnregisterDistribution(L"test-url-download"); });
+
+            auto [output, error] = LxsstuLaunchWslAndCaptureOutput(L"--install --no-launch test-url-download");
+            VERIFY_ARE_EQUAL(
+                output,
+                L"Downloading: FriendlyName\r\nInstalling: FriendlyName\r\nDistribution successfully installed. It can be "
+                L"launched via 'wsl.exe -d test-url-download'\r\n");
+
+            VERIFY_ARE_EQUAL(error, L"");
+        }
     }
 
     TEST_METHOD(ModernInstallEndToEnd)


### PR DESCRIPTION
## Summary of the Pull Request

This change solves an issue where wsl.exe fails to download a distribution files if the last part of the URL contains characters that are illegal in file names. 
In that situation, wsl.exe fails with `wsl/InstallDistro/ERROR_INVALID_NAME`

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This change simply generates a `<name>.wsl|.appx` file based on the distribution name. Note that `DownloadFile()` will pick a different name if the file happens to already exist 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Added test coverage 
