### PR TITLE
Remove the explicit desktop field when creating a Windows process

### DIFF
--- a/src/windows/common/SubProcess.cpp
+++ b/src/windows/common/SubProcess.cpp
@@ -92,11 +92,6 @@ void SubProcess::SetFlags(DWORD Flag)
     WI_SetAllFlags(m_flags, Flag);
 }
 
-void SubProcess::SetDesktop(LPCWSTR Desktop)
-{
-    m_desktop = Desktop;
-}
-
 void SubProcess::SetToken(HANDLE Token)
 {
     m_token = Token;

--- a/src/windows/common/SubProcess.h
+++ b/src/windows/common/SubProcess.h
@@ -37,7 +37,6 @@ public:
     void InheritHandle(HANDLE Handle);
     void SetEnvironment(LPVOID Environment);
     void SetWorkingDirectory(LPCWSTR Directory);
-    void SetDesktop(LPCWSTR Desktop);
     void SetToken(HANDLE Token);
     void SetShowWindow(WORD Show);
     void SetFlags(DWORD Flag);

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -195,7 +195,6 @@ CreateProcessResult CreateProcess(_In_ CreateProcessParsed* Parsed, _In_ HANDLE 
     wsl::windows::common::helpers::SetHandleInheritable(StdErr);
 
     wsl::windows::common::SubProcess process(Parsed->ApplicationName.c_str(), Parsed->CommandLine(), CREATE_UNICODE_ENVIRONMENT);
-    process.SetDesktop(L"winsta0\\default");
 
     CreateProcessResult Result{};
     if (Parsed->CreatePseudoconsole)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change removes the explicit lpDesktop flag when creating a Windows process. 

Windows threads inherit their parent's desktop by default. See: https://learn.microsoft.com/en-us/windows/win32/winstation/thread-connection-to-a-desktop 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #13909
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
