### PR TITLE
cleanup: switch drvfs.cpp to use common MountUtil helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ bin/
 *.nupkg
 build/
 generated/
-Microsoft.WSL.PluginApi.nuspec
+*.nuspec
 test/linux/unit_tests/wsl_unit_tests
 *.dir/
 UserConfig.cmake

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -247,7 +247,11 @@ try
     //
 
     int Result = access(Target, F_OK);
-    if (Result == 0)
+    if (Result < 0)
+    {
+        LOG_STDERR(errno);
+    }
+    else
     {
         auto Parsed = mountutil::MountParseFlags(Options);
         Result = UtilMount(Source, Target, FsType, Parsed.MountFlags, Parsed.StringOptions.c_str(), std::chrono::seconds{2});
@@ -255,15 +259,7 @@ try
 
     if (ExitCode)
     {
-        if (Result < 0)
-        {
-            LOG_STDERR(errno);
-            *ExitCode = c_exitCodeMountFail;
-        }
-        else
-        {
-            *ExitCode = 0;
-        }
+        *ExitCode = Result < 0 ? c_exitCodeMountFail : 0;
     }
 
     return Result;

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -255,8 +255,15 @@ try
 
     if (ExitCode)
     {
-        LOG_STDERR(errno);
-        *ExitCode = Result < 0 ? c_exitCodeMountFail : 0;
+        if (Result < 0)
+        {
+            LOG_STDERR(errno);
+            *ExitCode = c_exitCodeMountFail;
+        }
+        else
+        {
+            *ExitCode = 0;
+        }
     }
 
     return Result;


### PR DESCRIPTION
The drvfs.cpp version of MountWithRetry was almost identical to the version in util.cpp. This change removes the duplicate mount retry helper.