### PR TITLE
Introduce a new wsl.conf config value to allow distributions to opt-in to cgroupv1 mounts

### DIFF
--- a/src/linux/init/WslDistributionConfig.cpp
+++ b/src/linux/init/WslDistributionConfig.cpp
@@ -55,7 +55,8 @@ WslDistributionConfig::WslDistributionConfig(const char* configFilePath)
         ConfigKey(c_ConfigBootSystemdOption, BootInit),
         ConfigKey("boot.initTimeout", BootInitTimeout),
         ConfigKey(c_ConfigBootProtectBinfmtOption, BootProtectBinfmt),
-        ConfigKey(c_ConfigBootProtectBinfmtOption, BootProtectBinfmt),
+
+        ConfigKey(c_ConfigEnableGuiAppsOption, GuiAppsEnabled),
     };
 
     //

--- a/src/linux/init/WslDistributionConfig.cpp
+++ b/src/linux/init/WslDistributionConfig.cpp
@@ -28,6 +28,7 @@ WslDistributionConfig::WslDistributionConfig(const char* configFilePath)
         ConfigKey("automount.options", DrvFsOptions),
         ConfigKey(c_ConfigMountFsTabOption, MountFsTab),
         ConfigKey(c_ConfigLinkOsLibsOption, LinkOsLibs),
+        ConfigKey("automount.cgroups", {{"v1", CGroupVersion::v1}, {"v2", CGroupVersion::v2}}, CGroup, nullptr),
 
         ConfigKey("filesystem.umask", Umask),
 
@@ -54,8 +55,7 @@ WslDistributionConfig::WslDistributionConfig(const char* configFilePath)
         ConfigKey(c_ConfigBootSystemdOption, BootInit),
         ConfigKey("boot.initTimeout", BootInitTimeout),
         ConfigKey(c_ConfigBootProtectBinfmtOption, BootProtectBinfmt),
-
-        ConfigKey(c_ConfigEnableGuiAppsOption, GuiAppsEnabled),
+        ConfigKey(c_ConfigBootProtectBinfmtOption, BootProtectBinfmt),
     };
 
     //

--- a/src/linux/init/WslDistributionConfig.h
+++ b/src/linux/init/WslDistributionConfig.h
@@ -48,6 +48,12 @@ struct WslDistributionConfig
     WslDistributionConfig(WslDistributionConfig&&) = default;
     WslDistributionConfig& operator=(WslDistributionConfig&&) = default;
 
+    enum class CGroupVersion
+    {
+        v1 = 0,
+        v2 = 1
+    };
+
     bool AutoMount = true;
     bool AutoUpdateTimezone = true;
     std::optional<std::string> BootCommand;
@@ -71,6 +77,7 @@ struct WslDistributionConfig
     bool AppendGpuLibPath = true;
     bool GpuEnabled = true;
     bool LinkOsLibs = true;
+    CGroupVersion CGroup = CGroupVersion::v2;
 
     //
     // Values not set by /etc/wsl.conf.

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1850,6 +1850,10 @@ try
             return;
         }
     }
+    else
+    {
+        THROW_LAST_ERROR_IF(mount("tmpfs", CGROUP_MOUNTPOINT, "tmpfs", (MS_NOSUID | MS_NODEV | MS_NOEXEC), "mode=755") < 0);
+    }
 
     //
     // Mount cgroup v1 when running in WSL1 mode or when a WSL2 distro has automount.cgroups=v1 specified.

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1852,7 +1852,7 @@ try
     }
 
     //
-    // Mount cgroup v1 when running in WSL1 mode.
+    // Mount cgroup v1 when running in WSL1 mode or when a WSL2 distro has automount.cgroups=v1 specified.
     //
     // Open the /proc/cgroups file and parse each line, ignoring malformed
     // lines and disabled controllers.

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -73,6 +73,8 @@ Abstract:
 #define MOUNTS_DEVICE_FIELD 0
 #define MOUNTS_FSTYPE_FIELD 2
 
+using wsl::linux::WslDistributionConfig;
+
 static void ConfigApplyWindowsLibPath(const wsl::linux::WslDistributionConfig& Config);
 
 static bool CreateLoginSession(const wsl::linux::WslDistributionConfig& Config, const char* Username, uid_t Uid);
@@ -567,7 +569,7 @@ Return Value:
     // Initialize cgroups based on what the kernel supports.
     //
 
-    ConfigInitializeCgroups();
+    ConfigInitializeCgroups(Config);
 
     //
     // Attempt to register the NT interop binfmt extension.
@@ -1783,7 +1785,7 @@ Return Value:
         {LX_WSL2_GUI_APP_SUPPORT_ENV, "1"}};
 }
 
-void ConfigInitializeCgroups(void)
+void ConfigInitializeCgroups(wsl::linux::WslDistributionConfig& Config)
 
 /*++
 
@@ -1795,7 +1797,7 @@ Routine Description:
 
 Arguments:
 
-    None.
+    Config - Supplies the distribution configuration.
 
 Return Value:
 
@@ -1805,50 +1807,78 @@ Return Value:
 
 try
 {
-
-    //
-    // For WSL2 mount cgroup v2.
-    //
-    // N.B. Cgroup v2 is not implemented for WSL1.
-    //
+    std::vector<std::string> DisabledControllers;
 
     if (UtilIsUtilityVm())
     {
-        const auto Target = CGROUP_MOUNTPOINT;
+        if (Config.CGroup == WslDistributionConfig::CGroupVersion::v1)
+        {
+            auto commandLine = UtilReadFileContent("/proc/cmdline");
+            auto position = commandLine.find(CGROUPS_NO_V1);
+            if (position != std::string::npos)
+            {
+                auto list = commandLine.substr(position + sizeof(CGROUPS_NO_V1) - 1);
+                auto end = list.find_first_of(" \n");
+                if (end != std::string::npos)
+                {
+                    list = list.substr(0, end);
+                }
+
+                if (list == "all")
+                {
+                    LOG_WARNING("Distribution has cgroupv1 enabled, but kernel command line has {}all. Falling back to cgroupv2", CGROUPS_NO_V1);
+                    Config.CGroup = WslDistributionConfig::CGroupVersion::v2;
+                }
+                else
+                {
+                    DisabledControllers = wsl::shared::string::Split(list, ',');
+                }
+            }
+        }
+
+        if (Config.CGroup == WslDistributionConfig::CGroupVersion::v1)
+        {
+            THROW_LAST_ERROR_IF(mount("tmpfs", CGROUP_MOUNTPOINT, "tmpfs", (MS_NOSUID | MS_NODEV | MS_NOEXEC), "mode=755") < 0);
+        }
+
+        const auto Target = Config.CGroup == WslDistributionConfig::CGroupVersion::v1 ? CGROUP_MOUNTPOINT "/unified" : CGROUP_MOUNTPOINT;
         THROW_LAST_ERROR_IF(
             UtilMount(CGROUP2_DEVICE, Target, CGROUP2_DEVICE, (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RELATIME), "nsdelegate") < 0);
-    }
-    else
-    {
-        //
-        // Mount cgroup v1 when running in WSL1 mode.
-        //
-        // Open the /proc/cgroups file and parse each line, ignoring malformed
-        // lines and disabled controllers.
-        //
 
-        THROW_LAST_ERROR_IF(mount("tmpfs", CGROUP_MOUNTPOINT, "tmpfs", (MS_NOSUID | MS_NODEV | MS_NOEXEC), "mode=755") < 0);
-
-        wil::unique_file Cgroups{fopen(CGROUPS_FILE, "r")};
-        THROW_LAST_ERROR_IF(!Cgroups);
-
-        ssize_t BytesRead;
-        char* Line = nullptr;
-        auto LineCleanup = wil::scope_exit([&]() { free(Line); });
-        size_t LineLength = 0;
-        while ((BytesRead = getline(&Line, &LineLength, Cgroups.get())) != -1)
+        if (Config.CGroup == WslDistributionConfig::CGroupVersion::v2)
         {
-            char* Subsystem = nullptr;
-            bool Enabled = false;
-            if ((UtilParseCgroupsLine(Line, &Subsystem, &Enabled) < 0) || (Enabled == false))
-            {
-                continue;
-            }
-
-            auto Target = std::format("{}/{}", CGROUP_MOUNTPOINT, Subsystem);
-            THROW_LAST_ERROR_IF(
-                UtilMount(CGROUP_DEVICE, Target.c_str(), CGROUP_DEVICE, (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RELATIME), Subsystem) < 0);
+            return;
         }
+    }
+
+    //
+    // Mount cgroup v1 when running in WSL1 mode.
+    //
+    // Open the /proc/cgroups file and parse each line, ignoring malformed
+    // lines and disabled controllers.
+    //
+
+    wil::unique_file Cgroups{fopen(CGROUPS_FILE, "r")};
+    THROW_LAST_ERROR_IF(!Cgroups);
+
+    ssize_t BytesRead;
+    char* Line = nullptr;
+    auto LineCleanup = wil::scope_exit([&]() { free(Line); });
+    size_t LineLength = 0;
+    while ((BytesRead = getline(&Line, &LineLength, Cgroups.get())) != -1)
+    {
+        char* Subsystem = nullptr;
+        bool Enabled = false;
+        if ((UtilParseCgroupsLine(Line, &Subsystem, &Enabled) < 0) || (Enabled == false) ||
+            std::find(DisabledControllers.begin(), DisabledControllers.end(), Subsystem) != DisabledControllers.end())
+
+        {
+            continue;
+        }
+
+        auto Target = std::format("{}/{}", CGROUP_MOUNTPOINT, Subsystem);
+        THROW_LAST_ERROR_IF(
+            UtilMount(CGROUP_DEVICE, Target.c_str(), CGROUP_DEVICE, (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RELATIME), Subsystem) < 0);
     }
 }
 CATCH_LOG()

--- a/src/linux/init/config.h
+++ b/src/linux/init/config.h
@@ -406,7 +406,7 @@ void ConfigHandleInteropMessage(
     const MESSAGE_HEADER* Header,
     const wsl::linux::WslDistributionConfig& Config);
 
-void ConfigInitializeCgroups(void);
+void ConfigInitializeCgroups(wsl::linux::WslDistributionConfig& Config);
 
 int ConfigInitializeInstance(wsl::shared::SocketChannel& Channel, gsl::span<gsl::byte> Buffer, wsl::linux::WslDistributionConfig& Config);
 


### PR DESCRIPTION
…
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change introduces a new `/etc/wsl.conf` config value to allow a specific distribution to opt-in to unified cgroup mount instead of just cgroupv2:

```
[automount]
cgroups=v1|v2

```

While this config value only has two options, it's designed as an enum to allow for other values in the future. 
This will help solve issues like #13328, where systemd worked on earlier versions of WSL (before unified cgroup support was dropped). 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
