### PR TITLE
Signal the VM termination event to unblock any pending call when the service stops

### DIFF
--- a/src/windows/service/exe/LSWUserSession.h
+++ b/src/windows/service/exe/LSWUserSession.h
@@ -12,8 +12,10 @@ Abstract:
 
 --*/
 #pragma once
+#include "LSWVirtualMachine.h"
 
 namespace wsl::windows::service::lsw {
+
 class LSWUserSessionImpl
 {
 public:
@@ -21,10 +23,19 @@ public:
     LSWUserSessionImpl(LSWUserSessionImpl&&) = default;
     LSWUserSessionImpl& operator=(LSWUserSessionImpl&&) = default;
 
+    ~LSWUserSessionImpl();
+
     PSID GetUserSid() const;
+
+    HRESULT CreateVirtualMachine(const VIRTUAL_MACHINE_SETTINGS* Settings, ILSWVirtualMachine** VirtualMachine);
+
+    void OnVmTerminated(LSWVirtualMachine* machine);
 
 private:
     wil::unique_tokeninfo_ptr<TOKEN_USER> m_tokenInfo;
+
+    std::recursive_mutex m_virtualMachinesLock;
+    std::vector<LSWVirtualMachine*> m_virtualMachines;
 };
 
 class DECLSPEC_UUID("a9b7a1b9-0671-405c-95f1-e0612cb4ce8f") LSWUserSession

--- a/src/windows/service/exe/LSWUserSessionFactory.h
+++ b/src/windows/service/exe/LSWUserSessionFactory.h
@@ -23,4 +23,6 @@ public:
 
     STDMETHODIMP CreateInstance(_In_ IUnknown* pUnkOuter, _In_ REFIID riid, _Out_ void** ppCreated) override;
 };
+
+void ClearLswSessionsAndBlockNewInstances();
 } // namespace wsl::windows::service::lsw

--- a/src/windows/service/exe/LSWVirtualMachine.h
+++ b/src/windows/service/exe/LSWVirtualMachine.h
@@ -18,15 +18,19 @@ Abstract:
 #include "Dmesg.h"
 
 namespace wsl::windows::service::lsw {
+
+class LSWUserSessionImpl;
+
 class DECLSPEC_UUID("0CFC5DC1-B6A7-45FC-8034-3FA9ED73CE30") LSWVirtualMachine
     : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, ILSWVirtualMachine, IFastRundown>
 
 {
 public:
-    LSWVirtualMachine(const VIRTUAL_MACHINE_SETTINGS& Settings, PSID Sid);
+    LSWVirtualMachine(const VIRTUAL_MACHINE_SETTINGS& Settings, PSID Sid, LSWUserSessionImpl* UserSession);
     ~LSWVirtualMachine();
 
     void Start();
+    void OnSessionTerminating();
 
     IFACEMETHOD(AttachDisk(_In_ PCWSTR Path, _In_ BOOL ReadOnly, _Out_ LPSTR* Device, _Out_ ULONG* Lun)) override;
     IFACEMETHOD(Mount(_In_ LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags)) override;
@@ -88,5 +92,6 @@ private:
     std::map<ULONG, AttachedDisk> m_attachedDisks;
     std::mutex m_lock;
     std::mutex m_portRelaylock;
+    LSWUserSessionImpl* m_userSession;
 };
 } // namespace wsl::windows::service::lsw

--- a/src/windows/service/exe/ServiceMain.cpp
+++ b/src/windows/service/exe/ServiceMain.cpp
@@ -241,6 +241,7 @@ void WslService::ServiceStopped()
 
     // Terminate all user sessions.
     ClearSessionsAndBlockNewInstances();
+    wsl::windows::service::lsw::ClearLswSessionsAndBlockNewInstances();
 
     // Disconnect from the LxCore driver.
     if (g_lxcoreInitialized)


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to signal the VM termination event when the service stops, which will unblock any pending calls, allowing the service to correctly stop 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
