### PR TITLE
WSLA: Switch to using the system distro vhd.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,6 @@ find_nuget_package(Microsoft.WSL.bsdtar BSDTARD /build/native/bin)
 find_nuget_package(Microsoft.WSL.LinuxSdk LINUXSDK /)
 find_nuget_package(Microsoft.WSL.TestDistro TEST_DISTRO /)
 find_nuget_package(Microsoft.WSL.TestData WSL_TEST_DATA /build/native/bin/${TARGET_PLATFORM})
-find_nuget_package(Microsoft.WSL.WslaRootfs WSLA_TEST_DISTRO /build/native/bin/${TARGET_PLATFORM})
 find_nuget_package(Microsoft.WSLg WSLG /build/native/bin)
 find_nuget_package(StrawberryPerl PERL /)
 find_nuget_package(vswhere VSWHERE /tools)
@@ -388,10 +387,6 @@ if (DEFINED WSL_DEV_BINARY_PATH) # Development shortcut to make the package smal
                             WSL_KERNEL_MODULES_PATH="${WSL_DEV_BINARY_PATH}/modules.vhd"
                             WSL_DEV_INSTALL_PATH="${WSL_DEV_BINARY_PATH}"
                             WSL_GPU_LIB_PATH="${WSL_DEV_BINARY_PATH}/lib")
-
-    if (NOT OFFICIAL_BUILD AND ${TARGET_PLATFORM} STREQUAL "x64")
-        add_compile_definitions(WSLA_TEST_DISTRO_PATH="${WSLA_TEST_DISTRO_SOURCE_DIR}/rootfs.vhd")
-    endif()
 endif()
 
 # Common include paths

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -16,7 +16,6 @@ if(WSL_DEV_BINARY_PATH)
     execute_process(
         COMMAND icacls.exe "${WSL_DEV_BINARY_PATH}/system.vhd" "/grant:r" "Everyone:(R)" /Q
         COMMAND icacls.exe "${WSL_DEV_BINARY_PATH}/modules.vhd" "/grant:r" "Everyone:(R)" /Q
-        COMMAND icacls.exe "${WSLA_TEST_DISTRO_SOURCE_DIR}/rootfs.vhd" "/grant:r" "Everyone:(R)" /Q
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         COMMAND_ERROR_IS_FATAL ANY)
 

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -41,12 +41,6 @@
                 <File Id="system.vhd" Source="${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd"/>
                 <?endif?>
 
-
-                <!-- Temporary runtime VHD. TODO: Update once the final VHD is available. -->
-                <?if "${WSL_DEV_BINARY_PATH}" = "" AND "${TARGET_PLATFORM}" = "x64" ?>
-                <File Id="wslarootfs.vhd" Name="wslarootfs.vhd" Source="${WSLA_TEST_DISTRO_SOURCE_DIR}/rootfs.vhd"/>
-                <?endif?>
-
                 <!-- Installation folder -->
                 <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\MSI">
                     <RegistryValue Name="InstallLocation" Value="[INSTALLDIR]" Type="string" />

--- a/packages.config
+++ b/packages.config
@@ -23,7 +23,7 @@
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.1.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />
-  <package id="Microsoft.WSLg" version="1.0.74" />
+  <package id="Microsoft.WSLg" version="1.0.75" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="StrawberryPerl" version="5.32.1.1" />
   <package id="vswhere" version="3.1.7" />

--- a/packages.config
+++ b/packages.config
@@ -23,8 +23,7 @@
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.1.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />
-  <package id="Microsoft.WSL.WslaRootfs" version="0.1.3" />
-  <package id="Microsoft.WSLg" version="1.0.72" />
+  <package id="Microsoft.WSLg" version="1.0.74" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="StrawberryPerl" version="5.32.1.1" />
   <package id="vswhere" version="3.1.7" />

--- a/src/windows/wslaservice/exe/WSLAContainer.cpp
+++ b/src/windows/wslaservice/exe/WSLAContainer.cpp
@@ -597,7 +597,9 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Create(
     {
         // TODO: UDP support
         // TODO: Investigate ipv6 support.
-        auto& portEntry = request.HostConfig.PortBindings[std::format("{}/tcp", e.ContainerPort)];
+        auto portKey = std::format("{}/tcp", e.ContainerPort);
+        request.ExposedPorts[portKey] = {};
+        auto& portEntry = request.HostConfig.PortBindings[portKey];
         portEntry.emplace_back(common::docker_schema::PortMapping{.HostIp = "127.0.0.1", .HostPort = std::to_string(e.VmPort)});
     }
 

--- a/src/windows/wslaservice/exe/WSLASession.cpp
+++ b/src/windows/wslaservice/exe/WSLASession.cpp
@@ -110,12 +110,13 @@ WSLAVirtualMachine::Settings WSLASession::CreateVmSettings(const WSLA_SESSION_SE
     else
     {
 
-#ifdef WSLA_TEST_DISTRO_PATH
+#ifdef WSL_SYSTEM_DISTRO_PATH
 
-        vmSettings.RootVhd = TEXT(WSLA_TEST_DISTRO_PATH);
+        vmSettings.RootVhd = TEXT(WSL_SYSTEM_DISTRO_PATH);
 
 #else
-        vmSettings.RootVhd = std::filesystem::path(common::wslutil::GetMsiPackagePath().value()) / L"wslarootfs.vhd";
+
+        vmSettings.RootVhd = std::filesystem::path(common::wslutil::GetMsiPackagePath().value()) / L"system.vhd";
 
 #endif
 

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -313,7 +313,8 @@ class WSLATests
 
         {
             std::string expectedError =
-                "pull access denied for does-not, repository does not exist or may require 'docker login'";
+                "pull access denied for does-not, repository does not exist or may require 'docker login': denied: requested "
+                "access to the resource is denied";
 
             WSLAErrorDetails error;
             VERIFY_ARE_EQUAL(session->PullImage("does-not:exist", nullptr, nullptr, &error.Error), WSLA_E_IMAGE_NOT_FOUND);


### PR DESCRIPTION
This changes moves WSLA to use the WSL system distro vhd instead of its own. This will allow for lower disk and memory usage for the product.