### PR TITLE
Implement WSLA API to mount and unmount Windows folders via plan9

### DIFF
--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -375,6 +375,7 @@ typedef enum _LX_MESSAGE_TYPE
     LxMessageLswFork,
     LxMessageLswForkResult,
     LxMessageLswConnect,
+    LxMessageLswAccept,
     LxMessageLswWaitPid,
     LxMessageLswWaitPidResponse,
     LxMessageLswSignal,
@@ -482,6 +483,7 @@ inline auto ToString(LX_MESSAGE_TYPE messageType)
         X(LxMessageLswFork)
         X(LxMessageLswForkResult)
         X(LxMessageLswConnect)
+        X(LxMessageLswAccept)
         X(LxMessageLswWaitPid)
         X(LxMessageLswWaitPidResponse)
         X(LxMessageLswSignal)
@@ -1656,15 +1658,26 @@ struct LSW_TTY_RELAY
     PRETTY_PRINT(FIELD(Header), FIELD(TtyMaster), FIELD(TtyInput), FIELD(TtyOutput));
 };
 
-struct LSW_CONNECT
+struct LSW_ACCEPT
 {
-    static inline auto Type = LxMessageLswConnect;
+    static inline auto Type = LxMessageLswAccept;
     using TResponse = RESULT_MESSAGE<uint32_t>;
-    DECLARE_MESSAGE_CTOR(LSW_CONNECT);
+    DECLARE_MESSAGE_CTOR(LSW_ACCEPT);
 
     MESSAGE_HEADER Header;
     int32_t Fd = -1; // TODO: multiple at once
     PRETTY_PRINT(FIELD(Header), FIELD(Fd));
+};
+
+struct LSW_CONNECT
+{
+    static inline auto Type = LxMessageLswConnect;
+    using TResponse = RESULT_MESSAGE<int32_t>;
+    DECLARE_MESSAGE_CTOR(LSW_CONNECT);
+
+    MESSAGE_HEADER Header;
+    uint32_t HostPort;
+    PRETTY_PRINT(FIELD(Header), FIELD(HostPort));
 };
 
 enum LswOpenFlags // Must match FileDescriptorType.

--- a/src/windows/common/hcs.cpp
+++ b/src/windows/common/hcs.cpp
@@ -42,6 +42,17 @@ void wsl::windows::common::hcs::AddPlan9Share(
     ModifyComputeSystem(ComputeSystem, wsl::shared::ToJsonW(request).c_str(), UserToken);
 }
 
+void wsl::windows::common::hcs::RemovePlan9Share(_In_ HCS_SYSTEM ComputeSystem, _In_ PCWSTR AccessName, _In_ UINT32 Port)
+{
+    ModifySettingRequest<Plan9Share> request{};
+    request.RequestType = ModifyRequestType::Remove;
+    request.ResourcePath = L"VirtualMachine/Devices/Plan9/Shares";
+    request.Settings.AccessName = AccessName;
+    request.Settings.Port = Port;
+
+    ModifyComputeSystem(ComputeSystem, wsl::shared::ToJsonW(request).c_str());
+}
+
 void wsl::windows::common::hcs::AddVhd(_In_ HCS_SYSTEM ComputeSystem, _In_ PCWSTR VhdPath, _In_ ULONG Lun, _In_ bool ReadOnly)
 {
     ModifySettingRequest<Attachment> request{};

--- a/src/windows/common/hcs.hpp
+++ b/src/windows/common/hcs.hpp
@@ -45,6 +45,8 @@ void AddPlan9Share(
     _In_ Plan9ShareFlags Flags,
     _In_opt_ HANDLE UserToken = nullptr);
 
+void RemovePlan9Share(_In_ HCS_SYSTEM ComputeSystem, _In_ PCWSTR AccessName, _In_ UINT32 Port);
+
 void AddVhd(_In_ HCS_SYSTEM ComputeSystem, _In_ PCWSTR VhdPath, _In_ ULONG Lun, _In_ bool ReadOnly = false);
 
 void AddPassThroughDisk(_In_ HCS_SYSTEM ComputeSystem, _In_ PCWSTR Disk, _In_ ULONG Lun);

--- a/src/windows/lswclient/DllMain.cpp
+++ b/src/windows/lswclient/DllMain.cpp
@@ -416,3 +416,17 @@ try
                : S_OK;
 }
 CATCH_RETURN();
+
+HRESULT WslMountWindowsFolder(LSWVirtualMachineHandle VirtualMachine, LPCWSTR WindowsPath, const char* Target, BOOL ReadOnly)
+try
+{
+    return reinterpret_cast<ILSWVirtualMachine*>(VirtualMachine)->MountWindowsFolder(WindowsPath, Target, ReadOnly);
+}
+CATCH_RETURN();
+
+HRESULT WslUnmountWindowsFolder(LSWVirtualMachineHandle VirtualMachine, const char* Target)
+try
+{
+    return reinterpret_cast<ILSWVirtualMachine*>(VirtualMachine)->UnmountWindowsFolder(Target);
+}
+CATCH_RETURN();

--- a/src/windows/lswclient/LSWApi.h
+++ b/src/windows/lswclient/LSWApi.h
@@ -205,6 +205,10 @@ HRESULT WslInstallComponents(enum WslInstallComponent Components, WslInstallCall
 // Used for testing until the package is published.
 HRESULT WslSetPackageUrl(LPCWSTR Url);
 
+HRESULT WslMountWindowsFolder(LSWVirtualMachineHandle VirtualMachine, LPCWSTR WindowsPath, const char* LinuxPath, BOOL ReadOnly);
+
+HRESULT WslUnmountWindowsFolder(LSWVirtualMachineHandle VirtualMachine, const char* LinuxPath);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/windows/lswclient/lswclient.def
+++ b/src/windows/lswclient/lswclient.def
@@ -19,3 +19,5 @@ EXPORTS
     WslQueryMissingComponents
     WslInstallComponents
     WslSetPackageUrl
+    WslMountWindowsFolder
+    WslUnmountWindowsFolder

--- a/src/windows/service/exe/LSWVirtualMachine.h
+++ b/src/windows/service/exe/LSWVirtualMachine.h
@@ -44,8 +44,11 @@ public:
     IFACEMETHOD(MapPort(_In_ int Family, _In_ short WindowsPort, _In_ short LinuxPort, _In_ BOOL Remove)) override;
     IFACEMETHOD(Unmount(_In_ const char* Path)) override;
     IFACEMETHOD(DetachDisk(_In_ ULONG Lun)) override;
+    IFACEMETHOD(MountWindowsFolder(_In_ LPCWSTR WindowsPath, _In_ LPCSTR LinuxPath, _In_ BOOL ReadOnly)) override;
+    IFACEMETHOD(UnmountWindowsFolder(_In_ LPCSTR LinuxPath)) override;
 
 private:
+    static int32_t MountImpl(wsl::shared::SocketChannel& Channel, LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags);
     static void CALLBACK s_OnExit(_In_ HCS_EVENT* Event, _In_opt_ void* Context);
     static bool ParseTtyInformation(const LSW_PROCESS_FD* Fds, ULONG FdCount, const LSW_PROCESS_FD** TtyInput, const LSW_PROCESS_FD** TtyOutput);
 
@@ -90,7 +93,8 @@ private:
     wil::unique_handle m_portRelayChannelWrite;
 
     std::map<ULONG, AttachedDisk> m_attachedDisks;
-    std::mutex m_lock;
+    std::map<std::string, std::wstring> m_plan9Mounts;
+    std::recursive_mutex m_lock;
     std::mutex m_portRelaylock;
     LSWUserSessionImpl* m_userSession;
 };

--- a/src/windows/service/inc/wslservice.idl
+++ b/src/windows/service/inc/wslservice.idl
@@ -461,6 +461,8 @@ interface ILSWVirtualMachine : IUnknown
     HRESULT MapPort([in] int Family, [in] short WindowsPort, [in] short LinuxPort, [in] BOOL Remove);
     HRESULT Unmount([in] LPCSTR Path);
     HRESULT DetachDisk([in] ULONG Lun);
+    HRESULT MountWindowsFolder([in] LPCWSTR WindowsPath, [in] LPCSTR LinuxPath, [in] BOOL ReadOnly);
+    HRESULT UnmountWindowsFolder([in] LPCSTR LinuxPath);
 }
 
 typedef

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1363,14 +1363,24 @@ WslConfigChange::~WslConfigChange()
     }
 }
 
+std::wstring ReadFileContent(const std::string& Path)
+{
+    std::ifstream configRead(Path);
+    return std::wstring{std::istreambuf_iterator<char>(configRead), {}};
+}
+
+std::wstring ReadFileContent(const std::wstring& Path)
+{
+    std::wifstream configRead(Path);
+    return std::wstring{std::istreambuf_iterator<wchar_t>(configRead), {}};
+}
+
 // writes global WSL 2 config settings at %userprofile%/.wslconfig
 std::wstring LxssWriteWslConfig(const std::wstring& Content)
 {
     auto path = getenv("userprofile") + std::string("\\.wslconfig");
 
-    std::wifstream configRead(path);
-    auto previousContent = std::wstring{std::istreambuf_iterator<wchar_t>(configRead), {}};
-    configRead.close();
+    auto previousContent = ReadFileContent(path);
 
     std::wofstream config(path);
     VERIFY_IS_TRUE(config.good());

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -515,3 +515,6 @@ wil::unique_hkey OpenDistributionKey(LPCWSTR Name);
 void ValidateOutput(LPCWSTR CommandLine, const std::wstring& ExpectedOutput, const std::wstring& ExpectedWarnings = L"", int ExitCode = -1);
 
 std::string ReadToString(SOCKET Handle);
+
+std::wstring ReadFileContent(const std::string& Path);
+std::wstring ReadFileContent(const std::wstring& Path);

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -887,6 +887,7 @@ class LSWTests
             VERIFY_ARE_EQUAL(WslMountWindowsFolder(vm.get(), L"relative-path", "/win-path", true), E_INVALIDARG);
             VERIFY_ARE_EQUAL(WslMountWindowsFolder(vm.get(), L"C:\\does-not-exist", "/win-path", true), HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND));
             VERIFY_ARE_EQUAL(WslUnmountWindowsFolder(vm.get(), "/not-mounted"), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(WslUnmountWindowsFolder(vm.get(), "/proc"), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
 
             // Validate that folders that are manually unmounted from the guest are handled properly
             VERIFY_SUCCEEDED(WslMountWindowsFolder(vm.get(), testFolder.c_str(), "/win-path", true));

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -814,4 +814,79 @@ class LSWTests
         // Verify that the thread is unstuck
         stuckThread.join();
     }
+
+    TEST_METHOD(WindowsMounts)
+    {
+        WSL2_TEST_ONLY();
+
+        VirtualMachineSettings settings{};
+        settings.CPU.CpuCount = 4;
+        settings.DisplayName = L"LSW";
+        settings.Memory.MemoryMb = 2048;
+        settings.Options.BootTimeoutMs = 30 * 1000;
+        settings.Networking.Mode = NetworkingModeNAT;
+
+        auto vm = CreateVm(&settings);
+
+        auto expectMount = [&](const std::string& target, const std::optional<std::string>& options) {
+            auto cmd = std::format("set -o pipefail ; findmnt '{}' | tail  -n 1", target);
+            auto [pid, in, out, err] = LaunchCommand(vm.get(), {"/bin/bash", "-c", cmd.c_str()});
+
+            auto output = ReadToString((SOCKET)out.get());
+            auto error = ReadToString((SOCKET)err.get());
+
+            WaitResult result{};
+            VERIFY_SUCCEEDED(WslWaitForLinuxProcess(vm.get(), pid, INFINITE, &result));
+            if (result.Code != (options.has_value() ? 0 : 1))
+            {
+                LogError("%hs failed. code=%i, output: %hs, error: %hs", cmd.c_str(), result.Code, output.c_str(), error.c_str());
+                VERIFY_FAIL();
+            }
+
+            if (options.has_value() && !PathMatchSpecA(output.c_str(), options->c_str()))
+            {
+                std::wstring message = std::format(L"Output: '{}' didn't match pattern: '{}'", output, options.value());
+                VERIFY_FAIL(message.c_str());
+            }
+        };
+
+        auto testFolder = std::filesystem::current_path() / "test-folder";
+        std::filesystem::create_directories(testFolder);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testFolder); });
+
+        // Validate writeable mount.
+        {
+            VERIFY_SUCCEEDED(WslMountWindowsFolder(vm.get(), testFolder.c_str(), "/win-path", false));
+            expectMount("/win-path", "/win-path*9p*rw,relatime,aname=*,cache=5,access=client,msize=65536,trans=fd,rfd=*,wfd=*");
+
+            // Validate that mount can't be stacked on each other
+            VERIFY_ARE_EQUAL(WslMountWindowsFolder(vm.get(), testFolder.c_str(), "/win-path", false), HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
+
+            // Validate that folder is writeable from linux
+            VERIFY_ARE_EQUAL(RunCommand(vm.get(), {"/bin/bash", "-c", "echo -n content > /win-path/file.txt && sync"}), 0);
+            VERIFY_ARE_EQUAL(ReadFileContent(testFolder / "file.txt"), L"content");
+
+            VERIFY_SUCCEEDED(WslUnmountWindowsFolder(vm.get(), "/win-path"));
+            expectMount("/win-path", {});
+        }
+
+        // Validate read-only mount.
+        {
+            VERIFY_SUCCEEDED(WslMountWindowsFolder(vm.get(), testFolder.c_str(), "/win-path", true));
+            expectMount("/win-path", "/win-path*9p*rw,relatime,aname=*,cache=5,access=client,msize=65536,trans=fd,rfd=*,wfd=*");
+
+            // Validate that folder is not writeable from linux
+            VERIFY_ARE_EQUAL(RunCommand(vm.get(), {"/bin/bash", "-c", "echo -n content > /win-path/file.txt"}), 1);
+
+            VERIFY_SUCCEEDED(WslUnmountWindowsFolder(vm.get(), "/win-path"));
+            expectMount("/win-path", {});
+        }
+
+        // Validate various error paths
+        {
+            VERIFY_ARE_EQUAL(WslMountWindowsFolder(vm.get(), L"relative-path", "/win-path", true), E_INVALIDARG);
+            VERIFY_ARE_EQUAL(WslMountWindowsFolder(vm.get(), L"C:\\does-not-exist", "/win-path", true), HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND));
+            VERIFY_ARE_EQUAL(WslUnmountWindowsFolder(vm.get(), "/not-mounted"), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+        }
+    }
 };

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -887,6 +887,13 @@ class LSWTests
             VERIFY_ARE_EQUAL(WslMountWindowsFolder(vm.get(), L"relative-path", "/win-path", true), E_INVALIDARG);
             VERIFY_ARE_EQUAL(WslMountWindowsFolder(vm.get(), L"C:\\does-not-exist", "/win-path", true), HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND));
             VERIFY_ARE_EQUAL(WslUnmountWindowsFolder(vm.get(), "/not-mounted"), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+
+            // Validate that folders that are manually unmounted from the guest are handled properly
+            VERIFY_SUCCEEDED(WslMountWindowsFolder(vm.get(), testFolder.c_str(), "/win-path", true));
+            expectMount("/win-path", "/win-path*9p*rw,relatime,aname=*,cache=5,access=client,msize=65536,trans=fd,rfd=*,wfd=*");
+
+            VERIFY_ARE_EQUAL(RunCommand(vm.get(), {"/usr/bin/umount", "/win-path"}), 0);
+            VERIFY_SUCCEEDED(WslUnmountWindowsFolder(vm.get(), "/win-path"));
         }
     }
 };

--- a/test/windows/LSWTests.cpp
+++ b/test/windows/LSWTests.cpp
@@ -170,7 +170,7 @@ class LSWTests
         VERIFY_ARE_EQUAL(RunCommand(vm.get(), cmd), 32L);
 
         // Verify that unmount fails now.
-        VERIFY_ARE_EQUAL(WslUnmount(vm.get(), "/mnt"), E_FAIL);
+        VERIFY_ARE_EQUAL(WslUnmount(vm.get(), "/mnt"), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
 
         // Detach the disk
         VERIFY_SUCCEEDED(WslDetachDisk(vm.get(), attachedDisk.ScsiLun));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change introduces WLSA APIs to mount and unmount Windows folders in the vm via plan9

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
