### PR TITLE
Add logic to force terminate the VM if the session lock can't be acquired for 30 seconds when the service stops

### DIFF
--- a/src/windows/service/exe/LxssUserSession.h
+++ b/src/windows/service/exe/LxssUserSession.h
@@ -54,6 +54,13 @@ typedef struct _LXSS_VM_MODE_SETUP_CONTEXT
     std::shared_ptr<LxssRunningInstance> instance;
 } LXSS_VM_MODE_SETUP_CONTEXT, *PLXSS_VM_MODE_SETUP_CONTEXT;
 
+enum class ShutdownBehavior
+{
+    Wait,
+    Force,
+    ForceAfter30Seconds
+};
+
 /// <summary>
 /// Each COM client gets a unique LxssUserSession object which contains a std::weak_ptr to a LxssUserSessionImpl for that user.
 /// </summary>
@@ -491,7 +498,7 @@ public:
     /// <summary>
     /// Terminates all running instances and the Linux utility vm.
     /// </summary>
-    HRESULT Shutdown(_In_ bool PreventNewInstances = false, _In_ bool ForceTerminate = false);
+    HRESULT Shutdown(_In_ bool PreventNewInstances = false, ShutdownBehavior Behavior = ShutdownBehavior::Wait);
 
     /// <summary>
     /// Worker thread for logging telemetry about processes running inside of WSL.
@@ -784,7 +791,7 @@ private:
     /// <summary>
     /// Lock for protecting various lists.
     /// </summary>
-    std::recursive_mutex m_instanceLock;
+    std::recursive_timed_mutex m_instanceLock;
 
     /// <summary>
     /// Contains the currently running utility VM's.

--- a/src/windows/service/exe/LxssUserSessionFactory.cpp
+++ b/src/windows/service/exe/LxssUserSessionFactory.cpp
@@ -49,7 +49,7 @@ void ClearSessionsAndBlockNewInstancesLockHeld(std::optional<std::vector<std::sh
             // since that could lead to a deadlock if FindSessionByCookie is called since that would try to lock g_sessionLock
             // while holding the session inner lock
 
-            session->Shutdown(true);
+            session->Shutdown(true, ShutdownBehavior::ForceAfter30Seconds);
         }
 
         sessions.reset();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds new logic to force terminate the VM if we can't acquire the user session lock for 30 seconds. This should help avoid MSI installation being stuck because wslservice is waiting on the lock to terminate the VM (See #11013).

Thiswill only help when upgrading into a build that contains this commit, so we should expect the new upgrade to show the same issues. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
