### PR TITLE
Don't display a warning when the binfmt process doesn't have a controlling terminal

### DIFF
--- a/src/linux/init/binfmt.cpp
+++ b/src/linux/init/binfmt.cpp
@@ -678,12 +678,19 @@ Return Value:
 
     //
     // Ensure that stdin represents the foreground process group.
+    // N.B. It's possible that standard file descriptors point to tty while the process
+    // has no controlling terminal (in case its parent called setsid() without opening a new terminal for instance).
+    // See https://github.com/microsoft/WSL/issues/13173.
     //
 
     auto processGroup = tcgetpgrp(0);
     if (processGroup < 0)
     {
-        LOG_STDERR("tcgetpgrp failed");
+        if (errno != ENOTTY)
+        {
+            LOG_STDERR("tcgetpgrp failed");
+        }
+
         return;
     }
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -6119,5 +6119,16 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         VERIFY_ARE_EQUAL(err, L"");
     }
 
+    // Validate that calling the binfmt interpreter with tty fd's but not controlling terminal doesn't display a warning.
+    // See https://github.com/microsoft/WSL/issues/13173.
+    TEST_METHOD(SetSidNoWarning)
+    {
+        auto [out, err] =
+            LxsstuLaunchWslAndCaptureOutput(L"socat - 'EXEC:setsid --wait cmd.exe /c echo OK',pty,setsid,ctty,stderr");
+
+        VERIFY_ARE_EQUAL(out, L"OK\r\r\n");
+        VERIFY_ARE_EQUAL(err, L"");
+    }
+
 }; // namespace UnitTests
 } // namespace UnitTests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change prevents the binfmt interpret from displaying a stderr warning when the process has no controlling terminal while having tty fds. 


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** Link to issue #13173
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
