### PR TITLE
Packages: Update Microsoft.WSLg version 1.0.73

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />
-  <package id="Microsoft.WSLg" version="1.0.72" />
+  <package id="Microsoft.WSLg" version="1.0.73" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="StrawberryPerl" version="5.32.1.1" />
   <package id="vswhere" version="3.1.7" />


### PR DESCRIPTION
This change updates to the latest version of WSLg, the primary difference with this package is that is saves 85MB of space by trimming unused files from the .vhd.