### PR TITLE
Resolve issue with buttons on notifications not working correctly

### DIFF
--- a/src/windows/common/notifications.cpp
+++ b/src/windows/common/notifications.cpp
@@ -86,8 +86,8 @@ try
                     </binding>
                 </visual>
                 <actions>
-                    <action arguments='--{}' content='{}'/>
-                    <action arguments='--{}' content='{}'/>
+                    <action arguments='{}' content='{}'/>
+                    <action arguments='{}' content='{}'/>
                 </actions>
             </toast>)",
         Localization::MessageNewWslVersionAvailable(Localization::Options::DontImpersonate),
@@ -118,8 +118,8 @@ try
                     </binding>
                 </visual>
                 <actions>
-                    <action arguments='--{} {}' content='{}'/>
-                    <action arguments='--{} {}' content="{}"/>
+                    <action arguments='{} {}' content='{}'/>
+                    <action arguments='{} {}' content="{}"/>
                 </actions>
             </toast>)",
         Localization::MessagePerformanceTip(Localization::Options::DontImpersonate),
@@ -151,7 +151,7 @@ try
                    </binding>
                </visual>
                <actions>
-                   <action arguments='--{}' content='{}'/>
+                   <action arguments='{}' content='{}'/>
                </actions>
            </toast>)",
         Localization::MessageWarningDuringStartup(),
@@ -176,7 +176,7 @@ try
                    </binding>
                </visual>
                <actions>
-                   <action arguments='--{}' content='{}'/>
+                   <action arguments='{}' content='{}'/>
                </actions>
            </toast>)",
         Localization::MessageMissingOptionalComponents(),

--- a/src/windows/inc/wslhost.h
+++ b/src/windows/inc/wslhost.h
@@ -33,5 +33,5 @@ LPCWSTR const handle_option = L"--handle";
 LPCWSTR const event_option = L"--event";
 LPCWSTR const parent_option = L"--parent";
 LPCWSTR const vm_id_option = L"--vm-id";
-LPCWSTR const embedding_option = L"--Embedding";
+LPCWSTR const embedding_option = L"-Embedding";
 } // namespace wslhost

--- a/src/windows/service/exe/LxssUserSession.h
+++ b/src/windows/service/exe/LxssUserSession.h
@@ -503,7 +503,7 @@ public:
     /// <summary>
     /// Worker thread for logging telemetry about processes running inside of WSL.
     /// </summary>
-    void TelemetryWorker(_In_ wil::unique_socket&& socket, _In_ bool drvFsNotifications) const;
+    void TelemetryWorker(_In_ wil::unique_socket&& socket) const;
 
     /// <summary>
     /// Terminates a distribution by it's client identifier.

--- a/src/windows/wslhost/main.cpp
+++ b/src/windows/wslhost/main.cpp
@@ -74,12 +74,10 @@ public:
         // Log telemetry when a WSL notification is activated, used to determine user engagement for notifications
         WSL_LOG_TELEMETRY("NotificationActivate", PDT_ProductAndServicePerformance, TraceLoggingValue(invokedArgs, "Arguments"));
 
-        // Prepend the executable name to the arguments so getopt can be used to parse the arguments.
-        auto commandLine = wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle());
-        commandLine += L" ";
-        commandLine += invokedArgs;
+        // Prepend the executable name to the arguments.
+        auto commandLine = std::format(L"\"{}\" {}", wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()), invokedArgs);
 
-        ArgumentParser parser(GetCommandLineW(), wslhost::binary_name);
+        ArgumentParser parser(commandLine.c_str(), wslhost::binary_name);
         parser.AddArgument(
             []() {
                 std::wstring path;

--- a/src/windows/wslhost/main.cpp
+++ b/src/windows/wslhost/main.cpp
@@ -74,10 +74,7 @@ public:
         // Log telemetry when a WSL notification is activated, used to determine user engagement for notifications
         WSL_LOG_TELEMETRY("NotificationActivate", PDT_ProductAndServicePerformance, TraceLoggingValue(invokedArgs, "Arguments"));
 
-        // Prepend the executable name to the arguments.
-        auto commandLine = std::format(L"\"{}\" {}", wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()), invokedArgs);
-
-        ArgumentParser parser(commandLine.c_str(), wslhost::binary_name);
+        ArgumentParser parser(invokedArgs, wslhost::binary_name, 0);
         parser.AddArgument(
             []() {
                 std::wstring path;


### PR DESCRIPTION
This pull request resolves an issue where the buttons on notifications were not working properly. This regressed with the introduction of the command line parsing helper class because this is difficult to test programmatically. There are three changes:

1. Pass arguments to wslhost.exe correctly (fix double `--` character insertion)
2. Escape `C:\Program Files\WSL\wslhost.exe` path to resolve issue with space in the path name.
3. Fix issue where the COM embedding variable was incorrectly changed from `-Embedding` to `--Embedding`
4. NFC: Push logic to read disabled notification registry key into the TelemetryWorker method.

Resolves #13908