### PR TITLE
wsla: Mount the target on / when the chroot flag is set

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -394,6 +394,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_MOUNT& Me
         if (WI_IsFlagSet(Message.Flags, WSLA_MOUNT::Chroot))
         {
             THROW_LAST_ERROR_IF(chdir(target));
+            THROW_LAST_ERROR_IF(mount(".", "/", nullptr, MS_MOVE, nullptr) < 0);
             THROW_LAST_ERROR_IF(chroot("."));
         }
 

--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -46,6 +46,8 @@ extern int EnableInterface(int Socket, const char* Name);
 
 extern int SetCloseOnExec(int Fd, bool Enable);
 
+int Chroot(const char* Target);
+
 extern int g_LogFd;
 
 void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_GET_DISK& Message, const gsl::span<gsl::byte>& Buffer)
@@ -393,9 +395,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_MOUNT& Me
 
         if (WI_IsFlagSet(Message.Flags, WSLA_MOUNT::Chroot))
         {
-            THROW_LAST_ERROR_IF(chdir(target));
-            THROW_LAST_ERROR_IF(mount(".", "/", nullptr, MS_MOVE, nullptr) < 0);
-            THROW_LAST_ERROR_IF(chroot("."));
+            THROW_LAST_ERROR_IF(Chroot(target) < 0);
         }
 
         response.Result = 0;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a chroot issue causing `nerdctl exec` to fail.  

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
