### PR TITLE
Fix crash in the 'ListSessionsReturnsSessionWithDisplayName' test case

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -194,11 +194,10 @@ class WSLATests
 
         // Act: list sessions
         wil::unique_cotaskmem_array_ptr<WSLA_SESSION_INFORMATION> sessions;
-        ULONG count = 0;
-        VERIFY_SUCCEEDED(userSession->ListSessions(&sessions, &count));
+        VERIFY_SUCCEEDED(userSession->ListSessions(&sessions, sessions.size_address<ULONG>()));
 
         // Assert
-        VERIFY_ARE_EQUAL(count, 1u);
+        VERIFY_ARE_EQUAL(sessions.size(), 1u);
         const auto& info = sessions[0];
 
         // SessionId is implementation detail (starts at 1), so we only assert DisplayName here.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a WI_ASSERT() hitting in the tests.

Stack: 

```
# Child-SP          RetAddr               Call Site
00 000000ac`8aafde28 00007ffb`21ee9333     ntdll!ZwWaitForMultipleObjects+0x14 [minkernel\ntdll\daytona\objfre\amd64\usrstubs.asm @ 964] 
01 000000ac`8aafde30 00007ffb`21ee9201     KERNELBASE!WaitForMultipleObjectsEx+0x123 [minkernel\kernelbase\synch.c @ 1551] 
02 000000ac`8aafe120 00007ffb`227a12d0     KERNELBASE!WaitForMultipleObjects+0x11 [minkernel\kernelbase\synch.c @ 1403] 
03 000000ac`8aafe160 00007ffb`227c87cd     kernel32!WerpReportFaultInternal+0x62c [onecore\windows\feedback\core\faultrep\lib\faultrep.cpp @ 1073] 
04 000000ac`8aafe2e0 00007ffb`21fc712c     kernel32!WerpReportFault+0xc5 [onecore\windows\feedback\core\faultrep\lib\faultrep.cpp @ 1384] 
05 000000ac`8aafe330 00007ffb`2492a623     KERNELBASE!UnhandledExceptionFilter+0x34c [minkernel\kernelbase\xcpt.c @ 701] 
06 (Inline Function) --------`--------     ntdll!RtlpThreadExceptionFilter+0x2e [minkernel\ldr\rtlstrt.c @ 958] 
07 000000ac`8aafe420 00007ffb`248e19b3     ntdll!RtlUserThreadStart$filt$0+0x3f [minkernel\ldr\rtlstrt.c @ 1185] 
08 000000ac`8aafe450 00007ffb`2492632f     ntdll!__C_specific_handler+0x93 [minkernel\crts\crtw32\misc\riscchandler.c @ 446] 
09 000000ac`8aafe4c0 00007ffb`247d2327     ntdll!RtlpExecuteHandlerForException+0xf [minkernel\ntos\rtl\amd64\xcptmisc.asm @ 132] 
0a 000000ac`8aafe4f0 00007ffb`24925c6e     ntdll!RtlDispatchException+0x437 [minkernel\ntos\rtl\amd64\exdsptch.c @ 680] 
0b 000000ac`8aafec40 00007ffa`0aa3552f     ntdll!KiUserExceptionDispatch+0x2e [minkernel\ntos\rtl\amd64\trampoln.asm @ 771] 
0c 000000ac`8aaff370 00007ffa`0aa45dfe     wsltests!wil::unique_any_array_ptr<WSLA_SESSION_INFORMATION,wil::function_deleter<void (__cdecl*)(void *),&CoTaskMemFree>,wil::empty_deleter>::operator[]+0x1f [C:\Users\piboulay\repos\wsl\packages\Microsoft.Windows.ImplementationLibrary.1.0.251108.1\include\wil\resource.h @ 1174] 
0d 000000ac`8aaff390 00007ffa`0aa39fea     wsltests!WSLATests::ListSessionsReturnsSessionWithDisplayName+0x34e [C:\Users\piboulay\repos\wsl\test\windows\WSLATests.cpp @ 219] 
0e 000000ac`8aaff630 00007ffa`0aa252b4     wsltests!WEX::Private::TestInvokeFunctor<WSLATests>::operator()+0x1a [C:\Users\piboulay\repos\wsl\packages\Microsoft.Taef.10.100.251104001\build\include\WexTestClass.h @ 603] 
0f 000000ac`8aaff660 00007ffa`0aa2514f     wsltests!WEX::Private::SafeInvoke_Impl<WEX::Private::TestInvokeFunctor<WSLATests> >+0x34 [C:\Users\piboulay\repos\wsl\packages\Microsoft.Taef.10.100.251104001\build\include\WexTestClass.h @ 214] 
10 000000ac`8aaff6c0 00007ffa`0aa4bef8     wsltests!WEX::Private::SafeInvoke<WEX::Private::TestInvokeFunctor<WSLATests> >+0x4f [C:\Users\piboulay\repos\wsl\packages\Microsoft.Taef.10.100.251104001\build\include\WexTestClass.h @ 331] 
11 000000ac`8aaff7a0 00007ffa`9b3a2e18     wsltests!`WSLATests::ListSessionsReturnsSessionWithDisplayName_TAEF_PinTestMethodInfo'::`2'::TAEF_TestInvoker::TAEF_Invoke+0x28 [C:\Users\piboulay\repos\wsl\test\windows\WSLATests.cpp @ 196] 
12 000000ac`8aaff7e0 00007ffa`a2b9ac16     TE_Loaders!WEX::TestExecution::NativeTestClassInstance::InvokeMethod+0x198 [C:\__w\1\s\src\TAEF\Loaders\NativeTestClassInstance.cpp @ 168]
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
