### PR TITLE
Update UserConfig.cmake.sample to make VHDs readable by everyone

### DIFF
--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -2,26 +2,38 @@
 
 message(STATUS "Loading user configuration")
 
-# # Uncomment to enable development packages (smaller, faster to install)
+# Uncomment to enable development packages (smaller, faster to install)
 # # Note: system.vhd fails to mount if symlink / hardlink, so COPY is needed.
 # set(WSL_DEV_BINARY_PATH "C:/wsldev")
-# file(MAKE_DIRECTORY ${WSL_DEV_BINARY_PATH})
-# file(CREATE_LINK "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/kernel" "${WSL_DEV_BINARY_PATH}/kernel" SYMBOLIC)
-# file(COPY_FILE "${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd" "${WSL_DEV_BINARY_PATH}/system.vhd" ONLY_IF_DIFFERENT)
-# file(COPY_FILE "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/modules.vhd" "${WSL_DEV_BINARY_PATH}/modules.vhd" ONLY_IF_DIFFERENT)
-# file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/msrdc.exe" "${WSL_DEV_BINARY_PATH}/msrdc.exe" SYMBOLIC)
-# file(CREATE_LINK "${WSLG_SOURCE_DIR}/wslg.rdp" "${WSL_DEV_BINARY_PATH}/wslg.rdp" SYMBOLIC)
-# file(CREATE_LINK "${WSLG_SOURCE_DIR}/wslg_desktop.rdp" "${WSL_DEV_BINARY_PATH}/wslg_desktop.rdp" SYMBOLIC)
-# file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdclientax.dll" "${WSL_DEV_BINARY_PATH}/rdclientax.dll" SYMBOLIC)
-# file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdpnanoTransport.dll" "${WSL_DEV_BINARY_PATH}/rdpnanoTransport.dll" SYMBOLIC)
-# file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/RdpWinStlHelper.dll" "${WSL_DEV_BINARY_PATH}/RdpWinStlHelper.dll" SYMBOLIC)
-# file(CREATE_LINK "${MSAL_SOURCE_DIR}/${TARGET_PLATFORM}/msal.wsl.proxy.exe" "${WSL_DEV_BINARY_PATH}/msal.wsl.proxy.exe" SYMBOLIC)
-# file(CREATE_LINK "${BIN}/wsldevicehost.dll" "${WSL_DEV_BINARY_PATH}/wsldevicehost.dll" SYMBOLIC)
-# file(CREATE_LINK "${DIRECT3D_SOURCE_DIR}/lib/${TARGET_PLATFORM}" "${WSL_DEV_BINARY_PATH}/lib" SYMBOLIC)
 
-# foreach(LANG ${SUPPORTED_LANGS})
-#    file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/${LANG}" "${WSL_DEV_BINARY_PATH}/${LANG}" SYMBOLIC)
-# endforeach()
+if(WSL_DEV_BINARY_PATH)
+    file(MAKE_DIRECTORY ${WSL_DEV_BINARY_PATH})
+    file(CREATE_LINK "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/kernel" "${WSL_DEV_BINARY_PATH}/kernel" SYMBOLIC)
+    file(COPY_FILE "${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd" "${WSL_DEV_BINARY_PATH}/system.vhd" ONLY_IF_DIFFERENT)
+    file(COPY_FILE "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/modules.vhd" "${WSL_DEV_BINARY_PATH}/modules.vhd" ONLY_IF_DIFFERENT)
+
+    # read-only VHD's need to be world readable to mount successfully.
+    execute_process(
+        COMMAND icacls.exe "${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd" "/grant:r" "Everyone:(R)" /Q
+        COMMAND icacls.exe "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/modules.vhd" "/grant:r" "Everyone:(R)" /Q
+        COMMAND icacls.exe "${WSLA_TEST_DISTRO_SOURCE_DIR}/rootfs.vhd" "/grant:r" "Everyone:(R)" /Q
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        COMMAND_ERROR_IS_FATAL ANY)
+
+    file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/msrdc.exe" "${WSL_DEV_BINARY_PATH}/msrdc.exe" SYMBOLIC)
+    file(CREATE_LINK "${WSLG_SOURCE_DIR}/wslg.rdp" "${WSL_DEV_BINARY_PATH}/wslg.rdp" SYMBOLIC)
+    file(CREATE_LINK "${WSLG_SOURCE_DIR}/wslg_desktop.rdp" "${WSL_DEV_BINARY_PATH}/wslg_desktop.rdp" SYMBOLIC)
+    file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdclientax.dll" "${WSL_DEV_BINARY_PATH}/rdclientax.dll" SYMBOLIC)
+    file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdpnanoTransport.dll" "${WSL_DEV_BINARY_PATH}/rdpnanoTransport.dll" SYMBOLIC)
+    file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/RdpWinStlHelper.dll" "${WSL_DEV_BINARY_PATH}/RdpWinStlHelper.dll" SYMBOLIC)
+    file(CREATE_LINK "${MSAL_SOURCE_DIR}/${TARGET_PLATFORM}/msal.wsl.proxy.exe" "${WSL_DEV_BINARY_PATH}/msal.wsl.proxy.exe" SYMBOLIC)
+    file(CREATE_LINK "${BIN}/wsldevicehost.dll" "${WSL_DEV_BINARY_PATH}/wsldevicehost.exe" SYMBOLIC)
+    file(CREATE_LINK "${DIRECT3D_SOURCE_DIR}/lib/${TARGET_PLATFORM}" "${WSL_DEV_BINARY_PATH}/lib" SYMBOLIC)
+
+    foreach(LANG ${SUPPORTED_LANGS})
+        file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/${LANG}" "${WSL_DEV_BINARY_PATH}/${LANG}" SYMBOLIC)
+    endforeach()
+endif()
 
 # # Uncomment to skip building, packaging and installing wslsettings
 # set(WSL_BUILD_WSL_SETTINGS false)

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -12,10 +12,10 @@ if(WSL_DEV_BINARY_PATH)
     file(COPY_FILE "${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd" "${WSL_DEV_BINARY_PATH}/system.vhd" ONLY_IF_DIFFERENT)
     file(COPY_FILE "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/modules.vhd" "${WSL_DEV_BINARY_PATH}/modules.vhd" ONLY_IF_DIFFERENT)
 
-    # read-only VHD's need to be world readable to mount successfully.
+    # read-only VHDs need to be world readable to mount successfully.
     execute_process(
-        COMMAND icacls.exe "${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd" "/grant:r" "Everyone:(R)" /Q
-        COMMAND icacls.exe "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/modules.vhd" "/grant:r" "Everyone:(R)" /Q
+        COMMAND icacls.exe "${WSL_DEV_BINARY_PATH}/system.vhd" "/grant:r" "Everyone:(R)" /Q
+        COMMAND icacls.exe "${WSL_DEV_BINARY_PATH}/modules.vhd" "/grant:r" "Everyone:(R)" /Q
         COMMAND icacls.exe "${WSLA_TEST_DISTRO_SOURCE_DIR}/rootfs.vhd" "/grant:r" "Everyone:(R)" /Q
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         COMMAND_ERROR_IS_FATAL ANY)
@@ -27,7 +27,7 @@ if(WSL_DEV_BINARY_PATH)
     file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdpnanoTransport.dll" "${WSL_DEV_BINARY_PATH}/rdpnanoTransport.dll" SYMBOLIC)
     file(CREATE_LINK "${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/RdpWinStlHelper.dll" "${WSL_DEV_BINARY_PATH}/RdpWinStlHelper.dll" SYMBOLIC)
     file(CREATE_LINK "${MSAL_SOURCE_DIR}/${TARGET_PLATFORM}/msal.wsl.proxy.exe" "${WSL_DEV_BINARY_PATH}/msal.wsl.proxy.exe" SYMBOLIC)
-    file(CREATE_LINK "${BIN}/wsldevicehost.dll" "${WSL_DEV_BINARY_PATH}/wsldevicehost.exe" SYMBOLIC)
+    file(CREATE_LINK "${BIN}/wsldevicehost.dll" "${WSL_DEV_BINARY_PATH}/wsldevicehost.dll" SYMBOLIC)
     file(CREATE_LINK "${DIRECT3D_SOURCE_DIR}/lib/${TARGET_PLATFORM}" "${WSL_DEV_BINARY_PATH}/lib" SYMBOLIC)
 
     foreach(LANG ${SUPPORTED_LANGS})


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates UserConfig.cmake to make the VHDs readable by everyone, which will solve the E_ACCESSDENIED issues that 
can hit when $WSL_DEV_BINARY_PATH is set


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
