### PR TITLE
WSLA: enable port mapping for virtioproxy mode, and add virtiofs / virtioproxy test coverage

### DIFF
--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -570,7 +570,7 @@ void WSLAVirtualMachine::ConfigureNetworking()
     }
     else
     {
-        m_networkEngine = std::make_unique<wsl::core::VirtioNetworking>(std::move(gnsChannel), true, m_guestDeviceManager, m_userToken);
+        m_networkEngine = std::make_unique<wsl::core::VirtioNetworking>(std::move(gnsChannel), false, m_guestDeviceManager, m_userToken);
     }
 
     m_networkEngine->Initialize();


### PR DESCRIPTION
Turns out previous virtioproxy networking was creating a second loopback adapter which was interfering with the port relay that NAT uses. When turnign this off, port relay using the hvsocket / wslrelay.exe mechanism work just fine. In a future change we should look at adding this support to wsldevicehost.dll itself so we don't need a separate relay process, but this is fine for now.

Also ensure that virtiofs is being tested for container volumes, removes unneeded setting of the networking mode in various places (which will make it easier to test virtio proxy networking mode and eventually switch to it as the default).