### PR TITLE
virtiofs: implement best-effort removal of flexiov devices

### DIFF
--- a/src/windows/common/DeviceHostProxy.h
+++ b/src/windows/common/DeviceHostProxy.h
@@ -14,6 +14,8 @@ public:
 
     GUID AddNewDevice(const GUID& Type, const wil::com_ptr<IPlan9FileSystem>& Plan9Fs, const std::wstring& VirtIoTag);
 
+    void RemoveDevice(const GUID& Type, const GUID& InstanceId);
+
     void AddRemoteFileSystem(const GUID& ImplementationClsid, const std::wstring& Tag, const wil::com_ptr<IPlan9FileSystem>& Plan9Fs);
 
     wil::com_ptr<IPlan9FileSystem> GetRemoteFileSystem(const GUID& ImplementationClsid, std::wstring_view Tag);

--- a/src/windows/common/GuestDeviceManager.h
+++ b/src/windows/common/GuestDeviceManager.h
@@ -22,6 +22,7 @@ class GuestDeviceManager
 {
 public:
     GuestDeviceManager(_In_ const std::wstring& machineId, _In_ const GUID& runtimeId);
+    ~GuestDeviceManager();
 
     _Requires_lock_not_held_(m_lock)
     GUID AddGuestDevice(
@@ -33,6 +34,7 @@ public:
         _In_ UINT32 Flags,
         _In_ HANDLE UserToken);
 
+    _Requires_lock_not_held_(m_lock)
     GUID AddNewDevice(_In_ const GUID& deviceId, _In_ const wil::com_ptr<IPlan9FileSystem>& server, _In_ PCWSTR tag);
 
     void AddRemoteFileSystem(_In_ REFCLSID clsid, _In_ PCWSTR tag, _In_ const wil::com_ptr<IPlan9FileSystem>& server);
@@ -41,7 +43,8 @@ public:
 
     wil::com_ptr<IPlan9FileSystem> GetRemoteFileSystem(_In_ REFCLSID clsid, _In_ std::wstring_view tag);
 
-    void Shutdown();
+    _Requires_lock_not_held_(m_lock)
+    void RemoveGuestDevice(_In_ const GUID& DeviceId, _In_ const GUID& InstanceId);
 
 private:
     _Requires_lock_held_(m_lock)

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -774,10 +774,7 @@ WslCoreVm::~WslCoreVm() noexcept
     }
 
     // Shutdown virtio device hosts.
-    if (m_guestDeviceManager)
-    {
-        m_guestDeviceManager->Shutdown();
-    }
+    m_guestDeviceManager.reset();
 
     // Call RevokeVmAccess on each VHD that was added to the utility VM. This
     // ensures that the ACL on the VHD does not grow unbounded.

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -32,6 +32,12 @@ enum WSLAMountFlags
     WSLAMountFlagsWriteableOverlayFs = 4,
 };
 
+struct MountedFolderInfo
+{
+    std::wstring ShareName;
+    std::optional<GUID> InstanceId; // For VirtioFS devices
+};
+
 class WSLAUserSessionImpl;
 
 class DECLSPEC_UUID("0CFC5DC1-B6A7-45FC-8034-3FA9ED73CE30") WSLAVirtualMachine
@@ -163,7 +169,7 @@ private:
     wil::unique_handle m_portRelayChannelWrite;
 
     std::map<ULONG, AttachedDisk> m_attachedDisks;
-    std::map<std::string, std::wstring> m_mountedWindowsFolders;
+    std::map<std::string, MountedFolderInfo> m_mountedWindowsFolders;
     std::recursive_mutex m_lock;
     std::mutex m_portRelaylock;
 };

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -32,12 +32,6 @@ enum WSLAMountFlags
     WSLAMountFlagsWriteableOverlayFs = 4,
 };
 
-struct MountedFolderInfo
-{
-    std::wstring ShareName;
-    std::optional<GUID> InstanceId; // For VirtioFS devices
-};
-
 class WSLAUserSessionImpl;
 
 class DECLSPEC_UUID("0CFC5DC1-B6A7-45FC-8034-3FA9ED73CE30") WSLAVirtualMachine
@@ -49,6 +43,12 @@ public:
     {
         int Fd;
         wil::unique_socket Socket;
+    };
+
+    struct MountedFolderInfo
+    {
+        std::wstring ShareName;
+        std::optional<GUID> InstanceId; // Only used for VirtioFS devices
     };
 
     struct Settings
@@ -113,6 +113,7 @@ private:
     ConnectedSocket ConnectSocket(wsl::shared::SocketChannel& Channel, int32_t Fd);
     static void OpenLinuxFile(wsl::shared::SocketChannel& Channel, const char* Path, uint32_t Flags, int32_t Fd);
     void LaunchPortRelay();
+    void RemoveShare(_In_ const MountedFolderInfo& MountInfo);
 
     std::filesystem::path GetCrashDumpFolder();
     void CreateVmSavedStateFile();


### PR DESCRIPTION
This change implements best effort removal of flexiov devices so these devices will currently accumulate while the VM is running, which is not ideal. This is because HCS is currently missing the plumbing for this which I am working on. When that support is ready, the RemoveDevice call will light up without any future changes to the WSL codebase.