### PR TITLE
install: do not attempt to install distros if a reboot is required

### DIFF
--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -568,10 +568,7 @@ int Install(_In_ std::wstring_view commandLine)
     }
 
     bool rebootRequired = InstallPrerequisites(installWslOptionalComponent);
-    if (rebootRequired)
-    {
-        noLaunchAfterInstall = false;
-    }
+    noLaunchAfterInstall |= rebootRequired;
 
     // Install a distribution only if no reboot is required, or if we're on the --legacy path (to maintain old behavior).
     const Distribution* legacyDistro = nullptr;
@@ -647,10 +644,10 @@ int Install(_In_ std::wstring_view commandLine)
 
 bool InstallPrerequisites(_In_ bool installWslOptionalComponent)
 {
-    const auto missingComponents = WslInstall::CheckForMissingOptionalComponents(installWslOptionalComponent);
+    const auto [rebootRequired, missingComponents] = WslInstall::CheckForMissingOptionalComponents(installWslOptionalComponent);
     if (missingComponents.empty())
     {
-        return false;
+        return rebootRequired;
     }
 
     // Install any optional components that have not yet been installed.
@@ -671,7 +668,7 @@ bool InstallPrerequisites(_In_ bool installWslOptionalComponent)
         WslInstall::InstallOptionalComponents(missingComponents);
     }
 
-    return true;
+    return rebootRequired;
 }
 
 int LaunchProcess(_In_opt_ LPCWSTR filename, _In_ int argc, _In_reads_(argc) LPCWSTR argv[], _In_ const LaunchProcessOptions& options)

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -226,7 +226,7 @@ std::pair<bool, std::vector<std::wstring>> WslInstall::CheckForMissingOptionalCo
         missingComponents.emplace_back(c_optionalFeatureNameVmp);
     }
 
-    // If any components are no present, a reboot is required.
+    // If any required components are not present, a reboot is required.
     bool rebootRequired = !missingComponents.empty();
 
     // Query the list of optional components that have already been installed.

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -211,7 +211,7 @@ try
 }
 CATCH_RETURN()
 
-std::vector<std::wstring> WslInstall::CheckForMissingOptionalComponents(_In_ bool requireWslOptionalComponent)
+std::pair<bool, std::vector<std::wstring>> WslInstall::CheckForMissingOptionalComponents(_In_ bool requireWslOptionalComponent)
 {
     // Include the WSL optional component if it was requested, or if the OS is not Windows 11 or later.
     std::vector<std::wstring> missingComponents;
@@ -226,6 +226,9 @@ std::vector<std::wstring> WslInstall::CheckForMissingOptionalComponents(_In_ boo
         missingComponents.emplace_back(c_optionalFeatureNameVmp);
     }
 
+    // If any components are no present, a reboot is required.
+    bool rebootRequired = !missingComponents.empty();
+
     // Query the list of optional components that have already been installed.
     const auto installedComponents = GetInstalledOptionalComponents();
     for (const auto& component : installedComponents)
@@ -233,7 +236,7 @@ std::vector<std::wstring> WslInstall::CheckForMissingOptionalComponents(_In_ boo
         std::erase(missingComponents, component);
     }
 
-    return missingComponents;
+    return {rebootRequired, std::move(missingComponents)};
 }
 
 void WslInstall::InstallOptionalComponents(const std::vector<std::wstring>& components)

--- a/src/windows/common/WslInstall.h
+++ b/src/windows/common/WslInstall.h
@@ -40,7 +40,7 @@ public:
         _In_ const std::optional<std::wstring>& location,
         _In_ const std::optional<uint64_t>& vhdSize);
 
-    static std::vector<std::wstring> CheckForMissingOptionalComponents(_In_ bool requireWslOptionalComponent);
+    static std::pair<bool, std::vector<std::wstring>> CheckForMissingOptionalComponents(_In_ bool requireWslOptionalComponent);
 
     static void InstallOptionalComponents(const std::vector<std::wstring>& components);
 


### PR DESCRIPTION
This change resolves an issue where `wsl.exe --install` would attempt to install distributions if a required optional component was not present. This was due to a logic bug that was not correctly checking if a reboot was required prior to downloading the distributions.