### PR TITLE
Fix: Always use 'WSLInterop` as the binfmt name

### DIFF
--- a/src/linux/init/binfmt.h
+++ b/src/linux/init/binfmt.h
@@ -19,15 +19,6 @@ Abstract:
 //
 
 #define LX_INIT_BINFMT_NAME "WSLInterop"
-
-//
-// Name of the WSL 'late' binfmt_misc interpreter.
-// This name is used by the wsl-binfmt systemd unit which
-// registers the interpreter a second time after systemd-binfmt to make sure
-// that wsl's interpreter is always registered last.
-//
-
-#define LX_INIT_BINFMT_NAME_LATE "WSLInterop-late"
 #define BINFMT_MISC_MOUNT_TARGET "/proc/sys/fs/binfmt_misc"
 #define BINFMT_MISC_REGISTER_FILE BINFMT_MISC_MOUNT_TARGET "/register"
 #define BINFMT_INTEROP_REGISTRATION_STRING(Name) ":" Name ":M::MZ::" LX_INIT_PATH ":P"

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -365,8 +365,8 @@ ExecStart=/bin/mount -o bind,ro,X-mount.mkdir -t none /mnt/wslg/.X11-unix /tmp/.
 ExecStop=
 ExecStart=/bin/sh -c '(echo -1 > {}/{}) ; (echo "{}" > {})' )",
                 BINFMT_MISC_MOUNT_TARGET,
-                LX_INIT_BINFMT_NAME_LATE,
-                BINFMT_INTEROP_REGISTRATION_STRING(LX_INIT_BINFMT_NAME_LATE),
+                LX_INIT_BINFMT_NAME,
+                BINFMT_INTEROP_REGISTRATION_STRING(LX_INIT_BINFMT_NAME),
                 BINFMT_MISC_REGISTER_FILE);
 
             // Install the override for systemd-binfmt.service.


### PR DESCRIPTION
This change switches the systemd unit used to prevent overriding of the WSL interop binfmt interpreter to use the original name for the interpreter. This is being done because at least one codebase (azure logon cli) has taken a dependency on the presence of this specifically named entry.

For testing I have run though the interop / binfmt unit tests, as well as verified that WSL interop continues to function even if a conflicting interpreter (such as the mono runtime) is installed.