### PR TITLE
Implement clean instance terminate when using systemd

### DIFF
--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -477,8 +477,12 @@ bool WslCoreInstance::RequestStop(_In_ bool Force)
             terminateMessage.Header.MessageSize = sizeof(terminateMessage);
             terminateMessage.Force = Force;
 
-            const auto& terminateResponse = m_initChannel->GetChannel().Transaction(terminateMessage, nullptr, m_socketTimeout);
-            shutdown = terminateResponse.Result;
+            m_initChannel->GetChannel().SendMessage(terminateMessage);
+            auto [message, span] = m_initChannel->GetChannel().ReceiveMessageOrClosed<RESULT_MESSAGE<bool>>(m_socketTimeout);
+            if (message)
+            {
+                shutdown = message->Result;
+            }
         }
     CATCH_LOG()
 


### PR DESCRIPTION
This change ensures that `systemctl poweroff` gets time to do its work before terminating the VM.

- [x] **Closes:** Link to issue #13435 

