### PR TITLE
Look up systemctl from $PATH for user session checks

### DIFF
--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -2704,7 +2704,7 @@ try
 
     if (Config.BootInitTimeout > 0)
     {
-        auto cmd = std::format("/usr/bin/systemctl is-active user@{}.service", Uid);
+        auto cmd = std::format("systemctl is-active user@{}.service", Uid);
         try
         {
             return wsl::shared::retry::RetryWithTimeout<bool>(


### PR DESCRIPTION
This is already done in other instances where init calls systemctl, and we rely on init to find systemctl in PATH on NixOS, as we don't (really) have a /usr.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
