### PR TITLE
Typo in Dutch: versiie -> versie

### DIFF
--- a/localization/strings/nl-NL/Resources.resw
+++ b/localization/strings/nl-NL/Resources.resw
@@ -293,7 +293,8 @@ en 'wsl.exe --install &lt;Distro&gt;' om te installeren.</value>
   </data>
   <data name="MessageEnableVirtualization" xml:space="preserve">
     <value>WSL2 wordt niet ondersteund met de huidige computerconfiguratie. 
-Schakel het optionele onderdeel Virtual Machine Platform in en zorg ervoor dat virtualisatie is ingeschakeld in het BIOS.
+
+Schakel het optionele onderdeel Virtual Machine Platform in en zorg ervoor dat virtualisatie is ingeschakeld in het BIOS.
 Schakel Virtual Machine Platform in door uit te voeren: wsl.exe --install --no-distribution
 Ga naar https://aka.ms/enablevirtualization</value>
     <comment>{Locked="--install "}{Locked="--no-distribution
@@ -606,7 +607,7 @@ Argumenten voor het beheren van distributies in het Windows-subsysteem voor Linu
 "}{Locked="--quiet,"}{Locked="--verbose,"}{Locked="--online,"}{Locked="--install'"}{Locked="--set-default,"}{Locked="--set-version "}{Locked="--terminate,"}{Locked="--unregister "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessagePackageVersions" xml:space="preserve">
-    <value>WSL-versiie: {}
+    <value>WSL-versie: {}
 Kernelversie: {}
 WSLg-versie: {}
 MSRDC-versie: {}
@@ -1869,4 +1870,5 @@ U hebt ook toegang tot meer externe VS Code-opties via het opdrachtpalet in VS C
   <data name="Settings_VMIdleTimeoutTextBox.AutomationProperties.HelpText" xml:space="preserve">
     <value>Het aantal milliseconden dat een VM inactief is voordat deze wordt afgesloten.</value>
   </data>
+
 </root>


### PR DESCRIPTION
Not sure where these other changes in the diff are coming from, I just meant:

```diff
-    <value>WSL-versiie: {}
+    <value>WSL-versie: {}
```

I used GitHub's web editor. I guess it's wonky.

Just ask any translation tool or dictionary how to translate English "version" to Dutch, and maybe apply it yourself. I don't care either way.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
