### PR TITLE
cleanup: cleanup for virtio networking dns

### DIFF
--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -65,14 +65,15 @@ void VirtioNetworking::Initialize()
         device_options << L"gateway_ip=" << default_route;
     }
 
-    auto dns_servers = m_networkSettings->DnsServersString();
-    if (!dns_servers.empty())
+    // Get initial DNS settings for device options.
+    auto initialDns = m_dnsUpdateHelper.GetCurrentDnsSettings(networking::DnsSettingsFlags::IncludeVpn);
+    if (!initialDns.Servers.empty())
     {
         if (device_options.tellp() > 0)
         {
             device_options << L";";
         }
-        device_options << L"nameservers=" << dns_servers;
+        device_options << L"nameservers=" << wsl::shared::string::MultiByteToWide(wsl::shared::string::Join(initialDns.Servers, ','));
     }
 
     auto lock = m_lock.lock_exclusive();
@@ -104,15 +105,9 @@ void VirtioNetworking::Initialize()
         m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId);
     }
 
-    // Update DNS information.
-    if (!dns_servers.empty())
-    {
-        // TODO: DNS domain suffixes
-        hns::DNS dnsSettings{};
-        dnsSettings.Options = LX_INIT_RESOLVCONF_FULL_HEADER;
-        dnsSettings.ServerList = dns_servers;
-        UpdateDns(std::move(dnsSettings));
-    }
+    // Send the initial DNS configuration to GNS and track it.
+    m_trackedDnsSettings = initialDns;
+    SendDnsUpdate(initialDns);
 
     if (m_enableLocalhostRelay)
     {
@@ -263,15 +258,23 @@ try
 {
     auto lock = m_lock.lock_exclusive();
     UpdateMtu();
+
+    // Check for DNS changes and send update if needed.
+    auto currentDns = m_dnsUpdateHelper.GetCurrentDnsSettings(networking::DnsSettingsFlags::IncludeVpn);
+    if (currentDns != m_trackedDnsSettings)
+    {
+        m_trackedDnsSettings = currentDns;
+        SendDnsUpdate(currentDns);
+    }
 }
 CATCH_LOG();
 
-void VirtioNetworking::UpdateDns(hns::DNS&& dnsSettings)
+void VirtioNetworking::SendDnsUpdate(const networking::DnsInfo& dnsSettings)
 {
     hns::ModifyGuestEndpointSettingRequest<hns::DNS> notification{};
     notification.RequestType = hns::ModifyRequestType::Update;
     notification.ResourceType = hns::GuestEndpointResourceType::DNS;
-    notification.Settings = std::move(dnsSettings);
+    notification.Settings = networking::BuildDnsNotification(dnsSettings);
     m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId);
 }
 

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -38,7 +38,7 @@ private:
     int ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET& addr, _In_ int protocol, _In_ bool isOpen) const;
     void RefreshGuestConnection(NL_NETWORK_CONNECTIVITY_HINT hint) noexcept;
     void SetupLoopbackDevice();
-    void UpdateDns(wsl::shared::hns::DNS&& dnsSettings);
+    void SendDnsUpdate(const networking::DnsInfo& dnsSettings);
     void UpdateMtu();
 
     mutable wil::srwlock m_lock;
@@ -54,7 +54,8 @@ private:
 
     std::optional<ULONGLONG> m_interfaceLuid;
     ULONG m_networkMtu = 0;
-    std::optional<wsl::core::networking::HostDnsInfo> m_dnsInfo;
+    networking::DnsUpdateHelper m_dnsUpdateHelper;
+    networking::DnsInfo m_trackedDnsSettings;
 
     // Note: this field must be destroyed first to stop the callbacks before any other field is destroyed.
     networking::unique_notify_handle m_networkNotifyHandle;

--- a/src/windows/common/WslCoreHostDnsInfo.h
+++ b/src/windows/common/WslCoreHostDnsInfo.h
@@ -38,6 +38,14 @@ inline bool operator!=(const DnsInfo& lhs, const DnsInfo& rhs) noexcept
 
 std::string GenerateResolvConf(_In_ const DnsInfo& Info);
 
+/// <summary>
+/// Builds an hns::DNS notification from DnsInfo settings.
+/// </summary>
+/// <param name="settings">The DNS settings to convert</param>
+/// <param name="useLinuxDomainEntry">If true, uses 'domain' entry for single suffix; otherwise uses 'search' for all
+/// suffixes</param> <returns>The hns::DNS notification ready to send via GNS channel</returns>
+wsl::shared::hns::DNS BuildDnsNotification(const DnsInfo& settings, bool useLinuxDomainEntry = false);
+
 std::vector<std::string> GetAllDnsSuffixes(const std::vector<IpAdapterAddress>& AdapterAddresses);
 
 DWORD GetBestInterface();
@@ -82,6 +90,24 @@ private:
     /// </summary>
     std::mutex m_lock;
     _Guarded_by_(m_lock) std::vector<IpAdapterAddress> m_addresses;
+};
+
+/// <summary>
+/// Helper class that fetches current DNS settings from the host.
+/// Callers are responsible for tracking changes if needed.
+/// </summary>
+class DnsUpdateHelper
+{
+public:
+    /// <summary>
+    /// Fetches current DNS settings from the host.
+    /// </summary>
+    /// <param name="flags">Flags controlling which DNS settings to include</param>
+    /// <returns>Current DNS settings</returns>
+    DnsInfo GetCurrentDnsSettings(DnsSettingsFlags flags);
+
+private:
+    HostDnsInfo m_hostDnsInfo;
 };
 
 using RegistryChangeCallback = std::function<void()>;

--- a/src/windows/common/WslCoreNetworkEndpointSettings.cpp
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.cpp
@@ -26,10 +26,8 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
         address,
         route,
         properties.MacAddress,
-        L"unuseddevicename",
         properties.InterfaceConstraint.InterfaceIndex,
-        properties.InterfaceConstraint.InterfaceMediaType,
-        properties.DNSServerList);
+        properties.InterfaceConstraint.InterfaceMediaType);
 }
 
 std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::GetHostEndpointSettings()
@@ -95,16 +93,6 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
         route.NextHopString = windows::common::string::SockAddrInetToWstring(route.NextHop);
     }
 
-    std::wstring dnsServerList;
-    for (const auto& serverAddress : dnsInfo.GetDnsSettings(DnsSettingsFlags::IncludeVpn).Servers)
-    {
-        if (!dnsServerList.empty())
-        {
-            dnsServerList += L",";
-        }
-        dnsServerList += wsl::shared::string::MultiByteToWide(serverAddress);
-    }
-
-    return std::shared_ptr<NetworkSettings>(new NetworkSettings(
-        bestInterface->NetworkGuid, address, route, macAddress, {}, bestInterface->IfIndex, bestInterface->IfType, dnsServerList));
+    return std::make_shared<NetworkSettings>(
+        bestInterface->NetworkGuid, address, route, macAddress, bestInterface->IfIndex, bestInterface->IfType);
 }

--- a/src/windows/common/WslCoreNetworkEndpointSettings.cpp
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.cpp
@@ -32,9 +32,7 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
 
 std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::GetHostEndpointSettings()
 {
-    HostDnsInfo dnsInfo;
-    dnsInfo.UpdateNetworkInformation();
-    auto addresses = dnsInfo.CurrentAddresses();
+    auto addresses = AdapterAddresses::GetCurrent();
     auto bestIndex = GetBestInterface();
     auto bestInterfacePtr =
         std::find_if(addresses.cbegin(), addresses.cend(), [&](const auto& address) { return address->IfIndex == bestIndex; });

--- a/src/windows/common/WslCoreNetworkEndpointSettings.h
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.h
@@ -258,33 +258,21 @@ struct NetworkSettings
 {
     NetworkSettings() = default;
 
-    NetworkSettings(
-        const GUID& interfaceGuid,
-        EndpointIpAddress preferredIpAddress,
-        EndpointRoute gateway,
-        std::wstring macAddress,
-        std::wstring deviceName,
-        uint32_t interfaceIndex,
-        uint32_t mediaType,
-        const std::wstring& dnsServerList) :
+    NetworkSettings(const GUID& interfaceGuid, EndpointIpAddress preferredIpAddress, EndpointRoute gateway, std::wstring macAddress, uint32_t interfaceIndex, uint32_t mediaType) :
         InterfaceGuid(interfaceGuid),
         PreferredIpAddress(std::move(preferredIpAddress)),
         MacAddress(std::move(macAddress)),
-        DeviceName(std::move(deviceName)),
         InterfaceIndex(interfaceIndex),
         InterfaceType(mediaType)
     {
         Routes.emplace(std::move(gateway));
-        DnsServers = wsl::shared::string::Split(dnsServerList, L',');
     }
 
     GUID InterfaceGuid{};
     EndpointIpAddress PreferredIpAddress{};
     std::set<EndpointIpAddress> IpAddresses{}; // Does not include PreferredIpAddress.
     std::set<EndpointRoute> Routes{};
-    std::vector<std::wstring> DnsServers{};
     std::wstring MacAddress;
-    std::wstring DeviceName;
     IF_INDEX InterfaceIndex = 0;
     IFTYPE InterfaceType = 0;
     ULONG IPv4InterfaceMtu = 0;
@@ -344,11 +332,6 @@ struct NetworkSettings
         });
     }
 
-    std::wstring DnsServersString() const
-    {
-        return wsl::shared::string::Join(DnsServers, L',');
-    }
-
     // will return ULONG_MAX if there's no configured MTU
     ULONG GetEffectiveMtu() const noexcept
     {
@@ -386,7 +369,6 @@ std::shared_ptr<NetworkSettings> GetHostEndpointSettings();
         TraceLoggingValue((settings)->PreferredIpAddress.PrefixLength, "preferredIpAddressPrefixLength"), \
         TraceLoggingValue((settings)->IpAddressesString().c_str(), "ipAddresses"), \
         TraceLoggingValue((settings)->RoutesString().c_str(), "routes"), \
-        TraceLoggingValue((settings)->DnsServersString().c_str(), "dnsServerList"), \
         TraceLoggingValue((settings)->MacAddress.c_str(), "macAddress"), \
         TraceLoggingValue((settings)->IPv4InterfaceMtu, "IPv4InterfaceMtu"), \
         TraceLoggingValue((settings)->IPv6InterfaceMtu, "IPv6InterfaceMtu"), \


### PR DESCRIPTION
This change cleans up how DNS update messages are handled between NAT, Mirrored, and VirtioProxy networking modes. It also resolves an issue with VirtioProxy networking would update DNS information once and not send updates if the host information changed.