### PR TITLE
More stable link for Ubuntu and Ubuntu-24.04

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -6,7 +6,7 @@
                 "FriendlyName": "Ubuntu",
                 "Default": true,
                 "Amd64Url": {
-                    "Url": "https://releases.ubuntu.com/noble/ubuntu-24.04.3-wsl-amd64.wsl",
+                    "Url": "https://releases.ubuntu.com/24.04.3/ubuntu-24.04.3-wsl-amd64.wsl",
                     "Sha256": "c74833a55e525b1e99e1541509c566bb3e32bdb53bf27ea3347174364a57f47c"
                 },
                 "Arm64Url": {
@@ -19,7 +19,7 @@
                 "FriendlyName": "Ubuntu 24.04 LTS",
                 "Default": false,
                 "Amd64Url": {
-                    "Url": "https://releases.ubuntu.com/noble/ubuntu-24.04.3-wsl-amd64.wsl",
+                    "Url": "https://releases.ubuntu.com/24.04.3/ubuntu-24.04.3-wsl-amd64.wsl",
                     "Sha256": "c74833a55e525b1e99e1541509c566bb3e32bdb53bf27ea3347174364a57f47c"
                 },
                 "Arm64Url": {


### PR DESCRIPTION
## Summary of the Pull Request

The existing AMD64 link (using the release name - "noble" in this case) will break next year as it did two weeks ago when Ubuntu 24.04.3 LTS was released.

The link I propose here will remain stable when the next point release comes out, following the same pattern already in place for ARM64.

To prove my point we can use this pattern to fetch the previous version of Ubuntu 24.04:

- This works: https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-wsl-amd64.wsl

- This doesn't: https://releases.ubuntu.com/noble/ubuntu-24.04.2-wsl-amd64.wsl

Doing this now means we prevent future issues in a transparent way, nothing changes for users in the present.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Verify the link pattern by downloading the previous version of Ubuntu 24.04 LTS (24.04.2).


To prove my point we can use this pattern to fetch the previous version of Ubuntu 24.04:

- The proposed pattern works: https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-wsl-amd64.wsl

- The existing one doesn't: https://releases.ubuntu.com/noble/ubuntu-24.04.2-wsl-amd64.wsl