### PR TITLE
Fix dmesg warning from enable crash dump collection

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -855,7 +855,7 @@ int WSLAEntryPoint(int Argc, char* Argv[])
     }
 
     //
-    // Enable dump colleciton when processes crash.
+    // Enable dump collection when processes crash.
     //
     WSLAEnableCrashDumpCollection();
 

--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -513,9 +513,6 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_MOUNT& Me
         if (WI_IsFlagSet(Message.Flags, WSLA_MOUNT::Chroot))
         {
             THROW_LAST_ERROR_IF(Chroot(target) < 0);
-
-            // Reconfigure crash dump collection after chroot so symlink & core_pattern resolve correctly.
-            WSLAEnableCrashDumpCollection();
         }
 
         response.Result = 0;
@@ -816,9 +813,6 @@ int WSLAEntryPoint(int Argc, char* Argv[])
         return -1;
     }
 
-    // Enable crash dump collection.
-    WSLAEnableCrashDumpCollection();
-
     //
     // Open kmesg for logging and ensure that the file descriptor is not set to one of the standard file descriptors.
     //
@@ -859,6 +853,11 @@ int WSLAEntryPoint(int Argc, char* Argv[])
         LOG_ERROR("setrlimit(RLIMIT_MEMLOCK) failed {}", errno);
         return -1;
     }
+
+    //
+    // Enable dump colleciton when processes crash.
+    //
+    WSLAEnableCrashDumpCollection();
 
     //
     // Enable logging when processes receive fatal signals.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This change eliminates an unnecessary write to `/proc/sys/kernel/core_pattern` in WSLAInit after the chroot operation. Crash dump collection is already configured at the `WSLAEntryPoint` before chroot, so the post-chroot write adds no value.

After chroot, /proc is not mounted in the new root, causing the write to fail. The failed write previously logged an error, creating noise without functional impact.

Additionally, this PR moves the WSLAEnableCrashDumpCollection call to later in WSLAEntryPoint so that logging is fully initialized when crash dump collection is enabled.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
