### PR TITLE
Update Microsoft.WSL.DeviceHost to remove lxutil.dll dependency

### DIFF
--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -24,7 +24,7 @@ parameters:
     type: object
     default:
       - target: "wsl;libwsl;wslg;wslservice;wslhost;wslrelay;wslinstaller;wslinstall;initramfs;wslserviceproxystub;wslsettings;wslinstallerproxystub;testplugin"
-        pattern: "wsl.exe,libwsl.dll,wslg.exe,wslservice.exe,wslhost.exe,wslrelay.exe,wslinstaller.exe,wslinstall.dll,wslserviceproxystub.dll,wslsettings.dll,wslsettings.exe,wslinstallerproxystub.dll,wsldevicehost.dll,lxutil.dll,WSLDVCPlugin.dll,testplugin.dll,wsldeps.dll"
+        pattern: "wsl.exe,libwsl.dll,wslg.exe,wslservice.exe,wslhost.exe,wslrelay.exe,wslinstaller.exe,wslinstall.dll,wslserviceproxystub.dll,wslsettings.dll,wslsettings.exe,wslinstallerproxystub.dll,wsldevicehost.dll,WSLDVCPlugin.dll,testplugin.dll,wsldeps.dll"
       - target: "msixgluepackage"
         pattern: "gluepackage.msix"
       - target: "msipackage"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,13 +74,11 @@ find_nuget_package(Wix WIX /tools/net6.0/any)
 if (${TARGET_PLATFORM} STREQUAL "x64")
     find_nuget_package(Microsoft.DXCore.Linux.amd64fre DXCORE /build/native)
     find_nuget_package(Microsoft.WSL.Dependencies.amd64fre WSLDEPS /build/native)
-    find_nuget_package(Microsoft.WSL.LxUtil.amd64fre LXUTIL /build/native)
 endif()
 
 if (${TARGET_PLATFORM} STREQUAL "arm64")
     find_nuget_package(Microsoft.DXCore.Linux.arm64fre DXCORE /build/native)
     find_nuget_package(Microsoft.WSL.Dependencies.arm64fre WSLDEPS /build/native)
-    find_nuget_package(Microsoft.WSL.LxUtil.arm64fre LXUTIL /build/native)
 endif()
 
 # Wsl Settings packages
@@ -152,7 +150,6 @@ file(MAKE_DIRECTORY ${GENERATED_DIR})
 
 set(PACKAGE_CERTIFICATE ${GENERATED_DIR}/dev-cert.pfx)
 file(CREATE_LINK ${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.dll ${BIN}/wsldevicehost.dll)
-file(CREATE_LINK ${LXUTIL_SOURCE_DIR}/bin/lxutil.dll ${BIN}/lxutil.dll)
 file(CREATE_LINK ${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_DLL} ${BIN}/${WSLG_TS_PLUGIN_DLL})
 file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.dll ${BIN}/wsldeps.dll)
 
@@ -203,7 +200,6 @@ add_compile_definitions(UNICODE
                         WSL_DEVICE_HOST_VERSION="${WSL_DEVICE_HOST_VERSION}"
                         COMMIT_HASH="${COMMIT_HASH}"
                         WSL_PACKAGE_VERSION="${PACKAGE_VERSION}"
-                        LXUTIL_VERSION="${LXUTIL_VERSION}"
                         MSRDC_VERSION="${MSRDC_VERSION}"
                         DIRECT3D_VERSION="${DIRECT3D_VERSION}"
                         DXCORE_VERSION="${DXCORE_VERSION}"
@@ -235,7 +231,6 @@ endif()
 
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)
-link_directories(${LXUTIL_SOURCE_DIR}/lib/)
 set(COMMON_LINK_LIBRARIES
     ws2_32.lib
     Userenv.lib

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -242,7 +242,6 @@
                     <File Id="RdpWinStlHelper.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/RdpWinStlHelper.dll" />
                 <?endif?>
                 <File Id="wsldevicehost.dll" Source="${BIN}/wsldevicehost.dll" />
-                <File Id="lxutil.dll" Source="${BIN}/lxutil.dll" />
                 <File Id="${WSLG_TS_PLUGIN_DLL}" Source="${BIN}/${WSLG_TS_PLUGIN_DLL}" />
 
                 <!-- MSRDC Plugin registration -->

--- a/packages.config
+++ b/packages.config
@@ -18,11 +18,9 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.0.0-20251015.1" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.0.0-20251201.1" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
-  <package id="Microsoft.WSL.LxUtil.amd64fre" version="10.0.26100.1-240331-1435.ge-release" />
-  <package id="Microsoft.WSL.LxUtil.arm64fre" version="10.0.26100.1-240331-1435.ge-release" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />
   <package id="Microsoft.WSLg" version="1.0.71" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />


### PR DESCRIPTION
This change updates the Microsoft.WSL.DeviceHost to version 1.0.0-20251022.1 which no longer has a dependency on lxutil.dll.