### PR TITLE
User/beenachauhan/wsladiag localization support

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1871,4 +1871,50 @@ You can also access more VS Code Remote options through the command palette with
   <data name="Settings_VMIdleTimeoutTextBox.AutomationProperties.HelpText" xml:space="preserve">
     <value>The number of milliseconds that a VM is idle, before it is shut down.</value>
   </data>
+  <data name="Settings_VMIdleTimeoutTextBox.AutomationProperties.HelpText" xml:space="preserve">
+    <value>The number of milliseconds that a VM is idle, before it is shut down.</value>
+  </data>
+  <data name="MessageWsladiagUsage" xml:space="preserve">
+    <value>wsladiag - WSLA diagnostics tool
+Usage:
+  wsladiag list
+  wsladiag shell &lt;SessionName&gt; [--verbose]
+  wsladiag --help</value>
+    <comment>{Locked="wsladiag"}{Locked="list"}{Locked="shell"}{Locked="--verbose"}{Locked="--help"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="MessageWslaSessionNotFound" xml:space="preserve">
+    <value>Session not found: '{}'</value>
+    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
+  </data>
+  <data name="MessageWslaOpenSessionFailed" xml:space="preserve">
+    <value>OpenSessionByName('{}') failed</value>
+    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
+  </data>
+  <data name="MessageWslaNoSessionsFound" xml:space="preserve">
+    <value>No WSLA sessions found.</value>
+  </data>
+  <data name="MessageWslaSessionsFound" xml:space="preserve">
+    <value>Found {} WSLA session(s):</value>
+    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
+  </data>
+  <data name="MessageWslaShellExited" xml:space="preserve">
+    <value>{} exited with: {}</value>
+    <comment>{FixedPlaceholder="{}"}String inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslaShellSignalled" xml:space="preserve">
+    <value> (signalled)</value>
+  </data>
+  <data name="MessageWslaHeaderId" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="MessageWslaHeaderCreatorPid" xml:space="preserve">
+    <value>Creator PID</value>
+  </data>
+  <data name="MessageWslaHeaderDisplayName" xml:space="preserve">
+    <value>Display Name</value>
+  </data>
+  <data name="MessageWslaUnknownCommand" xml:space="preserve">
+    <value>Unknown command: '{}'</value>
+    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
+  </data>
 </root>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1891,7 +1891,7 @@ Usage:
   <value>No WSLA sessions found.</value>
 </data>
 <data name="MessageWslaSessionsFound" xml:space="preserve">
-  <value>Found {} WSLA session(s):</value>
+  <value>Found {} WSLA session{}:</value>
   <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
 </data>
 <data name="MessageWslaShellExited" xml:space="preserve">

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1877,7 +1877,7 @@ Usage:
   wsladiag list
   wsladiag shell &lt;SessionName&gt; [--verbose]
   wsladiag --help</value>
-  <comment>{Locked="--verbose]"}{Locked="--help"}Command line arguments, file names and string inserts should not be translated</comment>
+  <comment>{Locked="--verbose"}{Locked="--help"}Command line arguments, file names and string inserts should not be translated</comment>
 </data>
 <data name="MessageWslaSessionNotFound" xml:space="preserve">
   <value>Session not found: '{}'</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1872,46 +1872,46 @@ You can also access more VS Code Remote options through the command palette with
     <value>The number of milliseconds that a VM is idle, before it is shut down.</value>
   </data>
   <data name="MessageWsladiagUsage" xml:space="preserve">
-  <value>wsladiag - WSLA diagnostics tool
+    <value>wsladiag - WSLA diagnostics tool
 Usage:
   wsladiag list
   wsladiag shell &lt;SessionName&gt; [--verbose]
   wsladiag --help</value>
-  <comment>{Locked="--verbose]"}{Locked="--help"}Command line arguments, file names and string inserts should not be translated</comment>
-</data>
-<data name="MessageWslaSessionNotFound" xml:space="preserve">
-  <value>Session not found: '{}'</value>
-  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
-</data>
-<data name="MessageWslaOpenSessionFailed" xml:space="preserve">
-  <value>OpenSessionByName('{}') failed</value>
-  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
-</data>
-<data name="MessageWslaNoSessionsFound" xml:space="preserve">
-  <value>No WSLA sessions found.</value>
-</data>
-<data name="MessageWslaSessionsFound" xml:space="preserve">
-  <value>Found {} WSLA session{}:</value>
-  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
-</data>
-<data name="MessageWslaShellExited" xml:space="preserve">
-  <value>{} exited with: {}</value>
-  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
-</data>
-<data name="MessageWslaShellSignalled" xml:space="preserve">
-  <value> (signalled)</value>
-</data>
-<data name="MessageWslaHeaderId" xml:space="preserve">
-  <value>ID</value>
-</data>
-<data name="MessageWslaHeaderCreatorPid" xml:space="preserve">
-  <value>Creator PID</value>
-</data>
-<data name="MessageWslaHeaderDisplayName" xml:space="preserve">
-  <value>Display Name</value>
-</data>
-<data name="MessageWslaUnknownCommand" xml:space="preserve">
-  <value>Unknown command: '{}'</value>
-  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
-</data>
+    <comment>{Locked="--verbose]"}{Locked="--help"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslaSessionNotFound" xml:space="preserve">
+    <value>Session not found: '{}'</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslaOpenSessionFailed" xml:space="preserve">
+    <value>OpenSessionByName('{}') failed</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslaNoSessionsFound" xml:space="preserve">
+    <value>No WSLA sessions found.</value>
+  </data>
+  <data name="MessageWslaSessionsFound" xml:space="preserve">
+    <value>Found {} WSLA session{}:</value>
+    <comment>{FixedPlaceholder="{}"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslaShellExited" xml:space="preserve">
+    <value>{} exited with: {}</value>
+    <comment>{FixedPlaceholder="{}"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslaShellSignalled" xml:space="preserve">
+    <value> (signalled)</value>
+  </data>
+  <data name="MessageWslaHeaderId" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="MessageWslaHeaderCreatorPid" xml:space="preserve">
+    <value>Creator PID</value>
+  </data>
+  <data name="MessageWslaHeaderDisplayName" xml:space="preserve">
+    <value>Display Name</value>
+  </data>
+  <data name="MessageWslaUnknownCommand" xml:space="preserve">
+    <value>Unknown command: '{}'</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
 </root>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1871,50 +1871,47 @@ You can also access more VS Code Remote options through the command palette with
   <data name="Settings_VMIdleTimeoutTextBox.AutomationProperties.HelpText" xml:space="preserve">
     <value>The number of milliseconds that a VM is idle, before it is shut down.</value>
   </data>
-  <data name="Settings_VMIdleTimeoutTextBox.AutomationProperties.HelpText" xml:space="preserve">
-    <value>The number of milliseconds that a VM is idle, before it is shut down.</value>
-  </data>
   <data name="MessageWsladiagUsage" xml:space="preserve">
-    <value>wsladiag - WSLA diagnostics tool
+  <value>wsladiag - WSLA diagnostics tool
 Usage:
   wsladiag list
   wsladiag shell &lt;SessionName&gt; [--verbose]
   wsladiag --help</value>
-    <comment>{Locked="wsladiag"}{Locked="list"}{Locked="shell"}{Locked="--verbose"}{Locked="--help"}Command line arguments should not be translated</comment>
-  </data>
-  <data name="MessageWslaSessionNotFound" xml:space="preserve">
-    <value>Session not found: '{}'</value>
-    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
-  </data>
-  <data name="MessageWslaOpenSessionFailed" xml:space="preserve">
-    <value>OpenSessionByName('{}') failed</value>
-    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
-  </data>
-  <data name="MessageWslaNoSessionsFound" xml:space="preserve">
-    <value>No WSLA sessions found.</value>
-  </data>
-  <data name="MessageWslaSessionsFound" xml:space="preserve">
-    <value>Found {} WSLA session(s):</value>
-    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
-  </data>
-  <data name="MessageWslaShellExited" xml:space="preserve">
-    <value>{} exited with: {}</value>
-    <comment>{FixedPlaceholder="{}"}String inserts should not be translated</comment>
-  </data>
-  <data name="MessageWslaShellSignalled" xml:space="preserve">
-    <value> (signalled)</value>
-  </data>
-  <data name="MessageWslaHeaderId" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="MessageWslaHeaderCreatorPid" xml:space="preserve">
-    <value>Creator PID</value>
-  </data>
-  <data name="MessageWslaHeaderDisplayName" xml:space="preserve">
-    <value>Display Name</value>
-  </data>
-  <data name="MessageWslaUnknownCommand" xml:space="preserve">
-    <value>Unknown command: '{}'</value>
-    <comment>{FixedPlaceholder="{}"}String insert should not be translated</comment>
-  </data>
+  <comment>{Locked="--verbose]"}{Locked="--help"}Command line arguments, file names and string inserts should not be translated</comment>
+</data>
+<data name="MessageWslaSessionNotFound" xml:space="preserve">
+  <value>Session not found: '{}'</value>
+  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+</data>
+<data name="MessageWslaOpenSessionFailed" xml:space="preserve">
+  <value>OpenSessionByName('{}') failed</value>
+  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+</data>
+<data name="MessageWslaNoSessionsFound" xml:space="preserve">
+  <value>No WSLA sessions found.</value>
+</data>
+<data name="MessageWslaSessionsFound" xml:space="preserve">
+  <value>Found {} WSLA session(s):</value>
+  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+</data>
+<data name="MessageWslaShellExited" xml:space="preserve">
+  <value>{} exited with: {}</value>
+  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+</data>
+<data name="MessageWslaShellSignalled" xml:space="preserve">
+  <value> (signalled)</value>
+</data>
+<data name="MessageWslaHeaderId" xml:space="preserve">
+  <value>ID</value>
+</data>
+<data name="MessageWslaHeaderCreatorPid" xml:space="preserve">
+  <value>Creator PID</value>
+</data>
+<data name="MessageWslaHeaderDisplayName" xml:space="preserve">
+  <value>Display Name</value>
+</data>
+<data name="MessageWslaUnknownCommand" xml:space="preserve">
+  <value>Unknown command: '{}'</value>
+  <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+</data>
 </root>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1877,7 +1877,7 @@ Usage:
   wsladiag list
   wsladiag shell &lt;SessionName&gt; [--verbose]
   wsladiag --help</value>
-  <comment>{Locked="--verbose"}{Locked="--help"}Command line arguments, file names and string inserts should not be translated</comment>
+  <comment>{Locked="--verbose]"}{Locked="--help"}Command line arguments, file names and string inserts should not be translated</comment>
 </data>
 <data name="MessageWslaSessionNotFound" xml:space="preserve">
   <value>Session not found: '{}'</value>

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -213,7 +213,6 @@ static int RunListCommand(bool /*verbose*/)
     }
 
     wslutil::PrintMessage(Localization::MessageWslaSessionsFound(sessions.size()), stdout);
-
     // Compute column widths from headers + data .
     const auto idHeader = Localization::MessageWslaHeaderId();
     const auto pidHeader = Localization::MessageWslaHeaderCreatorPid();

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -182,7 +182,7 @@ static int RunShellCommand(const std::wstring& sessionName, bool verbose)
     wsl::windows::common::relay::InterruptableRelay(ttyOut.get(), consoleOut, exitEvent.get());
 
     process.GetExitEvent().wait();
-    auto [code, signalled] = process.GetExitState();
+    auto [exitCode, signalled] = process.GetExitState();
 
     std::wstring shellWide(shell.begin(), shell.end());
     std::wstring message = Localization::MessageWslaShellExited(shellWide.c_str(), exitCode);

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -23,9 +23,6 @@ Abstract:
 
 using namespace wsl::shared;
 namespace wslutil = wsl::windows::common::wslutil;
-using wsl::shared::Localization;
-using wsl::windows::common::Context;
-using wsl::windows::common::ExecutionContext;
 using wsl::windows::common::WSLAProcessLauncher;
 
 // Adding a helper to factor error handling between all the arguments.
@@ -212,7 +209,7 @@ static int RunListCommand(bool /*verbose*/)
         return 0;
     }
 
-    wslutil::PrintMessage(Localization::MessageWslaSessionsFound(sessions.size()), stdout);
+    wslutil::PrintMessage(Localization::MessageWslaSessionsFound(sessions.size(), sessions.size() == 1 ? L"" : L"s"), stdout);
     // Compute column widths from headers + data.
     const auto idHeader = Localization::MessageWslaHeaderId();
     const auto pidHeader = Localization::MessageWslaHeaderCreatorPid();
@@ -305,16 +302,6 @@ int wsladiag_main(std::wstring_view commandLine)
     parser.AddArgument(help, L"--help", L'h');
     parser.AddArgument(verbose, L"--verbose", L'v');
 
-    auto printUsage = []() {
-        wslutil::PrintMessage(
-            L"wsladiag - WSLA diagnostics tool\n"
-            L"Usage:\n"
-            L"  wsladiag list\n"
-            L"  wsladiag shell <SessionName> [--verbose]\n"
-            L"  wsladiag --help\n",
-            stderr);
-    };
-
     try
     {
         parser.Parse();
@@ -324,7 +311,7 @@ int wsladiag_main(std::wstring_view commandLine)
         const auto hr = wil::ResultFromCaughtException();
         if (hr == E_INVALIDARG)
         {
-            printUsage();
+            PrintUsage();
             return 1;
         }
         throw;
@@ -332,7 +319,7 @@ int wsladiag_main(std::wstring_view commandLine)
 
     if (help || verb.empty())
     {
-        printUsage();
+        PrintUsage();
         return 0;
     }
     else if (verb == L"list")
@@ -343,7 +330,7 @@ int wsladiag_main(std::wstring_view commandLine)
     {
         if (shellSession.empty())
         {
-            printUsage();
+            PrintUsage();
             return 1;
         }
         return RunShellCommand(shellSession, verbose);

--- a/src/windows/wsladiag/wsladiag.cpp
+++ b/src/windows/wsladiag/wsladiag.cpp
@@ -213,7 +213,7 @@ static int RunListCommand(bool /*verbose*/)
     }
 
     wslutil::PrintMessage(Localization::MessageWslaSessionsFound(sessions.size()), stdout);
-    // Compute column widths from headers + data .
+    // Compute column widths from headers + data.
     const auto idHeader = Localization::MessageWslaHeaderId();
     const auto pidHeader = Localization::MessageWslaHeaderCreatorPid();
     const auto nameHeader = Localization::MessageWslaHeaderDisplayName();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds localization support to wsladiag by replacing all hardcoded user-facing strings with localized messages from Resources.resw. All messages (usage, errors, session list output) are now accessible via the Localization class.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x ] **Tests:** Added/updated if needed and all pass
- [x ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Added 11 new localization entries to [Resources.resw] for wsladiag-specific messages
 - Updated [wsladiag.cpp] to use [Localization::MessageWslaXxx()] for all user-facing output including:
Usage information
- Session not found / open session failed errors
- Session list output (headers, no sessions message, session count)
- Shell exit status messages
- Unknown command errors
- Added [using wsl::shared::Localization;]declaration following existing codebase patterns
- All existing WsladiagTests pass (8/8 tests validate localized message output)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built project successfully with cmake --build build-vs-x64 --config Debug --parallel
Ran all wsladiag tests: [bin\x64\debug\test.bat /name:*WsladiagTests*]- All 8 tests passed
Manually tested commands:
[wsladiag.exe --help] - displays localized usage
wsladiag.exe list - displays localized session list or "No WSLA sessions found"
wsladiag.exe shell InvalidSession - displays localized error "Session not found: 'InvalidSession'"
wsladiag.exe badcommand - displays localized "Unknown command: 'badcommand'" error
