### PR TITLE
Expose the VM ID inside user distros

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -321,6 +321,9 @@ Please enable the "Windows Subsystem for Linux" optional component to use WSL1.<
     --msal-proxy-path
         Display the path to the MSAL proxy application.
 
+    --vm-id
+        Display the WSL VM ID.
+
     --version
         Display the version of the WSL package.
 
@@ -328,6 +331,7 @@ Please enable the "Windows Subsystem for Linux" optional component to use WSL1.<
         Do not print a newline.</value>
     <comment>{Locked="--networking-mode
 "}{Locked="--msal-proxy-path
+"}{Locked="--vm-id
 "}{Locked="--version
 "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -2582,7 +2582,7 @@ void ProcessLaunchInitMessage(
             DISTRO_PATH,
             enableGuiApps,
             Config,
-            nullptr,
+            wsl::shared::string::FromSpan(Buffer, Message->VmIdOffset),
             wsl::shared::string::FromSpan(Buffer, Message->DistributionNameOffset),
             nullptr,
             wsl::shared::string::FromSpan(Buffer, Message->InstallPathOffset),

--- a/src/linux/init/wslinfo.cpp
+++ b/src/linux/init/wslinfo.cpp
@@ -23,12 +23,14 @@ Abstract:
 #include "defs.h"
 #include "Localization.h"
 #include "CommandLine.h"
+#include "../../shared/inc/lxinitshared.h"
 
 enum class WslInfoMode
 {
     GetNetworkingMode,
     MsalProxyPath,
-    WslVersion
+    WslVersion,
+    VMId
 };
 
 int WslInfoEntry(int Argc, char* Argv[])
@@ -65,6 +67,7 @@ Return Value:
     parser.AddArgument(UniqueSetValue<WslInfoMode, WslInfoMode::MsalProxyPath>{Mode, Usage}, WSLINFO_MSAL_PROXY_PATH);
     parser.AddArgument(UniqueSetValue<WslInfoMode, WslInfoMode::WslVersion>{Mode, Usage}, WSLINFO_WSL_VERSION);
     parser.AddArgument(UniqueSetValue<WslInfoMode, WslInfoMode::WslVersion>{Mode, Usage}, WSLINFO_WSL_VERSION_LEGACY);
+    parser.AddArgument(UniqueSetValue<WslInfoMode, WslInfoMode::VMId>{Mode, Usage}, WSLINFO_WSL_VMID);
     parser.AddArgument(NoOp{}, WSLINFO_WSL_HELP);
     parser.AddArgument(noNewLine, nullptr, WSLINFO_NO_NEWLINE);
 
@@ -143,6 +146,22 @@ Return Value:
     else if (Mode.value() == WslInfoMode::WslVersion)
     {
         std::cout << WSL_PACKAGE_VERSION;
+    }
+    else if (Mode.value() == WslInfoMode::VMId)
+    {
+        auto value = UtilGetEnvironmentVariable(LX_WSL2_VM_ID_ENV);
+        if (value.empty())
+        {
+            std::cerr << Localization::MessageNoValueFound() << "\n";
+            return 1;
+        }
+
+        std::cout << value;
+    }
+    else
+    {
+        assert(false && "Unknown WslInfoMode");
+        return 1;
     }
 
     if (!noNewLine)

--- a/src/linux/init/wslinfo.h
+++ b/src/linux/init/wslinfo.h
@@ -20,6 +20,7 @@ Abstract:
 #define WSLINFO_NETWORKING_MODE "--networking-mode"
 #define WSLINFO_WSL_VERSION "--version"
 #define WSLINFO_WSL_VERSION_LEGACY "--wsl-version"
+#define WSLINFO_WSL_VMID "--vm-id"
 #define WSLINFO_WSL_HELP "--help"
 #define WSLINFO_NO_NEWLINE 'n'
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -842,6 +842,18 @@ class UnitTests
                 L"Invalid command line argument: --invalid\nPlease use 'wslinfo --help' to get a list of supported "
                 L"arguments.\n");
         }
+
+        if (LxsstuVmMode())
+        {
+            // Get the VM ID from the distro and validate that it not null.
+            auto [vmId, vmIdErr] = LxsstuLaunchWslAndCaptureOutput(L"env | grep 'WSL2_VM_ID' | awk -F= '{print $2}'");
+            VERIFY_ARE_NOT_EQUAL(vmId, L"");
+
+            // Ensure that the response from wslinfo matches the VM id from the distros environment
+            auto [out, err] = LxsstuLaunchWslAndCaptureOutput(L"wslinfo --vm-id");
+            VERIFY_ARE_EQUAL(out, std::format(L"{}", vmId));
+            VERIFY_ARE_EQUAL(err, L"");
+        }
     }
 
     TEST_METHOD(WslPath)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Prior to this change it was not possible to find the ID of the VM responsible for providing WSL distro instances.

With this change, the VM ID is now exposed inside user distros via `wslinfo` and as an environment variable.

A benefit of this change is that a listener can be configured host side using the ID allowing connections from inside user distros.

For example, using Go, we can:

```
hvsock.Listen(hvsock.Addr{
		VMID:      guid,
		ServiceID: svcid,
	})
```

Where guid is the ID of the VM.

And from inside a distro, we can establish a vsock connection by using the appropriate port.

Looking forward to discussing this PR a bit more!

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
The changes here have been validated by locally testing the change inside a user distro & also by adding and running unit tests.

The vm id can be accessed by:

* Using `wslinfo --vm-id`
* Fetching at the environment variables inside the distro

![image](https://github.com/user-attachments/assets/ef839be1-6dfd-4c38-b444-d983f465dcab)


