### PR TITLE
Fix midl warning around WSLA_CONTAINER strings being const

### DIFF
--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -153,8 +153,8 @@ enum WSLA_CONTAINER_STATE
 
 struct WSLA_CONTAINER
 {
-    LPCWSTR Name;
-    LPCWSTR Image;
+    LPWSTR Name;
+    LPWSTR Image;
     enum WSLA_CONTAINER_STATE State;
 
     // TODO: Add creation timestamp and other fields that the command line tool might want to display.


### PR DESCRIPTION
This change resolves the below MIDL warnings.

```
.\wslaservice.idl(277): warning MIDL2279: [out] parameters may not have "const" : [ Type 'LPCWSTR' ( Parameter 'Images' ) ] [C:\src\WSL\src\windows\wslaservice\inc\wslaserviceidl.vcxproj]
.\wslaservice.idl(277): warning MIDL2279: [out] parameters may not have "const" : [ Type 'LPCWSTR' ( Parameter 'Images' ) ] [C:\src\WSL\src\windows\wslaservice\inc\wslaserviceidl.vcxproj]
```