### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/distributions.yml
+++ b/.github/workflows/distributions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           
         - name: Run validation
           run: python distributions/validate.py distributions/DistributionInfo.json

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
         id-token: write
     steps:
       - name: Checkout actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install packages
         run: pip install mkdocs-mermaid2-plugin mkdocs --break-system-packages

--- a/.github/workflows/issue_edited.yml
+++ b/.github/workflows/issue_edited.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps: 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - uses: ./.github/actions/triage
       with: 

--- a/.github/workflows/modern-distributions.yml
+++ b/.github/workflows/modern-distributions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             fetch-depth: 0
 

--- a/.github/workflows/new_issue.yml
+++ b/.github/workflows/new_issue.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps: 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - uses: ./.github/actions/triage
       with: 

--- a/.github/workflows/new_issue_comment.yml
+++ b/.github/workflows/new_issue_comment.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ !github.event.issue.pull_request && github.event.issue.user.id == github.event.comment.user.id }}
     steps: 
         - name: Checkout repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
         
         - uses: ./.github/actions/triage
           with: 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
