### PR TITLE
Implement WSLA API to unmount & detach disks

### DIFF
--- a/src/linux/init/LSWInit.cpp
+++ b/src/linux/init/LSWInit.cpp
@@ -429,7 +429,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_SIGNAL& Me
 
 void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_UNMOUNT& Message, const gsl::span<gsl::byte>& Buffer)
 {
-    Channel.SendResultMessage<int32_t>(umount(Message.Buffer));
+    Channel.SendResultMessage<int32_t>(umount(Message.Buffer) == 0 ? 0 : errno);
 }
 
 void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_DETACH& Message, const gsl::span<gsl::byte>& Buffer)

--- a/src/linux/init/LSWInit.cpp
+++ b/src/linux/init/LSWInit.cpp
@@ -427,6 +427,18 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_SIGNAL& Me
     Channel.SendResultMessage(result < 0 ? errno : 0);
 }
 
+void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_UNMOUNT& Message, const gsl::span<gsl::byte>& Buffer)
+{
+    Channel.SendResultMessage<int32_t>(umount(Message.Buffer));
+}
+
+void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_DETACH& Message, const gsl::span<gsl::byte>& Buffer)
+{
+    sync();
+
+    Channel.SendResultMessage<int32_t>(DetachScsiDisk(Message.Lun));
+}
+
 template <typename TMessage, typename... Args>
 void HandleMessage(wsl::shared::SocketChannel& Channel, LX_MESSAGE_TYPE Type, const gsl::span<gsl::byte>& Buffer)
 {
@@ -461,7 +473,7 @@ void ProcessMessage(wsl::shared::SocketChannel& Channel, LX_MESSAGE_TYPE Type, c
 {
     try
     {
-        HandleMessage<LSW_GET_DISK, LSW_MOUNT, LSW_EXEC, LSW_FORK, LSW_CONNECT, LSW_WAITPID, LSW_SIGNAL, LSW_TTY_RELAY, LSW_PORT_RELAY>(
+        HandleMessage<LSW_GET_DISK, LSW_MOUNT, LSW_EXEC, LSW_FORK, LSW_CONNECT, LSW_WAITPID, LSW_SIGNAL, LSW_TTY_RELAY, LSW_PORT_RELAY, LSW_UNMOUNT, LSW_DETACH>(
             Channel, Type, Buffer);
     }
     catch (...)

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -383,6 +383,8 @@ typedef enum _LX_MESSAGE_TYPE
     LxMessageLswMapPort,
     LxMessageLswConnectRelay,
     LxMessageLswPortRelay,
+    LxMessageLswUnmount,
+    LxMessageLswDetach,
 } LX_MESSAGE_TYPE,
     *PLX_MESSAGE_TYPE;
 
@@ -487,6 +489,8 @@ inline auto ToString(LX_MESSAGE_TYPE messageType)
         X(LxMessageLswMapPort)
         X(LxMessageLswConnectRelay)
         X(LxMessageLswPortRelay)
+        X(LxMessageLswUnmount)
+        X(LxMessageLswDetach)
     default:
         return "<unexpected LX_MESSAGE_TYPE>";
     }
@@ -1757,6 +1761,31 @@ struct LSW_PORT_RELAY
     MESSAGE_HEADER Header;
 
     PRETTY_PRINT(FIELD(Header));
+};
+
+struct LSW_UNMOUNT
+{
+    static inline auto Type = LxMessageLswUnmount;
+    using TResponse = RESULT_MESSAGE<int32_t>;
+
+    DECLARE_MESSAGE_CTOR(LSW_UNMOUNT);
+    MESSAGE_HEADER Header;
+
+    char Buffer[];
+
+    PRETTY_PRINT(FIELD(Header), FIELD(Buffer));
+};
+
+struct LSW_DETACH
+{
+    static inline auto Type = LxMessageLswDetach;
+    using TResponse = RESULT_MESSAGE<int32_t>;
+
+    DECLARE_MESSAGE_CTOR(LSW_DETACH);
+    MESSAGE_HEADER Header;
+    unsigned int Lun;
+
+    PRETTY_PRINT(FIELD(Header), FIELD(Lun));
 };
 
 typedef struct _LX_MINI_INIT_IMPORT_RESULT

--- a/src/windows/lswclient/DllMain.cpp
+++ b/src/windows/lswclient/DllMain.cpp
@@ -110,9 +110,9 @@ CATCH_RETURN();
 HRESULT WslAttachDisk(LSWVirtualMachineHandle VirtualMachine, const DiskAttachSettings* Settings, AttachedDiskInformation* AttachedDisk)
 {
     wil::unique_cotaskmem_ansistring device;
-    RETURN_IF_FAILED(reinterpret_cast<ILSWVirtualMachine*>(VirtualMachine)->AttachDisk(Settings->WindowsPath, Settings->ReadOnly, &device));
+    RETURN_IF_FAILED(reinterpret_cast<ILSWVirtualMachine*>(VirtualMachine)
+                         ->AttachDisk(Settings->WindowsPath, Settings->ReadOnly, &device, &AttachedDisk->ScsiLun));
 
-    // TODO: wire LUN
     auto deviceSize = strlen(device.get());
     WI_VERIFY(deviceSize < sizeof(AttachedDiskInformation::Device));
 
@@ -284,6 +284,15 @@ try
 }
 CATCH_RETURN();
 
+HRESULT WslUnmount(LSWVirtualMachineHandle VirtualMachine, const char* Path)
+{
+    return reinterpret_cast<ILSWVirtualMachine*>(VirtualMachine)->Unmount(Path);
+}
+
+HRESULT WslDetachDisk(LSWVirtualMachineHandle VirtualMachine, ULONG Lun)
+{
+    return reinterpret_cast<ILSWVirtualMachine*>(VirtualMachine)->DetachDisk(Lun);
+}
 EXTERN_C BOOL STDAPICALLTYPE DllMain(_In_ HINSTANCE Instance, _In_ DWORD Reason, _In_opt_ LPVOID Reserved)
 {
     wil::DLLMain(Instance, Reason, Reserved);

--- a/src/windows/lswclient/LSWApi.h
+++ b/src/windows/lswclient/LSWApi.h
@@ -179,6 +179,10 @@ HRESULT WslMapPort(LSWVirtualMachineHandle VirtualMachine, const struct PortMapp
 
 HRESULT WslUnmapPort(LSWVirtualMachineHandle VirtualMachine, const struct PortMappingSettings* Settings);
 
+HRESULT WslUnmount(LSWVirtualMachineHandle VirtualMachine, const char* Path);
+
+HRESULT WslDetachDisk(LSWVirtualMachineHandle VirtualMachine, ULONG Lun);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/windows/lswclient/lswclient.def
+++ b/src/windows/lswclient/lswclient.def
@@ -14,3 +14,5 @@ EXPORTS
     WslLaunchDebugShell
     WslMapPort
     WslUnmapPort
+    WslDetachDisk
+    WslUnmount

--- a/src/windows/service/exe/LSWVirtualMachine.h
+++ b/src/windows/service/exe/LSWVirtualMachine.h
@@ -28,7 +28,7 @@ public:
 
     void Start();
 
-    IFACEMETHOD(AttachDisk(_In_ PCWSTR Path, _In_ BOOL ReadOnly, _Out_ LPSTR* Device)) override;
+    IFACEMETHOD(AttachDisk(_In_ PCWSTR Path, _In_ BOOL ReadOnly, _Out_ LPSTR* Device, _Out_ ULONG* Lun)) override;
     IFACEMETHOD(Mount(_In_ LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags)) override;
     IFACEMETHOD(CreateLinuxProcess(
         _In_ const LSW_CREATE_PROCESS_OPTIONS* Options, _In_ ULONG FdCount, _In_ LSW_PROCESS_FD* Fd, _Out_ HANDLE* Handles, _Out_ LSW_CREATE_PROCESS_RESULT* Result)) override;
@@ -38,6 +38,8 @@ public:
     IFACEMETHOD(RegisterCallback(_In_ ITerminationCallback* callback)) override;
     IFACEMETHOD(GetDebugShellPipe(_Out_ LPWSTR* pipePath)) override;
     IFACEMETHOD(MapPort(_In_ int Family, _In_ short WindowsPort, _In_ short LinuxPort, _In_ BOOL Remove)) override;
+    IFACEMETHOD(Unmount(_In_ const char* Path)) override;
+    IFACEMETHOD(DetachDisk(_In_ ULONG Lun)) override;
 
 private:
     static void CALLBACK s_OnExit(_In_ HCS_EVENT* Event, _In_opt_ void* Context);

--- a/src/windows/service/inc/wslservice.idl
+++ b/src/windows/service/inc/wslservice.idl
@@ -449,7 +449,7 @@ interface ITerminationCallback : IUnknown
 ]
 interface ILSWVirtualMachine : IUnknown
 {
-    HRESULT AttachDisk([in] LPCWSTR Path, [in] BOOL ReadOnly, [out] LPSTR* Device);
+    HRESULT AttachDisk([in] LPCWSTR Path, [in] BOOL ReadOnly, [out] LPSTR* Device, [out] ULONG* Lun);
     HRESULT Mount([in, unique] LPCSTR Source, [in] LPCSTR Target, [in] LPCSTR Type, [in] LPCSTR Options, [in] ULONG Flags); 
     HRESULT CreateLinuxProcess([in] const LSW_CREATE_PROCESS_OPTIONS* Options, [in] ULONG FdCount, [in, unique, size_is(FdCount)] LSW_PROCESS_FD* Fds, [out, size_is(FdCount)] HVSOCKET_HANDLE* Handles, [out] LSW_CREATE_PROCESS_RESULT* Result);
     HRESULT WaitPid([in] LONG Pid, [in] ULONGLONG TimeoutMs,  [out] ULONG* State, [out] int* Code);
@@ -458,6 +458,8 @@ interface ILSWVirtualMachine : IUnknown
     HRESULT RegisterCallback([in] ITerminationCallback* terminationCallback);
     HRESULT GetDebugShellPipe([out] LPWSTR* pipePath);
     HRESULT MapPort([in] int Family, [in] short WindowsPort, [in] short LinuxPort, [in] BOOL Remove);
+    HRESULT Unmount([in] LPCSTR Path);
+    HRESULT DetachDisk([in] ULONG Lun);
 }
 
 typedef

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -124,6 +124,8 @@ class LSWTests
 
     TEST_METHOD(AttachDetach)
     {
+        WSL2_TEST_ONLY();
+
         VirtualMachineSettings settings{};
         settings.CPU.CpuCount = 4;
         settings.DisplayName = L"LSW";

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -122,6 +122,62 @@ class LSWTests
         return vm;
     }
 
+    TEST_METHOD(AttachDetach)
+    {
+        VirtualMachineSettings settings{};
+        settings.CPU.CpuCount = 4;
+        settings.DisplayName = L"LSW";
+        settings.Memory.MemoryMb = 1024;
+        settings.Options.BootTimeoutMs = 30000;
+        auto vm = CreateVm(&settings);
+
+#ifdef WSL_DEV_INSTALL_PATH
+
+        auto vhdPath = std::filesystem::path(WSL_DEV_INSTALL_PATH) / "system.vhd";
+#else
+
+        auto msiPath = wsl::windows::common::wslutil::GetMsiPackagePath();
+        VERIFY_IS_TRUE(msiPath.has_value());
+
+        auto vhdPath = std::filesystem::path(msiPath.value()) / "tools" / "system.vhd";
+
+#endif
+
+        auto blockDeviceExists = [&](ULONG Lun) {
+            std::string device = std::format("/sys/bus/scsi/devices/0:0:0:{}", Lun);
+            std::vector<const char*> cmd{"/usr/bin/test", "-d", device.c_str()};
+            return RunCommand(vm.get(), cmd) == 0;
+        };
+
+        // Attach the disk.
+        DiskAttachSettings attachSettings{vhdPath.c_str(), true};
+        AttachedDiskInformation attachedDisk{};
+        VERIFY_SUCCEEDED(WslAttachDisk(vm.get(), &attachSettings, &attachedDisk));
+        VERIFY_IS_TRUE(blockDeviceExists(attachedDisk.ScsiLun));
+
+        // Mount it to /mnt.
+        MountSettings mountSettings{attachedDisk.Device, "/mnt", "ext4", "ro"};
+        VERIFY_SUCCEEDED(WslMount(vm.get(), &mountSettings));
+
+        // Validate that the mountpoint is present.
+        std::vector<const char*> cmd{"/usr/bin/mountpoint", "/mnt"};
+        VERIFY_ARE_EQUAL(RunCommand(vm.get(), cmd), 0L);
+
+        // Unmount /mnt.
+        VERIFY_SUCCEEDED(WslUnmount(vm.get(), "/mnt"));
+        VERIFY_ARE_EQUAL(RunCommand(vm.get(), cmd), 32L);
+
+        // Verify that unmount fails now.
+        VERIFY_ARE_EQUAL(WslUnmount(vm.get(), "/mnt"), E_FAIL);
+
+        // Detach the disk
+        VERIFY_SUCCEEDED(WslDetachDisk(vm.get(), attachedDisk.ScsiLun));
+        VERIFY_IS_FALSE(blockDeviceExists(attachedDisk.ScsiLun));
+
+        // Verify that disk can't be detached twice
+        VERIFY_ARE_EQUAL(WslDetachDisk(vm.get(), attachedDisk.ScsiLun), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+    }
+
     TEST_METHOD(CustomDmesgOutput)
     {
         WSL2_TEST_ONLY();

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -141,7 +141,7 @@ class LSWTests
         auto msiPath = wsl::windows::common::wslutil::GetMsiPackagePath();
         VERIFY_IS_TRUE(msiPath.has_value());
 
-        auto vhdPath = std::filesystem::path(msiPath.value()) / "tools" / "system.vhd";
+        auto vhdPath = std::filesystem::path(msiPath.value()) / "system.vhd";
 
 #endif
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change implements API's to unmount() mountpoints, and detach disks from the WSLA Virtual machine 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
