### PR TITLE
Add vmrs collection

### DIFF
--- a/src/windows/common/hcs_schema.h
+++ b/src/windows/common/hcs_schema.h
@@ -22,6 +22,12 @@ Abstract:
         Json[#Value] = (Object).Value.value(); \
     }
 
+#define ASSIGN_IF_PRESENT(Json, Object, Value) \
+    if (Json.contains(#Value)) \
+    { \
+        (Object).Value = Json.at(#Value).get_to((Object).Value); \
+    }
+
 namespace wsl::windows::common::hcs {
 
 enum class ModifyRequestType
@@ -510,10 +516,8 @@ inline void to_json(nlohmann::json& j, const GuestErrorSaveReport& g)
 
 inline void from_json(const nlohmann::json& j, GuestErrorSaveReport& r)
 {
-    if (j.contains("SaveStateFile"))
-        r.SaveStateFile = j.at("SaveStateFile").get<std::wstring>();
-    if (j.contains("Status"))
-        r.Status = j.at("Status").get<int32_t>();
+    ASSIGN_IF_PRESENT(j, r, SaveStateFile);
+    ASSIGN_IF_PRESENT(j, r, Status);
 }
 
 struct CrashReport
@@ -531,10 +535,8 @@ inline void to_json(nlohmann::json& j, const CrashReport& c)
 
 inline void from_json(const nlohmann::json& j, CrashReport& c)
 {
-    if (j.contains("CrashLog"))
-        c.CrashLog = j.at("CrashLog").get<std::wstring>();
-    if (j.contains("GuestCrashSaveInfo"))
-        c.GuestCrashSaveInfo = j.at("GuestCrashSaveInfo").get<GuestErrorSaveReport>();
+    ASSIGN_IF_PRESENT(j, c, CrashLog);
+    ASSIGN_IF_PRESENT(j, c, GuestCrashSaveInfo);
 }
 
 enum class NotificationType
@@ -564,18 +566,12 @@ struct GuestCrashAttribution
 inline void to_json(nlohmann::json& j, const GuestCrashAttribution& g)
 {
     j = nlohmann::json::object();
-    if (g.CrashParameters.has_value())
-    {
-        j["CrashParameters"] = g.CrashParameters.value();
-    }
+    OMIT_IF_EMPTY(j, g, CrashParameters)
 }
 
 inline void from_json(const nlohmann::json& j, GuestCrashAttribution& g)
 {
-    if (j.contains("CrashParameters"))
-    {
-        g.CrashParameters = j.at("CrashParameters").get<std::vector<uint64_t>>();
-    }
+    ASSIGN_IF_PRESENT(j, g, CrashParameters);
 }
 
 // Attribution record (trimmed to GuestCrash only for now)
@@ -587,18 +583,12 @@ struct AttributionRecord
 inline void to_json(nlohmann::json& j, const AttributionRecord& a)
 {
     j = nlohmann::json::object();
-    if (a.GuestCrash.has_value())
-    {
-        j["GuestCrash"] = a.GuestCrash.value();
-    }
+    OMIT_IF_EMPTY(j, a, GuestCrash)
 }
 
 inline void from_json(const nlohmann::json& j, AttributionRecord& a)
 {
-    if (j.contains("GuestCrash"))
-    {
-        a.GuestCrash = j.at("GuestCrash").get<GuestCrashAttribution>();
-    }
+    ASSIGN_IF_PRESENT(j, a, GuestCrash);
 }
 
 struct SystemExitStatus
@@ -618,10 +608,8 @@ inline void to_json(nlohmann::json& j, const SystemExitStatus& s)
 inline void from_json(const nlohmann::json& j, SystemExitStatus& s)
 {
     s.Status = j.at("Status").get<int32_t>();
-    if (j.contains("ExitType"))
-        s.ExitType = j.at("ExitType").get<NotificationType>();
-    if (j.contains("Attribution"))
-        s.Attribution = j.at("Attribution").get<std::vector<AttributionRecord>>();
+    ASSIGN_IF_PRESENT(j, s, ExitType);
+    ASSIGN_IF_PRESENT(j, s, Attribution);
 }
 
 } // namespace wsl::windows::common::hcs

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -1180,10 +1180,10 @@ std::filesystem::path WSLAVirtualMachine::GetCrashDumpFolder()
 
 void WSLAVirtualMachine::CreateVmSavedStateFile()
 {
-    const auto filename = std::format(L"{}{}-{}{}", 
-        SAVED_STATE_FILE_PREFIX, 
+    const auto filename = std::format(L"{}{}-{}{}",
+        SAVED_STATE_FILE_PREFIX,
         std::time(nullptr), 
-        m_vmIdString, 
+        m_vmIdString,
         SAVED_STATE_FILE_EXTENSION);
 
     auto savedStateFile = m_crashDumpFolder / filename;
@@ -1229,7 +1229,7 @@ void WSLAVirtualMachine::WriteCrashLog(const std::wstring& crashLog)
         std::wofstream outputFile(filePath.wstring());
         THROW_HR_IF(E_UNEXPECTED, !outputFile.is_open());
 
-        outputFile << crashLog; 
+        outputFile << crashLog;
         THROW_HR_IF(E_UNEXPECTED, outputFile.fail());
     }
 

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -253,6 +253,7 @@ void WSLAVirtualMachine::Start()
         THROW_HR(E_NOTIMPL);
         auto bootThis = hcs::UefiBootEntry{};
         bootThis.DeviceType = hcs::UefiBootDevice::VmbFs;
+        // bootThis.VmbFsRootPath = m_rootFsPath.c_str();
         bootThis.DevicePath = L"\\" LXSS_VM_MODE_KERNEL_NAME;
         bootThis.OptionalData = kernelCmdLine;
         hcs::Uefi uefiSettings{};
@@ -437,7 +438,7 @@ try
         reinterpret_cast<WSLAVirtualMachine*>(Context)->OnCrash(Event);
     }
 }
-CATCH_LOG();
+CATCH_LOG(); 
 
 void WSLAVirtualMachine::OnExit(_In_ const HCS_EVENT* Event)
 {
@@ -1153,10 +1154,15 @@ try
     }
 
     // Mount the packaged libraries.
+
 #ifdef WSL_GPU_LIB_PATH
+
     auto packagedLibPath = std::filesystem::path(TEXT(WSL_GPU_LIB_PATH));
+
 #else
+
     auto packagedLibPath = wslutil::GetBasePath() / L"lib";
+
 #endif
 
     auto packagedLibMountPoint = std::format("{}/packaged", LibrariesMountPoint);

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -1180,7 +1180,8 @@ std::filesystem::path WSLAVirtualMachine::GetCrashDumpFolder()
 
 void WSLAVirtualMachine::CreateVmSavedStateFile()
 {
-    const auto filename = std::format(L"{}{}-{}{}",
+    const auto filename = std::format(
+        L"{}{}-{}{}",
         SAVED_STATE_FILE_PREFIX,
         std::time(nullptr), 
         m_vmIdString,

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -438,7 +438,7 @@ try
         reinterpret_cast<WSLAVirtualMachine*>(Context)->OnCrash(Event);
     }
 }
-CATCH_LOG(); 
+CATCH_LOG()
 
 void WSLAVirtualMachine::OnExit(_In_ const HCS_EVENT* Event)
 {

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -65,6 +65,7 @@ private:
 
     void ConfigureNetworking();
     void OnExit(_In_ const HCS_EVENT* Event);
+    void OnCrash(_In_ const HCS_EVENT* Event);
 
     std::tuple<int32_t, int32_t, wsl::shared::SocketChannel> Fork(enum WSLA_FORK::ForkType Type);
     std::tuple<int32_t, int32_t, wsl::shared::SocketChannel> Fork(wsl::shared::SocketChannel& Channel, enum WSLA_FORK::ForkType Type);
@@ -73,6 +74,10 @@ private:
     ConnectedSocket ConnectSocket(wsl::shared::SocketChannel& Channel, int32_t Fd);
     static void OpenLinuxFile(wsl::shared::SocketChannel& Channel, const char* Path, uint32_t Flags, int32_t Fd);
     void LaunchPortRelay();
+
+    static std::filesystem::path GetCrashDumpFolder(std::wstring vmIdString);
+    void CreateVmSavedStateFile();
+    void WriteCrashLog(std::wstring crashLog);
 
     std::vector<ConnectedSocket> CreateLinuxProcessImpl(
         _In_ const WSLA_CREATE_PROCESS_OPTIONS* Options,
@@ -100,6 +105,12 @@ private:
     std::wstring m_debugShellPipe;
 
     wsl::windows::common::hcs::unique_hcs_system m_computeSystem;
+
+    std::filesystem::path m_vmSavedStateFile;
+    std::filesystem::path m_crashDumpFolder;
+    bool m_vmSavedStateCaptured = false;
+    bool m_crashLogCaptured = false;
+
     std::shared_ptr<DmesgCollector> m_dmesgCollector;
     wil::unique_event m_vmExitEvent{wil::EventOptions::ManualReset};
     wil::unique_event m_vmTerminatingEvent{wil::EventOptions::ManualReset};

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -75,9 +75,10 @@ private:
     static void OpenLinuxFile(wsl::shared::SocketChannel& Channel, const char* Path, uint32_t Flags, int32_t Fd);
     void LaunchPortRelay();
 
-    static std::filesystem::path GetCrashDumpFolder(std::wstring vmIdString);
+    static std::filesystem::path GetCrashDumpFolder();
     void CreateVmSavedStateFile();
-    void WriteCrashLog(std::wstring crashLog);
+    void EnforceVmSavedStateFileLimit();
+    void WriteCrashLog(const std::wstring& crashLog);
 
     std::vector<ConnectedSocket> CreateLinuxProcessImpl(
         _In_ const WSLA_CREATE_PROCESS_OPTIONS* Options,

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -84,13 +84,6 @@ private:
     void EnforceVmSavedStateFileLimit();
     void WriteCrashLog(const std::wstring& crashLog);
 
-    std::vector<ConnectedSocket> CreateLinuxProcessImpl(
-        _In_ const WSLA_CREATE_PROCESS_OPTIONS* Options,
-        _In_ ULONG FdCount,
-        _In_ WSLA_PROCESS_FD* Fd,
-        _Out_ WSLA_CREATE_PROCESS_RESULT* Result,
-        const TPrepareCommandLine& PrepareCommandLine = [](const auto&) {});
-
     Microsoft::WRL::ComPtr<WSLAProcess> CreateLinuxProcessImpl(
         _In_ const WSLA_PROCESS_OPTIONS& Options, int* Errno = nullptr, const TPrepareCommandLine& PrepareCommandLine = [](const auto&) {});
 

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -75,7 +75,7 @@ private:
     static void OpenLinuxFile(wsl::shared::SocketChannel& Channel, const char* Path, uint32_t Flags, int32_t Fd);
     void LaunchPortRelay();
 
-    static std::filesystem::path GetCrashDumpFolder();
+    std::filesystem::path GetCrashDumpFolder();
     void CreateVmSavedStateFile();
     void EnforceVmSavedStateFileLimit();
     void WriteCrashLog(const std::wstring& crashLog);
@@ -103,6 +103,7 @@ private:
     int m_coldDiscardShiftSize{};
     bool m_running = false;
     PSID m_userSid{};
+    wil::unique_handle m_userToken;
     std::wstring m_debugShellPipe;
 
     wsl::windows::common::hcs::unique_hcs_system m_computeSystem;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This change allows WSLA service to collect a .vmrs file and crash log in the event of a guest kernel panic.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
