### PR TITLE
Fix for CVE-2025-53788

### DIFF
--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -231,6 +231,8 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
         // copies of the initrd file and private kernel.
         if constexpr (wsl::shared::Arm64)
         {
+            auto impersonate = wil::impersonate_token(m_userToken.get());
+
             m_rootFsPath = m_tempPath / LXSS_ROOTFS_DIRECTORY;
             wil::CreateDirectoryDeep(m_rootFsPath.c_str());
             auto initRdPath = m_installPath / LXSS_TOOLS_DIRECTORY / LXSS_VM_MODE_INITRD_NAME;


### PR DESCRIPTION
Now that the fix for [CVE-2025-53788](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-53788) is present in both GA and prerelease versions of WSL, the fix can be submitted upstream.

To summarize the issue, when using a private kernel on ARM64, we were missing a call to impersonate the com client which meant that CopyFileW was being called with the system token. This allowed copying files that the user may no otherwise have access to the %TEMP% directory.