### PR TITLE
logging: add more settings to vm create begin / end events.

### DIFF
--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -197,9 +197,15 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
     auto kernelModules =
         LoadDefaultKernelModules ? std::vector<std::wstring>{L"tun", L"ip_tables", L"br_netfilter"} : std::vector<std::wstring>{};
 
-    for (auto& e : wsl::shared::string::Split(userKernelModules, L','))
+    if (!userKernelModules.empty())
     {
-        kernelModules.emplace_back(std::move(e));
+        for (const auto& e : wsl::shared::string::Split(userKernelModules, L','))
+        {
+            if (!e.empty())
+            {
+                kernelModules.emplace_back(e);
+            }
+        }
     }
 
     KernelModulesList = wsl::shared::string::Join(kernelModules, L',');

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -194,15 +194,15 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         DefaultDistributionLocation = wsl::windows::common::filesystem::GetLocalAppDataPath(UserToken) / "wsl";
     }
 
-    if (!LoadDefaultKernelModules)
-    {
-        KernelModulesList.clear();
-    }
+    auto kernelModules =
+        LoadDefaultKernelModules ? std::vector<std::wstring>{L"tun", L"ip_tables", L"br_netfilter"} : std::vector<std::wstring>{};
 
     for (auto& e : wsl::shared::string::Split(userKernelModules, L','))
     {
-        KernelModulesList.emplace_back(std::move(e));
+        kernelModules.emplace_back(std::move(e));
     }
+
+    KernelModulesList = wsl::shared::string::Join(kernelModules, L',');
 }
 
 void wsl::core::Config::SaveNetworkingSettings(_In_opt_ HANDLE UserToken) const

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -201,10 +201,7 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
     {
         for (const auto& e : wsl::shared::string::Split(userKernelModules, L','))
         {
-            if (!e.empty())
-            {
-                kernelModules.emplace_back(e);
-            }
+            kernelModules.emplace_back(std::move(e));
         }
     }
 

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -107,8 +107,8 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         ConfigKey(ConfigSetting::MaxCrashDumpCount, MaxCrashDumpCount),
         ConfigKey(ConfigSetting::DistributionInstallPath, DefaultDistributionLocation),
         ConfigKey(ConfigSetting::InstanceIdleTimeout, InstanceIdleTimeout),
-        ConfigKey(ConfigSetting::LoadDefaultKernelModules, LoadDefaultKernelModules, &loadKernelModulesPresence),
-        ConfigKey(ConfigSetting::LoadKernelModules, userKernelModules, &loadKernelModulesPresence),
+        ConfigKey(ConfigSetting::LoadDefaultKernelModules, LoadDefaultKernelModules, &LoadKernelModulesPresence),
+        ConfigKey(ConfigSetting::LoadKernelModules, userKernelModules, &LoadKernelModulesPresence),
 
         // Features that were previously experimental (the old header is maintained for compatibility).
         ConfigKey({ConfigSetting::NetworkingMode, ConfigSetting::Experimental::NetworkingMode}, wsl::core::NetworkingModes, NetworkingMode, &NetworkingModePresence),
@@ -287,7 +287,7 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
 {
     // Determine the maximum number of processors that can be added to the VM.
     // If the user did not supply a processor count, use the maximum.
-    const auto MaximumProcessorCount = wsl::windows::common::wslutil::GetLogicalProcessorCount();
+    MaximumProcessorCount = wsl::windows::common::wslutil::GetLogicalProcessorCount();
     if (ProcessorCount <= 0)
     {
         ProcessorCount = MaximumProcessorCount;

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -14,10 +14,10 @@ Abstract:
 
 #pragma once
 
+#define T_ENUM(c, n) TraceLoggingValue(wsl::core::ToString((c).n), #n)
 #define T_PRESENT(c, n) TraceLoggingValue((c).n == ConfigKeyPresence::Present, #n)
 #define T_SET(c, n) TraceLoggingValue(!(c).n.empty(), #n "Set")
-#define T_STRING(c, n) TraceLoggingValue(wsl::core::ToString((c).n), #n)
-#define T_STRING_VECTOR(c, n) TraceLoggingValue(wsl::shared::string::Join((c).n, L',').c_str(), #n)
+#define T_STRING(c, n) TraceLoggingValue((c).n.c_str(), #n)
 #define T_VALUE(c, n) TraceLoggingValue((c).n, #n)
 
 #define CONFIG_TELEMETRY(c) \
@@ -27,11 +27,11 @@ Abstract:
         T_VALUE(c, EnableHostAddressLoopback), T_VALUE(c, EnableHostFileSystemAccess), T_VALUE(c, EnableIpv6), \
         T_VALUE(c, EnableLocalhostRelay), T_VALUE(c, EnableNestedVirtualization), T_VALUE(c, EnableSafeMode), \
         T_VALUE(c, EnableSparseVhd), T_VALUE(c, EnableVirtio), T_VALUE(c, EnableVirtio9p), T_VALUE(c, EnableVirtioFs), \
-        T_STRING(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), \
-        T_VALUE(c, KernelDebugPort), T_SET(c, KernelModulesPath), T_STRING_VECTOR(c, KernelModulesList), T_SET(c, KernelPath), \
+        T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), \
+        T_VALUE(c, KernelDebugPort), T_SET(c, KernelModulesPath), T_STRING(c, KernelModulesList), T_SET(c, KernelPath), \
         T_VALUE(c, LoadDefaultKernelModules), T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), \
-        T_VALUE(c, MaximumProcessorCount), T_STRING(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), \
-        T_STRING(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), \
+        T_VALUE(c, MaximumProcessorCount), T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), \
+        T_ENUM(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), \
         T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
 namespace wsl::core {
@@ -304,11 +304,10 @@ struct Config
     void SaveNetworkingSettings(_In_opt_ HANDLE UserToken) const;
     static unsigned long WriteConfigFile(_In_ LPCWSTR ConfigFilePath, _In_ ConfigKey KeyToWrite, _In_ bool RemoveKey = false);
 
-    // Values set in ParseConfigFile
     std::filesystem::path KernelPath;
     std::wstring KernelCommandLine;
+    std::wstring KernelModulesList;
     std::filesystem::path KernelModulesPath;
-    std::vector<std::wstring> KernelModulesList = {L"tun", L"ip_tables", L"br_netfilter"};
     UINT64 MemorySizeBytes = 0;
     UINT64 MaximumMemorySizeBytes = 0;
     int ProcessorCount = 0;

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -14,26 +14,25 @@ Abstract:
 
 #pragma once
 
-#define T_SET(c, n) TraceLoggingValue(!(c).n.empty(), "config." #n "Set")
-
-#define T_PRESENT(val, n) TraceLoggingValue(val == ConfigKeyPresence::Present, "config." #n "Set")
-
-#define T_STRING(c, n) TraceLoggingValue(wsl::core::ToString((c).n), "config." #n "String")
-
-#define T_VALUE(c, n) TraceLoggingValue((c).n, "config." #n)
+#define T_PRESENT(c, n) TraceLoggingValue((c).n == ConfigKeyPresence::Present, #n)
+#define T_SET(c, n) TraceLoggingValue(!(c).n.empty(), #n "Set")
+#define T_STRING(c, n) TraceLoggingValue(wsl::core::ToString((c).n), #n)
+#define T_STRING_VECTOR(c, n) TraceLoggingValue(wsl::shared::string::Join((c).n, L',').c_str(), #n)
+#define T_VALUE(c, n) TraceLoggingValue((c).n, #n)
 
 #define CONFIG_TELEMETRY(c) \
     T_VALUE(c, BestEffortDnsParsing), T_VALUE(c, DhcpTimeout), T_VALUE(c, EnableAutoProxy), T_VALUE(c, EnableDebugConsole), \
-        T_VALUE(c, EnableDhcp), T_VALUE(c, EnableDnsProxy), T_VALUE(c, EnableDnsTunneling), T_VALUE(c, EnableGpuSupport), \
-        T_VALUE(c, EnableGuiApps), T_VALUE(c, EnableHardwarePerformanceCounters), T_VALUE(c, EnableHostAddressLoopback), \
-        T_VALUE(c, EnableHostFileSystemAccess), T_VALUE(c, EnableIpv6), T_SET(c, KernelModulesPath), \
+        T_VALUE(c, EnableDebugShell), T_VALUE(c, EnableDhcp), T_VALUE(c, EnableDnsProxy), T_VALUE(c, EnableDnsTunneling), \
+        T_VALUE(c, EnableGpuSupport), T_VALUE(c, EnableGuiApps), T_VALUE(c, EnableHardwarePerformanceCounters), \
+        T_VALUE(c, EnableHostAddressLoopback), T_VALUE(c, EnableHostFileSystemAccess), T_VALUE(c, EnableIpv6), \
         T_VALUE(c, EnableLocalhostRelay), T_VALUE(c, EnableNestedVirtualization), T_VALUE(c, EnableSafeMode), \
         T_VALUE(c, EnableSparseVhd), T_VALUE(c, EnableVirtio), T_VALUE(c, EnableVirtio9p), T_VALUE(c, EnableVirtioFs), \
         T_STRING(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), \
-        T_VALUE(c, KernelDebugPort), T_SET(c, KernelPath), T_PRESENT((c).loadKernelModulesPresence, loadKernelModules), \
-        T_VALUE(c, LoadDefaultKernelModules), T_STRING(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), \
-        T_VALUE(c, MountDeviceTimeout), T_STRING(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), \
-        T_VALUE(c, SwapSizeBytes), T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
+        T_VALUE(c, KernelDebugPort), T_SET(c, KernelModulesPath), T_STRING_VECTOR(c, KernelModulesList), T_SET(c, KernelPath), \
+        T_VALUE(c, LoadDefaultKernelModules), T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), \
+        T_VALUE(c, MaximumProcessorCount), T_STRING(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), \
+        T_STRING(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), \
+        T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
 namespace wsl::core {
 constexpr auto ToString(ConfigKeyPresence key)
@@ -320,7 +319,7 @@ struct Config
     std::filesystem::path SwapFilePath;
     bool EnableLocalhostRelay = true;
     ConfigKeyPresence LocalhostRelayConfigPresence = ConfigKeyPresence::Absent;
-    ConfigKeyPresence loadKernelModulesPresence = ConfigKeyPresence::Absent;
+    ConfigKeyPresence LoadKernelModulesPresence = ConfigKeyPresence::Absent;
     bool LoadDefaultKernelModules = true;
     bool EnableNestedVirtualization = !shared::Arm64 && windows::common::helpers::IsWindows11OrAbove();
     bool EnableVirtio9p = false;

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -545,7 +545,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     message->DefaultKernel = m_defaultKernel;
     message->KernelModulesDeviceId = modulesLun;
     message.WriteString(message->HostnameOffset, wsl::windows::common::filesystem::GetLinuxHostName());
-    message.WriteString(message->KernelModulesListOffset, wsl::shared::string::Join<wchar_t>(m_vmConfig.KernelModulesList, L','));
+    message.WriteString(message->KernelModulesListOffset, m_vmConfig.KernelModulesList);
     message->DnsTunnelingIpAddress = m_vmConfig.DnsTunnelingIpAddress.value_or(0);
 
     m_miniInitChannel.SendMessage<LX_MINI_INIT_EARLY_CONFIG_MESSAGE>(message.Span());


### PR DESCRIPTION
While looking at some trace data I realized there are some additional VM settings that could be added to improve our diagnostic story. This PR adds the following to the createvm begin / end events:

* EnableDebugShell
* KernelModulesList
* MaximumMemorySizeBytes
* MaximumProcessorCount