### PR TITLE
Fix service crash when collecting a linux crash dump when maxCrashDumpCount is set to 0

### DIFF
--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -594,6 +594,8 @@ std::wstring wsl::windows::common::wslutil::DownloadFile(std::wstring_view Url, 
 
 void wsl::windows::common::wslutil::EnforceFileLimit(LPCWSTR Path, size_t Limit, const std::function<bool(const std::filesystem::directory_entry&)>& pred)
 {
+    WI_ASSERT(Limit > 0);
+
     std::map<std::filesystem::file_time_type, std::filesystem::path> files;
     for (auto const& e : std::filesystem::directory_iterator{Path})
     {
@@ -603,7 +605,7 @@ void wsl::windows::common::wslutil::EnforceFileLimit(LPCWSTR Path, size_t Limit,
         }
     }
 
-    if (Limit < 0 || files.size() < Limit)
+    if (files.size() < Limit)
     {
         return;
     }

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -594,7 +594,10 @@ std::wstring wsl::windows::common::wslutil::DownloadFile(std::wstring_view Url, 
 
 void wsl::windows::common::wslutil::EnforceFileLimit(LPCWSTR Path, size_t Limit, const std::function<bool(const std::filesystem::directory_entry&)>& pred)
 {
-    WI_ASSERT(Limit > 0);
+    if (Limit <= 0)
+    {
+        return;
+    }
 
     std::map<std::filesystem::file_time_type, std::filesystem::path> files;
     for (auto const& e : std::filesystem::directory_iterator{Path})

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1272,7 +1272,10 @@ void WslCoreVm::CollectCrashDumps(wil::unique_socket&& listenSocket) const
                        e.path().filename().string().find(dumpPrefix) == 0;
             };
 
-            wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
+            if (m_vmConfig.MaxCrashDumpCount > 0)
+            {
+                wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
+            }
 
             wil::unique_hfile file{CreateFileW(fullPath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_TEMPORARY, nullptr)};
             THROW_LAST_ERROR_IF(!file);
@@ -2381,7 +2384,10 @@ void WslCoreVm::OnCrash(_In_ LPCWSTR Details)
                    e.path().extension() == c_extension && e.path().has_filename() && e.path().filename().wstring().find(c_prefix) == 0;
         };
 
-        wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
+        if (m_vmConfig.MaxCrashDumpCount > 0)
+        {
+            wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
+        }
 
         {
             std::wofstream outputFile(tracePath.wstring());

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1272,10 +1272,7 @@ void WslCoreVm::CollectCrashDumps(wil::unique_socket&& listenSocket) const
                        e.path().filename().string().find(dumpPrefix) == 0;
             };
 
-            if (m_vmConfig.MaxCrashDumpCount > 0)
-            {
-                wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
-            }
+            wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
 
             wil::unique_hfile file{CreateFileW(fullPath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_TEMPORARY, nullptr)};
             THROW_LAST_ERROR_IF(!file);
@@ -2384,10 +2381,7 @@ void WslCoreVm::OnCrash(_In_ LPCWSTR Details)
                    e.path().extension() == c_extension && e.path().has_filename() && e.path().filename().wstring().find(c_prefix) == 0;
         };
 
-        if (m_vmConfig.MaxCrashDumpCount > 0)
-        {
-            wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
-        }
+        wsl::windows::common::wslutil::EnforceFileLimit(m_vmConfig.CrashDumpFolder.c_str(), m_vmConfig.MaxCrashDumpCount, pred);
 
         {
             std::wofstream outputFile(tracePath.wstring());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a potential service crash that can hit when a linux crash dump is collected when `wsl2.maxCrashDumpCount` is set to zero and the crash folder doesn't contain any crash files. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
