### PR TITLE
Add termination callback support and rethink ownership model to match the new API

### DIFF
--- a/src/windows/wslaservice/exe/WSLASession.cpp
+++ b/src/windows/wslaservice/exe/WSLASession.cpp
@@ -21,16 +21,38 @@ using wsl::windows::service::wsla::WSLASession;
 
 WSLASession::WSLASession(const WSLA_SESSION_SETTINGS& Settings, WSLAUserSessionImpl& userSessionImpl, const VIRTUAL_MACHINE_SETTINGS& VmSettings) :
     m_sessionSettings(Settings),
-    m_userSession(userSessionImpl),
-    m_virtualMachine(std::make_optional<WSLAVirtualMachine>(VmSettings, userSessionImpl.GetUserSid(), &userSessionImpl)),
+    m_userSession(&userSessionImpl),
+    m_virtualMachine(wil::MakeOrThrow<WSLAVirtualMachine>(VmSettings, userSessionImpl.GetUserSid(), &userSessionImpl)),
     m_displayName(Settings.DisplayName)
 {
+    WSL_LOG("SessionCreated", TraceLoggingValue(m_displayName.c_str(), "DisplayName"));
+
     if (Settings.TerminationCallback != nullptr)
     {
         m_virtualMachine->RegisterCallback(Settings.TerminationCallback);
     }
 
     m_virtualMachine->Start();
+}
+
+WSLASession::~WSLASession()
+{
+    WSL_LOG("SessionTerminated", TraceLoggingValue(m_displayName.c_str(), "DisplayName"));
+
+    std::lock_guard lock{m_lock};
+
+    // N.B. Since we currently allow clients to acquire a reference to WSLAVirtualMachine(), it's possible
+    // for m_virtualMachine to outlive the session if the client keeps the reference long enough.
+    // TODO: Remove this logic once GetVirtualMachine() is removed
+    if (m_virtualMachine)
+    {
+        m_virtualMachine->OnSessionTerminated();
+    }
+
+    if (m_userSession != nullptr)
+    {
+        m_userSession->OnSessionTerminated(this);
+    }
 }
 
 HRESULT WSLASession::GetDisplayName(LPWSTR* DisplayName)
@@ -85,7 +107,7 @@ HRESULT WSLASession::ListContainers(WSLA_CONTAINER** Images, ULONG* Count)
 HRESULT WSLASession::GetVirtualMachine(IWSLAVirtualMachine** VirtualMachine)
 {
     std::lock_guard lock{m_lock};
-    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine.has_value());
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);
 
     THROW_IF_FAILED(m_virtualMachine->QueryInterface(__uuidof(IWSLAVirtualMachine), (void**)VirtualMachine));
     return S_OK;
@@ -100,7 +122,7 @@ try
     }
 
     std::lock_guard lock{m_lock};
-    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine.has_value());
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);
 
     return m_virtualMachine->CreateLinuxProcess(Options, Process, Errno);
 }
@@ -111,15 +133,24 @@ HRESULT WSLASession::FormatVirtualDisk(LPCWSTR Path)
     return E_NOTIMPL;
 }
 
+void WSLASession::OnUserSessionTerminating()
+{
+    std::lock_guard lock{m_lock};
+    WI_ASSERT(m_userSession != nullptr);
+
+    m_userSession = nullptr;
+    m_virtualMachine.Reset();
+}
+
 HRESULT WSLASession::Shutdown(ULONG Timeout)
 try
 {
     std::lock_guard lock{m_lock};
-    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine.has_value());
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);
 
     THROW_IF_FAILED(m_virtualMachine->Shutdown(Timeout));
 
-    m_virtualMachine.reset();
+    m_virtualMachine.Reset();
     return S_OK;
 }
 CATCH_RETURN();

--- a/src/windows/wslaservice/exe/WSLASession.cpp
+++ b/src/windows/wslaservice/exe/WSLASession.cpp
@@ -41,12 +41,10 @@ WSLASession::~WSLASession()
 
     std::lock_guard lock{m_lock};
 
-    // N.B. Since we currently allow clients to acquire a reference to WSLAVirtualMachine(), it's possible
-    // for m_virtualMachine to outlive the session if the client keeps the reference long enough.
-    // TODO: Remove this logic once GetVirtualMachine() is removed
     if (m_virtualMachine)
     {
         m_virtualMachine->OnSessionTerminated();
+        m_virtualMachine.Reset();
     }
 
     if (m_userSession != nullptr)

--- a/src/windows/wslaservice/exe/WSLASession.cpp
+++ b/src/windows/wslaservice/exe/WSLASession.cpp
@@ -25,6 +25,11 @@ WSLASession::WSLASession(const WSLA_SESSION_SETTINGS& Settings, WSLAUserSessionI
     m_virtualMachine(std::make_optional<WSLAVirtualMachine>(VmSettings, userSessionImpl.GetUserSid(), &userSessionImpl)),
     m_displayName(Settings.DisplayName)
 {
+    if (Settings.TerminationCallback != nullptr)
+    {
+        m_virtualMachine->RegisterCallback(Settings.TerminationCallback);
+    }
+
     m_virtualMachine->Start();
 }
 

--- a/src/windows/wslaservice/exe/WSLASession.h
+++ b/src/windows/wslaservice/exe/WSLASession.h
@@ -24,6 +24,7 @@ class DECLSPEC_UUID("4877FEFC-4977-4929-A958-9F36AA1892A4") WSLASession
 {
 public:
     WSLASession(const WSLA_SESSION_SETTINGS& Settings, WSLAUserSessionImpl& userSessionImpl, const VIRTUAL_MACHINE_SETTINGS& VmSettings);
+    ~WSLASession();
 
     IFACEMETHOD(GetDisplayName)(LPWSTR* DisplayName) override;
 
@@ -47,10 +48,12 @@ public:
 
     IFACEMETHOD(Shutdown(_In_ ULONG)) override;
 
+    void OnUserSessionTerminating();
+
 private:
     WSLA_SESSION_SETTINGS m_sessionSettings; // TODO: Revisit to see if we should have session settings as a member or not
-    WSLAUserSessionImpl& m_userSession;
-    std::optional<WSLAVirtualMachine> m_virtualMachine;
+    WSLAUserSessionImpl* m_userSession = nullptr;
+    Microsoft::WRL::ComPtr<WSLAVirtualMachine> m_virtualMachine;
     std::wstring m_displayName;
     std::mutex m_lock;
 };

--- a/src/windows/wslaservice/exe/WSLAUserSession.cpp
+++ b/src/windows/wslaservice/exe/WSLAUserSession.cpp
@@ -71,7 +71,7 @@ HRESULT wsl::windows::service::wsla::WSLAUserSessionImpl::CreateSession(
 
     {
         std::lock_guard lock(m_wslaSessionsLock);
-        m_wslaSessions.emplace_back(session.Get());
+        m_sessions.emplace_back(session.Get());
     }
 
     THROW_IF_FAILED(session.CopyTo(__uuidof(IWSLASession), (void**)WslaSession));

--- a/src/windows/wslaservice/exe/WSLAUserSession.cpp
+++ b/src/windows/wslaservice/exe/WSLAUserSession.cpp
@@ -24,39 +24,22 @@ WSLAUserSessionImpl::WSLAUserSessionImpl(HANDLE Token, wil::unique_tokeninfo_ptr
 
 WSLAUserSessionImpl::~WSLAUserSessionImpl()
 {
-    // Manually signal the VM termination events. This prevents being stuck on an API call that holds the VM lock.
+    // In case there are still COM references on sessions, signal that the user session is terminating
+    // so the sessions are all in a 'terminated' state.
     {
         std::lock_guard lock(m_lock);
 
-        for (auto* e : m_virtualMachines)
+        for (auto& e : m_sessions)
         {
-            e->OnSessionTerminating();
+            e->OnUserSessionTerminating();
         }
     }
 }
 
-void WSLAUserSessionImpl::OnVmTerminated(WSLAVirtualMachine* machine)
+void WSLAUserSessionImpl::OnSessionTerminated(WSLASession* Session)
 {
     std::lock_guard lock(m_lock);
-    auto pred = [machine](const auto* e) { return machine == e; };
-
-    // Remove any stale VM reference.
-    m_virtualMachines.erase(std::remove_if(m_virtualMachines.begin(), m_virtualMachines.end(), pred), m_virtualMachines.end());
-}
-
-HRESULT WSLAUserSessionImpl::CreateVirtualMachine(const VIRTUAL_MACHINE_SETTINGS* Settings, IWSLAVirtualMachine** VirtualMachine)
-{
-    auto vm = wil::MakeOrThrow<WSLAVirtualMachine>(*Settings, GetUserSid(), this);
-
-    {
-        std::lock_guard lock(m_lock);
-        m_virtualMachines.emplace_back(vm.Get());
-    }
-
-    vm->Start();
-    THROW_IF_FAILED(vm.CopyTo(__uuidof(IWSLAVirtualMachine), (void**)VirtualMachine));
-
-    return S_OK;
+    WI_VERIFY(m_sessions.erase(Session) == 1);
 }
 
 PSID WSLAUserSessionImpl::GetUserSid() const
@@ -69,10 +52,11 @@ HRESULT wsl::windows::service::wsla::WSLAUserSessionImpl::CreateSession(
 {
     auto session = wil::MakeOrThrow<WSLASession>(*Settings, *this, *VmSettings);
 
-    {
-        std::lock_guard lock(m_wslaSessionsLock);
-        m_sessions.emplace_back(session.Get());
-    }
+    std::lock_guard lock(m_wslaSessionsLock);
+    auto it = m_sessions.emplace(session.Get());
+
+    // Client now owns the session.
+    // TODO: Add a flag for the client to specify that the session should outlive its process.
 
     THROW_IF_FAILED(session.CopyTo(__uuidof(IWSLASession), (void**)WslaSession));
 
@@ -92,16 +76,6 @@ HRESULT wsl::windows::service::wsla::WSLAUserSession::GetVersion(_Out_ WSLA_VERS
 
     return S_OK;
 }
-
-HRESULT wsl::windows::service::wsla::WSLAUserSession::CreateVirtualMachine(const VIRTUAL_MACHINE_SETTINGS* Settings, IWSLAVirtualMachine** VirtualMachine)
-try
-{
-    auto session = m_session.lock();
-    RETURN_HR_IF(RPC_E_DISCONNECTED, !session);
-
-    return session->CreateVirtualMachine(Settings, VirtualMachine);
-}
-CATCH_RETURN();
 
 HRESULT wsl::windows::service::wsla::WSLAUserSession::CreateSession(
     const WSLA_SESSION_SETTINGS* Settings, const VIRTUAL_MACHINE_SETTINGS* VmSettings, IWSLASession** WslaSession)

--- a/src/windows/wslaservice/exe/WSLAUserSession.h
+++ b/src/windows/wslaservice/exe/WSLAUserSession.h
@@ -29,10 +29,9 @@ public:
 
     PSID GetUserSid() const;
 
-    HRESULT CreateVirtualMachine(const VIRTUAL_MACHINE_SETTINGS* Settings, IWSLAVirtualMachine** VirtualMachine);
     HRESULT CreateSession(const WSLA_SESSION_SETTINGS* Settings, const VIRTUAL_MACHINE_SETTINGS* VmSettings, IWSLASession** WslaSession);
 
-    void OnVmTerminated(WSLAVirtualMachine* machine);
+    void OnSessionTerminated(WSLASession* Session);
 
 private:
     wil::unique_tokeninfo_ptr<TOKEN_USER> m_tokenInfo;
@@ -41,10 +40,7 @@ private:
     std::recursive_mutex m_lock;
 
     // TODO-WSLA: Consider using a weak_ptr to easily destroy when the last client reference is released.
-    std::vector<Microsoft::WRL::ComPtr<WSLASession>> m_sessions;
-
-    // N.B. m_virtualMachines needs to be destroyed before m_session because OnVmTerminated() accesses m_virtualMachines.
-    std::vector<WSLAVirtualMachine*> m_virtualMachines; // TODO: Remove virtual machine awareness from WSLAUserSession
+    std::unordered_set<WSLASession*> m_sessions;
 };
 
 class DECLSPEC_UUID("a9b7a1b9-0671-405c-95f1-e0612cb4ce8f") WSLAUserSession
@@ -56,7 +52,6 @@ public:
     WSLAUserSession& operator=(const WSLAUserSession&) = delete;
 
     IFACEMETHOD(GetVersion)(_Out_ WSLA_VERSION* Version) override;
-    IFACEMETHOD(CreateVirtualMachine)(const VIRTUAL_MACHINE_SETTINGS* Settings, IWSLAVirtualMachine** VirtualMachine) override; // TODO: Remove virtual machine awareness from WSLAUserSession
     IFACEMETHOD(CreateSession)(const WSLA_SESSION_SETTINGS* WslaSessionSettings, const VIRTUAL_MACHINE_SETTINGS* VmSettings, IWSLASession** WslaSession) override;
     IFACEMETHOD(ListSessions)(_Out_ WSLA_SESSION_INFORMATION** Sessions, _Out_ ULONG* SessionsCount) override;
     IFACEMETHOD(OpenSession)(_In_ ULONG Id, _Out_ IWSLASession** Session) override;

--- a/src/windows/wslaservice/exe/WSLAUserSession.h
+++ b/src/windows/wslaservice/exe/WSLAUserSession.h
@@ -38,13 +38,13 @@ private:
     wil::unique_tokeninfo_ptr<TOKEN_USER> m_tokenInfo;
 
     std::recursive_mutex m_wslaSessionsLock;
-    // TODO-WSLA: Consider using a weak_ptr to easily destroy when the last client reference is released.
-    std::vector<Microsoft::WRL::ComPtr<WSLASession>> m_wslaSessions;
     std::recursive_mutex m_lock;
-    std::vector<WSLAVirtualMachine*> m_virtualMachines; // TODO: Remove virtual machine awareness from WSLAUserSession
 
     // TODO-WSLA: Consider using a weak_ptr to easily destroy when the last client reference is released.
     std::vector<Microsoft::WRL::ComPtr<WSLASession>> m_sessions;
+
+    // N.B. m_virtualMachines needs to be destroyed before m_session because OnVmTerminated() accesses m_virtualMachines.
+    std::vector<WSLAVirtualMachine*> m_virtualMachines; // TODO: Remove virtual machine awareness from WSLAUserSession
 };
 
 class DECLSPEC_UUID("a9b7a1b9-0671-405c-95f1-e0612cb4ce8f") WSLAUserSession

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -32,7 +32,7 @@ constexpr auto SAVED_STATE_FILE_EXTENSION = L".vmrs";
 constexpr auto SAVED_STATE_FILE_PREFIX = L"saved-state-";
 
 WSLAVirtualMachine::WSLAVirtualMachine(const VIRTUAL_MACHINE_SETTINGS& Settings, PSID UserSid, WSLAUserSessionImpl* Session) :
-    m_settings(Settings), m_userSid(UserSid), m_userSession(Session)
+    m_settings(Settings), m_userSid(UserSid)
 {
     THROW_IF_FAILED(CoCreateGuid(&m_vmId));
 
@@ -57,11 +57,10 @@ HRESULT WSLAVirtualMachine::GetDebugShellPipe(LPWSTR* pipePath)
 
 void WSLAVirtualMachine::OnSessionTerminated()
 {
+    // This method is called when the WSLA session is terminated.
+    // When that happens, signal the terminating event to cancel any pending operation
+
     std::lock_guard mutex(m_lock);
-    WI_ASSERT(m_userSession != nullptr);
-
-    m_userSession = nullptr;
-
     if (m_vmTerminatingEvent.is_signaled())
     {
         return;

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -992,8 +992,7 @@ try
 }
 CATCH_RETURN();
 
-HRESULT WSLAVirtualMachine::RegisterCallback(ITerminationCallback* callback)
-try
+void WSLAVirtualMachine::RegisterCallback(ITerminationCallback* callback)
 {
     std::lock_guard lock(m_lock);
 
@@ -1001,10 +1000,7 @@ try
 
     // N.B. this calls AddRef() on the callback
     m_terminationCallback = callback;
-
-    return S_OK;
 }
-CATCH_RETURN();
 
 bool WSLAVirtualMachine::ParseTtyInformation(
     const WSLA_PROCESS_FD* Fds, ULONG FdCount, const WSLA_PROCESS_FD** TtyInput, const WSLA_PROCESS_FD** TtyOutput, const WSLA_PROCESS_FD** TtyControl)

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -144,6 +144,5 @@ private:
     std::map<std::string, std::wstring> m_plan9Mounts;
     std::recursive_mutex m_lock;
     std::mutex m_portRelaylock;
-    WSLAUserSessionImpl* m_userSession;
 };
 } // namespace wsl::windows::service::wsla

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -48,7 +48,7 @@ public:
     ~WSLAVirtualMachine();
 
     void Start();
-    void OnSessionTerminating();
+    void OnSessionTerminated();
 
     IFACEMETHOD(CreateLinuxProcess(_In_ const WSLA_PROCESS_OPTIONS* Options, _Out_ IWSLAProcess** Process, _Out_ int* Errno)) override;
     IFACEMETHOD(WaitPid(_In_ LONG Pid, _In_ ULONGLONG TimeoutMs, _Out_ ULONG* State, _Out_ int* Code)) override;
@@ -119,6 +119,8 @@ private:
     PSID m_userSid{};
     wil::unique_handle m_userToken;
     std::wstring m_debugShellPipe;
+
+    std::mutex m_trackedProcessesLock;
     std::vector<WSLAProcess*> m_trackedProcesses;
 
     wsl::windows::common::hcs::unique_hcs_system m_computeSystem;

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -54,7 +54,6 @@ public:
     IFACEMETHOD(WaitPid(_In_ LONG Pid, _In_ ULONGLONG TimeoutMs, _Out_ ULONG* State, _Out_ int* Code)) override;
     IFACEMETHOD(Signal(_In_ LONG Pid, _In_ int Signal)) override;
     IFACEMETHOD(Shutdown(ULONGLONG _In_ TimeoutMs)) override;
-    IFACEMETHOD(RegisterCallback(_In_ ITerminationCallback* callback)) override;
     IFACEMETHOD(GetDebugShellPipe(_Out_ LPWSTR* pipePath)) override;
     IFACEMETHOD(MapPort(_In_ int Family, _In_ short WindowsPort, _In_ short LinuxPort, _In_ BOOL Remove)) override;
     IFACEMETHOD(Unmount(_In_ const char* Path)) override;
@@ -64,6 +63,7 @@ public:
     void MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_ LPCSTR DriversMountpoint, _In_ DWORD Flags);
 
     void OnProcessReleased(int Pid);
+    void RegisterCallback(_In_ ITerminationCallback* callback);
 
     Microsoft::WRL::ComPtr<WSLAProcess> CreateLinuxProcess(
         _In_ const WSLA_PROCESS_OPTIONS& Options, int* Errno = nullptr, const TPrepareCommandLine& PrepareCommandLine = [](const auto&) {});

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -306,7 +306,6 @@ struct WSLA_SESSION_INFORMATION
 interface IWSLAUserSession : IUnknown
 {
     HRESULT GetVersion([out] WSLA_VERSION* Version);
-    HRESULT CreateVirtualMachine([in] const VIRTUAL_MACHINE_SETTINGS* Settings, [out]IWSLAVirtualMachine** VirtualMachine); // TODO: Delete once the new API is wired.
 
     // Session managment.
     HRESULT CreateSession([in] const struct WSLA_SESSION_SETTINGS* Settings, [in] const VIRTUAL_MACHINE_SETTINGS* VmSettings, [out]IWSLASession** Session);

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -197,7 +197,6 @@ interface IWSLAVirtualMachine : IUnknown
     HRESULT WaitPid([in] LONG Pid, [in] ULONGLONG TimeoutMs,  [out] ULONG* State, [out] int* Code);
     HRESULT Signal([in] LONG Pid, [in] int Signal);
     HRESULT Shutdown([in] ULONGLONG TimeoutMs);
-    HRESULT RegisterCallback([in] ITerminationCallback* terminationCallback);
     HRESULT GetDebugShellPipe([out] LPWSTR* pipePath);
     HRESULT MapPort([in] int Family, [in] short WindowsPort, [in] short LinuxPort, [in] BOOL Remove);
     HRESULT Unmount([in] LPCSTR Path);
@@ -233,6 +232,7 @@ struct _VIRTUAL_MACHINE_SETTINGS {  // TODO: Delete once the new API is wired.
 struct WSLA_SESSION_SETTINGS {
     LPCWSTR DisplayName;
     LPCWSTR StoragePath;
+    [unique] ITerminationCallback* TerminationCallback;
 
     // TODO: Termination callback, flags
 };

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -50,7 +50,7 @@ class WSLATests
         return true;
     }
 
-    wil::com_ptr<IWSLASession> CreateSession(VIRTUAL_MACHINE_SETTINGS& vmSettings)
+    wil::com_ptr<IWSLASession> CreateSession(VIRTUAL_MACHINE_SETTINGS& vmSettings, const WSLA_SESSION_SETTINGS& sessionSettings = {L"wsla-test"})
     {
         vmSettings.RootVhdType = "ext4";
 
@@ -58,10 +58,9 @@ class WSLATests
         VERIFY_SUCCEEDED(CoCreateInstance(__uuidof(WSLAUserSession), nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&userSession)));
         wsl::windows::common::security::ConfigureForCOMImpersonation(userSession.get());
 
-        WSLA_SESSION_SETTINGS settings{L"wsla-test"};
         wil::com_ptr<IWSLASession> session;
 
-        VERIFY_SUCCEEDED(userSession->CreateSession(&settings, &vmSettings, &session));
+        VERIFY_SUCCEEDED(userSession->CreateSession(&sessionSettings, &vmSettings, &session));
         return session;
     }
 
@@ -217,40 +216,57 @@ class WSLATests
         }
     }
 
-    /*
-    TODO: Implement once available.
     TEST_METHOD(TerminationCallback)
     {
         WSL2_TEST_ONLY();
 
-        std::promise<std::pair<WslVirtualMachineTerminationReason, std::wstring>> callbackInfo;
+        class DECLSPEC_UUID("7BC4E198-6531-4FA6-ADE2-5EF3D2A04DFF") CallbackInstance
+            : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, ITerminationCallback, IFastRundown>
+        {
 
-        auto callback = [](void* context, WslVirtualMachineTerminationReason reason, LPCWSTR details) -> HRESULT {
-            auto* future = reinterpret_cast<std::promise<std::pair<WslVirtualMachineTerminationReason, std::wstring>>*>(context);
+        public:
+            CallbackInstance(std::function<void(WSLAVirtualMachineTerminationReason, LPCWSTR)>&& callback) :
+                m_callback(std::move(callback))
+            {
+            }
 
-            future->set_value(std::make_pair(reason, details));
+            HRESULT OnTermination(WSLAVirtualMachineTerminationReason Reason, LPCWSTR Details) override
+            {
+                m_callback(Reason, Details);
+                return S_OK;
+            }
 
-            return S_OK;
+        private:
+            std::function<void(WSLAVirtualMachineTerminationReason, LPCWSTR)> m_callback;
         };
 
-        WslVirtualMachineSettings settings{};
-        settings.CPU.CpuCount = 4;
+        VIRTUAL_MACHINE_SETTINGS settings{};
+        settings.CpuCount = 4;
         settings.DisplayName = L"WSLA";
-        settings.Memory.MemoryMb = 1024;
-        settings.Options.BootTimeoutMs = 30000;
-        settings.Options.TerminationCallback = callback;
-        settings.Options.TerminationContext = &callbackInfo;
+        settings.MemoryMb = 2048;
+        settings.BootTimeoutMs = 30 * 1000;
+        settings.RootVhd = testVhd.c_str();
 
-        auto vm = CreateVm(&settings);
+        std::promise<std::pair<WSLAVirtualMachineTerminationReason, std::wstring>> promise;
 
-        VERIFY_SUCCEEDED(WslShutdownVirtualMachine(vm.get(), 30 * 1000));
+        CallbackInstance callback{[&](WSLAVirtualMachineTerminationReason reason, LPCWSTR details) {
+            promise.set_value(std::make_pair(reason, details));
+        }};
 
-        auto future = callbackInfo.get_future();
-        auto result = future.wait_for(std::chrono::seconds(10));
+        WSLA_SESSION_SETTINGS sessionSettings{L"wsla-test"};
+        sessionSettings.TerminationCallback = &callback;
+
+        auto session = CreateSession(settings, sessionSettings);
+
+        wil::com_ptr<IWSLAVirtualMachine> vm;
+        VERIFY_SUCCEEDED(session->GetVirtualMachine(&vm));
+        VERIFY_SUCCEEDED(vm->Shutdown(30 * 1000));
+        auto future = promise.get_future();
+        auto result = future.wait_for(std::chrono::seconds(30));
         auto [reason, details] = future.get();
-        VERIFY_ARE_EQUAL(reason, WslVirtualMachineTerminationReasonShutdown);
+        VERIFY_ARE_EQUAL(reason, WSLAVirtualMachineTerminationReasonShutdown);
         VERIFY_ARE_NOT_EQUAL(details, L"");
-    }*/
+    }
 
     TEST_METHOD(InteractiveShell)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change does multiple things:

- Remove support for WSLAUserSession::CreateVirtualMachine(), since that was clashing with the WSLASesssion destruction logic
- Rework reference management so that the destruction logic is correct regardless of which COM reference are released first
- Implement the VM termination callback and re-enable test coverage

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
