### PR TITLE
Update to Azure Linux 3

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />
-  <package id="Microsoft.WSLg" version="1.0.71" />
+  <package id="Microsoft.WSLg" version="1.0.72" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="StrawberryPerl" version="5.32.1.1" />
   <package id="vswhere" version="3.1.7" />

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1252,6 +1252,7 @@ Return Value:
 
         std::string Config = std::format(
             "option subnet_mask, routers, broadcast, domain_name, domain_name_servers, domain_search, host_name, interface_mtu\n"
+            "noarp\n"
             "timeout {}\n",
             DhcpTimeout);
 

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1251,8 +1251,7 @@ Return Value:
         //
 
         std::string Config = std::format(
-            "option subnet_mask, routers, domain_name, domain_name_servers, domain_search, host_name, interface_mtu\n"
-            "noarp\n"
+            "option subnet_mask, routers, broadcast, domain_name, domain_name_servers, domain_search, host_name, interface_mtu\n"
             "timeout {}\n",
             DhcpTimeout);
 

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -72,8 +72,9 @@ Abstract:
 #define CROSS_DISTRO_SHARE_PATH "/mnt/wsl"
 #define DEVFS_PATH "/dev"
 #define DEVNULL_PATH DEVFS_PATH "/null"
-#define DHCLIENT_CONF_PATH "/dhclient.conf"
-#define DHCLIENT_PATH "/usr/sbin/dhclient"
+#define DHCPCD_CONF_PATH "/dhcpcd.conf"
+#define DHCPCD_PATH "/usr/sbin/dhcpcd"
+
 #define DISTRO_PATH "/distro"
 #define ETC_PATH "/etc"
 #define GPU_SHARE_PREFIX "/gpu_"
@@ -1230,11 +1231,12 @@ int StartDhcpClient(int DhcpTimeout)
 
 Routine Description:
 
-    Starts the dhcp client daemon.
+    Starts the dhcp client daemon. Blocks until the initial DHCP lease is acquired,
+    then the daemon continues running in the background to handle renewals.
 
 Arguments:
 
-    None.
+    DhcpTimeout - Supplies the timeout in seconds for the DHCP request.
 
 Return Value:
 
@@ -1243,37 +1245,21 @@ Return Value:
 --*/
 
 {
-    int ChildPid = UtilCreateChildProcess("dhcp", [DhcpTimeout]() {
+    int ChildPid = UtilCreateChildProcess("dhcpcd", [DhcpTimeout]() {
         //
-        // Create a new mount namespace for dhclient.
-        //
-
-        THROW_LAST_ERROR_IF(unshare(CLONE_NEWNS) < 0);
-
-        //
-        // When dhclient receives a DHCP response, it calls dhclient-script
-        // which creates a new file, and then moves it to /etc/resolv.conf.
-        // Because it's moved, it will overwrite any symlinks / hardlinks.
-        // Mounting /etc over /share allows resolv.conf to be written to /share.
-        //
-
-        THROW_LAST_ERROR_IF(mount(CROSS_DISTRO_SHARE_PATH, ETC_PATH, NULL, MS_BIND, NULL) < 0);
-
-        //
-        // Write the dhclient.conf config file.
+        // Write the dhcpcd.conf config file.
         //
 
         std::string Config = std::format(
-            "request subnet-mask, broadcast-address, routers,"
-            "domain-name, domain-name-servers, domain-search, host-name,"
-            "interface-mtu;\n"
-            "timeout {};\n",
+            "option subnet_mask, routers, domain_name, domain_name_servers, domain_search, host_name, interface_mtu\n"
+            "noarp\n"
+            "timeout {}\n",
             DhcpTimeout);
 
-        THROW_LAST_ERROR_IF(WriteToFile(DHCLIENT_CONF_PATH, Config.c_str()) < 0);
+        THROW_LAST_ERROR_IF(WriteToFile(DHCPCD_CONF_PATH, Config.c_str()) < 0);
 
-        execl(DHCLIENT_PATH, DHCLIENT_PATH, "-4", "eth0", "-cf", DHCLIENT_CONF_PATH, NULL);
-        LOG_ERROR("execl() failed, {}", errno);
+        execl(DHCPCD_PATH, DHCPCD_PATH, "-w", "-4", "-f", DHCPCD_CONF_PATH, "eth0", NULL);
+        LOG_ERROR("execl({}) failed {}", DHCPCD_PATH, errno);
     });
 
     if (ChildPid < 0)
@@ -1281,12 +1267,7 @@ Return Value:
         return -1;
     }
 
-    //
-    // Note: dhclient returns when the interface is successfully configured,
-    // but keeps a daemon running to maintain it.
-    //
-
-    return WaitForChild(ChildPid, DHCLIENT_PATH);
+    return WaitForChild(ChildPid, DHCPCD_PATH);
 }
 
 int StartGuestNetworkService(int GnsFd, wil::unique_fd&& DnsTunnelingFd, uint32_t DnsTunnelingIpAddress)

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1259,7 +1259,7 @@ Return Value:
         THROW_LAST_ERROR_IF(WriteToFile(DHCPCD_CONF_PATH, Config.c_str()) < 0);
 
         execl(DHCPCD_PATH, DHCPCD_PATH, "-w", "-4", "-f", DHCPCD_CONF_PATH, "eth0", NULL);
-        LOG_ERROR("execl({}) failed {}", DHCPCD_PATH, errno);
+        LOG_ERROR("execl({}) failed, {}", DHCPCD_PATH, errno);
     });
 
     if (ChildPid < 0)


### PR DESCRIPTION
This pull request updates system distro VHD used by WSL to Azure Linux 3. This required updates to the DHCP client implementation in the Linux initialization code, switching from `dhclient` to `dhcpcd` .

* Updated the `Microsoft.WSLg` package version from `1.0.71` to `1.0.72` in `packages.config`.
* Replaced all references to `dhclient` with `dhcpcd` in `src/linux/init/main.cpp`. 