### PR TITLE
Refactor wsladiag CLI parsing and fix shell PTY handling

### DIFF
--- a/src/shared/inc/CommandLine.h
+++ b/src/shared/inc/CommandLine.h
@@ -307,8 +307,8 @@ class ArgumentParser
 public:
 #ifdef WIN32
 
-    ArgumentParser(const std::wstring& CommandLine, LPCWSTR Name, int StartIndex = 1, bool IgnoreUnknownArgs = false) :
-        m_startIndex(StartIndex), m_name(Name), m_stopUnknownArgs(IgnoreUnknownArgs)
+    ArgumentParser(const std::wstring& CommandLine, LPCWSTR Name, int StartIndex = 1, bool stopUnknownArgs = false) :
+        m_startIndex(StartIndex), m_name(Name), m_stopUnknownArgs(stopUnknownArgs)
     {
         m_argv.reset(CommandLineToArgvW(std::wstring(CommandLine).c_str(), &m_argc));
         THROW_LAST_ERROR_IF(!m_argv);
@@ -316,8 +316,8 @@ public:
 
 #else
 
-    ArgumentParser(int argc, const char* const* argv, bool IgnoreUnknownArgs = false) :
-        m_argc(argc), m_argv(argv), m_startIndex(1), m_stopUnknownArgs(IgnoreUnknownArgs)
+    ArgumentParser(int argc, const char* const* argv, bool stopUnknownArgs = false) :
+        m_argc(argc), m_argv(argv), m_startIndex(1), m_stopUnknownArgs(stopUnknownArgs)
     {
     }
 
@@ -402,7 +402,7 @@ public:
                         const TChar* value = nullptr;
                         if (e.Positional)
                         {
-                            value = m_argv[i]; // Positional arguments directly receive arvg[i]
+                            value = m_argv[i]; // Positional arguments directly receive argv[i]
                         }
                         else if (i + 1 < m_argc)
                         {

--- a/src/shared/inc/CommandLine.h
+++ b/src/shared/inc/CommandLine.h
@@ -307,8 +307,8 @@ class ArgumentParser
 public:
 #ifdef WIN32
 
-    ArgumentParser(const std::wstring& CommandLine, LPCWSTR Name, int StartIndex = 1, bool stopUnknownArgs = false) :
-        m_startIndex(StartIndex), m_name(Name), m_stopUnknownArgs(stopUnknownArgs)
+    ArgumentParser(const std::wstring& CommandLine, LPCWSTR Name, int StartIndex = 1, bool ignoreUnknownArgs = false) :
+        m_startIndex(StartIndex), m_name(Name), m_ignoreUnknownArgs(ignoreUnknownArgs)
     {
         m_argv.reset(CommandLineToArgvW(std::wstring(CommandLine).c_str(), &m_argc));
         THROW_LAST_ERROR_IF(!m_argv);
@@ -316,8 +316,8 @@ public:
 
 #else
 
-    ArgumentParser(int argc, const char* const* argv, bool stopUnknownArgs = false) :
-        m_argc(argc), m_argv(argv), m_startIndex(1), m_stopUnknownArgs(stopUnknownArgs)
+    ArgumentParser(int argc, const char* const* argv, bool ignoreUnknownArgs = false) :
+        m_argc(argc), m_argv(argv), m_startIndex(1), m_ignoreUnknownArgs(ignoreUnknownArgs)
     {
     }
 
@@ -431,7 +431,7 @@ public:
 
             if (!foundMatch)
             {
-                if (m_stopUnknownArgs)
+                if (m_ignoreUnknownArgs)
                 {
                     break;
                 }
@@ -542,7 +542,7 @@ private:
 
     int m_startIndex{};
     const TChar* m_name{};
-    bool m_stopUnknownArgs{false};
+    bool m_ignoreUnknownArgs{false};
 };
 } // namespace wsl::shared
 

--- a/src/shared/inc/CommandLine.h
+++ b/src/shared/inc/CommandLine.h
@@ -307,7 +307,8 @@ class ArgumentParser
 public:
 #ifdef WIN32
 
-    ArgumentParser(const std::wstring& CommandLine, LPCWSTR Name, int StartIndex = 1) : m_startIndex(StartIndex), m_name(Name)
+    ArgumentParser(const std::wstring& CommandLine, LPCWSTR Name, int StartIndex = 1, bool IgnoreUnknownArgs = false) :
+        m_startIndex(StartIndex), m_name(Name), m_ignoreUnknownArgs(IgnoreUnknownArgs)
     {
         m_argv.reset(CommandLineToArgvW(std::wstring(CommandLine).c_str(), &m_argc));
         THROW_LAST_ERROR_IF(!m_argv);
@@ -315,7 +316,8 @@ public:
 
 #else
 
-    ArgumentParser(int argc, const char* const* argv) : m_argc(argc), m_argv(argv), m_startIndex(1)
+    ArgumentParser(int argc, const char* const* argv, bool IgnoreUnknownArgs = false) :
+        m_argc(argc), m_argv(argv), m_startIndex(1), m_ignoreUnknownArgs(IgnoreUnknownArgs)
     {
     }
 
@@ -429,6 +431,11 @@ public:
 
             if (!foundMatch)
             {
+                if (m_ignoreUnknownArgs)
+                {
+                    break;
+                }
+
                 THROW_USER_ERROR(wsl::shared::Localization::MessageInvalidCommandLine(m_argv[i], m_name ? m_name : m_argv[0]));
             }
 
@@ -535,6 +542,7 @@ private:
 
     int m_startIndex{};
     const TChar* m_name{};
+    bool m_ignoreUnknownArgs{false};
 };
 } // namespace wsl::shared
 

--- a/src/shared/inc/CommandLine.h
+++ b/src/shared/inc/CommandLine.h
@@ -308,7 +308,7 @@ public:
 #ifdef WIN32
 
     ArgumentParser(const std::wstring& CommandLine, LPCWSTR Name, int StartIndex = 1, bool IgnoreUnknownArgs = false) :
-        m_startIndex(StartIndex), m_name(Name), m_ignoreUnknownArgs(IgnoreUnknownArgs)
+        m_startIndex(StartIndex), m_name(Name), m_stopUnknownArgs(IgnoreUnknownArgs)
     {
         m_argv.reset(CommandLineToArgvW(std::wstring(CommandLine).c_str(), &m_argc));
         THROW_LAST_ERROR_IF(!m_argv);
@@ -317,7 +317,7 @@ public:
 #else
 
     ArgumentParser(int argc, const char* const* argv, bool IgnoreUnknownArgs = false) :
-        m_argc(argc), m_argv(argv), m_startIndex(1), m_ignoreUnknownArgs(IgnoreUnknownArgs)
+        m_argc(argc), m_argv(argv), m_startIndex(1), m_stopUnknownArgs(IgnoreUnknownArgs)
     {
     }
 
@@ -431,7 +431,7 @@ public:
 
             if (!foundMatch)
             {
-                if (m_ignoreUnknownArgs)
+                if (m_stopUnknownArgs)
                 {
                     break;
                 }
@@ -542,7 +542,7 @@ private:
 
     int m_startIndex{};
     const TChar* m_name{};
-    bool m_ignoreUnknownArgs{false};
+    bool m_stopUnknownArgs{false};
 };
 } // namespace wsl::shared
 

--- a/src/windows/common/ExecutionContext.h
+++ b/src/windows/common/ExecutionContext.h
@@ -66,6 +66,7 @@ enum Context : ULONGLONG
     UpdatePackage = 0x10000000000,
     QueryLatestGitHubRelease = 0x20000000000,
     VerifyChecksum = 0x40000000000,
+    WslaDiag = 0x80000000000,
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(Context)

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -191,7 +191,8 @@ static const std::map<Context, LPCWSTR> g_contextStrings{
     X(HNS),
     X(ReadDistroConfig),
     X(MoveDistro),
-    X(VerifyChecksum)};
+    X(VerifyChecksum),
+    X(WslaDiag)};
 
 #undef X
 

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -346,11 +346,6 @@ int wmain(int, wchar_t**)
     catch (...)
     {
         const auto hr = wil::ResultFromCaughtException();
-        if (hr == E_INVALIDARG)
-        {
-            PrintUsage();
-            return 1;
-        }
         return ReportError(L"wsladiag failed", hr);
     }
 }

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -165,8 +165,8 @@ static int RunShellCommand(std::wstring_view commandLine)
         THROW_IF_WIN32_BOOL_FALSE(GetConsoleScreenBufferInfoEx(consoleOut, &infoEx));
 
         WSLA_TERMINAL_CHANGED message{};
-        message.Columns = static_cast<unsigned short>(infoEx.srWindow.Right - infoEx.srWindow.Left + 1);
-        message.Rows = static_cast<unsigned short>(infoEx.srWindow.Bottom - infoEx.srWindow.Top + 1);
+        message.Columns = infoEx.srWindow.Right - infoEx.srWindow.Left + 1;
+        message.Rows = infoEx.srWindow.Bottom - infoEx.srWindow.Top + 1;
 
         controlChannel.SendMessage(message);
     };

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -8,7 +8,7 @@ Module Name:
 
 Abstract:
 
-    Entry point for the wsladiag tool, performs WSL runtime initialization and parses list/shell/help.
+    Entry point for the wsladiag tool. Provides diagnostic commands for WSLA sessions.
 
 --*/
 
@@ -24,32 +24,25 @@ Abstract:
 
 using namespace wsl::shared;
 namespace wslutil = wsl::windows::common::wslutil;
+using wsl::windows::common::Context;
+using wsl::windows::common::ExecutionContext;
 using wsl::windows::common::WSLAProcessLauncher;
 
-// Adding a helper to factor error handling between all the arguments.
+// Report an operation failure with localized context and HRESULT details.
 static int ReportError(const std::wstring& context, HRESULT hr)
 {
-    const std::wstring hrMessage = wslutil::GetErrorString(hr);
-
-    if (!hrMessage.empty())
-    {
-        wslutil::PrintMessage(std::format(L"{}: 0x{:08x} - {}", context, static_cast<uint32_t>(hr), hrMessage), stderr);
-    }
-    else
-    {
-        wslutil::PrintMessage(std::format(L"{}: 0x{:08x}", context, static_cast<uint32_t>(hr)), stderr);
-    }
-
+    auto errorString = wsl::windows::common::wslutil::ErrorCodeToString(hr);
+    wslutil::PrintMessage(context, stderr);
     return 1;
 }
 
-// Handler for `wsladiag shell <SessionName> [--verbose]` command - launches TTY-backed interactive shell.
+// Handler for `wsladiag shell <SessionName>` command.
 static int RunShellCommand(std::wstring_view commandLine)
 {
     std::wstring sessionName;
     bool verbose = false;
 
-    ArgumentParser parser(std::wstring{commandLine}, L"wsladiag", 2, false); // Skip "wsladiag.exe shell" to parse shell-specific args
+    ArgumentParser parser(std::wstring{commandLine}, L"wsladiag", 2, false);
     parser.AddPositionalArgument(sessionName, 0);
     parser.AddArgument(verbose, L"--verbose", L'v');
 
@@ -60,15 +53,6 @@ static int RunShellCommand(std::wstring_view commandLine)
         THROW_HR_WITH_USER_ERROR(
             E_INVALIDARG, wsl::shared::Localization::MessageMissingArgument(L"<SessionName>", L"wsladiag shell"));
     }
-
-    const auto log = [&](std::wstring_view msg) {
-        if (verbose)
-        {
-            wslutil::PrintMessage(std::wstring(msg), stdout);
-        }
-    };
-
-    log(std::format(L"[diag] shell='{}'", sessionName));
 
     wil::com_ptr<IWSLAUserSession> userSession;
     THROW_IF_FAILED(CoCreateInstance(__uuidof(WSLAUserSession), nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&userSession)));
@@ -87,8 +71,6 @@ static int RunShellCommand(std::wstring_view commandLine)
         return ReportError(Localization::MessageWslaOpenSessionFailed(sessionName.c_str()), hr);
     }
 
-    log(L"[diag] OpenSessionByName succeeded");
-
     // Console size for TTY.
     CONSOLE_SCREEN_BUFFER_INFO info{};
     THROW_LAST_ERROR_IF(!GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info));
@@ -105,12 +87,9 @@ static int RunShellCommand(std::wstring_view commandLine)
     launcher.AddFd(WSLA_PROCESS_FD{.Fd = 1, .Type = WSLAFdTypeTerminalOutput, .Path = nullptr});
     launcher.AddFd(WSLA_PROCESS_FD{.Fd = 2, .Type = WSLAFdTypeTerminalControl, .Path = nullptr});
 
-    log(std::format(L"[diag] tty rows={} cols={}", rows, cols));
     launcher.SetTtySize(rows, cols);
 
-    log(L"[diag] launching shell process...");
     auto process = launcher.Launch(*session);
-    log(L"[diag] shell launched (TTY)");
 
     auto ttyIn = process.GetStdHandle(0);
     auto ttyOut = process.GetStdHandle(1);
@@ -129,12 +108,11 @@ static int RunShellCommand(std::wstring_view commandLine)
     // Save/restore console state.
     DWORD originalInMode{};
     DWORD originalOutMode{};
+    const UINT originalOutCP = GetConsoleOutputCP();
+    const UINT originalInCP = GetConsoleCP();
 
     THROW_LAST_ERROR_IF(!GetConsoleMode(consoleIn, &originalInMode));
     THROW_LAST_ERROR_IF(!GetConsoleMode(consoleOut, &originalOutMode));
-
-    const UINT originalOutCP = GetConsoleOutputCP();
-    const UINT originalInCP = GetConsoleCP();
 
     auto restoreConsole = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
         LOG_IF_WIN32_BOOL_FALSE(SetConsoleMode(consoleIn, originalInMode));
@@ -158,19 +136,13 @@ static int RunShellCommand(std::wstring_view commandLine)
 
     auto exitEvent = wil::unique_event(wil::EventOptions::ManualReset);
 
-    auto ttyControl = process.GetStdHandle(2); // TerminalControl
-    wsl::shared::SocketChannel controlChannel{wil::unique_socket{(SOCKET)ttyControl.release()}, "TerminalControl", exitEvent.get()};
-
     auto updateTerminalSize = [&]() {
         CONSOLE_SCREEN_BUFFER_INFOEX infoEx{};
         infoEx.cbSize = sizeof(infoEx);
         THROW_IF_WIN32_BOOL_FALSE(GetConsoleScreenBufferInfoEx(consoleOut, &infoEx));
 
-        WSLA_TERMINAL_CHANGED message{};
-        message.Columns = infoEx.srWindow.Right - infoEx.srWindow.Left + 1;
-        message.Rows = infoEx.srWindow.Bottom - infoEx.srWindow.Top + 1;
-
-        controlChannel.SendMessage(message);
+        LOG_IF_FAILED(process.Get().ResizeTty(
+            infoEx.srWindow.Bottom - infoEx.srWindow.Top + 1, infoEx.srWindow.Right - infoEx.srWindow.Left + 1));
     };
 
     // Start input relay thread to forward console input to TTY
@@ -186,7 +158,7 @@ static int RunShellCommand(std::wstring_view commandLine)
         }
     });
 
-    auto joinInput = wil::scope_exit([&] {
+    auto joinInput = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
         exitEvent.SetEvent();
         if (inputThread.joinable())
         {
@@ -199,22 +171,30 @@ static int RunShellCommand(std::wstring_view commandLine)
 
     process.GetExitEvent().wait();
 
-    auto [exitCode, signalled] = process.GetExitState();
+    auto exitCode = process.GetExitCode();
 
     std::wstring shellWide(shell.begin(), shell.end());
-    wslutil::PrintMessage(Localization::MessageWslaShellExited(shellWide.c_str(), exitCode), stdout);
+    wslutil::PrintMessage(wsl::shared::Localization::MessageWslaShellExited(shellWide.c_str(), static_cast<int>(exitCode)), stdout);
 
-    return 0;
+    return static_cast<int>(exitCode);
 }
 
+// Handler for `wsladiag list` command.
 static int RunListCommand(std::wstring_view commandLine)
 {
     bool verbose = false;
 
-    ArgumentParser parser(std::wstring{commandLine}, L"wsladiag", 2, false); // Skip "wsladiag.exe list" to parse list-specific args
+    ArgumentParser parser(std::wstring{commandLine}, L"wsladiag", 2, false);
     parser.AddArgument(verbose, L"--verbose", L'v');
 
-    parser.Parse();
+    try
+    {
+        parser.Parse();
+    }
+    catch (...)
+    {
+        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, wsl::shared::Localization::MessageWsladiagUsage());
+    }
 
     wil::com_ptr<IWSLAUserSession> userSession;
     THROW_IF_FAILED(CoCreateInstance(__uuidof(WSLAUserSession), nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&userSession)));
@@ -235,7 +215,8 @@ static int RunListCommand(std::wstring_view commandLine)
     }
 
     wslutil::PrintMessage(Localization::MessageWslaSessionsFound(sessions.size(), sessions.size() == 1 ? L"" : L"s"), stdout);
-    // Compute column widths from headers + data.
+
+    // Use localized headers
     const auto idHeader = Localization::MessageWslaHeaderId();
     const auto pidHeader = Localization::MessageWslaHeaderCreatorPid();
     const auto nameHeader = Localization::MessageWslaHeaderDisplayName();
@@ -279,7 +260,6 @@ static int RunListCommand(std::wstring_view commandLine)
     for (const auto& s : sessions)
     {
         const wchar_t* displayName = s.DisplayName ? s.DisplayName : L"";
-
         wprintf(
             L"%-*lu  %-*lu  %-*ls\n",
             static_cast<int>(idWidth),
@@ -293,6 +273,7 @@ static int RunListCommand(std::wstring_view commandLine)
     return 0;
 }
 
+// Print localized usage message to stderr.
 static void PrintUsage()
 {
     wslutil::PrintMessage(Localization::MessageWsladiagUsage(), stderr);
@@ -300,7 +281,7 @@ static void PrintUsage()
 
 int wsladiag_main(std::wstring_view commandLine)
 {
-    // Basic initialization that was previously in this function.
+    // Initialize runtime and COM.
     wslutil::ConfigureCrt();
     wslutil::InitializeWil();
 
@@ -316,107 +297,75 @@ int wsladiag_main(std::wstring_view commandLine)
     THROW_IF_WIN32_ERROR(WSAStartup(MAKEWORD(2, 2), &data));
     auto wsaCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { WSACleanup(); });
 
-    // Enable contextualized error collection and create an ExecutionContext so
-    // THROW_HR_WITH_USER_ERROR will save a user-visible message.
-    wsl::windows::common::EnableContextualizedErrors(false);
+    // Parse the top-level verb (list, shell, --help).
+    ArgumentParser parser(std::wstring{commandLine}, L"wsladiag", 1, true);
 
-    FILE* warningsFile = nullptr;
-    const char* disableWarnings = getenv("WSL_DISABLE_WARNINGS");
-    if (disableWarnings == nullptr || strcmp(disableWarnings, "1") != 0)
+    bool help = false;
+    std::wstring verb;
+
+    parser.AddPositionalArgument(verb, 0);
+    parser.AddArgument(help, L"--help", L'h');
+
+    parser.Parse();
+
+    if (help || verb.empty())
     {
-        warningsFile = stderr;
+        PrintUsage();
+        return 0;
     }
 
-    std::optional<wsl::windows::common::ExecutionContext> context;
-    context.emplace(wsl::windows::common::Context::Wsl, warningsFile);
+    if (verb == L"list")
+    {
+        return RunListCommand(commandLine);
+    }
 
-    int exitCode = 0;
+    if (verb == L"shell")
+    {
+        return RunShellCommand(commandLine);
+    }
+
+    // Unknown verb - show usage and fail.
+    wslutil::PrintMessage(Localization::MessageWslaUnknownCommand(verb.c_str()), stderr);
+    PrintUsage();
+    return 1;
+}
+
+int wmain(int, wchar_t**)
+{
+    wsl::windows::common::EnableContextualizedErrors(false);
+
+    ExecutionContext context{Context::WslaDiag};
+    int exitCode = 1;
     HRESULT result = S_OK;
 
     try
     {
-        ArgumentParser parser(std::wstring{commandLine}, L"wsladiag", 1, true);
-
-        bool help = false;
-        std::wstring verb;
-
-        parser.AddPositionalArgument(verb, 0);
-        parser.AddArgument(help, L"--help", L'h');
-
-        parser.Parse(); // Let exceptions propagate to this try/catch
-
-        if (help || verb.empty())
-        {
-            PrintUsage();
-            exitCode = 0;
-        }
-        else if (verb == L"list")
-        {
-            exitCode = RunListCommand(commandLine);
-        }
-        else if (verb == L"shell")
-        {
-            exitCode = RunShellCommand(commandLine);
-        }
-        else
-        {
-            wslutil::PrintMessage(Localization::MessageWslaUnknownCommand(verb.c_str()), stderr);
-            PrintUsage();
-            exitCode = 1;
-        }
+        exitCode = wsladiag_main(GetCommandLineW());
     }
     catch (...)
     {
-        // Capture the exception HRESULT and fall through to printing contextualized error.
         result = wil::ResultFromCaughtException();
-        // Default nonzero exit code on failure.
-        exitCode = 1;
     }
 
-    // If there was a failure, attempt to print a contextualized error message collected
-    // by the ExecutionContext. Otherwise fall back to the HRESULT -> string path.
     if (FAILED(result))
     {
         try
         {
-            std::wstring errorString{};
-            if (context.has_value() && context->ReportedError().has_value())
+            if (auto reported = context.ReportedError())
             {
-                auto strings = wsl::windows::common::wslutil::ErrorToString(context->ReportedError().value());
-
-                // For most errors, show both message and code
-                errorString = wsl::shared::Localization::MessageErrorCode(strings.Message, strings.Code);
-
-                // Log telemetry for user-visible errors (matches other tools).
-                WSL_LOG("UserVisibleError", TraceLoggingValue(strings.Code.c_str(), "ErrorCode"));
+                auto strings = wsl::windows::common::wslutil::ErrorToString(*reported);
+                wslutil::PrintMessage(wsl::shared::Localization::MessageErrorCode(strings.Message, strings.Code), stderr);
             }
             else
             {
-                // Fallback: show basic HRESULT string.
-                errorString = wslutil::ErrorCodeToString(result);
+                wslutil::PrintMessage(wslutil::GetErrorString(result), stderr);
             }
-
-            wslutil::PrintMessage(errorString, stderr);
         }
         catch (...)
         {
             LOG_CAUGHT_EXCEPTION();
         }
-
     }
 
     return exitCode;
-}
-
-int wmain(int, wchar_t**)
-{
-    try
-    {
-        return wsladiag_main(GetCommandLineW());
-    }
-    catch (...)
-    {
-        const auto hr = wil::ResultFromCaughtException();
-        return ReportError(L"wsladiag failed", hr);
-    }
 }

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -360,21 +360,15 @@ int wmain(int, wchar_t**)
 
     if (FAILED(result))
     {
-        try
+        if (auto reported = context.ReportedError())
         {
-            if (auto reported = context.ReportedError())
-            {
-                auto strings = wsl::windows::common::wslutil::ErrorToString(*reported);
-                wslutil::PrintMessage(wsl::shared::Localization::MessageErrorCode(strings.Message, strings.Code), stderr);
-            }
-            else
-            {
-                wslutil::PrintMessage(wslutil::GetErrorString(result), stderr);
-            }
+            auto strings = wsl::windows::common::wslutil::ErrorToString(*reported);
+            wslutil::PrintMessage(strings.Message.empty() ? strings.Code : strings.Message, stderr);
         }
-        catch (...)
+        else
         {
-            LOG_CAUGHT_EXCEPTION();
+            // Fallback for errors without context
+            wslutil::PrintMessage(wslutil::GetErrorString(result), stderr);
         }
     }
 

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -52,23 +52,11 @@ static int RunShellCommand(std::wstring_view commandLine)
     parser.AddPositionalArgument(sessionName, 0);
     parser.AddArgument(verbose, L"--verbose", L'v');
 
-    try
-    {
-        parser.Parse();
-    }
-    catch (...)
-    {
-        const auto hr = wil::ResultFromCaughtException();
-        if (hr == E_INVALIDARG)
-        {
-            return 1;
-        }
-        throw;
-    }
+    parser.Parse();
 
     if (sessionName.empty())
     {
-        return 1;
+        THROW_HR(E_INVALIDARG);
     }
 
     const auto log = [&](std::wstring_view msg) {
@@ -168,31 +156,10 @@ static int RunShellCommand(std::wstring_view commandLine)
 
     auto exitEvent = wil::unique_event(wil::EventOptions::ManualReset);
 
-    std::optional<wsl::shared::SocketChannel> controlChannel;
-    try
-    {
-        auto ttyControl = process.GetStdHandle(2); // only once
-        controlChannel.emplace(wil::unique_socket{(SOCKET)ttyControl.release()}, "TerminalControl", exitEvent.get());
-    }
-    catch (const wil::ResultException& e)
-    {
-        const HRESULT hr = e.GetErrorCode();
-        if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
-        {
-            log(L"[diag] TerminalControl not available; live resize disabled");
-        }
-        else
-        {
-            throw; // or ReportError + return
-        }
-    }
+    auto ttyControl = process.GetStdHandle(2); // TerminalControl
+    wsl::shared::SocketChannel controlChannel{wil::unique_socket{(SOCKET)ttyControl.release()}, "TerminalControl", exitEvent.get()};
 
     auto updateTerminalSize = [&]() {
-        if (!controlChannel.has_value())
-        {
-            return;
-        }
-
         CONSOLE_SCREEN_BUFFER_INFOEX infoEx{};
         infoEx.cbSize = sizeof(infoEx);
         THROW_IF_WIN32_BOOL_FALSE(GetConsoleScreenBufferInfoEx(consoleOut, &infoEx));
@@ -201,7 +168,7 @@ static int RunShellCommand(std::wstring_view commandLine)
         message.Columns = static_cast<unsigned short>(infoEx.srWindow.Right - infoEx.srWindow.Left + 1);
         message.Rows = static_cast<unsigned short>(infoEx.srWindow.Bottom - infoEx.srWindow.Top + 1);
 
-        controlChannel->SendMessage(message);
+        controlChannel.SendMessage(message);
     };
 
     // Start input relay thread to forward console input to TTY
@@ -228,8 +195,6 @@ static int RunShellCommand(std::wstring_view commandLine)
     // Relay tty output -> console (blocks until output ends).
     wsl::windows::common::relay::InterruptableRelay(ttyOut.get(), consoleOut, exitEvent.get());
 
-    // Output relay finished - signal input thread to stop and wait for process exit
-    exitEvent.SetEvent();
     process.GetExitEvent().wait();
 
     auto [exitCode, signalled] = process.GetExitState();
@@ -344,20 +309,7 @@ int wsladiag_main(std::wstring_view commandLine)
     parser.AddPositionalArgument(verb, 0);
     parser.AddArgument(help, L"--help", L'h');
 
-    try
-    {
-        parser.Parse();
-    }
-    catch (...)
-    {
-        const auto hr = wil::ResultFromCaughtException();
-        if (hr == E_INVALIDARG)
-        {
-            PrintUsage();
-            return 1;
-        }
-        throw;
-    }
+    parser.Parse(); // Let exceptions propagate to wmain for centralized handling
 
     if (help || verb.empty())
     {
@@ -381,7 +333,6 @@ int wsladiag_main(std::wstring_view commandLine)
     {
         wslutil::PrintMessage(Localization::MessageWslaUnknownCommand(verb.c_str()), stderr);
         PrintUsage();
-
         return 1;
     }
 }
@@ -395,6 +346,11 @@ int wmain(int, wchar_t**)
     catch (...)
     {
         const auto hr = wil::ResultFromCaughtException();
+        if (hr == E_INVALIDARG)
+        {
+            PrintUsage();
+            return 1;
+        }
         return ReportError(L"wsladiag failed", hr);
     }
 }


### PR DESCRIPTION
Summary of the Pull Request:
This PR refactors wsladiag command-line argument handling to use per-verb parsing and fixes multiple correctness and robustness issues in the interactive shell (PTY) path. It improves live terminal resize behavior, simplifies process lifecycle handling, and makes console cleanup more diagnosable, while preserving existing behavior by default.

Detailed Description:
Argument parsing

Refactors argument handling to be per-verb (list, shell), allowing each command to define and validate its own arguments.

Adds an opt-in relaxed mode to ArgumentParser to allow top-level verb dispatch without throwing on subcommand arguments. The default parsing behavior remains unchanged.

This makes the CLI easier to extend as additional wsladiag commands are added.

Shell / PTY handling

Fixes TTY size initialization by passing rows and columns in the correct order.

Restores and correctly handles live terminal resize using the TerminalControl FD.

Validation Steps Performed

Ran wsladiag list to verify session enumeration.

Ran wsladiag shell <SessionName> to verify interactive shell launch.

Verified interactive input/output behavior inside the shell.

Verified live terminal resize by resizing the console window while running commands such as top.

Verified clean process exit without hangs and correct console state restoration.