### PR TITLE
Enable the CreateContainer stdin test

### DIFF
--- a/src/windows/wslaservice/exe/WSLAContainer.cpp
+++ b/src/windows/wslaservice/exe/WSLAContainer.cpp
@@ -88,7 +88,6 @@ Microsoft::WRL::ComPtr<WSLAContainer> WSLAContainer::Create(const WSLA_CONTAINER
     if (hasStdin)
     {
         // For now return a proper error if the caller tries to pass stdin without a TTY to prevent hangs.
-        THROW_WIN32_IF(ERROR_NOT_SUPPORTED, hasTty == false);
         inputOptions.push_back("-i");
     }
 

--- a/src/windows/wslaservice/exe/WSLAContainer.cpp
+++ b/src/windows/wslaservice/exe/WSLAContainer.cpp
@@ -87,7 +87,6 @@ Microsoft::WRL::ComPtr<WSLAContainer> WSLAContainer::Create(const WSLA_CONTAINER
     std::vector<std::string> inputOptions;
     if (hasStdin)
     {
-        // For now return a proper error if the caller tries to pass stdin without a TTY to prevent hangs.
         inputOptions.push_back("-i");
     }
 

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1230,32 +1230,31 @@ class WSLATests
             ValidateProcessOutput(process, {{1, "testvalue\n"}});
         }
 
-        // Validate that starting containers works with the default entrypoint.
+        // Validate that starting containers works with the default entrypoint and content on stdin
         {
             WSLAContainerLauncher launcher(
                 "debian:latest", "test-default-entrypoint", "/bin/cat", {}, {}, ProcessFlags::Stdin | ProcessFlags::Stdout | ProcessFlags::Stderr);
 
             // For now, validate that trying to use stdin without a tty returns the appropriate error.
-            auto result = wil::ResultFromException([&]() { auto container = launcher.Launch(*session); });
+            auto container = launcher.Launch(*session);
 
-            VERIFY_ARE_EQUAL(result, HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED));
-
-            // This is hanging. nerdctl run seems to hang with -i is passed outside of a TTY context.
-            // TODO: Restore the test case once this is fixed.
-
-            /*
+            // TODO: nerdctl hangs if stdin is closed without writting to it.
+            // Add test coverage for that usecase once that the hang is fixed.
             auto process = container.GetInitProcess();
+            auto input = process.GetStdHandle(0);
 
-            std::string shellInput = "echo $SHELL\n exit";
-            std::unique_ptr<OverlappedIOHandle> writeStdin(
-                new WriteHandle(process.GetStdHandle(0), {shellInput.begin(), shellInput.end()}));
+            std::string shellInput = "foo";
+            std::vector<char> inputBuffer{shellInput.begin(), shellInput.end()};
+
+            std::unique_ptr<OverlappedIOHandle> writeStdin(new WriteHandle(std::move(input), inputBuffer));
+
             std::vector<std::unique_ptr<OverlappedIOHandle>> extraHandles;
             extraHandles.emplace_back(std::move(writeStdin));
 
             auto result = process.WaitAndCaptureOutput(INFINITE, std::move(extraHandles));
 
-            VERIFY_ARE_EQUAL(result.Output[1], "bash\n");
-            */
+            VERIFY_ARE_EQUAL(result.Output[2], "");
+            VERIFY_ARE_EQUAL(result.Output[1], "foo");
         }
 
         // Validate that stdin is empty if ProcessFlags::Stdin is not passed.

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1238,8 +1238,8 @@ class WSLATests
             // For now, validate that trying to use stdin without a tty returns the appropriate error.
             auto container = launcher.Launch(*session);
 
-            // TODO: nerdctl hangs if stdin is closed without writting to it.
-            // Add test coverage for that usecase once that the hang is fixed.
+            // TODO: nerdctl hangs if stdin is closed without writing to it.
+            // Add test coverage for that usecase once the hang is fixed.
             auto process = container.GetInitProcess();
             auto input = process.GetStdHandle(0);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Turns out that nerdctl only hangs if nothing is written on stdin before closing, so let's at least have test coverage for that scenario until the nerdctl hang is fixed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
