### PR TITLE
Fix WslDistributionConfig to not default-initialize optional fields

### DIFF
--- a/src/linux/init/WslDistributionConfig.h
+++ b/src/linux/init/WslDistributionConfig.h
@@ -84,8 +84,8 @@ struct WslDistributionConfig
     //
 
     bool GuiAppsEnabled = false;
-    std::optional<int> FeatureFlags = 0;
-    std::optional<LX_MINI_INIT_NETWORKING_MODE> NetworkingMode = LxMiniInitNetworkingModeNone;
+    std::optional<int> FeatureFlags;
+    std::optional<LX_MINI_INIT_NETWORKING_MODE> NetworkingMode;
     std::optional<std::string> VmId;
 
     //


### PR DESCRIPTION
While experimenting with the virtio9p and virtiofs tests I noticed that some of the testcases were failing because they were attempting to mount the socket-based 9p shares. This was due to the mount.drvfs helper using default-constructed config struct, which was inadvertently using config flags of zero instead of querying init for the real flags value.