### PR TITLE
Disable HTTP cache when reading the distribution manifest over HTTP

### DIFF
--- a/src/windows/common/Distribution.cpp
+++ b/src/windows/common/Distribution.cpp
@@ -101,7 +101,11 @@ DistributionList ReadFromManifest(const std::wstring& url)
         }
         else
         {
-            const winrt::Windows::Web::Http::HttpClient client;
+            const winrt::Windows::Web::Http::Filters::HttpBaseProtocolFilter filter;
+            filter.CacheControl().WriteBehavior(winrt::Windows::Web::Http::Filters::HttpCacheWriteBehavior::NoCache);
+            filter.CacheControl().ReadBehavior(winrt::Windows::Web::Http::Filters::HttpCacheReadBehavior::NoCache);
+
+            const winrt::Windows::Web::Http::HttpClient client(filter);
             const auto response = client.GetAsync(winrt::Windows::Foundation::Uri(url)).get();
             response.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change disables HTTP caching when reading the distribution manifest.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #13357 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
