### PR TITLE
WSLA: Add support for Windows 10

### DIFF
--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -120,8 +120,8 @@ WSLAVirtualMachine::~WSLAVirtualMachine()
             WI_ASSERT(std::filesystem::is_empty(m_vmSavedStateFile));
             std::filesystem::remove(m_vmSavedStateFile);
         }
+        CATCH_LOG()
     }
-    CATCH_LOG()
 
     if (m_processExitThread.joinable())
     {

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -148,7 +148,7 @@ void WSLAVirtualMachine::Start()
     systemSettings.ShouldTerminateOnLastHandleClosed = true;
 
     // Determine which schema version to use based on the Windows version. Windows 10 does not support
-    // newer schema versions and some feature may be disabled as a result.
+    // newer schema versions and some features may be disabled as a result.
     if (wsl::windows::common::helpers::IsWindows11OrAbove())
     {
         systemSettings.SchemaVersion.Major = 2;

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -149,7 +149,6 @@ private:
 
     GUID m_vmId{};
     std::wstring m_vmIdString;
-    wsl::windows::common::helpers::WindowsVersion m_windowsVersion = wsl::windows::common::helpers::GetWindowsVersion();
     int m_coldDiscardShiftSize{};
     bool m_running = false;
     PSID m_userSid{};


### PR DESCRIPTION
We have not yet determined if we will support Windows 10 for WSLA, but in the meantime this will ensure that we are able to run to test additional features and determine feasibility. This required two changes:
1. Disabling of the .vmrs dump collection on Win10
2. Disabling of Hyper-V firewall support on Win10 for NAT networking