### PR TITLE
test: add more path translation variations

### DIFF
--- a/test/linux/unit_tests/wslpath.c
+++ b/test/linux/unit_tests/wslpath.c
@@ -163,6 +163,13 @@ Return Value:
     LxtCheckResult(LxtCheckWslPathTranslation("C:/Foo/bar", "/mnt/c/Foo/bar", true));
     LxtCheckResult(LxtCheckWslPathTranslation("foo", "foo", true));
     LxtCheckResult(LxtCheckWslPathTranslation("foo\\", "foo/", true));
+    LxtCheckResult(LxtCheckWslPathTranslation("C:\\Program Files\\Git", "/mnt/c/Program Files/Git", true));
+    LxtCheckResult(LxtCheckWslPathTranslation("C:\\Program Files\\PowerShell\\7", "/mnt/c/Program Files/PowerShell/7", true));
+    LxtCheckResult(LxtCheckWslPathTranslation("C:\\Program Files (x86)\\Common Files", "/mnt/c/Program Files (x86)/Common Files", true));
+    LxtCheckResult(LxtCheckWslPathTranslation(
+        "C:\\Users\\Test User\\AppData\\Local\\Programs\\Microsoft VS Code\\bin",
+        "/mnt/c/Users/Test User/AppData/Local/Programs/Microsoft VS Code/bin",
+        true));
 
 ErrorExit:
     return Result;
@@ -241,6 +248,13 @@ Return Value:
     LxtCheckResult(LxtCheckWslPathTranslation("/mnt/c/Users", "C:\\Users", false));
     LxtCheckResult(LxtCheckWslPathTranslation("/mnt/c/Users/", "C:\\Users\\", false));
     LxtCheckResult(LxtCheckWslPathTranslation("/mnt/c/DOESNOTEXIST/", "C:\\DOESNOTEXIST\\", false));
+    LxtCheckResult(LxtCheckWslPathTranslation("/mnt/c/Program Files/Git", "C:\\Program Files\\Git", false));
+    LxtCheckResult(LxtCheckWslPathTranslation("/mnt/c/Program Files/PowerShell/7", "C:\\Program Files\\PowerShell\\7", false));
+    LxtCheckResult(LxtCheckWslPathTranslation("/mnt/c/Program Files (x86)/Common Files", "C:\\Program Files (x86)\\Common Files", false));
+    LxtCheckResult(LxtCheckWslPathTranslation(
+        "/mnt/c/Users/Test User/AppData/Local/Programs/Microsoft VS Code/bin",
+        "C:\\Users\\Test User\\AppData\\Local\\Programs\\Microsoft VS Code\\bin",
+        false));
 
 ErrorExit:
     return Result;

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -262,5 +262,39 @@ class SimpleTests
         std::transform(upperCaseGuidStringWide.begin(), upperCaseGuidStringWide.end(), upperCaseGuidStringWide.begin(), toupper);
         VERIFY_ARE_EQUAL(upperCaseGuidStringWide, wsl::shared::string::GuidToString<wchar_t>(guid, wsl::shared::string::GuidToStringFlags::Uppercase));
     }
+
+    TEST_METHOD(WindowsPathWithSpaces)
+    {
+        wil::unique_environstrings_ptr originalPath;
+        const DWORD pathLength = GetEnvironmentVariableW(L"PATH", nullptr, 0);
+        if (pathLength > 0)
+        {
+            originalPath.reset(static_cast<PWSTR>(HeapAlloc(GetProcessHeap(), 0, pathLength * sizeof(wchar_t))));
+            THROW_LAST_ERROR_IF_NULL(originalPath.get());
+            THROW_LAST_ERROR_IF(GetEnvironmentVariableW(L"PATH", originalPath.get(), pathLength) == 0);
+        }
+
+        auto cleanup = wil::scope_exit([&]() {
+            if (originalPath)
+            {
+                THROW_LAST_ERROR_IF(!SetEnvironmentVariableW(L"PATH", originalPath.get()));
+            }
+        });
+
+        const wchar_t* testPath =
+            L"C:\\Program Files\\Git\\cmd;"
+            L"C:\\Program Files\\PowerShell\\7;"
+            L"C:\\Program Files (x86)\\Common Files;"
+            L"C:\\Users\\Test User\\AppData\\Local\\Programs\\Microsoft VS Code\\bin";
+
+        THROW_LAST_ERROR_IF(!SetEnvironmentVariableW(L"PATH", testPath));
+
+        auto [output, __] = LxsstuLaunchWslAndCaptureOutput(L"echo $PATH");
+
+        VERIFY_IS_TRUE(output.find(L"/mnt/c/Program Files/Git/cmd") != std::wstring::npos);
+        VERIFY_IS_TRUE(output.find(L"/mnt/c/Program Files/PowerShell/7") != std::wstring::npos);
+        VERIFY_IS_TRUE(output.find(L"/mnt/c/Program Files (x86)/Common Files") != std::wstring::npos);
+        VERIFY_IS_TRUE(output.find(L"/mnt/c/Users/Test User/AppData/Local/Programs/Microsoft VS Code/bin") != std::wstring::npos);
+    }
 };
 } // namespace SimpleTests

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -289,7 +289,7 @@ class SimpleTests
 
         THROW_LAST_ERROR_IF(!SetEnvironmentVariableW(L"PATH", testPath));
 
-        auto [output, __] = LxsstuLaunchWslAndCaptureOutput(L"echo $PATH");
+        auto [output, _] = LxsstuLaunchWslAndCaptureOutput(L"echo $PATH");
 
         VERIFY_IS_TRUE(output.find(L"/mnt/c/Program Files/Git/cmd") != std::wstring::npos);
         VERIFY_IS_TRUE(output.find(L"/mnt/c/Program Files/PowerShell/7") != std::wstring::npos);


### PR DESCRIPTION
While triaging issues I came across #13794. To debug the issue, I wrote some additional test variations, which all seem to be passing. If there is an issue here, it's likely it is with something VsCode is doing.