### PR TITLE
Fix invalid arg exception thrown when OnVmTerminated is invoked by WSLAVirtualMachine destructor 

### DIFF
--- a/src/windows/wslaservice/exe/WSLAUserSession.cpp
+++ b/src/windows/wslaservice/exe/WSLAUserSession.cpp
@@ -42,8 +42,7 @@ void WSLAUserSessionImpl::OnVmTerminated(WSLAVirtualMachine* machine)
     // Remove any stale VM reference.
     if (!m_virtualMachines.empty())
     {
-        auto pred = [machine](const auto* e) { return machine == e; };
-        m_virtualMachines.erase(std::remove_if(m_virtualMachines.begin(), m_virtualMachines.end(), pred), m_virtualMachines.end());
+        std::erase_if(m_virtualMachines, [machine](const auto* e) { return machine == e; });
     }
 }
 

--- a/src/windows/wslaservice/exe/WSLAUserSession.cpp
+++ b/src/windows/wslaservice/exe/WSLAUserSession.cpp
@@ -38,10 +38,13 @@ WSLAUserSessionImpl::~WSLAUserSessionImpl()
 void WSLAUserSessionImpl::OnVmTerminated(WSLAVirtualMachine* machine)
 {
     std::lock_guard lock(m_lock);
-    auto pred = [machine](const auto* e) { return machine == e; };
 
     // Remove any stale VM reference.
-    m_virtualMachines.erase(std::remove_if(m_virtualMachines.begin(), m_virtualMachines.end(), pred), m_virtualMachines.end());
+    if (!m_virtualMachines.empty())
+    {
+        auto pred = [machine](const auto* e) { return machine == e; };
+        m_virtualMachines.erase(std::remove_if(m_virtualMachines.begin(), m_virtualMachines.end(), pred), m_virtualMachines.end());
+    }
 }
 
 HRESULT WSLAUserSessionImpl::CreateVirtualMachine(const VIRTUAL_MACHINE_SETTINGS* Settings, IWSLAVirtualMachine** VirtualMachine)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes an exception that could occur when removing stale virtual machine references in WSLAUserSessionImpl::OnVmTerminated. Previously, calling erase on an empty std::vector<WSLAVirtualMachine*> could trigger a debug assertion in MSVC STL due to invalid iterator bounds.

Why is m_virtualMachines empty during WSLAVirtualMachine destruction?
This can happen if:
- The WSLAUserSessionImpl object itself is being destroyed, which also destroys its member containers (like m_virtualMachines).
-  During destruction, the WSLAVirtualMachine destructor calls OnVmTerminated, but by this point, m_virtualMachines may already be empty (or even partially destroyed), so the erase operation is acting on an empty vector.

This exception consistently reproduces when stopping WSLAService via `net stop`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
