### PR TITLE
Don't throw when unregistering a distro that has a BasePath that does…

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2937,11 +2937,15 @@ void LxssUserSessionImpl::_DeleteDistributionLockHeld(_In_ const LXSS_DISTRO_CON
     CATCH_LOG()
 
     // If the basepath is empty, delete it.
-    if (std::filesystem::is_empty(Configuration.BasePath))
+    try
     {
-        LOG_IF_WIN32_BOOL_FALSE_MSG(
-            RemoveDirectory(Configuration.BasePath.c_str()), "Failed to delete %ls", Configuration.BasePath.c_str());
+        if (std::filesystem::is_empty(Configuration.BasePath))
+        {
+            LOG_IF_WIN32_BOOL_FALSE_MSG(
+                RemoveDirectory(Configuration.BasePath.c_str()), "Failed to delete %ls", Configuration.BasePath.c_str());
+        }
     }
+    CATCH_LOG();
 }
 
 _Requires_exclusive_lock_held_(m_instanceLock)

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -6095,5 +6095,29 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             "#Comment 127.0.0.1 microsoft.com windows.microsoft.com\n#AnotherComment\n127.0.0.1 wsl.dev", "127.0.0.1\twsl.dev\n");
     }
 
+    // Validate that a distribution can be unregistered even if its BasePath doesn't exist.
+    // See https://github.com/microsoft/WSL/issues/13004
+    TEST_METHOD(BrokenDistroUnregister)
+    {
+        const auto userKey = wsl::windows::common::registry::OpenLxssUserKey();
+        const auto distroKey = wsl::windows::common::registry::CreateKey(userKey.get(), L"{baa405ef-1822-4bbe-84e2-30e4c6330d42}");
+
+        auto revert = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
+            wsl::windows::common::registry::DeleteKey(userKey.get(), L"{baa405ef-1822-4bbe-84e2-30e4c6330d42}");
+        });
+
+        wsl::windows::common::registry::WriteString(distroKey.get(), nullptr, L"BasePath", L"C:\\DoesNotExit");
+        wsl::windows::common::registry::WriteString(distroKey.get(), nullptr, L"DistributionName", L"DummyBrokenDistro");
+        wsl::windows::common::registry::WriteDword(distroKey.get(), nullptr, L"DefaultUid", 0);
+        wsl::windows::common::registry::WriteDword(distroKey.get(), nullptr, L"Version", LXSS_DISTRO_VERSION_2);
+        wsl::windows::common::registry::WriteDword(distroKey.get(), nullptr, L"State", LxssDistributionStateInstalled);
+        wsl::windows::common::registry::WriteDword(distroKey.get(), nullptr, L"Flags", LXSS_DISTRO_FLAGS_VM_MODE);
+
+        auto [out, err] = LxsstuLaunchWslAndCaptureOutput(L"--unregister DummyBrokenDistro");
+
+        VERIFY_ARE_EQUAL(out, L"The operation completed successfully. \r\n");
+        VERIFY_ARE_EQUAL(err, L"");
+    }
+
 }; // namespace UnitTests
 } // namespace UnitTests


### PR DESCRIPTION
…n't exist

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds a catch block to make sure that no exception is returned to wsl.exe when unregistering a distro that has a non-existent BasePath 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** Link to issue #13004
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
