### PR TITLE
Fix typo in dutch translations

### DIFF
--- a/localization/strings/nl-NL/Resources.resw
+++ b/localization/strings/nl-NL/Resources.resw
@@ -1194,7 +1194,7 @@ Zie de herstelinstructies voor: https://aka.ms/wsldiskmountrecovery</value>
     <value>Een absoluut Windows-pad naar een aangepaste Linux-kernel.</value>
   </data>
   <data name="Settings_CustomKernelPathBrowseButton.Content" xml:space="preserve">
-    <value>Koor kernels bladeren</value>
+    <value>Door kernels bladeren</value>
   </data>
   <data name="Settings_CustomKernelPathTextBox.AutomationProperties.Name" xml:space="preserve">
     <value>Aangepaste kernel</value>


### PR DESCRIPTION
Fixed a typo by changing "Koor" to "Door" in the dutch translation.

## Summary of the Pull Request

## PR Checklist

- [x] **Closes:** Link to issue #13852
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

The word "Koor" is misspelled and should be "Door" like the button below it at kernermodules.

## Validation Steps Performed

- it's just a string typo.
