### PR TITLE
wslsettings: appropriately set heading level for PageHeaderTextBlockStyle

### DIFF
--- a/src/windows/wslsettings/Styles/CommonStyles.xaml
+++ b/src/windows/wslsettings/Styles/CommonStyles.xaml
@@ -44,6 +44,7 @@
             <Setter Property="FontSize" Value="20" />
             <Setter Property="FontWeight" Value="SemiBold" />
             <Setter Property="Margin" Value="1,28,0,4" />
+            <Setter Property="AutomationProperties.HeadingLevel" Value="Level1" />
         </Style.Setters>
     </Style>
 


### PR DESCRIPTION
This change resolves an accessibility issue where the sections on the left side of the wslsettings app are not being correctly tagged as headings, so narrator doesn't do the right thing.