### PR TITLE
wsla: Various improvements in the debug shell

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />
-  <package id="Microsoft.WSL.WslaRootfs" version="0.1.0" />
+  <package id="Microsoft.WSL.WslaRootfs" version="0.1.2" />
   <package id="Microsoft.WSLg" version="1.0.71" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="StrawberryPerl" version="5.32.1.1" />

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1538,7 +1538,7 @@ int WslaShell(_In_ std::wstring_view commandLine)
     sessionSettings.BootTimeoutMs = 30 * 1000;
     sessionSettings.MaximumStorageSizeMb = 4096;
 
-    std::string shell = "/bin/sh";
+    std::string shell = "/bin/bash";
 
     std::string containerImage;
     bool help = false;
@@ -1631,18 +1631,13 @@ int WslaShell(_In_ std::wstring_view commandLine)
     Info.cbSize = sizeof(Info);
     THROW_IF_WIN32_BOOL_FALSE(::GetConsoleScreenBufferInfoEx(Stdout, &Info));
 
-    wsl::windows::common::WSLAProcessLauncher launcher{shell, {shell}, {"TERM=xterm-256color"}, ProcessFlags::None};
-    launcher.AddFd(WSLA_PROCESS_FD{.Fd = 0, .Type = WSLAFdTypeTerminalInput});
-    launcher.AddFd(WSLA_PROCESS_FD{.Fd = 1, .Type = WSLAFdTypeTerminalOutput});
-    launcher.AddFd(WSLA_PROCESS_FD{.Fd = 2, .Type = WSLAFdTypeTerminalControl});
-    launcher.SetTtySize(Info.srWindow.Bottom - Info.srWindow.Top + 1, Info.srWindow.Right - Info.srWindow.Left + 1);
-
     if (containerImage.empty())
     {
-        wsl::windows::common::WSLAProcessLauncher launcher{shell, {shell}, {"TERM=xterm-256color"}, ProcessFlags::None};
+        wsl::windows::common::WSLAProcessLauncher launcher{shell, {shell, "--login"}, {"TERM=xterm-256color"}, ProcessFlags::None};
         launcher.AddFd(WSLA_PROCESS_FD{.Fd = 0, .Type = WSLAFdTypeTerminalInput});
         launcher.AddFd(WSLA_PROCESS_FD{.Fd = 1, .Type = WSLAFdTypeTerminalOutput});
         launcher.AddFd(WSLA_PROCESS_FD{.Fd = 2, .Type = WSLAFdTypeTerminalControl});
+        launcher.SetTtySize(Info.srWindow.Bottom - Info.srWindow.Top + 1, Info.srWindow.Right - Info.srWindow.Left + 1);
 
         process = launcher.Launch(*session);
     }
@@ -1659,6 +1654,8 @@ int WslaShell(_In_ std::wstring_view commandLine)
         containerOptions.Name = "test-container";
         containerOptions.InitProcessOptions.Fds = fds.data();
         containerOptions.InitProcessOptions.FdsCount = static_cast<DWORD>(fds.size());
+        containerOptions.InitProcessOptions.TtyColumns = Info.srWindow.Right - Info.srWindow.Left + 1;
+        containerOptions.InitProcessOptions.TtyRows = Info.srWindow.Right - Info.srWindow.Left + 1;
 
         container.emplace();
         THROW_IF_FAILED(session->CreateContainer(&containerOptions, &container.value()));

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1655,7 +1655,7 @@ int WslaShell(_In_ std::wstring_view commandLine)
         containerOptions.InitProcessOptions.Fds = fds.data();
         containerOptions.InitProcessOptions.FdsCount = static_cast<DWORD>(fds.size());
         containerOptions.InitProcessOptions.TtyColumns = Info.srWindow.Right - Info.srWindow.Left + 1;
-        containerOptions.InitProcessOptions.TtyRows = Info.srWindow.Right - Info.srWindow.Left + 1;
+        containerOptions.InitProcessOptions.TtyRows = Info.srWindow.Bottom - Info.srWindow.Top + 1;
 
         container.emplace();
         THROW_IF_FAILED(session->CreateContainer(&containerOptions, &container.value()));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds various improvements to the debug shell: 

- Use a debug rootfs by default, so packages can be installed 
- Switch to bash since it's available in the runtime image
- Open a login shell, which has colors, and $PATH exported by default 
- Fix a bug causing the tty size to not be set correctly on launch

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
