### PR TITLE
Update the initramfs generation logic to set 755 permissions on /init

### DIFF
--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -6267,5 +6267,14 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             std::wstring::npos);
     }
 
+    TEST_METHOD(InitPermissions)
+    {
+        WSL2_TEST_ONLY();
+
+        auto [out, _] = LxsstuLaunchWslAndCaptureOutput(L"stat -c %a /init");
+
+        VERIFY_ARE_EQUAL(out, L"755\n");
+    }
+
 }; // namespace UnitTests
 } // namespace UnitTests

--- a/tools/bin2cpio/CPIOImage.pm
+++ b/tools/bin2cpio/CPIOImage.pm
@@ -40,7 +40,7 @@ use constant TRAILER => "TRAILER!!!";
 #      like initramfs.
 #
 use constant INODE => 0;
-use constant MODE => oct("100777");
+use constant MODE => oct("100755");
 use constant UID => 0;
 use constant GID => 0;
 use constant NLINK => 0;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This isn't usually an issue since /init is bind-mounted read-only, but it causes issues in systemd since it thinks that it's world writeable. There shouldn't be any downside for setting the permissions to 755

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #13564
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
