### PR TITLE
Add eLxr official WSL image to the distribution manifest

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -198,6 +198,17 @@
                     "Sha256": "a5a2ceb8ca56b7245b909d021b0fd620427db349f02b8ef3b82b741bcb5611cd"
                 }
             }
+        ],
+        "eLxr": [
+            {
+                "Name": "eLxr-12",
+                "FriendlyName": "eLxr 12.12.0.0 GNU/Linux",
+                "Default": true,
+                "Amd64Url": {
+                    "Url": "https://gitlab.com/api/v4/projects/68007430/packages/generic/wsl/12.12.0.0/eLxr_WSL_AMD64_12.12.0.0.wsl",
+                    "Sha256": "f94e0c44be51550478100ea150b80535f955bf87487d1b964f4636d97478c05d"
+                }
+            }
         ]
     },
     "Default": "Ubuntu",


### PR DESCRIPTION
Update DistributionInfo.json to add "eLxr" section to "ModenDistributions". This commit adds eLxr to the Microsoft WSL's official distribution manifest, allowing users to pull and install it in an automated way (`wsl --install eLxr`).

eLxr WSL files are released at https://gitlab.com/elxr/debian/WSL/-/releases, the url is from there. sha256 is from https://gitlab.com/elxr/debian/WSL/-/packages/50799869

eLxr is from Wind River and Wind River is on the linux-distros list.
https://oss-security.openwall.org/wiki/mailing-lists/distros#linux-distribution-security-contacts-list

- [ ] Closes: https://github.com/microsoft/WSL/pull/13996
- [ ] Communication: I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] Tests: Added/updated if needed and all pass
- [ ] Localization:All end user facing strings can be localized
- [ ] Dev docs: Added/updated if needed

Test result:
eLxr WSL can be installed successfully:
- download WSL file from https://gitlab.com/api/v4/projects/68007430/packages/generic/wsl/12.12.0.0/eLxr_WSL_AMD64_12.12.0.0.wsl
- Win11 powershell: wsl --install --from-file eLxr_WSL_AMD64_12.12.0.0.wsl
