### PR TITLE
Add NixOS 25.05 to the distribution list

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -185,6 +185,17 @@
                     "Sha256": "a5a2ceb8ca56b7245b909d021b0fd620427db349f02b8ef3b82b741bcb5611cd"
                 }
             }
+        ],
+        "NixOS": [
+            {
+                "Name": "NixOS-25.05",
+                "FriendlyName": "NixOS 25.05",
+                "Default": true,
+                "Amd64Url": {
+                    "Url": "https://github.com/nix-community/NixOS-WSL/releases/download/2505.7.0/nixos.wsl",
+                    "Sha256": "b9db52dc217e7852f715a4693d604da91591158b2da884d67a637cb70d63b1e1"
+                }
+            }
         ]
     },
     "Default": "Ubuntu",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Add NixOS as a modern distribution to `DistributionInfo.json`
The tarball/.wsl-file is built from the sources available here: https://github.com/nix-community/NixOS-WSL/tree/release-25.05

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** Link to issue #11206
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

If there's anything that needs to be changed before NixOS can be added to the catalog, let me know. I will then create a new release and update this PR accordingly

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Several people use NixOS as their main distro for WSL without significant issues regularly. We have automated tests to prevent bugs we had in the past from being re-introduced.
