### PR TITLE
wslrelay KD: stay open after first disconnect

### DIFF
--- a/src/windows/wslrelay/main.cpp
+++ b/src/windows/wslrelay/main.cpp
@@ -115,10 +115,6 @@ try
 
         for (;;)
         {
-            if (exitEvent && WaitForSingleObject(exitEvent.get(), 0) == WAIT_OBJECT_0)
-            {
-                break;
-            }
 
             const wil::unique_socket socket(WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED));
             THROW_LAST_ERROR_IF(!socket);

--- a/src/windows/wslrelay/main.cpp
+++ b/src/windows/wslrelay/main.cpp
@@ -101,7 +101,7 @@ try
         // Ensure that the other end of the pipe has connected.
         wsl::windows::common::helpers::ConnectPipe(pipe.get(), (15 * 1000), {exitEvent.get()});
 
-        // Bind, listen, and accept a connection on the specified port.
+        // Bind and listen on the specified port (once)
         const wil::unique_socket listenSocket(WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED));
         THROW_LAST_ERROR_IF(!listenSocket);
 
@@ -113,14 +113,33 @@ try
 
         THROW_LAST_ERROR_IF(listen(listenSocket.get(), 1) == SOCKET_ERROR);
 
-        const wil::unique_socket socket(WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED));
-        THROW_LAST_ERROR_IF(!socket);
+        for (;;)
+        {
+            if (exitEvent && WaitForSingleObject(exitEvent.get(), 0) == WAIT_OBJECT_0)
+            {
+                break;
+            }
 
-        wsl::windows::common::socket::Accept(listenSocket.get(), socket.get(), INFINITE, exitEvent.get());
+            const wil::unique_socket socket(WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED));
+            THROW_LAST_ERROR_IF(!socket);
 
-        // Begin the relay.
-        wsl::windows::common::relay::BidirectionalRelay(
-            reinterpret_cast<HANDLE>(socket.get()), pipe.get(), 0x1000, wsl::windows::common::relay::RelayFlags::LeftIsSocket);
+            try
+            {
+                wsl::windows::common::socket::Accept(listenSocket.get(), socket.get(), INFINITE, exitEvent.get());
+
+                // Begin the relay for this connection
+                wsl::windows::common::relay::BidirectionalRelay(
+                    reinterpret_cast<HANDLE>(socket.get()), pipe.get(), 0x1000, 
+                    wsl::windows::common::relay::RelayFlags::LeftIsSocket);
+            }
+            catch (...)
+            {
+                LOG_CAUGHT_EXCEPTION();
+                
+                // Small delay to prevent tight loop on persistent errors
+                Sleep(100);
+            }
+        }
 
         break;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When the relay is running in kernel debug mode, it accepts a single connection and then closes when that client disconnects. This change makes it stay open and continue accepting connections.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

`telnet localhost 50000` multiple times.