### PR TITLE
Add support for using Linux files as processes' file descriptors

### DIFF
--- a/src/linux/init/LSWInit.cpp
+++ b/src/linux/init/LSWInit.cpp
@@ -88,6 +88,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_OPEN& Mess
     int flags = 0;
 
     WI_SetFlagIf(flags, O_APPEND, WI_IsFlagSet(Message.Flags, LswOpenFlagsAppend));
+    WI_SetFlagIf(flags, O_TRUNC, !WI_IsFlagSet(Message.Flags, LswOpenFlagsAppend) && WI_IsFlagSet(Message.Flags, LswOpenFlagsWrite));
     WI_SetFlagIf(flags, O_CREAT, WI_IsFlagSet(Message.Flags, LswOpenFlagsCreate));
     if (WI_IsFlagSet(Message.Flags, LswOpenFlagsRead) && WI_IsFlagSet(Message.Flags, LswOpenFlagsWrite))
     {

--- a/src/linux/init/LSWInit.cpp
+++ b/src/linux/init/LSWInit.cpp
@@ -120,6 +120,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_OPEN& Mess
     {
         result = errno;
         LOG_ERROR("dup2({}, {}) failed: {}", fd.get(), Message.Fd, result);
+        return;
     }
 
     result = 0;

--- a/src/linux/init/LSWInit.cpp
+++ b/src/linux/init/LSWInit.cpp
@@ -112,7 +112,6 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_OPEN& Mess
     if (!fd)
     {
         result = errno;
-
         LOG_ERROR("open({}, {}) failed: {}", path, flags, result);
         return;
     }

--- a/src/linux/init/LSWInit.cpp
+++ b/src/linux/init/LSWInit.cpp
@@ -78,6 +78,53 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_CONNECT& M
     THROW_LAST_ERROR_IF(dup2(Socket.get(), Message.Fd) < 0);
 }
 
+void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_OPEN& Message, const gsl::span<gsl::byte>& Buffer)
+{
+    int32_t result = EINVAL;
+
+    auto sendResult = wil::scope_exit([&]() { Channel.SendResultMessage(result); });
+
+    auto path = wsl::shared::string::FromMessageBuffer<LSW_OPEN>(Buffer);
+    int flags = 0;
+
+    WI_SetFlagIf(flags, O_APPEND, WI_IsFlagSet(Message.Flags, LswOpenFlagsAppend));
+    WI_SetFlagIf(flags, O_CREAT, WI_IsFlagSet(Message.Flags, LswOpenFlagsCreate));
+    if (WI_IsFlagSet(Message.Flags, LswOpenFlagsRead) && WI_IsFlagSet(Message.Flags, LswOpenFlagsWrite))
+    {
+        WI_SetFlag(flags, O_RDWR);
+    }
+    else if (WI_IsFlagSet(Message.Flags, LswOpenFlagsRead))
+    {
+        static_assert(O_RDONLY == 0);
+    }
+    else if (WI_IsFlagSet(Message.Flags, LswOpenFlagsWrite))
+    {
+        WI_SetFlag(flags, O_WRONLY);
+    }
+    else
+    {
+        LOG_ERROR("Invalid LSW_OPEN flags: {}", Message.Flags);
+        return; // Return -EINVAL if no opening flags are passed.
+    }
+
+    wil::unique_fd fd = open(path, flags);
+    if (!fd)
+    {
+        result = errno;
+
+        LOG_ERROR("open({}, {}) failed: {}", path, flags, result);
+        return;
+    }
+
+    if (dup2(fd.get(), Message.Fd) < 0)
+    {
+        result = errno;
+        LOG_ERROR("dup2({}, {}) failed: {}", fd.get(), Message.Fd, result);
+    }
+
+    result = 0;
+}
+
 void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const LSW_TTY_RELAY& Message, const gsl::span<gsl::byte>&)
 {
     THROW_LAST_ERROR_IF(fcntl(Message.TtyMaster, F_SETFL, O_NONBLOCK) < 0);
@@ -461,7 +508,7 @@ void ProcessMessage(wsl::shared::SocketChannel& Channel, LX_MESSAGE_TYPE Type, c
 {
     try
     {
-        HandleMessage<LSW_GET_DISK, LSW_MOUNT, LSW_EXEC, LSW_FORK, LSW_CONNECT, LSW_WAITPID, LSW_SIGNAL, LSW_TTY_RELAY, LSW_PORT_RELAY>(
+        HandleMessage<LSW_GET_DISK, LSW_MOUNT, LSW_EXEC, LSW_FORK, LSW_CONNECT, LSW_WAITPID, LSW_SIGNAL, LSW_TTY_RELAY, LSW_PORT_RELAY, LSW_OPEN>(
             Channel, Type, Buffer);
     }
     catch (...)

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -383,6 +383,7 @@ typedef enum _LX_MESSAGE_TYPE
     LxMessageLswMapPort,
     LxMessageLswConnectRelay,
     LxMessageLswPortRelay,
+    LxMessageLswOpen,
 } LX_MESSAGE_TYPE,
     *PLX_MESSAGE_TYPE;
 
@@ -487,6 +488,7 @@ inline auto ToString(LX_MESSAGE_TYPE messageType)
         X(LxMessageLswMapPort)
         X(LxMessageLswConnectRelay)
         X(LxMessageLswPortRelay)
+        X(LxMessageLswOpen)
     default:
         return "<unexpected LX_MESSAGE_TYPE>";
     }
@@ -1659,6 +1661,29 @@ struct LSW_CONNECT
     MESSAGE_HEADER Header;
     int32_t Fd = -1; // TODO: multiple at once
     PRETTY_PRINT(FIELD(Header), FIELD(Fd));
+};
+
+enum LswOpenFlags // Must match FileDescriptorType.
+{
+    LswOpenFlagsNone = 0,
+    LswOpenFlagsRead = 4,
+    LswOpenFlagsWrite = 8,
+    LswOpenFlagsAppend = 16,
+    LswOpenFlagsCreate = 32
+};
+
+struct LSW_OPEN
+{
+    static inline auto Type = LxMessageLswOpen;
+    using TResponse = RESULT_MESSAGE<int32_t>;
+    DECLARE_MESSAGE_CTOR(LSW_OPEN);
+
+    MESSAGE_HEADER Header;
+    uint32_t Flags;
+    int32_t Fd;
+    char Buffer[];
+
+    PRETTY_PRINT(FIELD(Header), FIELD(Flags), FIELD(Buffer));
 };
 
 enum LSWProcessState

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1687,7 +1687,7 @@ struct LSW_OPEN
     int32_t Fd;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Flags), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(Flags), FIELD(Fd), FIELD(Buffer));
 };
 
 enum LSWProcessState

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -159,6 +159,12 @@ inline const char* FromSpan(gsl::span<gsl::byte> Span, size_t Offset = 0)
     return String.data();
 }
 
+template <typename T>
+inline const char* FromMessageBuffer(const gsl::span<gsl::byte>& Span)
+{
+    return FromSpan(Span, offsetof(T, Buffer));
+}
+
 inline std::vector<const char*> ArrayFromSpan(gsl::span<gsl::byte> Span, size_t Offset = 0)
 {
     THROW_INVALID_ARG_IF(Span.size() < Offset);

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -608,6 +608,17 @@ std::wstring wsl::windows::common::wslutil::DownloadFileImpl(
     return handle;
 }
 
+[[nodiscard]] HANDLE wsl::windows::common::wslutil::DuplicateHandleToCallingProcess(_In_ HANDLE Handle)
+{
+    const wil::unique_handle caller = OpenCallingProcess(PROCESS_DUP_HANDLE);
+    THROW_LAST_ERROR_IF(!caller);
+
+    HANDLE handle;
+    THROW_IF_WIN32_BOOL_FALSE(DuplicateHandle(GetCurrentProcess(), Handle, caller.get(), &handle, 0, FALSE, DUPLICATE_SAME_ACCESS));
+
+    return handle;
+}
+
 void wsl::windows::common::wslutil::EnforceFileLimit(LPCWSTR Path, size_t Limit, const std::function<bool(const std::filesystem::directory_entry&)>& pred)
 {
     std::map<std::filesystem::file_time_type, std::filesystem::path> files;

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -88,6 +88,8 @@ std::wstring DownloadFileImpl(std::wstring_view Url, std::wstring Filename, cons
 
 [[nodiscard]] HANDLE DuplicateHandleFromCallingProcess(_In_ HANDLE handleInTarget);
 
+[[nodiscard]] HANDLE DuplicateHandleToCallingProcess(_In_ HANDLE Handle);
+
 void EnforceFileLimit(LPCWSTR Folder, size_t limit, const std::function<bool(const std::filesystem::directory_entry&)>& pred);
 
 std::wstring ErrorCodeToString(HRESULT Error);

--- a/src/windows/lswclient/DllMain.cpp
+++ b/src/windows/lswclient/DllMain.cpp
@@ -161,7 +161,8 @@ HRESULT WslCreateLinuxProcess(LSWVirtualMachineHandle VirtualMachine, CreateProc
     std::vector<LSW_PROCESS_FD> inputFd(UserSettings->FdCount);
     for (size_t i = 0; i < UserSettings->FdCount; i++)
     {
-        inputFd[i] = {UserSettings->FileDescriptors[i].Number, UserSettings->FileDescriptors[i].Type};
+        inputFd[i] = {
+            UserSettings->FileDescriptors[i].Number, UserSettings->FileDescriptors[i].Type, UserSettings->FileDescriptors[i].Path};
     }
 
     std::vector<HANDLE> fds(UserSettings->FdCount);

--- a/src/windows/lswclient/DllMain.cpp
+++ b/src/windows/lswclient/DllMain.cpp
@@ -162,10 +162,12 @@ HRESULT WslCreateLinuxProcess(LSWVirtualMachineHandle VirtualMachine, CreateProc
     for (size_t i = 0; i < UserSettings->FdCount; i++)
     {
         inputFd[i] = {
-            UserSettings->FileDescriptors[i].Number, UserSettings->FileDescriptors[i].Type, UserSettings->FileDescriptors[i].Path};
+            UserSettings->FileDescriptors[i].Number,
+            UserSettings->FileDescriptors[i].Type,
+            (char*)UserSettings->FileDescriptors[i].Path};
     }
 
-    std::vector<HANDLE> fds(UserSettings->FdCount);
+    std::vector<ULONG> fds(UserSettings->FdCount);
     if (fds.empty())
     {
         fds.resize(1); // COM doesn't like null pointers.
@@ -176,7 +178,7 @@ HRESULT WslCreateLinuxProcess(LSWVirtualMachineHandle VirtualMachine, CreateProc
 
     for (size_t i = 0; i < UserSettings->FdCount; i++)
     {
-        UserSettings->FileDescriptors[i].Handle = fds[i];
+        UserSettings->FileDescriptors[i].Handle = UlongToHandle(fds[i]);
     }
 
     *Pid = result.Pid;

--- a/src/windows/lswclient/LSWApi.h
+++ b/src/windows/lswclient/LSWApi.h
@@ -131,7 +131,7 @@ struct ProcessFileDescriptorSettings
 {
     int32_t Number;
     enum FileDescriptorType Type;
-    const char* Path; // Required when 
+    const char* Path; // Required when 'Type' has LinuxFileInput or LinuxFileOutput
     HANDLE Handle;
 };
 

--- a/src/windows/lswclient/LSWApi.h
+++ b/src/windows/lswclient/LSWApi.h
@@ -118,15 +118,20 @@ HRESULT WslMount(LSWVirtualMachineHandle VirtualMachine, const struct MountSetti
 
 enum FileDescriptorType
 {
-    Default,
-    TerminalInput,
-    TerminalOutput
+    Default = 0,
+    TerminalInput = 1,
+    TerminalOutput = 2,
+    LinuxFileInput = 4,
+    LinuxFileOutput = 8,
+    LinuxFileAppend = 16,
+    LinuxFileCreate = 32,
 };
 
 struct ProcessFileDescriptorSettings
 {
     int32_t Number;
-    enum FileDescriptorType Type; // Not implemented yet
+    enum FileDescriptorType Type;
+    const char* Path; // Required when 
     HANDLE Handle;
 };
 

--- a/src/windows/service/exe/LSWVirtualMachine.cpp
+++ b/src/windows/service/exe/LSWVirtualMachine.cpp
@@ -500,8 +500,8 @@ try
     {
         if (sockets[i])
         {
-            Handles[i] = HandleToUlong(
-                wsl::windows::common::wslutil::DuplicateHandleToCallingProcess(reinterpret_cast<HANDLE>(sockets[i].release())));
+            Handles[i] =
+                HandleToUlong(wsl::windows::common::wslutil::DuplicateHandleToCallingProcess(reinterpret_cast<HANDLE>(sockets[i].get())));
         }
     }
 

--- a/src/windows/service/exe/LSWVirtualMachine.h
+++ b/src/windows/service/exe/LSWVirtualMachine.h
@@ -31,7 +31,7 @@ public:
     IFACEMETHOD(AttachDisk(_In_ PCWSTR Path, _In_ BOOL ReadOnly, _Out_ LPSTR* Device)) override;
     IFACEMETHOD(Mount(_In_ LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags)) override;
     IFACEMETHOD(CreateLinuxProcess(
-        _In_ const LSW_CREATE_PROCESS_OPTIONS* Options, _In_ ULONG FdCount, _In_ LSW_PROCESS_FD* Fd, _Out_ HANDLE* Handles, _Out_ LSW_CREATE_PROCESS_RESULT* Result)) override;
+        _In_ const LSW_CREATE_PROCESS_OPTIONS* Options, _In_ ULONG FdCount, _In_ LSW_PROCESS_FD* Fd, _Out_ ULONG* Handles, _Out_ LSW_CREATE_PROCESS_RESULT* Result)) override;
     IFACEMETHOD(WaitPid(_In_ LONG Pid, _In_ ULONGLONG TimeoutMs, _Out_ ULONG* State, _Out_ int* Code)) override;
     IFACEMETHOD(Signal(_In_ LONG Pid, _In_ int Signal)) override;
     IFACEMETHOD(Shutdown(ULONGLONG _In_ TimeoutMs)) override;
@@ -53,6 +53,9 @@ private:
     wil::unique_socket ConnectSocket(wsl::shared::SocketChannel& Channel, int32_t Fd);
     void OpenLinuxFile(wsl::shared::SocketChannel& Channel, const char* Path, uint32_t Flags, int32_t Fd);
     void LaunchPortRelay();
+
+    std::vector<wil::unique_socket> CreateLinuxProcessImpl(
+        _In_ const LSW_CREATE_PROCESS_OPTIONS* Options, _In_ ULONG FdCount, _In_ LSW_PROCESS_FD* Fd, _Out_ LSW_CREATE_PROCESS_RESULT* Result);
 
     struct AttachedDisk
     {

--- a/src/windows/service/exe/LSWVirtualMachine.h
+++ b/src/windows/service/exe/LSWVirtualMachine.h
@@ -51,6 +51,7 @@ private:
     int32_t ExpectClosedChannelOrError(wsl::shared::SocketChannel& Channel);
 
     wil::unique_socket ConnectSocket(wsl::shared::SocketChannel& Channel, int32_t Fd);
+    void OpenLinuxFile(wsl::shared::SocketChannel& Channel, const char* Path, uint32_t Flags, int32_t Fd);
     void LaunchPortRelay();
 
     struct AttachedDisk

--- a/src/windows/service/inc/wslservice.idl
+++ b/src/windows/service/inc/wslservice.idl
@@ -425,7 +425,6 @@ typedef struct _LSW_PROCESS_FD
     LONG Fd;
     int Type;
     [string, unique] LPCSTR Path;
-    HVSOCKET_HANDLE Handle;
 } LSW_PROCESS_FD;
 
 typedef
@@ -453,7 +452,7 @@ interface ILSWVirtualMachine : IUnknown
 {
     HRESULT AttachDisk([in] LPCWSTR Path, [in] BOOL ReadOnly, [out] LPSTR* Device);
     HRESULT Mount([in, unique] LPCSTR Source, [in] LPCSTR Target, [in] LPCSTR Type, [in] LPCSTR Options, [in] ULONG Flags); 
-    HRESULT CreateLinuxProcess([in] const LSW_CREATE_PROCESS_OPTIONS* Options, [in] ULONG FdCount, [in, unique, size_is(FdCount), length_is(FdCount)] LSW_PROCESS_FD* Fds, [out, size_is(FdCount)] HVSOCKET_HANDLE* Handles, [out] LSW_CREATE_PROCESS_RESULT* Result);
+    HRESULT CreateLinuxProcess([in] const LSW_CREATE_PROCESS_OPTIONS* Options, [in] ULONG FdCount, [in, unique, size_is(FdCount)] LSW_PROCESS_FD* Fds, [out, size_is(FdCount)] ULONG* Handles, [out] LSW_CREATE_PROCESS_RESULT* Result);
     HRESULT WaitPid([in] LONG Pid, [in] ULONGLONG TimeoutMs,  [out] ULONG* State, [out] int* Code);
     HRESULT Signal([in] LONG Pid, [in] int Signal);
     HRESULT Shutdown([in] ULONGLONG TimeoutMs);

--- a/src/windows/service/inc/wslservice.idl
+++ b/src/windows/service/inc/wslservice.idl
@@ -424,6 +424,8 @@ typedef struct _LSW_PROCESS_FD
 {
     LONG Fd;
     int Type;
+    [string, unique] LPCSTR Path;
+    HVSOCKET_HANDLE Handle;
 } LSW_PROCESS_FD;
 
 typedef
@@ -451,7 +453,7 @@ interface ILSWVirtualMachine : IUnknown
 {
     HRESULT AttachDisk([in] LPCWSTR Path, [in] BOOL ReadOnly, [out] LPSTR* Device);
     HRESULT Mount([in, unique] LPCSTR Source, [in] LPCSTR Target, [in] LPCSTR Type, [in] LPCSTR Options, [in] ULONG Flags); 
-    HRESULT CreateLinuxProcess([in] const LSW_CREATE_PROCESS_OPTIONS* Options, [in] ULONG FdCount, [in, unique, size_is(FdCount)] LSW_PROCESS_FD* Fds, [out, size_is(FdCount)] HVSOCKET_HANDLE* Handles, [out] LSW_CREATE_PROCESS_RESULT* Result);
+    HRESULT CreateLinuxProcess([in] const LSW_CREATE_PROCESS_OPTIONS* Options, [in] ULONG FdCount, [in, unique, size_is(FdCount), length_is(FdCount)] LSW_PROCESS_FD* Fds, [out, size_is(FdCount)] HVSOCKET_HANDLE* Handles, [out] LSW_CREATE_PROCESS_RESULT* Result);
     HRESULT WaitPid([in] LONG Pid, [in] ULONGLONG TimeoutMs,  [out] ULONG* State, [out] int* Code);
     HRESULT Signal([in] LONG Pid, [in] int Signal);
     HRESULT Shutdown([in] ULONGLONG TimeoutMs);

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -479,8 +479,7 @@ class LSWTests
             createProcessSettings.Executable = Args[0];
             createProcessSettings.Arguments = Args.data();
             createProcessSettings.FileDescriptors = fds.data();
-            createProcessSettings.Environment = nullptr;
-            createProcessSettings.FdCount = static_cast<uint32_t>(fds.size());
+            createProcessSettings.FdCount = static_cast<DWORD>(fds.size());
 
             int pid{};
             VERIFY_ARE_EQUAL(WslCreateLinuxProcess(vm.get(), &createProcessSettings, &pid), expectedError.value_or(S_OK));
@@ -489,9 +488,8 @@ class LSWTests
         };
 
         {
-            auto fds = createProcess({"/bin/cat"}, {{1, LinuxFileInput, "/proc/self/cmdline"}});
-
-            VERIFY_ARE_EQUAL(ReadToString((SOCKET)fds[0].Handle), "/bin/cat");
+            auto fds = createProcess({"/bin/cat"}, {{0, LinuxFileInput, "/proc/self/comm"}, {1, Default, nullptr}});
+            VERIFY_ARE_EQUAL(ReadToString((SOCKET)fds[1].Handle), "cat\n");
         }
     }
 

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -465,7 +465,7 @@ class LSWTests
             const char* Path;
         };
 
-        auto createProcess = [&](std::vector<const char*> Args, const std::vector<FileFd>& Fds, std::optional<HRESULT> expectedError = {}) {
+        auto createProcess = [&](std::vector<const char*> Args, const std::vector<FileFd>& Fds, HRESULT expectedError = S_OK) {
             Args.emplace_back(nullptr);
 
             std::vector<ProcessFileDescriptorSettings> fds;
@@ -482,14 +482,100 @@ class LSWTests
             createProcessSettings.FdCount = static_cast<DWORD>(fds.size());
 
             int pid{};
-            VERIFY_ARE_EQUAL(WslCreateLinuxProcess(vm.get(), &createProcessSettings, &pid), expectedError.value_or(S_OK));
+            VERIFY_ARE_EQUAL(WslCreateLinuxProcess(vm.get(), &createProcessSettings, &pid), expectedError);
 
-            return fds;
+            std::vector<wil::unique_handle> handles;
+
+            for (const auto& e : fds)
+            {
+                handles.emplace_back(e.Handle);
+            }
+
+            return std::make_pair(std::move(handles), pid);
+        };
+
+        auto wait = [&](int pid) {
+            WaitResult result{};
+            VERIFY_SUCCEEDED(WslWaitForLinuxProcess(vm.get(), pid, INFINITE, &result));
+            VERIFY_ARE_EQUAL(result.State, ProcessStateExited);
+
+            return result.Code;
         };
 
         {
-            auto fds = createProcess({"/bin/cat"}, {{0, LinuxFileInput, "/proc/self/comm"}, {1, Default, nullptr}});
-            VERIFY_ARE_EQUAL(ReadToString((SOCKET)fds[1].Handle), "cat\n");
+            auto [fds, pid] = createProcess({"/bin/cat"}, {{0, LinuxFileInput, "/proc/self/comm"}, {1, Default, nullptr}});
+            VERIFY_ARE_EQUAL(ReadToString((SOCKET)fds[1].get()), "cat\n");
+            VERIFY_ARE_EQUAL(wait(pid), 0);
+        }
+
+        {
+            auto read = [&]() {
+                auto [readFds, readPid] = createProcess({"/bin/cat"}, {{0, LinuxFileInput, "/tmp/output"}, {1, Default, nullptr}});
+                VERIFY_ARE_EQUAL(wait(readPid), 0);
+
+                auto content = ReadToString((SOCKET)readFds[1].get());
+
+                return content;
+            };
+
+            // Write to a new file.
+            auto [fds, pid] = createProcess(
+                {"/bin/cat"},
+                {{0, Default, nullptr}, {1, static_cast<FileDescriptorType>(LinuxFileOutput | LinuxFileCreate), "/tmp/output"}});
+
+            constexpr auto content = "TestOutput";
+            VERIFY_IS_TRUE(WriteFile(fds[0].get(), content, static_cast<DWORD>(strlen(content)), nullptr, nullptr));
+            fds.clear();
+            VERIFY_ARE_EQUAL(wait(pid), 0);
+
+            VERIFY_ARE_EQUAL(read(), content);
+
+            // Append content to the same file
+            auto [appendFds, appendPid] = createProcess(
+                {"/bin/cat"},
+                {{0, Default, nullptr}, {1, static_cast<FileDescriptorType>(LinuxFileOutput | LinuxFileAppend), "/tmp/output"}});
+
+            VERIFY_IS_TRUE(WriteFile(appendFds[0].get(), content, static_cast<DWORD>(strlen(content)), nullptr, nullptr));
+            appendFds.clear();
+            VERIFY_ARE_EQUAL(wait(appendPid), 0);
+
+            VERIFY_ARE_EQUAL(read(), std::format("{}{}", content, content));
+
+            // Truncate the file
+            auto [truncFds, truncPid] = createProcess(
+                {"/bin/cat"}, {{0, Default, nullptr}, {1, static_cast<FileDescriptorType>(LinuxFileOutput), "/tmp/output"}});
+
+            VERIFY_IS_TRUE(WriteFile(truncFds[0].get(), content, static_cast<DWORD>(strlen(content)), nullptr, nullptr));
+            truncFds.clear();
+            VERIFY_ARE_EQUAL(wait(truncPid), 0);
+
+            VERIFY_ARE_EQUAL(read(), content);
+        }
+
+        // Test various error paths
+        {
+            createProcess({"/bin/cat"}, {{0, static_cast<FileDescriptorType>(LinuxFileOutput), "/tmp/DoesNotExist"}}, E_FAIL);
+            createProcess({"/bin/cat"}, {{0, static_cast<FileDescriptorType>(LinuxFileOutput), nullptr}}, E_INVALIDARG);
+            createProcess({"/bin/cat"}, {{0, static_cast<FileDescriptorType>(Default), "should-be-null"}}, E_INVALIDARG);
+            createProcess({"/bin/cat"}, {{0, static_cast<FileDescriptorType>(Default | LinuxFileOutput), nullptr}}, E_INVALIDARG);
+            createProcess({"/bin/cat"}, {{0, static_cast<FileDescriptorType>(LinuxFileAppend), nullptr}}, E_INVALIDARG);
+            createProcess({"/bin/cat"}, {{0, static_cast<FileDescriptorType>(LinuxFileInput | LinuxFileAppend), nullptr}}, E_INVALIDARG);
+        }
+
+        // Validate that read & write modes are respected
+        {
+            auto [fds, pid] = createProcess(
+                {"/bin/cat"}, {{0, LinuxFileInput, "/proc/self/comm"}, {1, LinuxFileInput, "/tmp/output"}, {2, Default, nullptr}});
+
+            VERIFY_ARE_EQUAL(ReadToString((SOCKET)fds[2].get()), "/bin/cat: write error: Bad file descriptor\n");
+            VERIFY_ARE_EQUAL(wait(pid), 1);
+        }
+
+        {
+            auto [fds, pid] = createProcess({"/bin/cat"}, {{0, LinuxFileOutput, "/tmp/output"}, {2, Default, nullptr}});
+
+            VERIFY_ARE_EQUAL(ReadToString((SOCKET)fds[1].get()), "/bin/cat: -: Bad file descriptor\n");
+            VERIFY_ARE_EQUAL(wait(pid), 1);
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds support for opening guest files as process' file descriptors

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The new LinuxFileInput, LinuxFileOutput, LinuxFileAppend and LinuxFileCreate can be used to control the flags of the file

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
