### PR TITLE
WSLA: Always user the token of the user that created the VM

### DIFF
--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -149,6 +149,7 @@ private:
     PSID m_userSid{};
     wil::shared_handle m_userToken;
     std::wstring m_debugShellPipe;
+    GUID m_virtioFsClassId;
 
     std::mutex m_trackedProcessesLock;
     std::vector<WSLAProcess*> m_trackedProcesses;


### PR DESCRIPTION
Currently there are a few paths that use COM impersonation to get the token of the calling user. For WSLA we want to always use the token of the user that created the VM.