### PR TITLE
Add more verbose output to bsdtar to help root cause 'ImportExportStdout' test failures

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -166,8 +166,8 @@
                 "FriendlyName": "Arch Linux",
                 "Default": true,
                 "Amd64Url": {
-                    "Url": "https://geo.mirror.pkgbuild.com/wsl/2025.09.01.145298/archlinux-2025.09.01.145298.wsl",
-                    "Sha256": "9b011093c7ad5d0dccd0be785c9d968c30b4fce3957f3f1868f2c1c4415ae841"
+                    "Url": "https://geo.mirror.pkgbuild.com/wsl/2025.10.01.148042/archlinux-2025.10.01.148042.wsl",
+                    "Sha256": "98a5792935c46476f471854bc93344b2b1d63f7947905ce4dd75d20a546db7ea"
                 }
             }
         ],

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -857,10 +857,10 @@ Return Value:
 
         if (WI_IsFlagSet(Flags, LxMiniInitMessageFlagVerbose))
         {
-            compressionArguments += "v";
+            compressionArguments += "vv";
         }
 
-        const char* arguments[] = {
+        std::vector<const char*> arguments{
             BSDTAR_PATH,
             "-C",
             Source,
@@ -872,7 +872,13 @@ Return Value:
             "-",
             ".",
             nullptr};
-        execv(BSDTAR_PATH, const_cast<char**>(arguments));
+
+        if (WI_IsFlagSet(Flags, LxMiniInitMessageFlagVerbose))
+        {
+            arguments.emplace(arguments.begin() + 3, "--totals");
+        }
+
+        execv(BSDTAR_PATH, const_cast<char**>(arguments.data()));
         LOG_ERROR("execl failed, {}", errno);
     });
 
@@ -1158,7 +1164,7 @@ Return Value:
             "-C",
             Destination,
             "-x",
-            WI_IsFlagSet(Flags, LxMiniInitMessageFlagVerbose) ? "-vp" : "-p",
+            WI_IsFlagSet(Flags, LxMiniInitMessageFlagVerbose) ? "-vvp" : "-p",
             "--xattrs",
             "--numeric-owner",
             "-f",

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -1926,7 +1926,7 @@ HRESULT LxssUserSessionImpl::SetVersion(_In_ LPCGUID DistroGuid, _In_ ULONG Vers
 
             if (m_utilityVm->GetConfig().SetVersionDebug)
             {
-                commandLine += " -v";
+                commandLine += " -vv --totals";
             }
 
             // Run the bsdtar elf binary expand the tar file using the socket as stdin.
@@ -1991,7 +1991,7 @@ HRESULT LxssUserSessionImpl::SetVersion(_In_ LPCGUID DistroGuid, _In_ ULONG Vers
 
             if (m_utilityVm->GetConfig().SetVersionDebug)
             {
-                commandLine += " -v";
+                commandLine += " -vv --totals";
             }
 
             // Run the bsdtar elf binary to create the tar file using the socket as stdout.

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -6080,6 +6080,9 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         auto cleanup =
             wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { LxsstuLaunchWsl(std::format(L"--unregister {}", test_distro)); });
 
+        // The below logline makes it easier to find the bsdtar output when debugging this test case.
+        fprintf(stderr, "Starting ImportExportStdout test case\n");
+
         auto commandLine = std::format(L"cmd.exe /c wsl --export {} - | wsl --import {} . -", LXSS_DISTRO_NAME_TEST_L, test_distro);
 
         VERIFY_ARE_EQUAL(LxsstuRunCommand(commandLine.data()), 0L);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
