### PR TITLE
wsla: Create a dedicated ETL provider for wslaservice.exe

### DIFF
--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -11,6 +11,7 @@
     <EventProvider Id="lxcore_service" Name="B99CDB5A-039C-5046-E672-1A0DE0A40211"/>
     <EventProvider Id="wsl_devicehost" Name="9d6c7b9e-2581-4d8a-b8c5-b90b4a17094a"/>
     <EventProvider Id="wslclient" Name="8cbb7724-7223-5d6f-8137-564dac45104d"/>
+    <EventProvider Id="wslaservice" Name="0383CE62-8F86-4766-AFB2-9D66A7FB1E90"/>
     <EventProvider Id="wslapi" Name="beb94edf-1a7b-5058-0696-ff9e6b1798d1"/>
     <EventProvider Id="vm_chipset" Name="de9ba731-7f33-4f44-98c9-6cac856b9f83"/>
     <EventProvider Id="vmcompute_dll" Name="AF7FD3A7-B248-460C-A9F5-FEC39EF8468C"/>

--- a/src/windows/common/WslTelemetry.cpp
+++ b/src/windows/common/WslTelemetry.cpp
@@ -32,6 +32,13 @@ TRACELOGGING_DEFINE_PROVIDER(
     (0xb99cdb5a, 0x039c, 0x5046, 0xe6, 0x72, 0x1a, 0x0d, 0xe0, 0xa4, 0x02, 0x11),
     TraceLoggingOptionMicrosoftTelemetry());
 
+TRACELOGGING_DEFINE_PROVIDER(
+    WslaServiceTelemetryProvider,
+    "Microsoft.Windows.Wsla",
+    // {0383CE62-8F86-4766-AFB2-9D66A7FB1E90}
+    (0x383ce62, 0x8f86, 0x4766, 0xaf, 0xb2, 0x9d, 0x66, 0xa7, 0xfb, 0x1e, 0x90),
+    TraceLoggingOptionMicrosoftTelemetry());
+
 #ifdef DEBUG
 #define HRESULT_STRING_VALUE \
     , TraceLoggingValue(wsl::windows::common::wslutil::ErrorCodeToString(failure->hr).c_str(), "HRESULTString")

--- a/src/windows/common/WslTelemetry.h
+++ b/src/windows/common/WslTelemetry.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 TRACELOGGING_DECLARE_PROVIDER(LxssTelemetryProvider);
 TRACELOGGING_DECLARE_PROVIDER(WslServiceTelemetryProvider);
+TRACELOGGING_DECLARE_PROVIDER(WslaServiceTelemetryProvider);
 #ifdef __cplusplus
 }
 #endif

--- a/src/windows/wslaservice/exe/ServiceMain.cpp
+++ b/src/windows/wslaservice/exe/ServiceMain.cpp
@@ -67,7 +67,7 @@ try
 
     // Initialize telemetry.
     // TODO-WSLA: Create a dedicated WSLA provider
-    WslTraceLoggingInitialize(WslServiceTelemetryProvider, !wsl::shared::OfficialBuild);
+    WslTraceLoggingInitialize(WslaServiceTelemetryProvider, !wsl::shared::OfficialBuild);
 
     WSL_LOG("Service starting", TraceLoggingLevel(WINEVENT_LEVEL_INFO));
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds a dedicated ETL provider for wslaservice.exe. The new ETL provider is also added to `wsl.wprp` so logs are automatically collected during testpasses 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
