### PR TITLE
virtio networking: fix two minor issues

### DIFF
--- a/src/windows/common/NatNetworking.cpp
+++ b/src/windows/common/NatNetworking.cpp
@@ -506,23 +506,12 @@ CATCH_LOG()
 
 void NatNetworking::UpdateMtu()
 {
-    unique_interface_table interfaceTable{};
-    THROW_IF_WIN32_ERROR(::GetIpInterfaceTable(AF_UNSPEC, &interfaceTable));
-
-    ULONG minMtu = ULONG_MAX;
-    for (ULONG index = 0; index < interfaceTable.get()->NumEntries; index++)
-    {
-        const auto& ipInterface = interfaceTable.get()->Table[index];
-        if (ipInterface.Connected)
-        {
-            minMtu = std::min(ipInterface.NlMtu, minMtu);
-        }
-    }
+    const auto minMtu = GetMinimumConnectedInterfaceMtu();
 
     // Only send the update if the MTU changed.
-    if (minMtu != ULONG_MAX && minMtu != m_networkMtu)
+    if (minMtu && minMtu.value() != m_networkMtu)
     {
-        m_networkMtu = minMtu;
+        m_networkMtu = minMtu.value();
 
         hns::ModifyGuestEndpointSettingRequest<hns::NetworkInterface> notification{};
         notification.ResourceType = hns::GuestEndpointResourceType::Interface;

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -24,6 +24,8 @@ VirtioNetworking::VirtioNetworking(
 
 VirtioNetworking::~VirtioNetworking()
 {
+    // Unregister the network notification callback to prevent it from using the GNS channel.
+    m_networkNotifyHandle.reset();
     // Stop the GNS channel to unblock any stuck communications with the guest.
     m_gnsChannel.Stop();
 }

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -22,6 +22,12 @@ VirtioNetworking::VirtioNetworking(
 {
 }
 
+VirtioNetworking::~VirtioNetworking()
+{
+    // Stop the GNS channel to unblock any stuck communications with the guest.
+    m_gnsChannel.Stop();
+}
+
 void VirtioNetworking::Initialize()
 try
 {
@@ -271,32 +277,25 @@ void VirtioNetworking::UpdateDns(hns::DNS&& dnsSettings)
 
 void VirtioNetworking::UpdateMtu()
 {
-    unique_interface_table interfaceTable{};
-    THROW_IF_WIN32_ERROR(::GetIpInterfaceTable(AF_UNSPEC, &interfaceTable));
-
-    ULONG minMtu = ULONG_MAX;
-    for (ULONG index = 0; index < interfaceTable.get()->NumEntries; index++)
-    {
-        const auto& ipInterface = interfaceTable.get()->Table[index];
-        if (ipInterface.Connected)
-        {
-            minMtu = std::min(ipInterface.NlMtu, minMtu);
-        }
-    }
+    const auto minMtu = GetMinimumConnectedInterfaceMtu();
 
     // Only send the update if the MTU changed.
-    if (minMtu != ULONG_MAX && minMtu != m_networkMtu)
+    if (minMtu && minMtu.value() != m_networkMtu)
     {
+        m_networkMtu = minMtu.value();
+
         hns::ModifyGuestEndpointSettingRequest<hns::NetworkInterface> notification{};
         notification.ResourceType = hns::GuestEndpointResourceType::Interface;
         notification.RequestType = hns::ModifyRequestType::Update;
-        notification.Settings.NlMtu = m_networkMtu;
         notification.Settings.Connected = true;
+        notification.Settings.NlMtu = m_networkMtu;
 
-        WSL_LOG("VirtioNetworking::UpdateMtu", TraceLoggingValue(m_networkMtu, "VirtioMtu"));
+        WSL_LOG(
+            "VirtioNetworking::UpdateMtu",
+            TraceLoggingValue(m_adapterId, "endpointId"),
+            TraceLoggingValue(m_networkMtu, "virtioMtu"));
 
-        // TODO: Why was this commented ?
-        // m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_endpointId);
+        m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId);
     }
 }
 

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -14,7 +14,7 @@ class VirtioNetworking : public INetworkingEngine
 {
 public:
     VirtioNetworking(GnsChannel&& gnsChannel, bool enableLocalhostRelay, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
-    ~VirtioNetworking() = default;
+    ~VirtioNetworking();
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.
     VirtioNetworking(const VirtioNetworking&) = delete;

--- a/src/windows/common/WslCoreNetworkingSupport.h
+++ b/src/windows/common/WslCoreNetworkingSupport.h
@@ -457,6 +457,11 @@ std::vector<wsl::core::networking::CurrentInterfaceInformation> EnumerateConnect
 bool IsMetered(ABI::Windows::Networking::Connectivity::NetworkCostType cost) noexcept;
 
 /// <summary>
+/// Gets the minimum MTU across all connected network interfaces.
+/// </summary>
+std::optional<ULONG> GetMinimumConnectedInterfaceMtu() noexcept;
+
+/// <summary>
 /// This instance acts as an IP_ADAPTER_ADDRESS pointer.
 /// </summary>
 class AdapterAddresses;


### PR DESCRIPTION
This change resolves two minor issues with the virtio proxy networking mode.
1. Stop the GNS channel when tearing down the VirtioNetworking class
2. Update logic to plumb through the MTU to the virtual adapter in the guest