### PR TITLE
cleanup: remove duplicate AppId registration for wsldevicehost.dll

### DIFF
--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -183,21 +183,12 @@
                 <!-- WslDeviceHost_VirtioFs (admin) -->
                 <RegistryKey Root="HKCR" Key="CLSID\{7e6ad219-d1b3-42d5-b8ee-d96324e64ff6}">
                     <RegistryValue Value="WslDeviceHost_VirtioFs_Admin" Type="string"/>
-                    <RegistryValue Name="AppId" Value="{7F82AD86-755B-4870-86B1-D2E68DFE8A49}" Type="string"/>
+                    <RegistryValue Name="AppId" Value="{17696EAC-9568-4CF5-BB8C-82515AAD6C09}" Type="string"/>
 
                     <RegistryKey Key="InProcServer32">
                         <RegistryValue Value="[INSTALLDIR]wsldevicehost.dll" Type="string"/>
                         <RegistryValue Name="ThreadingModel" Value="Both" Type="string"/>
                     </RegistryKey>
-                </RegistryKey>
-
-                <RegistryKey Root="HKCR" Key="AppID\{7F82AD86-755B-4870-86B1-D2E68DFE8A49}">
-                    <RegistryValue Name="DllSurrogate" Value="" Type="string"/>
-                    <RegistryValue Name="AppIDFlags" Value="2048" Type="integer"/><!--0x800-->
-
-                    <!-- O:BAG:BAD:(A;;CCDCSW;;;AU)(A;;CCDCSW;;;PS)(A;;CCDCSW;;;SY) -->
-                    <RegistryValue Name="AccessPermission" Value="01000480580000006800000000000000140000000200440003000000000014000B00000001010000000000050B000000000014000B00000001010000000000050A000000000014000B0000000101000000000005120000000102000000000005200000002002000001020000000000052000000020020000" Type="binary" />
-                    <RegistryValue Name="LaunchPermission" Value="01000480580000006800000000000000140000000200440003000000000014000B00000001010000000000050B000000000014000B00000001010000000000050A000000000014000B0000000101000000000005120000000102000000000005200000002002000001020000000000052000000020020000" Type="binary" />
                 </RegistryKey>
 
                 <!-- WslDeviceHost_VirtioFs -->

--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -461,7 +461,7 @@ extern "C" UINT __stdcall CleanMsixState(MSIHANDLE install)
         const std::map<LPCWSTR, LPCWSTR> keys{
             {L"SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application", L"WSL"},
             {L"SOFTWARE\\Classes\\CLSID", L"{7e6ad219-d1b3-42d5-b8ee-d96324e64ff6}"},
-            {L"SOFTWARE\\Classes\\AppID", L"{7F82AD86-755B-4870-86B1-D2E68DFE8A49}"},
+            {L"SOFTWARE\\Classes\\AppID", L"{17696EAC-9568-4CF5-BB8C-82515AAD6C09}"},
             {L"SOFTWARE\\Microsoft\\Terminal Server Client", L"Default"},
             {L"SOFTWARE\\Microsoft\\Terminal Server Client\\Default", L"OptionalAddIns"},
             {L"SOFTWARE\\Microsoft\\Terminal Server Client\\Default\\OptionalAddIns", L"WSLDVC_PACKAGE"}};

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2312,7 +2312,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         const std::vector<LPCWSTR> serviceKeys{
             L"SOFTWARE\\Microsoft\\Terminal Server Client\\Default\\OptionalAddIns\\WSLDVC_PACKAGE",
             L"SOFTWARE\\Classes\\CLSID\\{7e6ad219-d1b3-42d5-b8ee-d96324e64ff6}",
-            L"SOFTWARE\\Classes\\AppID\\{7F82AD86-755B-4870-86B1-D2E68DFE8A49}"};
+            L"SOFTWARE\\Classes\\AppID\\{17696EAC-9568-4CF5-BB8C-82515AAD6C09}"};
 
         for (const auto* keyName : serviceKeys)
         {


### PR DESCRIPTION
This pull request updates the AppID GUID used for the WslDeviceHost_VirtioFs_Admin COM registration to use the same AppID as the rest of the wsldevicehost COM classes. This was originally thought to support admin / non-admin VirtioFS shares, but the same AppId is able to run at both elevation levels due to COM impersonation.

There are existing tests that verify that admin / non-admin VirtioFs shares get the right permission.