### PR TITLE
Update wslg and don't expose $WSL2_VM_ID to user processes

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -24,7 +24,7 @@
   <package id="Microsoft.WSL.LxUtil.amd64fre" version="10.0.26100.1-240331-1435.ge-release" />
   <package id="Microsoft.WSL.LxUtil.arm64fre" version="10.0.26100.1-240331-1435.ge-release" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />
-  <package id="Microsoft.WSLg" version="1.0.66" />
+  <package id="Microsoft.WSLg" version="1.0.68" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="StrawberryPerl" version="5.28.0.1" />
   <package id="vswhere" version="3.1.7" />

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1662,17 +1662,6 @@ Return Value:
         ConfigAppendNtPath(Environment, Buffer);
     }
 
-    //
-    // If the VM ID environment variable is present, add it to the environment
-    // block.
-    //
-
-    auto VmId = getenv(LX_WSL2_VM_ID_ENV);
-    if (VmId)
-    {
-        Environment.AddVariable(LX_WSL2_VM_ID_ENV, VmId);
-    }
-
     return Environment;
 }
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -845,14 +845,15 @@ class UnitTests
 
         if (LxsstuVmMode())
         {
-            // Get the VM ID from the distro and validate that it not null.
-            auto [vmId, vmIdErr] = LxsstuLaunchWslAndCaptureOutput(L"env | grep 'WSL2_VM_ID' | awk -F= '{print $2}'");
-            VERIFY_ARE_NOT_EQUAL(vmId, L"");
+            // Validate that the VM ID is not propagated to user commands.
+            auto [vmId, vmIdErr] = LxsstuLaunchWslAndCaptureOutput(L"echo -n \"$WSL2_VM_ID\"");
+            VERIFY_ARE_EQUAL(vmId, L"");
 
-            // Ensure that the response from wslinfo matches the VM id from the distros environment
-            auto [out, err] = LxsstuLaunchWslAndCaptureOutput(L"wslinfo --vm-id");
-            VERIFY_ARE_EQUAL(out, std::format(L"{}", vmId));
-            VERIFY_ARE_EQUAL(err, L"");
+            // Ensure that the response from wslinfo has the VM ID.
+            auto [out, err] = LxsstuLaunchWslAndCaptureOutput(L"wslinfo -n --vm-id");
+            auto guid = wsl::shared::string::ToGuid(out.c_str());
+            VERIFY_IS_TRUE(guid.has_value());
+            VERIFY_IS_FALSE(IsEqualGUID(guid.value(), GUID_NULL));
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change is a followup from #13212. Now that [this changed](https://github.com/microsoft/wslg/pull/1351) has been merged in wslg, we can update to the latest version and get rid of $WSL2_VM_ID

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
