### PR TITLE
Fix ListImages() so it doesn't drop tags that share the same image

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -366,7 +366,7 @@ class WSLATests
             WSLA_DELETE_IMAGE_OPTIONS options{.Image = "debian:test-list-images", .Force = false, .NoPrune = false};
 
             wil::unique_cotaskmem_array_ptr<WSLA_DELETED_IMAGE_INFORMATION> deletedImages;
-            VERIFY_SUCCEEDED(session->DeleteImage(&options, &deletedImages, deletedImages.size_address<DWORD>(), nullptr));
+            VERIFY_SUCCEEDED(session->DeleteImage(&options, &deletedImages, deletedImages.size_address<ULONG>(), nullptr));
         });
 
         ExpectImagePresent(*session, "debian:test-list-images");

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -350,6 +350,33 @@ class WSLATests
         }
     }
 
+    TEST_METHOD(ListImages)
+    {
+        WSL2_TEST_ONLY();
+
+        // TODO: Add more test coverage once ListImages() is fully implemented.
+
+        // Validate that images with multiple tags are correctly returned.
+        auto session = CreateSession();
+        ExpectImagePresent(*session, "debian:latest");
+
+        ExpectCommandResult(session.get(), {"/usr/bin/docker", "tag", "debian:latest", "debian:test-list-images"}, 0);
+
+        auto cleanup = wil::scope_exit([&]() {
+            WSLA_DELETE_IMAGE_OPTIONS options{.Image = "debian:test-list-images", .Force = false, .NoPrune = false};
+
+            wil::unique_cotaskmem_array_ptr<WSLA_DELETED_IMAGE_INFORMATION> deletedImages;
+            VERIFY_SUCCEEDED(session->DeleteImage(&options, &deletedImages, deletedImages.size_address<DWORD>(), nullptr));
+        });
+
+        ExpectImagePresent(*session, "debian:test-list-images");
+        ExpectImagePresent(*session, "debian:latest");
+
+        cleanup.reset();
+        ExpectImagePresent(*session, "debian:test-list-images", false);
+        ExpectImagePresent(*session, "debian:latest");
+    }
+
     // TODO: Test that invalid tars are correctly handled.
     TEST_METHOD(LoadImage)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change improves ListImages() so it doesn't ignore additional tags on available images. 

Doing this now because this behavior can cause test failures with `-f`. ListImages() still need more work after this change 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
