### PR TITLE
Add back WSL2_VM_ID environment variable to the system distro.

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2258,7 +2258,16 @@ Return Value:
     if (Value != nullptr)
     {
         Config.VmId = Value;
-        unsetenv(LX_WSL2_VM_ID_ENV);
+
+        //
+        // Unset the environment variable for user distros.
+        //
+
+        Value = getenv(LX_WSL2_SHARED_MEMORY_OB_DIRECTORY);
+        if (!Value)
+        {
+            unsetenv(LX_WSL2_VM_ID_ENV);
+        }
     }
 
     //


### PR DESCRIPTION
This change adds back the VM ID environment variable to the system distro (WSLg runtime environment). Turns out weston has a dependency on this environment variable: https://github.com/microsoft/weston-mirror/blob/2318fecaeac1f1a2d5a7a042c34d931c71dae04c/rdprail-shell/shell.h#L56