### PR TITLE
CI: update issue for wslsettings being rebuilt and signature being overwritten

### DIFF
--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -121,6 +121,10 @@ stages:
           Codeql.PublishDatabaseLog: true
           Codeql.SourceRoot: src
           packageStagingDir: '$(Build.SourcesDirectory)\packageStagingDir'
+          ${{ if eq(parameters.isRelease, 'true') }}:
+            packageInputDirArg: '-DPACKAGE_INPUT_DIR=$(packageStagingDir)'
+          ${{ else }}:
+            packageInputDirArg: ''
 
         steps:
 
@@ -167,20 +171,7 @@ stages:
                 displayName: "CMake ${{ platform }}"
                 inputs:
                   workingDirectory: "."
-                  cmakeArgs: >-
-                    . --fresh -A ${{ platform }}
-                    -DCMAKE_BUILD_TYPE=Release
-                    -DCMAKE_SYSTEM_VERSION=10.0.26100.0
-                    -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION)
-                    -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION)
-                    -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }}
-                    -DOFFICIAL_BUILD=${{ parameters.isRelease }}
-                    -DPIPELINE_BUILD_ID=$(Build.BuildId)
-                    -DVSO_ORG=${{ parameters.vsoOrg }}
-                    -DVSO_PROJECT=${{ parameters.vsoProject }}
-                    -DWSL_BUILD_WSL_SETTINGS=true
-                    ${{ if eq(parameters.isRelease, 'true') }}:
-                      -DPACKAGE_INPUT_DIR=$(packageStagingDir)\${{ platform }}
+                  cmakeArgs: . --fresh -A ${{ platform }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }} -DOFFICIAL_BUILD=${{ parameters.isRelease }} -DPIPELINE_BUILD_ID=$(Build.BuildId) -DVSO_ORG=${{ parameters.vsoOrg }} -DVSO_PROJECT=${{ parameters.vsoProject }} -DWSL_BUILD_WSL_SETTINGS=true $(packageInputDirArg)\${{ platform }}
 
               # This additional Restore NuGet package task is added as a workaround for WSL Settings to have its packages restored properly.
               # Without this, building wsl settings may encounter the following error:

--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -24,7 +24,7 @@ parameters:
     type: object
     default:
       - target: "wsl;libwsl;wslg;wslservice;wslhost;wslrelay;wslinstaller;wslinstall;initramfs;wslserviceproxystub;wslsettings;wslinstallerproxystub;testplugin"
-        pattern: "wsl.exe,libwsl.dll,wslg.exe,wslservice.exe,wslhost.exe,wslrelay.exe,wslinstaller.exe,wslinstall.dll,wslserviceproxystub.dll,wslsettings.dll,wslsettings.exe,wslinstallerproxystub.dll,wsldevicehost.dll,WSLDVCPlugin.dll,testplugin.dll,wsldeps.dll"
+        pattern: "wsl.exe,libwsl.dll,wslg.exe,wslservice.exe,wslhost.exe,wslrelay.exe,wslinstaller.exe,wslinstall.dll,wslserviceproxystub.dll,wslsettings/wslsettings.dll,wslsettings/wslsettings.exe,wslinstallerproxystub.dll,wsldevicehost.dll,WSLDVCPlugin.dll,testplugin.dll,wsldeps.dll"
       - target: "msixgluepackage"
         pattern: "gluepackage.msix"
       - target: "msipackage"
@@ -120,6 +120,7 @@ stages:
           ob_sdl_codeSignValidation_excludes: -|**testbin\**
           Codeql.PublishDatabaseLog: true
           Codeql.SourceRoot: src
+          packageStagingDir: '$(Build.SourcesDirectory)\packageStagingDir'
 
         steps:
 
@@ -166,7 +167,7 @@ stages:
                 displayName: "CMake ${{ platform }}"
                 inputs:
                   workingDirectory: "."
-                  cmakeArgs: . --fresh -A ${{ platform }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }} -DOFFICIAL_BUILD=${{ parameters.isRelease }} -DPIPELINE_BUILD_ID=$(Build.BuildId) -DVSO_ORG=${{ parameters.vsoOrg }} -DVSO_PROJECT=${{ parameters.vsoProject }} -DWSL_BUILD_WSL_SETTINGS=true
+                  cmakeArgs: . --fresh -A ${{ platform }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }} -DOFFICIAL_BUILD=${{ parameters.isRelease }} -DPIPELINE_BUILD_ID=$(Build.BuildId) -DVSO_ORG=${{ parameters.vsoOrg }} -DVSO_PROJECT=${{ parameters.vsoProject }} -DWSL_BUILD_WSL_SETTINGS=true -DPACKAGE_INPUT_DIR=$(packageStagingDir)\${{ platform }}
 
               # This additional Restore NuGet package task is added as a workaround for WSL Settings to have its packages restored properly.
               # Without this, building wsl settings may encounter the following error:
@@ -196,7 +197,7 @@ stages:
                           AuthSignCertName: ${{ parameters.esrp.AuthSignCertName }}
                           AppRegistrationClientId: ${{ parameters.esrp.AppRegistrationClientId }}
                           AppRegistrationTenantId: ${{ parameters.esrp.AppRegistrationTenantId }}
-                          FolderPath: "bin\\${{ platform }}"
+                          FolderPath: "bin\\${{ platform }}\\Release"
                           Pattern: "${{ target.pattern }}"
                           UseMSIAuthentication: true
                           EsrpClientId: ${{ parameters.esrp.EsrpClientId }}
@@ -224,20 +225,27 @@ stages:
                                     }
                               ]
 
-                  # Replace the intermediate wslsettings binaries file with the signed versions so that any future steps building wslsettings will use the signed versions
-                  - task: PowerShell@2
-                    displayName: 'Replace wslsettings binaries in intermediate folder with signed versions'
-                    condition: and(succeeded(), eq('${{ parameters.isRelease }}', true))
-                    inputs:
-                      targetType: inline
-                      script: |
-                        $arch = '${{ platform }}'
-                        $wslsettingsbinpath = "bin\$arch\release\wslsettings"
-                        $wslsettingsobjpath = "src\windows\wslsettings\obj\$arch\release"
-                        # Update the timestamp of wslsettings.exe so that it doesn't get rebuilt
-                        (Get-Item $wslsettingsbinpath\wslsettings.exe).LastWriteTime = Get-Date
-                        Copy-Item $wslsettingsbinpath\wslsettings.dll $wslsettingsobjpath\wslsettings.dll -Force
-                        Copy-Item $wslsettingsbinpath\wslsettings.exe $wslsettingsobjpath\apphost.exe -Force
+                      - task: PowerShell@2
+                        displayName: "Copy signed ${{ target.target }} to staging (${{ platform }})"
+                        condition: and(succeeded(), eq('${{ parameters.isRelease }}', true))
+                        inputs:
+                          targetType: inline
+                          script: |
+                              $arch = '${{ platform }}'
+                              $pattern = '${{ target.pattern }}'
+                              $inputDir = "bin\$arch\Release"
+                              $outputDir = "$(packageStagingDir)\$arch"
+                              New-Item -ItemType Directory -Path "$outputDir\wslsettings" -Force
+                              foreach ($file in $pattern.Split(',')) {
+                                  $sourcePath = Join-Path $inputDir $file
+                                  if (Test-Path $sourcePath) {
+                                      $destPath = Join-Path $outputDir $file
+                                      Write-Host "Copying signed file: $sourcePath -> $destPath"
+                                      Copy-Item -Path $sourcePath -Destination $destPath -Force
+                                  } else {
+                                      Write-Warning "File not found: $sourcePath"
+                                  }
+                              }
 
               - script: cmake --build . --config Release -- -m
                 displayName: "Build installer msix and tests (${{ platform }})"
@@ -411,3 +419,4 @@ stages:
 
           - task: CodeQL3000Finalize@0
             condition: ${{ and(parameters.isNightly, eq(variables['Build.SourceBranch'], 'refs/heads/main'))}}
+

--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -167,7 +167,20 @@ stages:
                 displayName: "CMake ${{ platform }}"
                 inputs:
                   workingDirectory: "."
-                  cmakeArgs: . --fresh -A ${{ platform }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }} -DOFFICIAL_BUILD=${{ parameters.isRelease }} -DPIPELINE_BUILD_ID=$(Build.BuildId) -DVSO_ORG=${{ parameters.vsoOrg }} -DVSO_PROJECT=${{ parameters.vsoProject }} -DWSL_BUILD_WSL_SETTINGS=true -DPACKAGE_INPUT_DIR=$(packageStagingDir)\${{ platform }}
+                  cmakeArgs: >-
+                    . --fresh -A ${{ platform }}
+                    -DCMAKE_BUILD_TYPE=Release
+                    -DCMAKE_SYSTEM_VERSION=10.0.26100.0
+                    -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION)
+                    -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION)
+                    -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }}
+                    -DOFFICIAL_BUILD=${{ parameters.isRelease }}
+                    -DPIPELINE_BUILD_ID=$(Build.BuildId)
+                    -DVSO_ORG=${{ parameters.vsoOrg }}
+                    -DVSO_PROJECT=${{ parameters.vsoProject }}
+                    -DWSL_BUILD_WSL_SETTINGS=true
+                    ${{ if eq(parameters.isRelease, 'true') }}:
+                      -DPACKAGE_INPUT_DIR=$(packageStagingDir)\${{ platform }}
 
               # This additional Restore NuGet package task is added as a workaround for WSL Settings to have its packages restored properly.
               # Without this, building wsl settings may encounter the following error:

--- a/msipackage/CMakeLists.txt
+++ b/msipackage/CMakeLists.txt
@@ -6,7 +6,6 @@ if(DEFINED PACKAGE_INPUT_DIR)
     message(STATUS "Using signed binaries from ${PACKAGE_INPUT_DIR} for MSI packaging")
 else()
     set(PACKAGE_INPUT_DIR ${BIN})
-    message(STATUS "Using binaries from ${BIN} for MSI packaging")
 endif()
 
 set(OUTPUT_PACKAGE ${BIN}/wsl.msi)

--- a/msipackage/CMakeLists.txt
+++ b/msipackage/CMakeLists.txt
@@ -1,16 +1,30 @@
 set(BIN ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE})
+
+# For pipeline builds, use PACKAGE_INPUT_DIR if specified (contains signed binaries)
+# For local builds, use bin directory
+if(DEFINED PACKAGE_INPUT_DIR)
+    message(STATUS "Using signed binaries from ${PACKAGE_INPUT_DIR} for MSI packaging")
+else()
+    set(PACKAGE_INPUT_DIR ${BIN})
+    message(STATUS "Using binaries from ${BIN} for MSI packaging")
+endif()
+
 set(OUTPUT_PACKAGE ${BIN}/wsl.msi)
 set(PACKAGE_WIX_IN ${CMAKE_CURRENT_LIST_DIR}/package.wix.in)
 set(PACKAGE_WIX ${BIN}/package.wix)
 set(CAB_CACHE ${BIN}/cab)
-set(BINARIES wsl.exe;wslg.exe;wslhost.exe;wslrelay.exe;wslservice.exe;wslserviceproxystub.dll;init;initrd.img;wslinstall.dll)
-
+set(WINDOWS_BINARIES wsl.exe;wslg.exe;wslhost.exe;wslrelay.exe;wslservice.exe;wslserviceproxystub.dll;wslinstall.dll)
 if (WSL_BUILD_WSL_SETTINGS)
-    list(APPEND BINARIES_DEPENDENCIES "wslsettings/wslsettings.dll;wslsettings/wslsettings.exe;libwsl.dll")
+    list(APPEND WINDOWS_BINARIES "wslsettings/wslsettings.dll;wslsettings/wslsettings.exe;libwsl.dll")
 endif()
 
 set(BINARIES_DEPENDENCIES)
-foreach(binary ${BINARIES})
+foreach(binary ${WINDOWS_BINARIES})
+    list(APPEND BINARIES_DEPENDENCIES "${PACKAGE_INPUT_DIR}/${binary}")
+endforeach()
+
+set(LINUX_BINARIES init;initrd.img)
+foreach(binary ${LINUX_BINARIES})
     list(APPEND BINARIES_DEPENDENCIES "${BIN}/${binary}")
 endforeach()
 

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package Name="Windows Subsystem for Linux" Language="1033" InstallerVersion="500" Version="${PACKAGE_VERSION}" Manufacturer="Microsoft Corporation" UpgradeCode="6D5B792B-1EDC-4DE9-8EAD-201B820F8E82" Scope="perMachine" Compressed="${COMPRESS_PACKAGE}">
         <MajorUpgrade AllowDowngrades="yes"  Disallow="no"  />
         <MediaTemplate EmbedCab="yes" />
@@ -19,21 +19,21 @@
         <DirectoryRef Id="INSTALLDIR">
             <Component Id="wsl" Guid="F0C8D6BA-1502-41E7-BF72-D93DFA134730" UninstallWhenSuperseded="yes" DisableRegistryReflection="yes" Bitness="always64">
                 <RemoveFile Id="CleanUpWSLShortCut" Directory="ProgramMenuFolder" Name="WSL" On="uninstall"/>
-                <File Id="wsl.exe" Name="wsl.exe" Source="${BIN}/wsl.exe" KeyPath="yes">
+                <File Id="wsl.exe" Name="wsl.exe" Source="${PACKAGE_INPUT_DIR}/wsl.exe" KeyPath="yes">
                     <Shortcut Id="WSLShortcut" Name="WSL" Description="Windows Subsystem for Linux" Arguments="--cd ~" Advertise="yes" Directory="ProgramMenuFolder" Icon="wsl.ico">
                         <ShortcutProperty Key="System.AppUserModel.ID" Value="Microsoft.WSL"/>
                         <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{2B9C59C3-98F1-45C8-B87B-12AE3C7927E8}"/>
                     </Shortcut>
                 </File>
 
-                <File Id="wslg.exe" Name="wslg.exe" Source="${BIN}/wslg.exe" />
-                <File Id="wslhost.exe" Name="wslhost.exe" Source="${BIN}/wslhost.exe" />
-                <File Id="wslrelay.exe" Name="wslrelay.exe" Source="${BIN}/wslrelay.exe" />
-                <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${BIN}/wslserviceproxystub.dll" />
-                <File Id="wsldeps.dll" Name="wsldeps.dll" Source="${BIN}/wsldeps.dll" />
+                <File Id="wslg.exe" Name="wslg.exe" Source="${PACKAGE_INPUT_DIR}/wslg.exe" />
+                <File Id="wslhost.exe" Name="wslhost.exe" Source="${PACKAGE_INPUT_DIR}/wslhost.exe" />
+                <File Id="wslrelay.exe" Name="wslrelay.exe" Source="${PACKAGE_INPUT_DIR}/wslrelay.exe" />
+                <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${PACKAGE_INPUT_DIR}/wslserviceproxystub.dll" />
+                <File Id="wsldeps.dll" Name="wsldeps.dll" Source="${PACKAGE_INPUT_DIR}/wsldeps.dll" />
 
                 <?if "${WSL_BUILD_WSL_SETTINGS}" = "true" ?>
-                    <File Id="libwsl.dll" Name="libwsl.dll" Source="${BIN}/libwsl.dll" />
+                    <File Id="libwsl.dll" Name="libwsl.dll" Source="${PACKAGE_INPUT_DIR}/libwsl.dll" />
                 <?endif?>
 
                 <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
@@ -223,7 +223,7 @@
                 </RegistryKey>
 
                 <!-- Session 0 service -->
-                <File Id="wslservice.exe" Source="${BIN}/wslservice.exe" KeyPath="yes" />
+                <File Id="wslservice.exe" Source="${PACKAGE_INPUT_DIR}/wslservice.exe" KeyPath="yes" />
                 <ServiceInstall Name="WSLService" DisplayName="WSL Service" Description="WSL Service" Start="auto" Type="ownProcess" ErrorControl="normal" Account="LocalSystem" Vital="yes" Interactive="no" />
 
                 <!-- The service is stopped on uninstall and upgrade.
@@ -241,8 +241,8 @@
                     <File Id="rdpnanoTransport.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdpnanoTransport.dll" />
                     <File Id="RdpWinStlHelper.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/RdpWinStlHelper.dll" />
                 <?endif?>
-                <File Id="wsldevicehost.dll" Source="${BIN}/wsldevicehost.dll" />
-                <File Id="${WSLG_TS_PLUGIN_DLL}" Source="${BIN}/${WSLG_TS_PLUGIN_DLL}" />
+                <File Id="wsldevicehost.dll" Source="${PACKAGE_INPUT_DIR}/wsldevicehost.dll" />
+                <File Id="${WSLG_TS_PLUGIN_DLL}" Source="${PACKAGE_INPUT_DIR}/${WSLG_TS_PLUGIN_DLL}" />
 
                 <!-- MSRDC Plugin registration -->
                 <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Terminal Server Client\Default\OptionalAddIns\WSLDVC_PACKAGE">
@@ -292,7 +292,7 @@
             <ComponentGroup Id="wslsettings" Directory="WSLSETTINGS" Source="${BIN}/wslsettings">
                 <Component Id="wslsettingsnonserver" Guid="AB166073-8855-492B-95C8-C6E5939B66A5" Bitness="always64" DisableRegistryReflection="yes" UninstallWhenSuperseded="yes" Condition="MsiNTProductType = 1">
                     <RemoveFile Id="CleanUpWSLSettingsShortCutNonServer" Directory="ProgramMenuFolder" Name="WSLSettings" On="uninstall"/>
-                    <File Id="wslsettings.exe_nonserver" Source="${BIN}/wslsettings/wslsettings.exe" KeyPath="yes" ShortName="kyk8fs6a.exe">
+                    <File Id="wslsettings.exe_nonserver" Source="${PACKAGE_INPUT_DIR}/wslsettings/wslsettings.exe" KeyPath="yes" ShortName="kyk8fs6a.exe">
                         <Shortcut Id="WSLSettingsShortcutNonServer" Name="WSL Settings" Description="Windows Subsystem for Linux Settings" Advertise="yes" Directory="ProgramMenuFolder" Icon="wsl.ico">
                             <ShortcutProperty Key="System.AppUserModel.IsSystemComponent" Value="true"/>
                         </Shortcut>
@@ -323,7 +323,7 @@
                 </Component>
                 <Component Id="wslsettingsserver" Guid="EE2D69A0-4F55-4EC5-9576-4FAD70BC798E" Bitness="always64" DisableRegistryReflection="yes" UninstallWhenSuperseded="yes" Condition="MsiNTProductType &gt; 1">
                     <RemoveFile Id="CleanUpWSLSettingsShortCutServer" Directory="ProgramMenuFolder" Name="WSLSettings" On="uninstall"/>
-                    <File Id="wslsettings.exe_server" Source="${BIN}/wslsettings/wslsettings.exe" KeyPath="yes" ShortName="kyk8fs6b.exe">
+                    <File Id="wslsettings.exe_server" Source="${PACKAGE_INPUT_DIR}/wslsettings/wslsettings.exe" KeyPath="yes" ShortName="kyk8fs6b.exe">
                         <Shortcut Id="WSLSettingsShortcutServer" Name="WSL Settings" Description="Windows Subsystem for Linux Settings" Advertise="yes" Directory="ProgramMenuFolder" Icon="wsl.ico"/>
                     </File>
                     <!-- Protocol registration -->
@@ -350,7 +350,10 @@
                         </RegistryKey>
                     </RegistryKey>
                 </Component>
-                <Files Include="*.dll"/>
+                <File Id="wslsettings.dll" Source="${PACKAGE_INPUT_DIR}/wslsettings/wslsettings.dll"/>
+                <Files Include="*.dll">
+                    <Exclude Files="wslsettings.dll" />
+                </Files>
                 <Files Include="*.exe">
                     <Exclude Files="wslsettings.exe" />
                 </Files>
@@ -385,8 +388,8 @@
 
         </Feature>
 
-        <Binary Id="wslinstall.dll" SourceFile="${BIN}/wslinstall.dll" />
-        <Binary Id="msixpackage" SourceFile="${BIN}/gluepackage.msix"/>
+        <Binary Id="wslinstall.dll" SourceFile="${PACKAGE_INPUT_DIR}/wslinstall.dll" />
+        <Binary Id="msixpackage" SourceFile="${PACKAGE_INPUT_DIR}/gluepackage.msix"/>
 
         <CustomAction Id="ValidateInstall"
             Impersonate="no"
@@ -559,3 +562,4 @@
         <Property Id="MSIRMSHUTDOWN" Value="0" Secure="yes" />
     </Package>
 </Wix>
+


### PR DESCRIPTION
This should prevent cmake from rebuilding the wslsettings project and overwriting the signature files.