### PR TITLE
Pass --time to nerdctl stop to avoid timeouts when stopping stuck con…

### DIFF
--- a/src/windows/wslaservice/exe/WSLAContainer.cpp
+++ b/src/windows/wslaservice/exe/WSLAContainer.cpp
@@ -127,7 +127,7 @@ try
         m_state);
     ServiceProcessLauncher launcher(
         nerdctlPath, {nerdctlPath, "stop", m_name, "--time", std::to_string(static_cast<ULONG>(std::round(TimeoutMs / 1000)))});
-    // TODO: Figure out how we want to handle custom signals and timeout values.
+    // TODO: Figure out how we want to handle custom signals.
     // nerdctl stop has a --time and a --signal option that can be used
     // By default, it uses SIGTERM and a default timeout of 10 seconds.
     auto result = launcher.Launch(*m_parentVM).WaitAndCaptureOutput();

--- a/src/windows/wslaservice/exe/WSLAContainer.cpp
+++ b/src/windows/wslaservice/exe/WSLAContainer.cpp
@@ -125,12 +125,13 @@ try
         "Container '%hs' is not in a stoppable state: %i",
         m_name.c_str(),
         m_state);
-    ServiceProcessLauncher launcher(nerdctlPath, {nerdctlPath, "stop", m_name});
+    ServiceProcessLauncher launcher(
+        nerdctlPath, {nerdctlPath, "stop", m_name, "--time", std::to_string(static_cast<ULONG>(std::round(TimeoutMs / 1000)))});
     // TODO: Figure out how we want to handle custom signals and timeout values.
     // nerdctl stop has a --time and a --signal option that can be used
     // By default, it uses SIGTERM and a default timeout of 10 seconds.
-    auto result = launcher.Launch(*m_parentVM).Wait(TimeoutMs);
-    THROW_HR_IF_MSG(E_FAIL, result.first != 0, "%hs", launcher.FormatResult(result.first).c_str());
+    auto result = launcher.Launch(*m_parentVM).WaitAndCaptureOutput();
+    THROW_HR_IF_MSG(E_FAIL, result.Code != 0, "%hs", launcher.FormatResult(result).c_str());
 
     m_state = WslaContainerStateExited;
     return S_OK;


### PR DESCRIPTION
…tainers

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves multiple issues in the Stop() implementation:

- Use WaitAndCaptureOutput() to consume the nerdctl stop process output to avoid potential pipe deadlocks
- Pass the timeout to nerdctl via --time so that the container is killed after the user provided timeout (this allows a user to pass 0 to immediately kill the container) 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
