### PR TITLE
Configure defender process exceptions when running tests

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2081,7 +2081,7 @@ Return Value:
 
         for (const auto& e : defenderCommands)
         {
-            LogInfo("\"%s\" returned: %lu", e.c_str(), LxsstuRunCommand(std::format(L"Powershell -NoProfile -Command \"{}\"", e).data()));
+            LogInfo("\"%ls\" returned: %lu", e.c_str(), LxsstuRunCommand(std::format(L"Powershell -NoProfile -Command \"{}\"", e).data()));
         }
     }
 

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2071,23 +2071,6 @@ Return Value:
         THROW_HR_MSG(E_FAIL, "Test setup returned non-zero exit code %lu", ExitCode);
     }
 
-    if (!g_pipelineBuildId.empty())
-    {
-        std::vector<std::wstring> defenderCommands{
-            std::format(L"Add-MpPreference -ExclusionPath '{}'", wsl::windows::common::wslutil::GetMsiPackagePath().value()),
-            L"Add-MpPreference -ExclusionPath '.'",
-            L"Add-MpPreference -ExclusionProcess @('wsl.exe', 'wslg.exe', 'wslconfig.exe', 'wslrelay.exe', 'wslhost.exe', "
-            "'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe', 'te.processhost.exe')",
-            L"Set-MpPreference -DisableRealtimeMonitoring $true -DisableBehaviorMonitoring $true -MAPSReporting 0"
-
-        };
-
-        for (const auto& e : defenderCommands)
-        {
-            LogInfo("\"%ls\" returned: %lu", e.c_str(), LxsstuRunCommand(std::format(L"Powershell -NoProfile -Command \"{}\"", e).data()));
-        }
-    }
-
     return true;
 }
 

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2078,19 +2078,7 @@ Return Value:
             L"Add-MpPreference -ExclusionPath '.'",
             L"Add-MpPreference -ExclusionProcess @('wsl.exe', 'wslg.exe', 'wslconfig.exe', 'wslrelay.exe', 'wslhost.exe', "
             "'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe', 'te.processhost.exe')",
-            L"Set-MpPreference"
-            " -DisableBehaviorMonitoring $true"
-            " -DisableRealtimeMonitoring $true"
-            " -DisableScriptScanning $true"
-            " -DisableArchiveScanning $true"
-            " -DisableIOAVProtection $true"
-            " -MAPSReporting 0"
-            " -SubmitSamplesConsent 2"
-            " -UnknownThreatDefaultAction NoAction"
-            " -LowThreatDefaultAction NoAction"
-            " -ModerateThreatDefaultAction NoAction"
-            " -HighThreatDefaultAction NoAction"
-            " -SevereThreatDefaultAction NoAction"
+            L"Set-MpPreference -DisableRealtimeMonitoring $true -DisableBehaviorMonitoring $true -MAPSReporting 0"
 
         };
 

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2077,7 +2077,22 @@ Return Value:
             std::format(L"Add-MpPreference -ExclusionPath '{}'", wsl::windows::common::wslutil::GetMsiPackagePath().value()),
             L"Add-MpPreference -ExclusionPath '.'",
             L"Add-MpPreference -ExclusionProcess @('wsl.exe', 'wslg.exe', 'wslconfig.exe', 'wslrelay.exe', 'wslhost.exe', "
-            "'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe')"};
+            "'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe', 'te.processhost.exe')",
+            L"Set-MpPreference"
+            " -DisableBehaviorMonitoring $true"
+            " -DisableRealtimeMonitoring $true"
+            " -DisableScriptScanning $true"
+            " -DisableArchiveScanning $true"
+            " -DisableIOAVProtection $true"
+            " -MAPSReporting 0"
+            " -SubmitSamplesConsent 2"
+            " -UnknownThreatDefaultAction NoAction"
+            " -LowThreatDefaultAction NoAction"
+            " -ModerateThreatDefaultAction NoAction"
+            " -HighThreatDefaultAction NoAction"
+            " -SevereThreatDefaultAction NoAction"
+
+        };
 
         for (const auto& e : defenderCommands)
         {

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2073,12 +2073,16 @@ Return Value:
 
     if (!g_pipelineBuildId.empty())
     {
-        LxsstuRunCommand(std::format(
-                             L"Powershell -NoProfile -Command \"Add-MpPreference -ExclusionPath '{}'\"",
-                             wsl::windows::common::wslutil::GetMsiPackagePath().value())
-                             .data());
+        std::vector<std::wstring> defenderCommands{
+            std::format(L"Add-MpPreference -ExclusionPath '{}'", wsl::windows::common::wslutil::GetMsiPackagePath().value()),
+            L"Add-MpPreference -ExclusionPath '.'",
+            L"Add-MpPreference -ExclusionProcess @('wsl.exe', 'wslg.exe', 'wslconfig.exe', 'wslrelay.exe', 'wslhost.exe', "
+            "'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe')"};
 
-        LxsstuRunCommand(std::format(L"Powershell -NoProfile -Command \"Add-MpPreference -ExclusionPath '.'\"").data());
+        for (const auto& e : defenderCommands)
+        {
+            LogInfo("\"%s\" returned: %lu", e.c_str(), LxsstuRunCommand(std::format(L"Powershell -NoProfile -Command \"{}\"", e).data()));
+        }
     }
 
     return true;
@@ -2128,7 +2132,7 @@ Return Value:
         commandLine = std::format(L"Get-MpThreat > \"{}\\Get-MpThreat.txt\"", g_dumpFolder);
         LxsstuLaunchPowershellAndCaptureOutput(commandLine.data());
 
-        commandLine = std::format(L"Get-MpPreference > \"{}\\Get-MpPreference\"", g_dumpFolder);
+        commandLine = std::format(L"Get-MpPreference > \"{}\\Get-MpPreference.txt\"", g_dumpFolder);
         LxsstuLaunchPowershellAndCaptureOutput(commandLine.data());
     }
 

--- a/tools/test/CloudTest-Setup.bat
+++ b/tools/test/CloudTest-Setup.bat
@@ -6,6 +6,6 @@ setx /M CloudTestWorkerCustomTaefExe "%1\taef\te.exe"
 mkdir %2\WexLogFileOutput
 mklink /D %1\WexLogFileOutput %2\WexLogFileOutput
 
+rem These need to run before the package is installed
 powershell -NoProfile -Command "Add-MpPreference -ExclusionPath 'C:\Program Files\WSL'"
 powershell -NoProfile -Command "Add-MpPreference -ExclusionProcess @('wsl.exe', 'wslg.exe', 'wslconfig.exe', 'wslrelay.exe', 'wslhost.exe', 'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe', 'te.processhost.exe')"
-powershell -NoProfile -Command "Set-MpPreference -DisableRealtimeMonitoring $true -DisableBehaviorMonitoring $true -MAPSReporting 0"

--- a/tools/test/CloudTest-Setup.bat
+++ b/tools/test/CloudTest-Setup.bat
@@ -5,3 +5,7 @@ setx /M CloudTestWorkerCustomTaefExe "%1\taef\te.exe"
 
 mkdir %2\WexLogFileOutput
 mklink /D %1\WexLogFileOutput %2\WexLogFileOutput
+
+powershell -NoProfile -Command "Add-MpPreference -ExclusionPath 'C:\Program Files\WSL'"
+powershell -NoProfile -Command "Add-MpPreference -ExclusionProcess @('wsl.exe', 'wslg.exe', 'wslconfig.exe', 'wslrelay.exe', 'wslhost.exe', 'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe', 'te.processhost.exe')"
+powershell -NoProfile -Command "Set-MpPreference -DisableRealtimeMonitoring $true -DisableBehaviorMonitoring $true -MAPSReporting 0"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to create process level exclusions in the test module setup, which should help avoid reduce test failures caused by defender. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
