### PR TITLE
User/oneblue/initial tty size

### DIFF
--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1666,10 +1666,8 @@ struct WSLA_TTY_RELAY
     int32_t TtyInput;
     int32_t TtyOutput;
     int32_t TtyControl;
-    uint32_t Rows;
-    uint32_t Columns;
 
-    PRETTY_PRINT(FIELD(Header), FIELD(TtyMaster), FIELD(TtyInput), FIELD(TtyOutput), FIELD(TtyControl), FIELD(Rows), FIELD(Columns));
+    PRETTY_PRINT(FIELD(Header), FIELD(TtyMaster), FIELD(TtyInput), FIELD(TtyOutput), FIELD(TtyControl));
 };
 
 struct WSLA_ACCEPT

--- a/src/windows/common/WSLAProcessLauncher.cpp
+++ b/src/windows/common/WSLAProcessLauncher.cpp
@@ -48,6 +48,12 @@ void WSLAProcessLauncher::AddFd(WSLA_PROCESS_FD Fd)
     m_fds.push_back(Fd);
 }
 
+void WSLAProcessLauncher::SetTtySize(ULONG Rows, ULONG Columns)
+{
+    m_rows = Rows;
+    m_columns = Columns;
+}
+
 std::tuple<WSLA_PROCESS_OPTIONS, std::vector<const char*>, std::vector<const char*>> WSLAProcessLauncher::CreateProcessOptions()
 {
     std::vector<const char*> commandLine;
@@ -64,6 +70,8 @@ std::tuple<WSLA_PROCESS_OPTIONS, std::vector<const char*>, std::vector<const cha
     options.FdsCount = static_cast<DWORD>(m_fds.size());
     options.Environment = environment.data();
     options.EnvironmentCount = static_cast<DWORD>(environment.size());
+    options.TtyColumns = m_columns;
+    options.TtyRows = m_rows;
 
     return std::make_tuple(options, std::move(commandLine), std::move(environment));
 }

--- a/src/windows/common/WSLAProcessLauncher.h
+++ b/src/windows/common/WSLAProcessLauncher.h
@@ -96,6 +96,8 @@ protected:
     std::string m_executable;
     std::vector<std::string> m_arguments;
     std::vector<std::string> m_environment;
+    DWORD m_rows = 0;
+    DWORD m_columns = 0;
 };
 
 } // namespace wsl::windows::common

--- a/src/windows/common/WSLAProcessLauncher.h
+++ b/src/windows/common/WSLAProcessLauncher.h
@@ -82,6 +82,7 @@ public:
         ProcessFlags Flags = ProcessFlags::Stdout | ProcessFlags::Stderr);
 
     void AddFd(WSLA_PROCESS_FD Fd);
+    void SetTtySize(ULONG Rows, ULONG Columns);
 
     // TODO: Add overloads for IWSLAContainer once implemented.
     ClientRunningWSLAProcess Launch(IWSLASession& Session);

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1611,6 +1611,10 @@ int WslaShell(_In_ std::wstring_view commandLine)
     launcher.AddFd(WSLA_PROCESS_FD{.Fd = 1, .Type = WSLAFdTypeTerminalOutput});
     launcher.AddFd(WSLA_PROCESS_FD{.Fd = 2, .Type = WSLAFdTypeTerminalControl});
 
+    // Add the terminal size.
+    CONSOLE_SCREEN_BUFFER_INFOEX Info{};
+    Info.cbSize = sizeof(Info);
+
     auto process = launcher.Launch(*session);
 
     // Configure console for interactive usage.

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1606,21 +1606,23 @@ int WslaShell(_In_ std::wstring_view commandLine)
         THROW_HR_IF(E_FAIL, initProcess.WaitAndCaptureOutput().Code != 0);
     }
 
+    // Get the terminal size.
+    HANDLE Stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+    HANDLE Stdin = GetStdHandle(STD_INPUT_HANDLE);
+
+    CONSOLE_SCREEN_BUFFER_INFOEX Info{};
+    Info.cbSize = sizeof(Info);
+    THROW_IF_WIN32_BOOL_FALSE(::GetConsoleScreenBufferInfoEx(Stdout, &Info));
+
     wsl::windows::common::WSLAProcessLauncher launcher{shell, {shell}, {"TERM=xterm-256color"}, ProcessFlags::None};
     launcher.AddFd(WSLA_PROCESS_FD{.Fd = 0, .Type = WSLAFdTypeTerminalInput});
     launcher.AddFd(WSLA_PROCESS_FD{.Fd = 1, .Type = WSLAFdTypeTerminalOutput});
     launcher.AddFd(WSLA_PROCESS_FD{.Fd = 2, .Type = WSLAFdTypeTerminalControl});
-
-    // Add the terminal size.
-    CONSOLE_SCREEN_BUFFER_INFOEX Info{};
-    Info.cbSize = sizeof(Info);
+    launcher.SetTtySize(Info.srWindow.Bottom - Info.srWindow.Top + 1, Info.srWindow.Right - Info.srWindow.Left + 1);
 
     auto process = launcher.Launch(*session);
 
     // Configure console for interactive usage.
-
-    HANDLE Stdout = GetStdHandle(STD_OUTPUT_HANDLE);
-    HANDLE Stdin = GetStdHandle(STD_INPUT_HANDLE);
     {
         DWORD OutputMode{};
         THROW_LAST_ERROR_IF(!::GetConsoleMode(Stdout, &OutputMode));

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -863,6 +863,8 @@ Microsoft::WRL::ComPtr<WSLAProcess> WSLAVirtualMachine::CreateLinuxProcess(_In_ 
         relayMessage.TtyInput = ttyInput->Fd;
         relayMessage.TtyOutput = ttyOutput->Fd;
         relayMessage.TtyControl = ttyControl == nullptr ? -1 : ttyControl->Fd;
+        relayMessage.Rows = Options.TtyRows;
+        relayMessage.Columns = Options.TtyColumns;
         childChannel.SendMessage(relayMessage);
 
         auto result = ExpectClosedChannelOrError(childChannel);

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -82,7 +82,8 @@ private:
     void OnCrash(_In_ const HCS_EVENT* Event);
 
     std::tuple<int32_t, int32_t, wsl::shared::SocketChannel> Fork(enum WSLA_FORK::ForkType Type);
-    std::tuple<int32_t, int32_t, wsl::shared::SocketChannel> Fork(wsl::shared::SocketChannel& Channel, enum WSLA_FORK::ForkType Type);
+    std::tuple<int32_t, int32_t, wsl::shared::SocketChannel> Fork(
+        wsl::shared::SocketChannel& Channel, enum WSLA_FORK::ForkType Type, ULONG TtyRows = 0, ULONG TtyColumns = 0);
     int32_t ExpectClosedChannelOrError(wsl::shared::SocketChannel& Channel);
 
     ConnectedSocket ConnectSocket(wsl::shared::SocketChannel& Channel, int32_t Fd);

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -112,6 +112,8 @@ struct WSLA_PROCESS_OPTIONS
     ULONG EnvironmentCount;
     [unique, size_is(FdsCount)] WSLA_PROCESS_FD *Fds;
     int FdsCount;
+    ULONG TtyRows; // Only needed when tty fd's are passed.
+    ULONG TtyColumns;
 };
 
 struct WSLA_VOLUME


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the CreateLinuxProcess() to take in the tty size, so it's correctly set even the the Windows terminal is never manually resized. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
