### PR TITLE
Make the sample WSL_POST_BUILD_COMMAND more resilient

### DIFF
--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -30,7 +30,7 @@ message(STATUS "Loading user configuration")
 # set(WSL_BUILD_THIN_PACKAGE true)
 
 # # Uncomment to install the package as part of the build
-# set(WSL_POST_BUILD_COMMAND "powershell;./tools/deploy/deploy-to-host.ps1")
+# set(WSL_POST_BUILD_COMMAND "powershell;-ExecutionPolicy;Bypass;-NoProfile;-NonInteractive;./tools/deploy/deploy-to-host.ps1")
 
 # # Uncomment to reduce the verbosity of the appx package build
 # set(WSL_SILENT_APPX_BUILD true)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the sample WSL_POST_BUILD_COMMAND to include the usual `-ExecutionPolicy Bypass -NoProfile -NonInteractive` arguments when calling powershell

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
