### PR TITLE
Fix the 'WriteWslConfig' test case to reset .wslconfig when done 

### DIFF
--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2999,7 +2999,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
 
         {
             // Enable NetworkingMode::Mirrored for IgnoredPorts to be set correctly upon parsing.
-            config.Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+            WslConfigChange config(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
 
             // std::pair[0] = Written value, std::pair[1] = Actual/Expected value
             static const std::vector<std::pair<PCWSTR, PCWSTR>> filePathsToTest{
@@ -3153,7 +3153,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
 
         {
             // Enable NetworkingMode::Mirrored for IgnoredPorts to be set correctly upon parsing.
-            config.Update(LxssGenerateTestConfig());
+            WslConfigChange config(LxssGenerateTestConfig());
 
             // std::pair[0] = Written value, std::pair[1] = Actual/Expected value
             static const std::vector<std::pair<bool, bool>> booleansToTest{{false, false}, {true, true}};
@@ -3324,7 +3324,7 @@ autoProxy=false
 # end comment
 )"};
 
-            config.Update(customWslConfigContentOut);
+            WslConfigChange config(customWslConfigContentOut);
 
             wslConfig = createWslConfig(apiWslConfigFilePath);
             VERIFY_IS_NOT_NULL(wslConfig);
@@ -3409,7 +3409,7 @@ localhostForwarding=true
 autoProxy=false
 )"};
 
-            config.Update(customWslConfigContentOut);
+            WslConfigChange config(customWslConfigContentOut);
 
             wslConfig = createWslConfig(apiWslConfigFilePath);
             VERIFY_IS_NOT_NULL(wslConfig);
@@ -3455,7 +3455,7 @@ localhostForwarding=true
 autoProxy=false
 )"};
 
-            config.Update(customWslConfigContentOut);
+            WslConfigChange config(customWslConfigContentOut);
 
             wslConfig = createWslConfig(apiWslConfigFilePath);
             VERIFY_IS_NOT_NULL(wslConfig);

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2942,19 +2942,12 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         LxssDynamicFunction<decltype(GetWslConfigSetting)> getWslConfigSetting(libWslDllPath.c_str(), "GetWslConfigSetting");
         LxssDynamicFunction<decltype(SetWslConfigSetting)> setWslConfigSetting(libWslDllPath.c_str(), "SetWslConfigSetting");
 
-        // Delete the test config file. The original has already been saved as part of module setup.
+        // Reset the test config file. The original has already been saved as part of module setup.
         auto wslConfigFilePath = getenv("userprofile") + std::string("\\.wslconfig");
-        if (std::filesystem::exists(wslConfigFilePath))
-        {
-            std::error_code ec{};
-            VERIFY_IS_TRUE(std::filesystem::remove(wslConfigFilePath, ec));
-        }
+        WslConfigChange config{L""};
 
         auto apiWslConfigFilePath = getWslConfigFilePath();
         VERIFY_IS_TRUE(std::filesystem::path(wslConfigFilePath) == std::filesystem::path(apiWslConfigFilePath));
-
-        // Cleanup any leftover config files.
-        auto cleanup = wil::scope_exit([apiWslConfigFilePath] { std::filesystem::remove(apiWslConfigFilePath); });
 
         auto wslConfigDefaults = createWslConfig(nullptr);
         VERIFY_IS_NOT_NULL(wslConfigDefaults);
@@ -3006,7 +2999,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
 
         {
             // Enable NetworkingMode::Mirrored for IgnoredPorts to be set correctly upon parsing.
-            WslConfigChange config(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+            config.Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
 
             // std::pair[0] = Written value, std::pair[1] = Actual/Expected value
             static const std::vector<std::pair<PCWSTR, PCWSTR>> filePathsToTest{
@@ -3160,7 +3153,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
 
         {
             // Enable NetworkingMode::Mirrored for IgnoredPorts to be set correctly upon parsing.
-            WslConfigChange config(LxssGenerateTestConfig());
+            config.Update(LxssGenerateTestConfig());
 
             // std::pair[0] = Written value, std::pair[1] = Actual/Expected value
             static const std::vector<std::pair<bool, bool>> booleansToTest{{false, false}, {true, true}};
@@ -3331,7 +3324,7 @@ autoProxy=false
 # end comment
 )"};
 
-            WslConfigChange config(customWslConfigContentOut);
+            config.Update(customWslConfigContentOut);
 
             wslConfig = createWslConfig(apiWslConfigFilePath);
             VERIFY_IS_NOT_NULL(wslConfig);
@@ -3416,7 +3409,7 @@ localhostForwarding=true
 autoProxy=false
 )"};
 
-            WslConfigChange config(customWslConfigContentOut);
+            config.Update(customWslConfigContentOut);
 
             wslConfig = createWslConfig(apiWslConfigFilePath);
             VERIFY_IS_NOT_NULL(wslConfig);
@@ -3462,7 +3455,7 @@ localhostForwarding=true
 autoProxy=false
 )"};
 
-            WslConfigChange config(customWslConfigContentOut);
+            config.Update(customWslConfigContentOut);
 
             wslConfig = createWslConfig(apiWslConfigFilePath);
             VERIFY_IS_NOT_NULL(wslConfig);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR updates the 'WriteWslConfig' to reset .wslconfig after completion. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Without this change, the `scope_exit` causes .wslconfig to be deleted after that test case, which causes GUI apps to be enabled until .wslconfig is written to again, which exposes the tests to the known virtio deadlock 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
