### PR TITLE
Simplify CMake condition for WSL_POST_BUILD_COMMAND

### DIFF
--- a/msipackage/CMakeLists.txt
+++ b/msipackage/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 set_source_files_properties(${OUTPUT_PACKAGE} PROPERTIES GENERATED TRUE)
 
-if (DEFINED WSL_POST_BUILD_COMMAND AND NOT "${WSL_POST_BUILD_COMMAND}" STREQUAL "")
+if (DEFINED WSL_POST_BUILD_COMMAND)
     add_custom_command(
         TARGET msipackage
         POST_BUILD


### PR DESCRIPTION
This PR simplifies the CMake condition used for handling WSL_POST_BUILD_COMMAND.
The previous PR added an empty-string guard, but this follow-up restores the original form for clarity and to stay consistent with the rest of the build system.
