### PR TITLE
cleanup: switch from Microsoft::WRL::ComPtr to wil::com_ptr

### DIFF
--- a/src/windows/common/svccomm.cpp
+++ b/src/windows/common/svccomm.cpp
@@ -540,9 +540,7 @@ wsl::windows::common::SvcComm::SvcComm()
     };
 
     wsl::shared::retry::RetryWithTimeout<void>(
-        [this]() {
-            m_userSession = wil::CoCreateInstance<LxssUserSession, ILxssUserSession>(CLSCTX_LOCAL_SERVER);
-        },
+        [this]() { m_userSession = wil::CoCreateInstance<LxssUserSession, ILxssUserSession>(CLSCTX_LOCAL_SERVER); },
         std::chrono::seconds(1),
         std::chrono::minutes(1),
         retry_pred);

--- a/src/windows/common/svccomm.cpp
+++ b/src/windows/common/svccomm.cpp
@@ -541,15 +541,14 @@ wsl::windows::common::SvcComm::SvcComm()
 
     wsl::shared::retry::RetryWithTimeout<void>(
         [this]() {
-            THROW_IF_FAILED(CoCreateInstance(__uuidof(LxssUserSession), nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&m_userSession)));
+            m_userSession = wil::CoCreateInstance<LxssUserSession, ILxssUserSession>(CLSCTX_LOCAL_SERVER);
         },
         std::chrono::seconds(1),
         std::chrono::minutes(1),
         retry_pred);
 
     // Query client security interface.
-    wil::com_ptr_nothrow<IClientSecurity> clientSecurity;
-    THROW_IF_FAILED(m_userSession->QueryInterface(IID_PPV_ARGS(&clientSecurity)));
+    auto clientSecurity = m_userSession.query<IClientSecurity>();
 
     // Get the current proxy blanket settings.
     DWORD authnSvc, authzSvc, authnLvl, capabilities;

--- a/src/windows/inc/comservicehelper.h
+++ b/src/windows/inc/comservicehelper.h
@@ -77,7 +77,7 @@ namespace Windows { namespace Internal {
             // Tell COM how to mask fatal exceptions.
             if (ownProcess)
             {
-                Microsoft::WRL::ComPtr<IGlobalOptions> pIGLB;
+                wil::com_ptr<IGlobalOptions> pIGLB;
                 RETURN_IF_FAILED(CoCreateInstance(CLSID_GlobalOptions, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pIGLB)));
                 RETURN_IF_FAILED(pIGLB->Set(COMGLB_EXCEPTION_HANDLING, TExceptionPolicy));
             }
@@ -294,7 +294,7 @@ namespace Windows { namespace Internal {
         bool m_addedModuleReference = false;
 
         // COM callback object to support unloading shared-process services
-        Microsoft::WRL::ComPtr<IContextCallback> m_icc;
+        wil::com_ptr<IContextCallback> m_icc;
 
         // COM Server descriptor
         ServerDescriptor m_serverDescriptor{};

--- a/src/windows/service/exe/LxssIpTables.h
+++ b/src/windows/service/exe/LxssIpTables.h
@@ -262,7 +262,7 @@ private:
     /// <summary>
     /// COM firewall instance.
     /// </summary>
-    Microsoft::WRL::ComPtr<INetFwPolicy2> m_firewall;
+    wil::com_ptr<INetFwPolicy2> m_firewall;
 
     /// <summary>
     /// Lock to protect class members.
@@ -295,7 +295,7 @@ public:
     /// <summary>
     /// Constructor to take ownership of an existing rule.
     /// </summary>
-    LxssNetworkingFirewallPort(const std::shared_ptr<LxssNetworkingFirewall>& Firewall, const Microsoft::WRL::ComPtr<INetFwRule>& Existing);
+    LxssNetworkingFirewallPort(const std::shared_ptr<LxssNetworkingFirewall>& Firewall, const wil::com_ptr<INetFwRule>& Existing);
 
     /// <summary>
     /// Destructor.

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2674,8 +2674,7 @@ try
     THROW_IF_FAILED(shellLink->SetArguments(commandLine.c_str()));
     THROW_IF_FAILED(shellLink->SetIconLocation(ShortcutIcon, 0));
 
-    Microsoft::WRL::ComPtr<IPersistFile> storage;
-    THROW_IF_FAILED(shellLink->QueryInterface(IID_IPersistFile, &storage));
+    auto storage = shellLink.query<IPersistFile>();
     THROW_IF_FAILED(storage->Save(shortcutPath.c_str(), true));
 
     registration.Write(Property::ShortcutPath, shortcutPath.c_str());

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -351,7 +351,7 @@ private:
     wsl::shared::SocketChannel m_miniInitChannel;
     wil::unique_socket m_notifyChannel;
     SE_SID m_userSid;
-    Microsoft::WRL::ComPtr<DeviceHostProxy> m_deviceHostSupport;
+    wil::com_ptr<DeviceHostProxy> m_deviceHostSupport;
     std::shared_ptr<LxssRunningInstance> m_systemDistro;
     _Guarded_by_(m_lock) std::bitset<MAX_VHD_COUNT> m_lunBitmap;
     _Guarded_by_(m_lock) std::map<AttachedDisk, DiskState> m_attachedDisks;

--- a/test/windows/PolicyTests.cpp
+++ b/test/windows/PolicyTests.cpp
@@ -327,7 +327,7 @@ class PolicyTest
             const auto stop = std::chrono::steady_clock::now() + std::chrono::seconds{30};
             for (;;)
             {
-                Microsoft::WRL::ComPtr<ILxssUserSession> session;
+                wil::com_ptr<ILxssUserSession> session;
                 result = CoCreateInstance(CLSID_LxssUserSession, nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&session));
                 if (result == expectedResult || std::chrono::steady_clock::now() > stop)
                 {

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2448,8 +2448,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         // Validate that the shortcut is actually in the start menu
         VERIFY_IS_TRUE(shortcutPath.find(startMenu) != std::string::npos);
 
-        Microsoft::WRL::ComPtr<IPersistFile> storage;
-        VERIFY_SUCCEEDED(shellLink->QueryInterface(IID_IPersistFile, &storage));
+        auto storage = shellLink.query<IPersistFile>();
 
         VERIFY_SUCCEEDED(storage->Load(shortcutPath.c_str(), 0));
 


### PR DESCRIPTION
This pull request refactors COM pointer usage throughout the codebase to consistently use the `wil::com_ptr` smart pointer and related helper functions, replacing the previous use of `Microsoft::WRL::ComPtr`.