### PR TITLE
Enable bridge network test and reduce Stop() timeouts

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1347,7 +1347,7 @@ class WSLATests
             // Verify that the container is in running state.
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
 
-            VERIFY_SUCCEEDED(container.Get().Stop(15, 50000));
+            VERIFY_SUCCEEDED(container.Get().Stop(15, 0));
 
             // TODO: Once 'container run' is split into 'container create' + 'container start',
             // validate that Stop() on a container in 'Created' state returns ERROR_INVALID_STATE.
@@ -1413,14 +1413,14 @@ class WSLATests
                  {"test-unique-name", "debian:latest", WslaContainerStateExited}});
 
             // Verify that calling Stop() on exited containers is a no-op and state remains as WslaContainerStateExited.
-            VERIFY_SUCCEEDED(container.Get().Stop(15, 50000));
+            VERIFY_SUCCEEDED(container.Get().Stop(15, 0));
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
 
             // Verify that stopped containers can be deleted.
             VERIFY_SUCCEEDED(container.Get().Delete());
 
             // Verify that stopping a deleted container returns ERROR_INVALID_STATE.
-            VERIFY_ARE_EQUAL(container.Get().Stop(15, 50000), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
+            VERIFY_ARE_EQUAL(container.Get().Stop(15, 0), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
 
             // Verify that deleted containers can't be deleted again.
             VERIFY_ARE_EQUAL(container.Get().Delete(), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1504,7 +1504,7 @@ class WSLATests
                 0);
             VERIFY_ARE_EQUAL(result.Output[1], "'[\"host\"]'\n");
 
-            VERIFY_SUCCEEDED(container.Get().Stop(15, 50000));
+            VERIFY_SUCCEEDED(container.Get().Stop(15, 0));
 
             expectContainerList({{"test-network", "debian:latest", WslaContainerStateExited}});
 
@@ -1535,7 +1535,7 @@ class WSLATests
                 0);
             VERIFY_ARE_EQUAL(result.Output[1], "'[\"none\"]'\n");
 
-            VERIFY_SUCCEEDED(container.Get().Stop(15, 50000));
+            VERIFY_SUCCEEDED(container.Get().Stop(15, 0));
 
             expectContainerList({{"test-network", "debian:latest", WslaContainerStateExited}});
 
@@ -1563,10 +1563,15 @@ class WSLATests
         }
 
         // Test bridge when ready
-        /*
         {
             WSLAContainerLauncher launcher(
-                "debian:latest", "test-network", {}, {"sleep", "99999"}, {}, WSLA_CONTAINER_NETWORK_TYPE::WSLA_CONTAINER_NETWORK_BRIDGE, ProcessFlags::Stdout | ProcessFlags::Stderr);
+                "debian:latest",
+                "test-network",
+                {},
+                {"sleep", "99999"},
+                {},
+                WSLA_CONTAINER_NETWORK_TYPE::WSLA_CONTAINER_NETWORK_BRIDGE,
+                ProcessFlags::Stdout | ProcessFlags::Stderr);
 
             auto container = launcher.Launch(*session);
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
@@ -1576,7 +1581,7 @@ class WSLATests
                 0);
             VERIFY_ARE_EQUAL(result.Output[1], "'[\"bridge\"]'\n");
 
-            VERIFY_SUCCEEDED(container.Get().Stop(15, 50000));
+            VERIFY_SUCCEEDED(container.Get().Stop(15, 0));
 
             expectContainerList({{"test-network", "debian:latest", WslaContainerStateExited}});
 
@@ -1588,7 +1593,6 @@ class WSLATests
 
             expectContainerList({});
         }
-        */
     }
 
     TEST_METHOD(Exec)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR does two things: 

- Enable the bridge network tests
- Reduce the timeouts when calling Stop() in the ContainerNetwork test case (the current timeouts cause a 100 seconds delay when the test runs) 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
