### PR TITLE
tracing: add WSLA trace provider to wsl.wprp

### DIFF
--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -11,6 +11,7 @@
     <EventProvider Id="lxcore_service" Name="B99CDB5A-039C-5046-E672-1A0DE0A40211"/>
     <EventProvider Id="wsl_devicehost" Name="9d6c7b9e-2581-4d8a-b8c5-b90b4a17094a"/>
     <EventProvider Id="wslclient" Name="8cbb7724-7223-5d6f-8137-564dac45104d"/>
+    <EventProvider Id="wslaservice" Name="0383CE62-8F86-4766-AFB2-9D66A7FB1E90"/>
     <EventProvider Id="wslapi" Name="beb94edf-1a7b-5058-0696-ff9e6b1798d1"/>
     <EventProvider Id="vfpext" Name="9F2660EA-CFE7-428F-9850-AECA612619B0" />
     <EventProvider Id="vm_chipset" Name="de9ba731-7f33-4f44-98c9-6cac856b9f83"/>

--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -116,6 +116,7 @@
             <EventProviderId Value="lxcore_service"/>
             <EventProviderId Value="wsl_devicehost"/>
             <EventProviderId Value="wslclient"/>
+            <EventProviderId Value="wslaservice"/>
             <EventProviderId Value="wslapi"/>
             <EventProviderId Value="vfpext"/>
             <EventProviderId Value="vm_chipset"/>


### PR DESCRIPTION
Multiple times I have attempted to take WSLA traces without realizing that the WSLA provider is not present in the wprp profile on the default branch.