### PR TITLE
Mask systemd-networkd-wait-online.service during boot

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -327,6 +327,10 @@ int GenerateSystemdUnits(int Argc, char** Argv)
             File.reset();
         }
 
+        // Mask systemd-networkd-wait-online.service since WSL always ensures that networking is configured during boot.
+        // That unit can cause systemd boot timeouts since WSL's network interface is unmanaged by systemd.
+        THROW_LAST_ERROR_IF(symlink("/dev/null", std::format("{}/systemd-networkd-wait-online.service", installPath).c_str()) < 0);
+
         // Only create the wslg unit if both enabled in wsl.conf, and if the wslg folder actually exists.
         if (enableGuiApps && access("/mnt/wslg/runtime-dir", F_OK) == 0)
         {

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -211,6 +211,12 @@ class UnitTests
 
         auto revert = EnableSystemd();
         VERIFY_IS_TRUE(IsSystemdRunning(L"--system"));
+
+        // Validate that systemd-networkd-wait-online.service is masked.
+        auto [out, _] =
+            LxsstuLaunchWslAndCaptureOutput(L"systemctl status systemd-networkd-wait-online.service  | grep -iF Loaded:");
+
+        VERIFY_ARE_EQUAL(out, L"     Loaded: masked (Reason: Unit systemd-networkd-wait-online.service is masked.)\n");
     }
 
     TEST_METHOD(SystemdUser)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to mask `systemd-networkd-wait-online.service` during boot. That unit will always time out since WSL's interfaces are unmanaged by systemd and causes various issues during boot.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #13186
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
