### PR TITLE
Fix json invalid utf-8 from IconPath

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2683,7 +2683,7 @@ try
 
         e["name"] = WideToMultiByte(Configuration.Name);
         e["guid"] = WideToMultiByte(distributionProfileId);
-        e["icon"] = IconPath.string();
+        e["icon"] = WideToMultiByte(IconPath.native());
 
         // See https://github.com/microsoft/terminal/pull/18195. Supported in terminal >= 1.23
         e["pathTranslationStyle"] = "wsl";


### PR DESCRIPTION
## Summary of the Pull Request

When storing into the json container the `IconPath` value directly as a `std::string` we are subject to unspecified behaviour as Windows stores paths as 16-bit `wchar_t` , `std::string` doesn't convey a specific char encoding and the `std::filesystem` library doesn't mandate a specific conversion.

We need to access the icon path in its native format (which we assume to be `std::wstring`) and convert it to multibyte.

Details in the linked issue: #13339 


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #13339 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Validation Steps Performed

Repeat the process described in the issue #13339 with a build containing the proposed fix.