### PR TITLE
Restore the call to ApplyProcessMitigationPolicies in ServiceMain

### DIFF
--- a/src/windows/wslaservice/exe/ServiceMain.cpp
+++ b/src/windows/wslaservice/exe/ServiceMain.cpp
@@ -74,7 +74,7 @@ try
     // Don't kill the process on unknown C++ exceptions.
     wil::g_fResultFailFastUnknownExceptions = false;
 
-    // wsl::windows::common::security::ApplyProcessMitigationPolicies();
+    wsl::windows::common::security::ApplyProcessMitigationPolicies();
 
     // Initialize Winsock.
     WSADATA Data;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This was most likely disabled during testing

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
