### PR TITLE
Fix incorrect timeout causing WSL1 OOBE to fail if the OOBE process takes longer than 30 seconds

### DIFF
--- a/src/windows/common/LxssMessagePort.cpp
+++ b/src/windows/common/LxssMessagePort.cpp
@@ -169,7 +169,7 @@ std::vector<gsl::byte> LxssMessagePort::Receive(DWORD Timeout)
 
         if (Status == STATUS_PENDING)
         {
-            WaitForMessage(&IoStatus);
+            WaitForMessage(&IoStatus, Timeout);
             Status = IoStatus.Status;
             SizeReceived = static_cast<ULONG>(IoStatus.Information);
         }

--- a/src/windows/common/LxssMessagePort.cpp
+++ b/src/windows/common/LxssMessagePort.cpp
@@ -19,7 +19,6 @@ Abstract:
 // Defines.
 
 #define LAUNCH_PROCESS_DEFAULT_BUFFER_SIZE 1024
-#define LAUNCH_PROCESS_DEFAULT_TIMEOUT_MS 30000
 
 LxssMessagePort::LxssMessagePort(_In_ HANDLE MessagePort) : m_messagePort(MessagePort), m_messageEvent(wil::EventOptions::None)
 {
@@ -52,7 +51,7 @@ std::shared_ptr<LxssPort> LxssMessagePort::CreateSessionLeader(_In_ HANDLE Clien
     LX_INIT_CREATE_SESSION Message{{LxInitMessageCreateSession, sizeof(Message)}, MarshalId};
 
     Send(&Message, sizeof(Message));
-    auto LocalMessagePort = m_serverPort->WaitForConnection(LAUNCH_PROCESS_DEFAULT_TIMEOUT_MS);
+    auto LocalMessagePort = m_serverPort->WaitForConnection(c_defaultMessageTimeout);
     ReleaseConsole.release();
     return LocalMessagePort;
 }
@@ -156,7 +155,7 @@ void LxssMessagePort::Receive(_Out_writes_bytes_(Length) PVOID Buffer, _In_ ULON
     return;
 }
 
-std::vector<gsl::byte> LxssMessagePort::Receive()
+std::vector<gsl::byte> LxssMessagePort::Receive(DWORD Timeout)
 {
     IO_STATUS_BLOCK IoStatus;
     std::vector<gsl::byte> Message;
@@ -274,7 +273,7 @@ wil::unique_handle LxssMessagePort::UnmarshalVfsFile(_In_ LXBUS_IPC_HANDLE_ID Vf
 
 void LxssMessagePort::WaitForMessage(_In_ PIO_STATUS_BLOCK IoStatus, _In_ DWORD Timeout) const
 {
-    const DWORD WaitStatus = WaitForSingleObject(m_messageEvent.get(), LAUNCH_PROCESS_DEFAULT_TIMEOUT_MS);
+    const DWORD WaitStatus = WaitForSingleObject(m_messageEvent.get(), Timeout);
     if (WaitStatus == WAIT_TIMEOUT)
     {
         IO_STATUS_BLOCK IoStatusCancel;

--- a/src/windows/common/LxssMessagePort.h
+++ b/src/windows/common/LxssMessagePort.h
@@ -21,6 +21,8 @@ class LxssServerPort;
 class LxssMessagePort : public LxssPort
 {
 public:
+    static inline DWORD c_defaultMessageTimeout = 30000;
+
     LxssMessagePort(_In_ HANDLE MessagePort);
     LxssMessagePort(_In_ LxssMessagePort&& Source);
     LxssMessagePort(_In_ std::unique_ptr<LxssMessagePort>&& SourcePointer);
@@ -46,7 +48,7 @@ public:
     LXBUS_IPC_PROCESS_ID
     MarshalProcess(_In_ HANDLE ProcessHandle, _In_ bool TerminateOnClose) const;
 
-    std::vector<gsl::byte> Receive();
+    std::vector<gsl::byte> Receive(DWORD Timeout = c_defaultMessageTimeout);
 
     void ReleaseConsole(_In_ LXBUS_IPC_CONSOLE_ID ConsoleId) const;
 

--- a/src/windows/service/exe/LxssInstance.cpp
+++ b/src/windows/service/exe/LxssInstance.cpp
@@ -551,7 +551,9 @@ wil::unique_handle LxssInstance::_CreateLxProcess(
             m_oobeThread = std::thread([this, OobeMessagePort = std::move(OobeMessagePort), registration = std::move(registration)]() mutable {
                 try
                 {
-                    auto Message = OobeMessagePort->Receive();
+                    // N.B. The LX_INIT_OOBE_RESULT message is only sent once the OOBE process completes, which might be waiting on user input.
+                    // Do no set a timeout here otherwise the OOBE flow will fail if the OOBE process takes longer than expected.
+                    auto Message = OobeMessagePort->Receive(INFINITE);
                     auto* OobeResult = gslhelpers::try_get_struct<LX_INIT_OOBE_RESULT>(gsl::make_span(Message));
                     THROW_HR_IF(E_INVALIDARG, !OobeResult || (OobeResult->Header.MessageType != LxInitOobeResult));
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

If the OOBE process for a WSL1 distros takes more than 30 seconds, we'll hit the `LAUNCH_PROCESS_DEFAULT_TIMEOUT_MS` timeout which will cause the channel to be closed, which will fail the OOBE, causing all sorts of issues. 

This change removes the timeout for this specific transaction, so we don't fail WSL1 OOBE if it takes more than 30 seconds to complete 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This issue could cause OOBE failures looking like this: 

```
λ wsl --install <distro> --version 1
Installing: <distro>
Distribution successfully installed. It can be launched via 'wsl.exe -d  <distro>'
Launching  <distro>...
Provisioning the new WSL instance <distro>
This might take a while...

<After 30 seconds>
<3>WSL (10 - SessionLeader) ERROR: SendMessage:131: Failed to write message LxInitOobeResult. Channel: OOBE
<3>WSL (10) ERROR: Broken pipe @src/shared/inc\SocketChannel.h:132 (SendMessage)
<3>WSL (10 - SessionLeader) ERROR: CreateProcessCommon:805: Create process failed
```


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
