### PR TITLE
WSLA: Resolve issue preventing boot from pmem vhds

### DIFF
--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -309,14 +309,13 @@ void WSLAVirtualMachine::Start()
     }
     else
     {
-        hcs::VirtualPMemController pmemController;
-        pmemController.MaximumCount = 0;
-        pmemController.MaximumSizeBytes = 0;
+        hcs::VirtualPMemController pmemController{};
         pmemController.Backing = hcs::VirtualPMemBackingType::Virtual;
+        ULONG nextDeviceId = 0;
         auto attachPmemDisk = [&](PCWSTR path) {
-            ULONG deviceId = pmemController.MaximumCount;
-            pmemController.MaximumCount += 1;
-            hcs::VirtualPMemDevice vhd;
+            auto deviceId = nextDeviceId;
+            nextDeviceId += 1;
+            hcs::VirtualPMemDevice vhd{};
             vhd.HostPath = path;
             vhd.ReadOnly = true;
             vhd.ImageFormat = hcs::VirtualPMemImageFormat::Vhd1;

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1028,9 +1028,6 @@ class WSLATests
     {
         WSL2_TEST_ONLY();
 
-        LogSkipped("Skipping pmem test since mounting the WSLA VHD currently fails");
-        return;
-
         // Test with SCSI boot VHDs.
         {
             auto settings = GetDefaultSessionSettings();


### PR DESCRIPTION
This resolves an issue where a new root VHD stopped PMEM boot from working. This is because in the HCS stack there is a default max size that is applied when pmemController.MaximumCount != 0 and this max size was not large enough for the new VHD.