### PR TITLE
Fix version typos in dev-loop.md

### DIFF
--- a/doc/docs/dev-loop.md
+++ b/doc/docs/dev-loop.md
@@ -4,13 +4,13 @@
 
 The following tools are required to build WSL: 
 
-- CMake >= 2.25
+- CMake >= 3.25
     - Can be installed with `winget install Kitware.CMake`
 - Visual Studio with the following components:
     - Windows SDK 26100
     - MSBuild
     - Universal Windows platform support for v143 build tools (X64 and ARM64)
-    - MSVC v143 - VS 2020 C++ ARM64 build tools (Latest + Spectre) (X64 and ARM64)
+    - MSVC v143 - VS 2022 C++ ARM64 build tools (Latest + Spectre) (X64 and ARM64)
     - C++ core features
     - C++ ATL for latest v143 tools (X64 and ARM64)
     - C++ Clang compiler for Windows


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix version typos in dev-loop.md (CMake 3.25, VS 2022)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** Link to issue #13949
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This PR fixes two version typos in `doc/docs/dev-loop.md`:

1. CMake version: `2.25` → `3.25`
   - CMake 2.25 does not exist
   - Now consistent with `CMakeLists.txt` which specifies `cmake_minimum_required(VERSION 3.25)`

2. MSVC toolset version: `VS 2020` → `VS 2022`
   - VS 2020 does not exist
   - The v143 toolset corresponds to Visual Studio 2022

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Verified CMake version matches `CMakeLists.txt`
- Confirmed v143 toolset is Visual Studio 2022