### PR TITLE
virtiofs: add support for mounting directories (not just full volumes)

### DIFF
--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1729,10 +1729,6 @@ Return Value:
         if (strcmp(MountEnum.Current().FileSystemType, PLAN9_FS_TYPE) == 0)
         {
             MountSource = UtilParsePlan9MountSource(MountEnum.Current().SuperOptions);
-            if (MountSource.empty())
-            {
-                continue;
-            }
         }
         else if (strcmp(MountEnum.Current().FileSystemType, DRVFS_FS_TYPE) == 0)
         {
@@ -1741,9 +1737,14 @@ Return Value:
         }
         else if (strcmp(MountEnum.Current().FileSystemType, VIRTIO_FS_TYPE) == 0)
         {
-            MountSource = UtilParseVirtiofsMountSource(MountEnum.Current().Source);
+            MountSource = QueryVirtiofsMountSource(MountEnum.Current().Source);
         }
         else
+        {
+            continue;
+        }
+
+        if (MountSource.empty())
         {
             continue;
         }
@@ -2445,17 +2446,10 @@ try
                 NewMountOptions += ',';
             }
 
-            MountPlan9Filesystem(NewSource, MountEntry.MountPoint, NewMountOptions.c_str(), Message->Admin, Config);
+            MountPlan9Share(NewSource, MountEntry.MountPoint, NewMountOptions.c_str(), Message->Admin, Config);
         }
         else if (strcmp(MountEntry.FileSystemType, VIRTIO_FS_TYPE) == 0)
         {
-            std::string_view Source = MountEntry.Source;
-            std::string_view OldTag = Message->Admin ? LX_INIT_DRVFS_VIRTIO_TAG : LX_INIT_DRVFS_ADMIN_VIRTIO_TAG;
-            if (!wsl::shared::string::StartsWith(Source, OldTag))
-            {
-                continue;
-            }
-
             RemountVirtioFs(MountEntry.Source, MountEntry.MountPoint, MountEntry.MountOptions, Message->Admin);
         }
         else

--- a/src/linux/init/drvfs.h
+++ b/src/linux/init/drvfs.h
@@ -23,9 +23,12 @@ int MountDrvfs(const char* Source, const char* Target, const char* Options, std:
 
 int MountDrvfsEntry(int Argc, char* Argv[]);
 
-int MountPlan9Filesystem(
-    const char* Source, const char* Target, const char* Options, bool Admin, const wsl::linux::WslDistributionConfig& Config, int* ExitCode = nullptr);
+int MountPlan9Share(const char* Source, const char* Target, const char* Options, bool Admin, const wsl::linux::WslDistributionConfig& Config, int* ExitCode = nullptr);
+
+int MountPlan9(const char* Source, const char* Target, const char* Options, std::optional<bool> Admin, const wsl::linux::WslDistributionConfig& Config, int* ExitCode);
 
 int MountVirtioFs(const char* Source, const char* Target, const char* Options, std::optional<bool> Admin, const wsl::linux::WslDistributionConfig& Config, int* ExitCode = nullptr);
 
 int RemountVirtioFs(const char* Tag, const char* Target, const char* Options, bool Admin);
+
+std::string QueryVirtiofsMountSource(const char* Tag);

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -902,11 +902,12 @@ try
         }
         else if (strcmp(MountEnum.Current().FileSystemType, VIRTIO_FS_TYPE) == 0)
         {
-            MountSource = UtilParseVirtiofsMountSource(MountEnum.Current().Source);
+            MountSource = QueryVirtiofsMountSource(MountEnum.Current().Source);
             if (MountSource.empty())
             {
                 continue;
             }
+
             MountEnum.Current().Source = MountSource.data();
         }
         else if (strcmp(MountEnum.Current().FileSystemType, DRVFS_FS_TYPE) == 0)
@@ -2024,41 +2025,6 @@ Return Value:
     }
 
     return {};
-}
-
-std::string UtilParseVirtiofsMountSource(std::string_view Source)
-
-/*++
-
-Routine Description:
-
-    This routine parses the mount source to determine the actual source of a
-    a VirtioFs mount.
-
-Arguments:
-
-    Source - Supplies the source string.
-
-Return Value:
-
-    The mount source, or NULL if the source is not valid.
-
---*/
-
-{
-    std::string MountSource{};
-    if (wsl::shared::string::StartsWith(Source, LX_INIT_DRVFS_ADMIN_VIRTIO_TAG) && (Source.size() >= sizeof(LX_INIT_DRVFS_ADMIN_VIRTIO_TAG)))
-    {
-        MountSource = Source[sizeof(LX_INIT_DRVFS_ADMIN_VIRTIO_TAG) - 1];
-        MountSource += ":";
-    }
-    else if (wsl::shared::string::StartsWith(Source, LX_INIT_DRVFS_VIRTIO_TAG) && (Source.size() >= sizeof(LX_INIT_DRVFS_VIRTIO_TAG)))
-    {
-        MountSource = Source[sizeof(LX_INIT_DRVFS_VIRTIO_TAG) - 1];
-        MountSource += ":";
-    }
-
-    return MountSource;
 }
 
 std::vector<char> UtilParseWslEnv(char* NtEnvironment)

--- a/src/linux/init/util.h
+++ b/src/linux/init/util.h
@@ -257,8 +257,6 @@ int UtilParseCgroupsLine(char* Line, char** SubsystemName, bool* Enabled);
 
 std::string UtilParsePlan9MountSource(std::string_view MountOptions);
 
-std::string UtilParseVirtiofsMountSource(std::string_view MountOptions);
-
 std::vector<char> UtilParseWslEnv(char* NtEnvironment);
 
 int UtilProcessChildExitCode(int Status, const char* Name, int ExpectedStatus = 0, bool PrintError = true);

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -302,6 +302,7 @@ typedef enum _LX_MESSAGE_TYPE
     LxInitMessageAddVirtioFsDevice,
     LxInitMessageAddVirtioFsDeviceResponse,
     LxInitMessageRemountVirtioFsDevice,
+    LxInitMessageQueryVirtioFsDevice,
     LxInitMessageStartDistroInit,
     LxInitMessageCreateLoginSession,
     LxInitMessageStopPlan9Server,
@@ -1104,6 +1105,17 @@ typedef struct _LX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE
     PRETTY_PRINT(FIELD(Header), FIELD(Admin), STRING_FIELD(TagOffset));
 } LX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE, *PLX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE;
 
+typedef struct _LX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE
+{
+    static inline auto Type = LxInitMessageQueryVirtioFsDevice;
+    using TResponse = LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE;
+
+    MESSAGE_HEADER Header;
+    unsigned int TagOffset;
+    char Buffer[];
+
+    PRETTY_PRINT(FIELD(Header), STRING_FIELD(TagOffset));
+} LX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE, *PLX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE;
 //
 // The messages that can be sent to mini_init.
 //

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -52,26 +52,6 @@ inline unsigned int CopyToSpan(const std::string_view String, const gsl::span<gs
     return PreviousOffset;
 }
 
-inline bool IsDriveRoot(const std::string_view Path)
-{
-    bool IsRoot = true;
-    if (Path.length() == 3)
-    {
-        IsRoot &= Path[2] == '\\';
-    }
-
-    if (Path.length() == 2 || Path.length() == 3)
-    {
-        IsRoot &= isalpha(Path[0]) && Path[1] == ':';
-    }
-    else
-    {
-        IsRoot = false;
-    }
-
-    return IsRoot;
-}
-
 template <class T>
 inline bool EndsWith(const std::basic_string<T>& String, const std::basic_string_view<T> Suffix)
 {

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2149,7 +2149,7 @@ std::wstring WslCoreVm::AddVirtioFsShare(_In_ bool Admin, _In_ PCWSTR Path, _In_
     {
         // Generate a new unique tag for the share.
         //
-        // N.B. The tag can be maximum 36 characters long so a GUID withouts braces fits perfectly.
+        // N.B. The tag can be maximum 36 characters long so a GUID without braces fits perfectly.
         GUID tagGuid{};
         THROW_IF_FAILED(CoCreateGuid(&tagGuid));
 

--- a/test/linux/unit_tests/lxtfs.c
+++ b/test/linux/unit_tests/lxtfs.c
@@ -294,7 +294,7 @@ Return Value:
             snprintf(
                 Plan9Options,
                 sizeof(Plan9Options),
-                "aname=drvfs;path=%s%s;symlinkroot=/mnt/,cache=5,access=client,msize=65536,trans=fd,rfd=4,wfd=4",
+                "aname=drvfs;path=%s%s;symlinkroot=/mnt/,cache=5,access=client,msize=65536,trans=fd,rfd=*,wfd=*",
                 Plan9Source,
                 Temp);
         }

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1668,11 +1668,7 @@ Return Value:
 
         if (LxsstuVmMode())
         {
-            std::wstring Command = L"/bin/cp /data/test/log/";
-            Command += LogFileToken;
-            Command += L" $(wslpath '";
-            Command += LinuxLogPath;
-            Command += L"')";
+            std::wstring Command = std::format(L"/bin/cp /data/test/log/{} $(wslpath '{}')", LogFileToken, LinuxLogPath);
             VERIFY_NO_THROW(LxsstuRunTest(Command.c_str()));
         }
 

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -1347,6 +1347,6 @@ WSL2_DRVFS_TEST_CLASS(Plan9);
 
 // Disabled because it causes too much noise.
 // TODO: Enable again once virtiofs is stable
-WSL2_DRVFS_TEST_CLASS(VirtioFs);
+// WSL2_DRVFS_TEST_CLASS(VirtioFs);
 
 } // namespace DrvFsTests

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -226,12 +226,6 @@ public:
     {
         SKIP_TEST_ARM64();
 
-        if (Mode == DrvFsMode::VirtioFs)
-        {
-            LogSkipped("VirtioFS currently only supports mounting full drives");
-            return;
-        }
-
         constexpr auto MountPoint = "C:\\lxss_fat";
         constexpr auto VhdPath = "C:\\lxss_fat.vhdx";
         auto Cleanup = wil::scope_exit([MountPoint, VhdPath] { DeleteVolume(MountPoint, VhdPath); });
@@ -352,12 +346,6 @@ public:
         SKIP_TEST_ARM64();
         WSL_TEST_VERSION_REQUIRED(wsl::windows::common::helpers::WindowsBuildNumbers::Germanium);
 
-        if (Mode == DrvFsMode::VirtioFs)
-        {
-            LogSkipped("VirtioFS currently only supports mounting full drives");
-            return;
-        }
-
         constexpr auto MountPoint = "C:\\lxss_refs";
         constexpr auto VhdPath = "C:\\lxss_refs.vhdx";
         auto Cleanup = wil::scope_exit([MountPoint, VhdPath] { DeleteVolume(MountPoint, VhdPath); });
@@ -365,6 +353,68 @@ public:
         VERIFY_NO_THROW(CreateVolume("refs", 50000, MountPoint, VhdPath));
         VERIFY_NO_THROW(
             LxsstuRunTest((L"bash -c '" + SkipUnstableTestEnvVar + L" /data/test/wsl_unit_tests drvfs -m 6'").c_str(), L"drvfs6"));
+    }
+
+    void WslPath(DrvFsMode Mode)
+    {
+        VERIFY_NO_THROW(LxsstuRunTest(L"/data/test/wsl_unit_tests wslpath", L"wslpath"));
+
+        auto testWslPath = [](const std::wstring& testDir) {
+            auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testDir); });
+
+            std::filesystem::create_directory(testDir);
+
+            auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath -aw '{}'", testDir));
+            VERIFY_ARE_EQUAL((std::filesystem::canonical(std::filesystem::current_path()) / testDir).wstring() + L"\n", out);
+
+            std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath -wa '{}'", testDir));
+            VERIFY_ARE_EQUAL((std::filesystem::canonical(std::filesystem::current_path()) / testDir).wstring() + L"\n", out);
+
+            std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath '{}'", testDir));
+            VERIFY_ARE_EQUAL(std::format(L"{}\n", testDir), out);
+
+            std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath -a '{}'", testDir));
+            VERIFY_IS_TRUE(out.find(L"/mnt/") == 0);
+        };
+
+        testWslPath(L"wslpath-test-dir");
+        testWslPath(L"wslpath-测试目录-テスト");
+    }
+
+    void DrvFsMountUnicodePath(DrvFsMode Mode)
+    {
+        WSL2_TEST_ONLY();
+
+        // Create a Windows directory with unicode characters
+        constexpr auto unicodeDir = L"C:\\drvfs-测试-テスト";
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(unicodeDir); });
+
+        std::filesystem::create_directory(unicodeDir);
+
+        // Create a test file inside the directory
+        const auto testFilePath = std::filesystem::path(unicodeDir) / L"test-file.txt";
+        {
+            std::ofstream testFile(testFilePath);
+            testFile << "hello from unicode path";
+        }
+
+        // Mount the unicode directory using mount -t drvfs
+        constexpr auto mountPoint = L"/tmp/unicode-mount-test";
+        auto unmountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LxsstuLaunchWsl(std::format(L"-u root umount '{}'", mountPoint).c_str());
+            LxsstuLaunchWsl(std::format(L"-u root rmdir '{}'", mountPoint).c_str());
+        });
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"-u root mkdir -p '{}'", mountPoint).c_str()), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"-u root mount -t drvfs '{}' '{}'", unicodeDir, mountPoint).c_str()), 0);
+
+        // Verify we can read the test file through the mount
+        auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"cat '{}/test-file.txt'", mountPoint));
+        VERIFY_ARE_EQUAL(L"hello from unicode path", out);
+
+        // Verify we can list the directory
+        std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"ls '{}'", mountPoint));
+        VERIFY_IS_TRUE(out.find(L"test-file.txt") != std::wstring::npos);
     }
 
     // DrvFsTests Private Methods
@@ -935,7 +985,11 @@ private:
             const auto lines = LxssSplitString(output.Stdout, L"\n");
 
             VERIFY_ARE_EQUAL(lines.size(), 1);
-            VERIFY_IS_TRUE(output.Stdout.find(expectedType) == 0);
+
+            if (!expectedType.empty())
+            {
+                VERIFY_IS_TRUE(output.Stdout.find(expectedType) == 0);
+            }
         };
 
         std::wstring elevatedType;
@@ -951,8 +1005,7 @@ private:
             nonElevatedType = L"drvfs";
             break;
         case DrvFsMode::VirtioFs:
-            elevatedType = L"drvfsaC";
-            nonElevatedType = L"drvfsC";
+            // VirtioFs uses GUIDs as the tag so the value is not predictable.
             break;
 
         default:
@@ -1149,6 +1202,12 @@ class WSL1 : public DrvFsTests
         WSL1_TEST_ONLY();
         DrvFsTests::XattrDrvFs(DrvFsMode::WSL1);
     }
+
+    TEST_METHOD(WslPath)
+    {
+        WSL1_TEST_ONLY();
+        DrvFsTests::WslPath(DrvFsMode::WSL1);
+    }
 };
 
 #define WSL2_DRVFS_TEST_CLASS(_mode) \
@@ -1266,6 +1325,18 @@ class WSL1 : public DrvFsTests
             WSL2_TEST_ONLY(); \
             DrvFsTests::DrvFsReFs(DrvFsMode::##_mode##); \
         } \
+\
+        TEST_METHOD(WslPath) \
+        { \
+            WSL2_TEST_ONLY(); \
+            DrvFsTests::WslPath(DrvFsMode::##_mode##); \
+        } \
+\
+        TEST_METHOD(DrvFsMountUnicodePath) \
+        { \
+            WSL2_TEST_ONLY(); \
+            DrvFsTests::DrvFsMountUnicodePath(DrvFsMode::##_mode##); \
+        } \
     }
 
 WSL2_DRVFS_TEST_CLASS(Plan9);
@@ -1276,6 +1347,6 @@ WSL2_DRVFS_TEST_CLASS(Plan9);
 
 // Disabled because it causes too much noise.
 // TODO: Enable again once virtiofs is stable
-// WSL2_DRVFS_TEST_CLASS(VirtioFs);
+WSL2_DRVFS_TEST_CLASS(VirtioFs);
 
 } // namespace DrvFsTests

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -878,11 +878,6 @@ class UnitTests
         }
     }
 
-    TEST_METHOD(WslPath)
-    {
-        VERIFY_NO_THROW(LxsstuRunTest(L"/data/test/wsl_unit_tests wslpath", L"wslpath"));
-    }
-
     TEST_METHOD(FsTab)
     {
         //
@@ -5957,25 +5952,6 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             parse(parser);
             VERIFY_IS_TRUE(a);
             VERIFY_ARE_EQUAL(pos, L"-");
-        }
-
-        {
-            constexpr auto testDir = "wslpath-test-dir";
-            auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { std::filesystem::remove_all(testDir); });
-
-            std::filesystem::create_directory(testDir);
-
-            auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath -aw {}", testDir));
-            VERIFY_ARE_EQUAL((std::filesystem::canonical(std::filesystem::current_path()) / testDir).wstring() + L"\n", out);
-
-            std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath -wa {}", testDir));
-            VERIFY_ARE_EQUAL((std::filesystem::canonical(std::filesystem::current_path()) / testDir).wstring() + L"\n", out);
-
-            std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath {}", testDir));
-            VERIFY_ARE_EQUAL(std::format(L"{}\n", testDir), out);
-
-            std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"wslpath -a {}", testDir));
-            VERIFY_IS_TRUE(out.find(L"/mnt/") == 0);
         }
     }
 


### PR DESCRIPTION
The primary behavior change introduced by this PR is that virtiofs can now mount sub-directories instead of just the entire path. This is achieved by using a GUID tag for the vitiofs share and introducing a query method to ask the wsl service for the source of a virtiofs share, instead of relying on parsing the /proc/pid/mountinfo file.