### PR TITLE
Update Microsoft.RemoteDesktop.Client.MSRDC.SessionHost to version 1.2.6353

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
   <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="9.0.6" />
   <package id="Microsoft.NETCore.App.Runtime.win-x64" version="9.0.6" />
-  <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6228" />
+  <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6353" />
   <package id="Microsoft.Taef" version="10.97.250317001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.NET.Ref" version="10.0.26100.57" />


### PR DESCRIPTION
This change updates the version of MSRDC bundled with the WSL package to the latest public (non-insider) version. For more information about the changes in this version, see the [release notes](https://learn.microsoft.com/en-us/previous-versions/remote-desktop-client/whats-new-windows?tabs=windows-msrdc-msi#updates-for-version-126353).