### PR TITLE
virtiofs: fix an issue where if the VM is launched by an elevated user, non-elevated shells will have elevated virtiofs access.

### DIFF
--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1793,8 +1793,10 @@ void WslCoreVm::InitializeGuest()
         {
             try
             {
-                m_guestDeviceManager->AddSharedMemoryDevice(
-                    VIRTIO_FS_CLASS_ID, L"wslg", L"wslg", WSLG_SHARED_MEMORY_SIZE_MB, m_userToken.get());
+                // Use the appropriate virtiofs class ID based on m_userToken elevation.
+                const bool admin = wsl::windows::common::security::IsTokenElevated(m_userToken.get());
+                const GUID classId = admin ? VIRTIO_FS_ADMIN_CLASS_ID : VIRTIO_FS_CLASS_ID;
+                m_guestDeviceManager->AddSharedMemoryDevice(classId, L"wslg", L"wslg", WSLG_SHARED_MEMORY_SIZE_MB, m_userToken.get());
                 m_sharedMemoryRoot = std::format(L"WSL\\{}\\wslg", m_machineId);
             }
             CATCH_LOG()

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -276,7 +276,7 @@ public:
         SKIP_TEST_ARM64();
 
         TerminateDistribution();
-        WslKeepAlive keelAlive;
+        WslKeepAlive keepAlive;
 
         ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, Mode);
     }
@@ -288,7 +288,7 @@ public:
         SKIP_TEST_ARM64();
 
         TerminateDistribution();
-        WslKeepAlive keelAlive;
+        WslKeepAlive keepAlive;
 
         ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT | CREATE_NEW_CONSOLE, Mode);
     }
@@ -302,7 +302,7 @@ public:
         TerminateDistribution();
 
         const auto nonElevatedToken = GetNonElevatedToken();
-        WslKeepAlive keelAlive(nonElevatedToken.get());
+        WslKeepAlive keepAlive(nonElevatedToken.get());
 
         ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, Mode);
     }
@@ -316,7 +316,7 @@ public:
         TerminateDistribution();
 
         const auto nonElevatedToken = GetNonElevatedToken();
-        WslKeepAlive keelAlive(nonElevatedToken.get());
+        WslKeepAlive keepAlive(nonElevatedToken.get());
 
         ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT | CREATE_NEW_CONSOLE, Mode);
     }
@@ -328,7 +328,7 @@ public:
         SKIP_TEST_ARM64();
 
         WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true, .drvFsMode = Mode}));
-        WslKeepAlive keelAlive;
+        WslKeepAlive keepAlive;
 
         ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, Mode);
     }
@@ -342,7 +342,7 @@ public:
         WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true, .drvFsMode = Mode}));
 
         const auto nonElevatedToken = GetNonElevatedToken();
-        WslKeepAlive keelAlive(nonElevatedToken.get());
+        WslKeepAlive keepAlive(nonElevatedToken.get());
 
         ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, Mode);
     }

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -321,6 +321,32 @@ public:
         ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT | CREATE_NEW_CONSOLE, Mode);
     }
 
+    void DrvfsMountElevatedSystemDistroEnabled(DrvFsMode Mode)
+    {
+        WSL2_TEST_ONLY();
+        WINDOWS_11_TEST_ONLY(); // TODO: Enable on Windows 10 when virtio support is added
+        SKIP_TEST_ARM64();
+
+        WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true, .drvFsMode = Mode}));
+        WslKeepAlive keelAlive;
+
+        ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, Mode);
+    }
+
+    void DrvfsMountNonElevatedSystemDistroEnabled(DrvFsMode Mode)
+    {
+        WSL2_TEST_ONLY();
+        WINDOWS_11_TEST_ONLY(); // TODO: Enable on Windows 10 when virtio support is added
+        SKIP_TEST_ARM64();
+
+        WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true, .drvFsMode = Mode}));
+
+        const auto nonElevatedToken = GetNonElevatedToken();
+        WslKeepAlive keelAlive(nonElevatedToken.get());
+
+        ValidateDrvfsMounts(CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, Mode);
+    }
+
     static void XattrDrvFs(DrvFsMode Mode)
     {
         SKIP_TEST_ARM64();
@@ -946,6 +972,31 @@ private:
 
         const auto nonElevatedToken = GetNonElevatedToken();
         validate(nonElevatedType, nonElevatedToken.get());
+
+        // Elevated token should be able to create files at the root of the drive (/mnt/c)
+        {
+            const auto commandLine =
+                LxssGenerateWslCommandLine(L"touch /mnt/c/elevated_test_file.tmp && rm /mnt/c/elevated_test_file.tmp");
+
+            wsl::windows::common::SubProcess process(nullptr, commandLine.c_str(), CreateProcessFlags);
+            process.SetToken(nullptr);
+            process.SetShowWindow(SW_HIDE);
+
+            const auto output = process.RunAndCaptureOutput();
+            VERIFY_ARE_EQUAL(0, output.ExitCode, L"Elevated token should be able to create files at /mnt/c");
+        }
+
+        // Non-elevated token should NOT be able to create files at the root of the drive (/mnt/c)
+        {
+            const auto commandLine = LxssGenerateWslCommandLine(L"touch /mnt/c/nonelevated_test_file.tmp");
+
+            wsl::windows::common::SubProcess process(nullptr, commandLine.c_str(), CreateProcessFlags);
+            process.SetToken(nonElevatedToken.get());
+            process.SetShowWindow(SW_HIDE);
+
+            const auto output = process.RunAndCaptureOutput();
+            VERIFY_ARE_NOT_EQUAL(0, output.ExitCode, L"Non-elevated token should NOT be able to create files at /mnt/c (C:\\)");
+        }
     }
 
     static VOID VerifyDrvFsSymlink(const std::wstring& Path, const std::wstring& ExpectedTarget, bool Directory)
@@ -1197,6 +1248,18 @@ class WSL1 : public DrvFsTests
         { \
             WSL2_TEST_ONLY(); \
             DrvFsTests::DrvfsMountNonElevatedDifferentConsole(DrvFsMode::##_mode##); \
+        } \
+\
+        TEST_METHOD(DrvfsMountElevatedSystemDistroEnabled) \
+        { \
+            WSL2_TEST_ONLY(); \
+            DrvFsTests::DrvfsMountElevatedSystemDistroEnabled(DrvFsMode::##_mode##); \
+        } \
+\
+        TEST_METHOD(DrvfsMountNonElevatedSystemDistroEnabled) \
+        { \
+            WSL2_TEST_ONLY(); \
+            DrvFsTests::DrvfsMountNonElevatedSystemDistroEnabled(DrvFsMode::##_mode##); \
         } \
 \
         TEST_METHOD(XattrDrvFs) \


### PR DESCRIPTION
Resolves an issue with virtiofs when WSLg is enabled. If an elevated token launches the VM, then all virtiofs access will have access rights of the launching token. A test was added to validate the fix, the previous tests did not hit this because they run with WSLg disabled.