### PR TITLE
cleanup: add scsi disks during VM creation

### DIFF
--- a/src/windows/common/hcs_schema.h
+++ b/src/windows/common/hcs_schema.h
@@ -435,7 +435,7 @@ inline void to_json(nlohmann::json& j, const Chipset& chipset)
 
 struct Scsi
 {
-    std::map<std::string, EmptyObject> Attachments;
+    std::map<std::string, Attachment> Attachments;
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(Scsi, Attachments);
 };
 

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1730,7 +1730,7 @@ std::wstring WslCoreVm::GenerateConfigJson()
         return lun;
     };
 
-    if (m_systemDistroDeviceType = LxMiniInitMountDeviceTypeLun)
+    if (m_systemDistroDeviceType == LxMiniInitMountDeviceTypeLun)
     {
         m_systemDistroDeviceId = attachDisk(m_vmConfig.SystemDistroPath.c_str());
     }

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -451,27 +451,12 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     ReadGuestCapabilities();
 
     // Mount the system distro.
+    // N.B. If using SCSI, the system distro is added during VM creation.
     switch (m_systemDistroDeviceType)
     {
-    case LxMiniInitMountDeviceTypeLun:
-        m_systemDistroDeviceId =
-            AttachDiskLockHeld(m_vmConfig.SystemDistroPath.c_str(), DiskType::VHD, MountFlags::ReadOnly, {}, false, m_userToken.get());
-        break;
-
     case LxMiniInitMountDeviceTypePmem:
         m_systemDistroDeviceId = MountFileAsPersistentMemory(m_vmConfig.SystemDistroPath.c_str(), true);
         break;
-
-    default:
-        break;
-    }
-
-    // Mount the kernel modules VHD.
-    ULONG modulesLun = ULONG_MAX;
-    if (!m_vmConfig.KernelModulesPath.empty())
-    {
-        modulesLun =
-            AttachDiskLockHeld(m_vmConfig.KernelModulesPath.c_str(), DiskType::VHD, MountFlags::ReadOnly, {}, false, m_userToken.get());
     }
 
     // Attempt to create and mount the swap vhd.
@@ -543,7 +528,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     message->EnableSafeMode = m_vmConfig.EnableSafeMode;
     message->EnableDnsTunneling = m_vmConfig.EnableDnsTunneling;
     message->DefaultKernel = m_defaultKernel;
-    message->KernelModulesDeviceId = modulesLun;
+    message->KernelModulesDeviceId = m_kernelModulesDeviceId;
     message.WriteString(message->HostnameOffset, wsl::windows::common::filesystem::GetLinuxHostName());
     message.WriteString(message->KernelModulesListOffset, m_vmConfig.KernelModulesList);
     message->DnsTunnelingIpAddress = m_vmConfig.DnsTunnelingIpAddress.value_or(0);
@@ -1729,9 +1714,33 @@ std::wstring WslCoreVm::GenerateConfigJson()
         vmSettings.Chipset.Uefi = std::move(uefiSettings);
     }
 
-    // Initialize other devices.
-    vmSettings.Devices.Scsi["0"] = hcs::Scsi{};
-    hcs::HvSocket hvSocketConfig{};
+    // Initialize SCSI devices.
+    hcs::Scsi scsiController{};
+    auto attachDisk = [&](PCWSTR path) {
+        auto lun = ReserveLun();
+        hcs::Attachment disk{};
+        disk.Type = hcs::AttachmentType::VirtualDisk;
+        disk.Path = path;
+        disk.ReadOnly = true;
+        disk.SupportCompressedVolumes = true;
+        disk.AlwaysAllowSparseFiles = true;
+        disk.SupportEncryptedFiles = true;
+        scsiController.Attachments[std::to_string(lun)] = std::move(disk);
+        m_attachedDisks.emplace(AttachedDisk{DiskType::VHD, path, false}, DiskState{lun, {}, {}});
+        return lun;
+    };
+
+    if (m_systemDistroDeviceType = LxMiniInitMountDeviceTypeLun)
+    {
+        m_systemDistroDeviceId = attachDisk(m_vmConfig.SystemDistroPath.c_str());
+    }
+
+    if (!m_vmConfig.KernelModulesPath.empty())
+    {
+        m_kernelModulesDeviceId = attachDisk(m_vmConfig.KernelModulesPath.c_str());
+    }
+
+    vmSettings.Devices.Scsi["0"] = std::move(scsiController);
 
     // Construct a security descriptor that allows system and the current user.
     wil::unique_hlocal_string userSidString;
@@ -1740,6 +1749,7 @@ std::wstring WslCoreVm::GenerateConfigJson()
     std::wstring securityDescriptor{L"D:P(A;;FA;;;SY)(A;;FA;;;"};
     securityDescriptor += userSidString.get();
     securityDescriptor += L")";
+    hcs::HvSocket hvSocketConfig{};
     hvSocketConfig.HvSocketConfig.DefaultBindSecurityDescriptor = securityDescriptor;
     hvSocketConfig.HvSocketConfig.DefaultConnectSecurityDescriptor = securityDescriptor;
     vmSettings.Devices.HvSocket = std::move(hvSocketConfig);

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -242,7 +242,7 @@ private:
     void ReadGuestCapabilities();
 
     _Requires_lock_held_(m_lock)
-    ULONG ReserveLun(_In_ std::optional<ULONG> Lun);
+    ULONG ReserveLun(_In_ std::optional<ULONG> Lun = {});
 
     void RestorePassthroughDiskState(_In_ LPCWSTR Disk) const;
 
@@ -296,6 +296,7 @@ private:
     bool m_defaultKernel = true;
     LX_MINI_INIT_MOUNT_DEVICE_TYPE m_systemDistroDeviceType = LxMiniInitMountDeviceTypeInvalid;
     ULONG m_systemDistroDeviceId = ULONG_MAX;
+    ULONG m_kernelModulesDeviceId = ULONG_MAX;
     wsl::windows::common::hcs::unique_hcs_system m_system;
     wil::unique_socket m_listenSocket;
     std::function<void(GUID)> m_onExit;


### PR DESCRIPTION
This change moves from "hot adding" the system distro and kernel modules VHDs during runtime, to adding them to the initial creation JSON of the VM. This will have marginally better performance but also simplifies the flow and removes error paths.