### PR TITLE
WSLA: Implement virtioproxy networking mode

### DIFF
--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1547,7 +1547,7 @@ int WslaShell(_In_ std::wstring_view commandLine)
     settings.DisplayName = L"WSLA";
     settings.MemoryMb = 1024;
     settings.BootTimeoutMs = 30000;
-    settings.NetworkingMode = WSLANetworkingMode::WSLANetworkingModeNAT;
+    settings.NetworkingMode = WSLANetworkingModeNAT;
     std::wstring containerRootVhd;
     bool help = false;
 

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1547,7 +1547,7 @@ int WslaShell(_In_ std::wstring_view commandLine)
     settings.DisplayName = L"WSLA";
     settings.MemoryMb = 1024;
     settings.BootTimeoutMs = 30000;
-    settings.NetworkingMode = WSLANetworkingModeNAT;
+    settings.NetworkingMode = WSLANetworkingMode::WSLANetworkingModeNAT;
     std::wstring containerRootVhd;
     bool help = false;
 
@@ -1557,6 +1557,7 @@ int WslaShell(_In_ std::wstring_view commandLine)
     parser.AddArgument(reinterpret_cast<bool&>(settings.EnableDnsTunneling), L"--dns-tunneling");
     parser.AddArgument(Integer(settings.MemoryMb), L"--memory");
     parser.AddArgument(Integer(settings.CpuCount), L"--cpu");
+    parser.AddArgument(Integer(reinterpret_cast<int&>(settings.NetworkingMode)), L"--networking-mode");
     parser.AddArgument(Utf8String(fsType), L"--fstype");
     parser.AddArgument(containerRootVhd, L"--container-vhd");
     parser.AddArgument(help, L"--help");
@@ -1565,11 +1566,21 @@ int WslaShell(_In_ std::wstring_view commandLine)
     if (help)
     {
         const auto usage = std::format(
-            LR"({} --wsla [--vhd </path/to/vhd>] [--shell </path/to/shell>] [--memory <memory-mb>] [--cpu <cpus>] [--dns-tunneling] [--fstype <fstype>] [--container-vhd </path/to/vhd>] [--help])",
+            LR"({} --wsla [--vhd </path/to/vhd>] [--shell </path/to/shell>] [--memory <memory-mb>] [--cpu <cpus>] [--dns-tunneling] [--networking-mode <mode>] [--fstype <fstype>] [--container-vhd </path/to/vhd>] [--help])",
             WSL_BINARY_NAME);
 
         wprintf(L"%ls\n", usage.c_str());
         return 1;
+    }
+
+    switch (settings.NetworkingMode)
+    {
+    case WSLANetworkingMode::WSLANetworkingModeNone:
+    case WSLANetworkingMode::WSLANetworkingModeNAT:
+    case WSLANetworkingMode::WSLANetworkingModeVirtioProxy:
+        break;
+    default:
+        THROW_HR(E_INVALIDARG);
     }
 
     if (!containerRootVhd.empty())

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -16,6 +16,8 @@ Abstract:
 #include "INetworkingEngine.h"
 #include "hcs.hpp"
 #include "Dmesg.h"
+#include "DnsResolver.h"
+#include "GuestDeviceManager.h"
 #include "WSLAApi.h"
 #include "WSLAProcess.h"
 
@@ -120,7 +122,7 @@ private:
     int m_coldDiscardShiftSize{};
     bool m_running = false;
     PSID m_userSid{};
-    wil::unique_handle m_userToken;
+    wil::shared_handle m_userToken;
     std::wstring m_debugShellPipe;
 
     std::mutex m_trackedProcessesLock;
@@ -133,6 +135,7 @@ private:
     bool m_vmSavedStateCaptured = false;
     bool m_crashLogCaptured = false;
 
+    std::shared_ptr<GuestDeviceManager> m_guestDeviceManager;
     std::shared_ptr<DmesgCollector> m_dmesgCollector;
     wil::unique_event m_vmExitEvent{wil::EventOptions::ManualReset};
     wil::unique_event m_vmTerminatingEvent{wil::EventOptions::ManualReset};

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -209,7 +209,8 @@ interface IWSLAVirtualMachine : IUnknown
 typedef enum _WSLANetworkingMode
 {
     WSLANetworkingModeNone,
-    WSLANetworkingModeNAT
+    WSLANetworkingModeNAT,
+    WSLANetworkingModeVirtioProxy
 } WSLANetworkingMode;
 
 typedef

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -380,6 +380,31 @@ class WSLATests
         VERIFY_ARE_EQUAL(result.Output[1], std::format("nameserver {}\n", LX_INIT_DNS_TUNNELING_IP_ADDRESS));
     }
 
+    TEST_METHOD(VirtioProxyNetworking)
+    {
+        WSL2_TEST_ONLY();
+
+        VIRTUAL_MACHINE_SETTINGS settings{};
+        settings.CpuCount = 4;
+        settings.DisplayName = L"WSLA";
+        settings.MemoryMb = 2048;
+        settings.BootTimeoutMs = 30 * 1000;
+        settings.NetworkingMode = WSLANetworkingModeVirtioProxy;
+        settings.RootVhd = testVhd.c_str();
+
+        auto session = CreateSession(settings);
+
+        // Validate that eth0 has an ip address
+        ExpectCommandResult(
+            session.get(),
+            {"/bin/bash",
+             "-c",
+             "ip a  show dev eth0 | grep -iF 'inet ' |  grep -E '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}'"},
+            0);
+
+        ExpectCommandResult(session.get(), {"/bin/grep", "-iF", "nameserver", "/etc/resolv.conf"}, 0);
+    }
+
     TEST_METHOD(OpenFiles)
     {
         WSL2_TEST_ONLY();


### PR DESCRIPTION
This change implements the VirtioProxy networking mode for WSLA. This required moving the VirtioProxy and GnsChannel classes into the common library (with NatNetworking). I also included the cleanup change to VirtioNetworking that was just merged to main in this PR.

DNS tunneling is currently not supported with this networking mode, so an error is returned. With this change I have updated the default networking move of `wsl.exe --wsla` to also use VirtioProxy networking mode.