### PR TITLE
WSLA: Update logging infra to only log to hvc1 if available

### DIFF
--- a/src/linux/init/common.h
+++ b/src/linux/init/common.h
@@ -137,15 +137,23 @@ auto LogImpl(int fd, const std::format_string<Args...>& format, Args&&... args)
     }
 
 #define GNS_LOG_INFO(str, ...) \
-    if (g_TelemetryFd != -1) { \
-        LogImpl(g_TelemetryFd, "{}: {} - " str "\n", g_threadName.c_str(), __FUNCTION__, ##__VA_ARGS__); \
+    { \
+        if (g_TelemetryFd != -1) \
+        { \
+            LogImpl(g_TelemetryFd, "{}: {} - " str "\n", g_threadName.c_str(), __FUNCTION__, ##__VA_ARGS__); \
+        } \
     }
 
 #define GNS_LOG_ERROR(str, ...) \
-    if (g_TelemetryFd != -1) { \
-        LogImpl(g_TelemetryFd, "{}: {} - ERROR: " str "\n", g_threadName.c_str(), __FUNCTION__, ##__VA_ARGS__); \
-    } else { \
-        LOG_ERROR(str, ##__VA_ARGS__); \
+    { \
+        if (g_TelemetryFd != -1) \
+        { \
+            LogImpl(g_TelemetryFd, "{}: {} - ERROR: " str "\n", g_threadName.c_str(), __FUNCTION__, ##__VA_ARGS__); \
+        } \
+        else \
+        { \
+            LOG_ERROR(str, ##__VA_ARGS__); \
+        } \
     }
 
 #define FATAL_ERROR(str, ...) FATAL_ERROR_EX(1, str, ##__VA_ARGS__)

--- a/src/linux/init/common.h
+++ b/src/linux/init/common.h
@@ -137,13 +137,15 @@ auto LogImpl(int fd, const std::format_string<Args...>& format, Args&&... args)
     }
 
 #define GNS_LOG_INFO(str, ...) \
-    { \
+    if (g_TelemetryFd != -1) { \
         LogImpl(g_TelemetryFd, "{}: {} - " str "\n", g_threadName.c_str(), __FUNCTION__, ##__VA_ARGS__); \
     }
 
 #define GNS_LOG_ERROR(str, ...) \
-    { \
+    if (g_TelemetryFd != -1) { \
         LogImpl(g_TelemetryFd, "{}: {} - ERROR: " str "\n", g_threadName.c_str(), __FUNCTION__, ##__VA_ARGS__); \
+    } else { \
+        LOG_ERROR(str, ##__VA_ARGS__); \
     }
 
 #define FATAL_ERROR(str, ...) FATAL_ERROR_EX(1, str, ##__VA_ARGS__)

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1643,11 +1643,12 @@ Return Value:
     }
 
     // Initialize logging to the hvc console device responsible for logging telemetry.
+    // If the device is not present, error messages will be logged to kmesg.
     if (UtilIsUtilityVm())
     {
         devicePath = DEVFS_PATH "/" LX_INIT_HVC_TELEMETRY;
         g_TelemetryFd = TEMP_FAILURE_RETRY(open(devicePath, (O_WRONLY | O_CLOEXEC)));
-        if (g_TelemetryFd < 0)
+        if (g_TelemetryFd < 0 && errno != ENODEV)
         {
             LOG_ERROR("open({}) failed {}", devicePath, errno);
         }

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -224,27 +224,16 @@ void WSLAVirtualMachine::Start()
         vmSettings.Devices.ComPorts["0"] = hcs::ComPort{m_dmesgCollector->EarlyConsoleName()};
     }
 
+    // The primary "console" will be a virtio serial device.
     if (helpers::IsVirtioSerialConsoleSupported())
     {
-        vmSettings.Devices.VirtioSerial.emplace();
-
-        // The primary "console" will be a virtio serial device.
-
         kernelCmdLine += L" console=hvc0 debug";
+        vmSettings.Devices.VirtioSerial.emplace();
         hcs::VirtioSerialPort virtioPort{};
         virtioPort.Name = L"hvc0";
         virtioPort.NamedPipe = m_dmesgCollector->VirtioConsoleName();
         virtioPort.ConsoleSupport = true;
         vmSettings.Devices.VirtioSerial->Ports["0"] = std::move(virtioPort);
-
-        if (!m_debugShellPipe.empty())
-        {
-            hcs::VirtioSerialPort virtioPort;
-            virtioPort.Name = L"hvc1";
-            virtioPort.NamedPipe = m_debugShellPipe;
-            virtioPort.ConsoleSupport = true;
-            vmSettings.Devices.VirtioSerial->Ports["1"] = std::move(virtioPort);
-        }
     }
 
     // Set up boot params.

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.h
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.h
@@ -153,7 +153,6 @@ private:
     bool m_running = false;
     PSID m_userSid{};
     wil::shared_handle m_userToken;
-    std::wstring m_debugShellPipe;
     GUID m_virtioFsClassId;
 
     std::mutex m_trackedProcessesLock;


### PR DESCRIPTION
This change gets rid of an error in kmesg about /dev/hvc1 if it is not present (which is it not for WSLA), and updates the GNS error logging macro to log directly to kmesg instead of the telemetry channel if it is not present.