### PR TITLE
Update Microsoft.WSL.DeviceHost package to version 1.0.0-20251015.1

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.0.0-20241009.4" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.0.0-20251015.1" />
   <package id="Microsoft.WSL.Kernel" version="6.6.87.2-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.LxUtil.amd64fre" version="10.0.26100.1-240331-1435.ge-release" />


### PR DESCRIPTION
This new version of the WSL device host package contains support for ICMP packages with the virtioproxy networking mode.