### PR TITLE
test: enable NATPortMapping test

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -823,8 +823,7 @@ class WSLATests
         //
         // TODO: revisit this in the future to avoid pulling packages from the network.
         auto installSocat = WSLAProcessLauncher("/bin/sh", {"/bin/sh", "-c", "tdnf install socat -y"}).Launch(*session);
-        auto result = installSocat.WaitAndCaptureOutput();
-        VERIFY_ARE_EQUAL(result.Code, 0);
+        ValidateProcessOutput(installSocat, {});
 
         auto listen = [&](short port, const char* content, bool ipv6) {
             auto cmd = std::format("echo -n '{}' | /usr/bin/socat -dd TCP{}-LISTEN:{},reuseaddr -", content, ipv6 ? "6" : "", port);

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -817,16 +817,14 @@ class WSLATests
     {
         WSL2_TEST_ONLY();
 
-        // TODO: Enable again once socat is available in the runtime VHD.
-        LogSkipped("Skipping test since socat is required in the runtime VHD");
-        return;
+        auto session = CreateSession();
 
-        auto settings = GetDefaultSessionSettings();
-        settings.RootVhdOverride = testVhd.c_str(); // socat is required to run this test case.
-        settings.RootVhdTypeOverride = "ext4";
-        settings.NetworkingMode = WSLANetworkingModeNAT;
-
-        auto session = CreateSession(settings);
+        // Install socat in the container.
+        //
+        // TODO: revisit this in the future to avoid pulling packages from the network.
+        auto installSocat = WSLAProcessLauncher("/bin/sh", {"/bin/sh", "-c", "tdnf install socat -y"}).Launch(*session);
+        auto result = installSocat.WaitAndCaptureOutput();
+        VERIFY_ARE_EQUAL(result.Code, 0);
 
         auto listen = [&](short port, const char* content, bool ipv6) {
             auto cmd = std::format("echo -n '{}' | /usr/bin/socat -dd TCP{}-LISTEN:{},reuseaddr -", content, ipv6 ? "6" : "", port);


### PR DESCRIPTION
This change enables the NAT port mapping WSLA test by installing socat at runtime. This should get this working and we can revisit this in the future by using a container with python or socat, for example.