### PR TITLE
test: improve test logging infra

### DIFF
--- a/test/linux/unit_tests/unittests.c
+++ b/test/linux/unit_tests/unittests.c
@@ -103,11 +103,11 @@ int main(int Argc, char* Argv[], char** Envp)
 
             if (LXT_SUCCESS(Result))
             {
-                LxtLogPassed("%s", false, LxtTests[Itr].Name);
+                LxtLogPassed("%s", LxtTests[Itr].Name);
             }
             else
             {
-                LxtLogError("%s", false, LxtTests[Itr].Name);
+                LxtLogError("%s", LxtTests[Itr].Name);
             }
 
             goto ErrorExit;

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1907,7 +1907,8 @@ Return Value:
     }
 
     LaunchArguments += CommandLine;
-    LogInfo("Test process exited with: %lu", LxsstuLaunchWsl(LaunchArguments.c_str()));
+    DWORD ExitCode = LxsstuLaunchWsl(LaunchArguments.c_str());
+    LogInfo("Test process exited with: %lu", ExitCode);
 
     //
     // Parse the contents of the linux log(s) files and relog.
@@ -1917,8 +1918,10 @@ Return Value:
     {
         THROW_IF_NTSTATUS_FAILED(LxsstuParseLinuxLogFiles(LogFileName, &TestPassed));
 
-        THROW_HR_IF(E_FAIL, !TestPassed);
+        VERIFY_IS_TRUE(TestPassed);
     }
+
+    VERIFY_ARE_EQUAL(0, ExitCode);
 
     return;
 }


### PR DESCRIPTION
While debugging a different test failure, I noticed two things:

1. It is possible that a crashing test process could still result in a passing test (if the test binary crashed without logging an error first)
2. There was an incorrect printf format string causing "PASS: null" to be printed instead of the test name