### PR TITLE
WSLA: Add null validation for CreateContainer Image and Name fields

### DIFF
--- a/src/windows/wslaservice/exe/WSLASession.cpp
+++ b/src/windows/wslaservice/exe/WSLASession.cpp
@@ -316,6 +316,10 @@ try
 {
     RETURN_HR_IF_NULL(E_POINTER, containerOptions);
 
+    // Validate that Image and Name are not null - even though struct pointer is non-null, string fields can be null
+    RETURN_HR_IF(E_INVALIDARG, containerOptions->Image == nullptr);
+    RETURN_HR_IF(E_INVALIDARG, containerOptions->Name == nullptr);
+
     std::lock_guard lock{m_lock};
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);
 

--- a/src/windows/wslaservice/exe/WSLASession.cpp
+++ b/src/windows/wslaservice/exe/WSLASession.cpp
@@ -316,7 +316,7 @@ try
 {
     RETURN_HR_IF_NULL(E_POINTER, containerOptions);
 
-    // Validate that Image and Name are not null - even though struct pointer is non-null, string fields can be null
+    // Validate that Image and Name are not null.
     RETURN_HR_IF(E_INVALIDARG, containerOptions->Image == nullptr);
     RETURN_HR_IF(E_INVALIDARG, containerOptions->Name == nullptr);
 

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1225,6 +1225,32 @@ class WSLATests
             auto [hresult, container] = launcher.LaunchNoThrow(*session);
             VERIFY_ARE_EQUAL(hresult, E_FAIL); // TODO: Have a nicer error code when the image is not found.
         }
+
+        // Test null image name
+        {
+            WSLA_CONTAINER_OPTIONS options{};
+            options.Image = nullptr;
+            options.Name = "test-container";
+            options.InitProcessOptions.CommandLine = nullptr;
+            options.InitProcessOptions.CommandLineCount = 0;
+
+            wil::com_ptr<IWSLAContainer> container;
+            auto hr = session->CreateContainer(&options, &container);
+            VERIFY_ARE_EQUAL(hr, E_INVALIDARG);
+        }
+
+        // Test null container name
+        {
+            WSLA_CONTAINER_OPTIONS options{};
+            options.Image = "debian:latest";
+            options.Name = nullptr;
+            options.InitProcessOptions.CommandLine = nullptr;
+            options.InitProcessOptions.CommandLineCount = 0;
+
+            wil::com_ptr<IWSLAContainer> container;
+            auto hr = session->CreateContainer(&options, &container);
+            VERIFY_ARE_EQUAL(hr, E_INVALIDARG);
+        }
     }
 
     TEST_METHOD(ContainerState)


### PR DESCRIPTION
This change resolves two wslaservice.exe crashes due to missing validation of user-provided strings. I also added new test variations that would have previously crashed the service.