### PR TITLE
wslsettings: fix OOBE text truncation at 200% text scaling

### DIFF
--- a/src/windows/wslsettings/Controls/OOBEContent.xaml
+++ b/src/windows/wslsettings/Controls/OOBEContent.xaml
@@ -19,7 +19,7 @@
 
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
             <StackPanel
-                Margin="32,24"
+                Margin="{StaticResource ContentPageMargin}"
                 VerticalAlignment="Top"
                 Orientation="Vertical"
                 Spacing="12">

--- a/src/windows/wslsettings/Controls/OOBEContent.xaml.cs
+++ b/src/windows/wslsettings/Controls/OOBEContent.xaml.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Windows.UI.ViewManagement;
 
 namespace WslSettings.Controls
 {
@@ -10,6 +11,15 @@ namespace WslSettings.Controls
         public OOBEContent()
         {
             this.InitializeComponent();
+
+            // Adjust hero image height based on text scaling for better accessibility
+            var settings = new UISettings();
+            double textScaleFactor = settings.TextScaleFactor;
+            double baseImageHeight = 280.0;
+
+            // Reduce image height when text scaling increases to preserve content space
+            // Use inverse relationship: as text gets larger, image gets proportionally smaller
+            HeroImageHeight = Math.Max(baseImageHeight / textScaleFactor, 200.0);
         }
 
         public string Title

--- a/src/windows/wslsettings/Controls/OOBEContent.xaml.cs
+++ b/src/windows/wslsettings/Controls/OOBEContent.xaml.cs
@@ -8,18 +8,39 @@ namespace WslSettings.Controls
 {
     public sealed partial class OOBEContent : UserControl
     {
+        // Constants for hero image height calculations
+        private const double BaseImageHeight = 280.0;
+        private const double MinimumImageHeight = 200.0;
+
+        private static readonly UISettings Settings = new UISettings();
+
         public OOBEContent()
         {
             this.InitializeComponent();
 
-            // Adjust hero image height based on text scaling for better accessibility
-            var settings = new UISettings();
-            double textScaleFactor = settings.TextScaleFactor;
-            double baseImageHeight = 280.0;
+            // Set initial hero image height based on current text scaling
+            UpdateHeroImageHeight();
+
+            // Subscribe to text scale factor changes for dynamic updates
+            Settings.TextScaleFactorChanged += OnTextScaleFactorChanged;
+
+            // Ensure event cleanup when control is unloaded
+            this.Unloaded += (s, e) => Settings.TextScaleFactorChanged -= OnTextScaleFactorChanged;
+        }
+
+        private void UpdateHeroImageHeight()
+        {
+            double textScaleFactor = Settings.TextScaleFactor;
 
             // Reduce image height when text scaling increases to preserve content space
             // Use inverse relationship: as text gets larger, image gets proportionally smaller
-            HeroImageHeight = Math.Max(baseImageHeight / textScaleFactor, 200.0);
+            HeroImageHeight = Math.Max(BaseImageHeight / textScaleFactor, MinimumImageHeight);
+        }
+
+        private void OnTextScaleFactorChanged(UISettings sender, object args)
+        {
+            // Update hero image height when text scaling changes at runtime
+            this.DispatcherQueue.TryEnqueue(() => UpdateHeroImageHeight());
         }
 
         public string Title
@@ -56,6 +77,6 @@ namespace WslSettings.Controls
         public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register("Description", typeof(string), typeof(OOBEContent), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty HeroImageProperty = DependencyProperty.Register("HeroImage", typeof(string), typeof(OOBEContent), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty PageContentProperty = DependencyProperty.Register("PageContent", typeof(object), typeof(OOBEContent), new PropertyMetadata(new Grid()));
-        public static readonly DependencyProperty HeroImageHeightProperty = DependencyProperty.Register("HeroImageHeight", typeof(double), typeof(OOBEContent), new PropertyMetadata(280.0));
+        public static readonly DependencyProperty HeroImageHeightProperty = DependencyProperty.Register("HeroImageHeight", typeof(double), typeof(OOBEContent), new PropertyMetadata(BaseImageHeight));
     }
 }

--- a/src/windows/wslsettings/LibWsl.cs
+++ b/src/windows/wslsettings/LibWsl.cs
@@ -80,7 +80,7 @@ namespace LibWsl
 
         internal static bool __TryGetNativeToManagedMapping(IntPtr native, out global::LibWsl.WslConfig managed)
         {
-    
+
             return NativeToManagedMap.TryGetValue(native, out managed);
         }
 
@@ -171,7 +171,7 @@ namespace LibWsl
 
         internal static bool __TryGetNativeToManagedMapping(IntPtr native, out global::LibWsl.WslConfigSetting managed)
         {
-    
+
             return NativeToManagedMap.TryGetValue(native, out managed);
         }
 

--- a/src/windows/wslsettings/Windows/OOBEWindow.xaml
+++ b/src/windows/wslsettings/Windows/OOBEWindow.xaml
@@ -5,8 +5,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:windowex="using:WinUIEx"
-    MinWidth="480"
-    MinHeight="480"
+    MinWidth="600"
+    MinHeight="600"
     Closed="Window_Closed"
     mc:Ignorable="d">
     <Window.SystemBackdrop>


### PR DESCRIPTION
Add text scaling factor to window resize calculation and make hero image height responsive to text scaling. Increase minimum window size for better accessibility. Fix MAS 1.4.4 compliance for OOBE dialog.
