### PR TITLE
virtiofs: enable test case for mapping virtiofs MAP_PRIVATE

### DIFF
--- a/test/linux/unit_tests/drvfs.c
+++ b/test/linux/unit_tests/drvfs.c
@@ -3475,6 +3475,10 @@ Return Value:
     // is what execve uses.
     //
 
+    LxtCheckMapErrno(Mapping = mmap(NULL, 2, PROT_READ, MAP_PRIVATE, Fd, 0));
+    LxtCheckMemoryEqual(Mapping, "MZ", 2);
+    LxtCheckResult(munmap(Mapping, 2));
+
     if (g_LxtFsInfo.FsType != LxtFsTypeVirtioFs)
     {
         LxtCheckMapErrno(Mapping = mmap(NULL, 2, PROT_READ, MAP_SHARED, Fd, 0));
@@ -3482,7 +3486,7 @@ Return Value:
     }
     else
     {
-        LxtLogInfo("TODO: debug virtiofs handling of app exec links");
+        LxtLogInfo("TODO: virtiofs does not support MAP_SHARED");
     }
 
 ErrorExit:


### PR DESCRIPTION
This test enables the virtiofs variation for mapping an app execution link as MAP_PRIVATE and clarifies what support is missing.