### PR TITLE
wsla: Use a mount timeout when mounting a disk

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -374,7 +374,8 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_MOUNT& Me
 
         const char* source = readField(Message.SourceIndex);
         const char* target = readField(Message.DestinationIndex);
-        THROW_LAST_ERROR_IF(UtilMount(source, target, readField(Message.TypeIndex), options.MountFlags, options.StringOptions.c_str()) < 0);
+        THROW_LAST_ERROR_IF(
+            UtilMount(source, target, readField(Message.TypeIndex), options.MountFlags, options.StringOptions.c_str(), c_defaultRetryTimeout) < 0);
 
         std::optional<std::string> overlayTarget;
         if (WI_IsFlagSet(Message.Flags, WSLA_MOUNT::OverlayFs))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change enables retrying with a timeout when mounting a disk in WSLA's init process. 

This test failure shows that the timeout is still needed: 

```
122517 | 2025-09-09 21:15:13.4574208 | Microsoft.Windows.Lxss.Manager | GuestLog | GuestLog | [    0.739732] /dev/sda: Can't open blockdev | 63603052-cafe-48b9-b284-258a0f225fcd |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |  
122518 | 2025-09-09 21:15:13.4582789 | Microsoft.Windows.Lxss.Manager | GuestLog | GuestLog | [    0.740248] WSL (1 - ) ERROR: UtilMount:1722: mount(/dev/sda, /mnt, ext4, 0x1x, ) failed 6 | 63603052-cafe-48b9-b284-258a0f225fcd |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |  
122519 | 2025-09-09 21:15:13.4588048 | Microsoft.Windows.Lxss.Manager | GuestLog | GuestLog | [    0.740952] sd 0:0:0:0: [sda] Attached SCSI disk | 63603052-cafe-48b9-b284-258a0f225fcd |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |  
122520 | 2025-09-09 21:15:13.4595195 | Microsoft.Windows.Lxss.Manager | GuestLog | GuestLog | [    0.741121] WSL (1) ERROR: No such device or address @WSLAInit.cpp:377 (HandleMessageImpl) | 63603052-cafe-48b9-b284-258a0f225fcd |   |   |   |   |   |   |   | 
```` 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
