### PR TITLE
Add an option to put a nuget suffix in the release pipeline parameters

### DIFF
--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -7,6 +7,10 @@ parameters:
     type: string
     default: ""
 
+  - name: nugetSuffix
+    type: string
+    default: ""
+
   - name: isNightly
     type: boolean
     default: false
@@ -160,7 +164,7 @@ stages:
               ${{ else }}:
                 script: |
                   Write-Host "##vso[task.setvariable variable=WSL_PACKAGE_VERSION;isOutput=true]$([string]('${{ parameters.packageVersion }}' + '.0'))"
-                  Write-Host "##vso[task.setvariable variable=WSL_NUGET_PACKAGE_VERSION;isOutput=true]$([string]('${{ parameters.packageVersion }}'))"
+                  Write-Host "##vso[task.setvariable variable=WSL_NUGET_PACKAGE_VERSION;isOutput=true]$([string]('${{ parameters.packageVersion }}{{ parameters.nugetSuffix }}'))"
 
           - ${{ each platform in parameters.platforms }}:
               - task: CMake@1

--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -303,7 +303,6 @@ stages:
             displayName: "Create the nuget directory"
 
           - ${{ each package in parameters.nugetPackages }}:
-              - script: Get-Content ${{ package }}
               - script: nuget.exe pack ${{ package }} -OutputDirectory $(ob_outputDirectory)\bin\nuget -NonInteractive
                 displayName: Build ${{ package }}
 

--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -164,7 +164,7 @@ stages:
               ${{ else }}:
                 script: |
                   Write-Host "##vso[task.setvariable variable=WSL_PACKAGE_VERSION;isOutput=true]$([string]('${{ parameters.packageVersion }}' + '.0'))"
-                  Write-Host "##vso[task.setvariable variable=WSL_NUGET_PACKAGE_VERSION;isOutput=true]$([string]('${{ parameters.packageVersion }}{{ parameters.nugetSuffix }}'))"
+                  Write-Host "##vso[task.setvariable variable=WSL_NUGET_PACKAGE_VERSION;isOutput=true]$([string]('${{ parameters.packageVersion }}${{ parameters.nugetSuffix }}'))"
 
           - ${{ each platform in parameters.platforms }}:
               - task: CMake@1
@@ -303,6 +303,7 @@ stages:
             displayName: "Create the nuget directory"
 
           - ${{ each package in parameters.nugetPackages }}:
+              - script: Get-Content ${{ package }}
               - script: nuget.exe pack ${{ package }} -OutputDirectory $(ob_outputDirectory)\bin\nuget -NonInteractive
                 displayName: Build ${{ package }}
 

--- a/.pipelines/wsl-build-release-onebranch.yml
+++ b/.pipelines/wsl-build-release-onebranch.yml
@@ -8,6 +8,11 @@ parameters:
   displayName: 'Test the release pipeline'
   type: string
   default: ''
+  
+- name: nugetSuffix
+  displayName: 'Nuget version suffix (must include "-")'
+  type: string
+  default: ''
 
 trigger:
   tags:
@@ -51,6 +56,7 @@ extends:
       parameters:
         isRelease: true
         packageVersion: ${{ iif(eq(parameters.testVersion, ''), variables['Build.SourceBranchName'], parameters.testVersion) }}
+        packageVersion: ${{ parameters.nugetSuffix }}
         traceLoggingConfig: $(ReleaseTraceLoggingConfig)
         vsoOrg: microsoft
         vsoProject: Microsoft.WSL
@@ -65,7 +71,7 @@ extends:
         packageVersion: ${{ iif(eq(parameters.testVersion, ''), variables['Build.SourceBranchName'], parameters.testVersion) }}
         bypassTests: ${{ parameters.bypassTests }}
 
-    - ${{ if eq(parameters.testVersion, '') }}:
+    - ${{ if or(eq(parameters.testVersion, ''), not(eq(parameters.nugetSuffix, ''))) }}:
         - template: nuget-stage.yml@self
           parameters:
             isNightly: false

--- a/.pipelines/wsl-build-release-onebranch.yml
+++ b/.pipelines/wsl-build-release-onebranch.yml
@@ -56,7 +56,7 @@ extends:
       parameters:
         isRelease: true
         packageVersion: ${{ iif(eq(parameters.testVersion, ''), variables['Build.SourceBranchName'], parameters.testVersion) }}
-        packageVersion: ${{ parameters.nugetSuffix }}
+        nugetSuffix: ${{ parameters.nugetSuffix }}
         traceLoggingConfig: $(ReleaseTraceLoggingConfig)
         vsoOrg: microsoft
         vsoProject: Microsoft.WSL


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds a new pipeline option to specify nuget suffixes in the release pipeline 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
