### PR TITLE
Update Microsoft.NETCore.App.Runtime packages version with fix for CVE-2025-55248

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="9.0.8" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="9.0.8" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="9.0.8" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="9.0.10" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="9.0.10" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6353" />
   <package id="Microsoft.Taef" version="10.97.250317001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />


### PR DESCRIPTION
Fixes https://github.com/microsoft/WSL/security/dependabot/8
Fixes https://github.com/microsoft/WSL/security/dependabot/9