### PR TITLE
Increase file descriptor limit in wsla init

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -637,7 +637,20 @@ int WSLAEntryPoint(int Argc, char* Argv[])
         g_LogFd = 3;
     }
 
+    //
+    // Increase the soft and hard limit for number of open file descriptors.
+    // N.B. the soft limit shouldn't be too high. See https://github.com/microsoft/WSL/issues/12985 .
+    //
+
     rlimit Limit{};
+    Limit.rlim_cur = 1024 * 10;
+    Limit.rlim_max = 1024 * 1024;
+    if (setrlimit(RLIMIT_NOFILE, &Limit) < 0)
+    {
+        LOG_ERROR("setrlimit(RLIMIT_NOFILE) failed {}", errno);
+        return -1;
+    }
+
     Limit.rlim_cur = 0x4000000;
     Limit.rlim_max = 0x4000000;
     if (setrlimit(RLIMIT_MEMLOCK, &Limit) < 0)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Increase file descriptor limit in wsla init.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified manually by running ulimit -n in interactive shell.