### PR TITLE
DNS: Simplify dns logic and switch to using 'search' instead of 'domain' which is obsolete.

### DIFF
--- a/src/linux/init/GnsEngine.cpp
+++ b/src/linux/init/GnsEngine.cpp
@@ -315,21 +315,17 @@ void GnsEngine::ProcessDNSChange(Interface& interface, const wsl::shared::hns::D
         content << L"nameserver " << server << L"\n";
     }
 
-    if (!payload.Domain.empty())
-    {
-        content << L"domain " << payload.Domain << L"\n";
-    }
-
+    // Use 'search' for DNS suffixes.
+    // Per resolv.conf(5): "The domain directive is an obsolete name for the search directive
+    // that handles one search list entry only."
+    // See: https://man7.org/linux/man-pages/man5/resolv.conf.5.html
     if (!payload.Search.empty())
     {
         content << L"search " << wsl::shared::string::Join(wsl::shared::string::Split(payload.Search, L','), L' ') << L"\n";
     }
 
     GNS_LOG_INFO(
-        "Setting DNS server domain to {}: {} on interfaceName {} ",
-        payload.Domain.c_str(),
-        content.str().c_str(),
-        interface.Name().c_str());
+        "Setting DNS search to {}: {} on interfaceName {} ", payload.Search.c_str(), content.str().c_str(), interface.Name().c_str());
 
     std::wofstream resolvConf;
     resolvConf.exceptions(std::ofstream::badbit | std::ofstream::failbit);

--- a/src/windows/common/NatNetworking.cpp
+++ b/src/windows/common/NatNetworking.cpp
@@ -26,7 +26,12 @@ static wil::srwlock g_endpointsInUseLock;
 static std::vector<GUID> g_endpointsInUse;
 
 NatNetworking::NatNetworking(
-    HCS_SYSTEM system, wsl::windows::common::hcs::unique_hcn_network&& network, GnsChannel&& gnsChannel, Config& config, wil::unique_socket&& dnsHvsocket, LPCWSTR dnsOptions) :
+    HCS_SYSTEM system,
+    wsl::windows::common::hcs::unique_hcn_network&& network,
+    GnsChannel&& gnsChannel,
+    Config& config,
+    wil::unique_socket&& dnsHvsocket,
+    LPCWSTR dnsOptions) :
     m_system(system), m_config(config), m_network(std::move(network)), m_dnsOptions(dnsOptions), m_gnsChannel(std::move(gnsChannel))
 {
     m_connectivityTelemetryEnabled = config.EnableTelemetry && !WslTraceLoggingShouldDisableTelemetry();

--- a/src/windows/common/NatNetworking.cpp
+++ b/src/windows/common/NatNetworking.cpp
@@ -26,8 +26,8 @@ static wil::srwlock g_endpointsInUseLock;
 static std::vector<GUID> g_endpointsInUse;
 
 NatNetworking::NatNetworking(
-    HCS_SYSTEM system, wsl::windows::common::hcs::unique_hcn_network&& network, GnsChannel&& gnsChannel, Config& config, wil::unique_socket&& dnsHvsocket) :
-    m_system(system), m_config(config), m_network(std::move(network)), m_gnsChannel(std::move(gnsChannel))
+    HCS_SYSTEM system, wsl::windows::common::hcs::unique_hcn_network&& network, GnsChannel&& gnsChannel, Config& config, wil::unique_socket&& dnsHvsocket, LPCWSTR dnsOptions) :
+    m_system(system), m_config(config), m_network(std::move(network)), m_dnsOptions(dnsOptions), m_gnsChannel(std::move(gnsChannel))
 {
     m_connectivityTelemetryEnabled = config.EnableTelemetry && !WslTraceLoggingShouldDisableTelemetry();
 
@@ -459,7 +459,7 @@ try
 
     if (latestDnsSettings != m_trackedDnsSettings)
     {
-        auto dnsNotification = BuildDnsNotification(latestDnsSettings);
+        auto dnsNotification = BuildDnsNotification(latestDnsSettings, m_dnsOptions);
 
         WSL_LOG(
             "NatNetworking::UpdateDns",

--- a/src/windows/common/NatNetworking.h
+++ b/src/windows/common/NatNetworking.h
@@ -69,12 +69,15 @@ private:
     // The latest DNS settings configured in Linux
     _Guarded_by_(m_lock) networking::DnsInfo m_trackedDnsSettings {};
 
+    // If true, DNS settings are retrieved from host adapters (mirrored mode)
+    // rather than using the shared access DNS proxy
+    bool m_useMirrorDnsSettings = false;
+
     GnsChannel m_gnsChannel;
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
     networking::EphemeralHcnEndpoint m_endpoint;
     ULONG m_networkMtu = 0;
 
-    std::optional<networking::HostDnsInfo> m_mirrorDnsInfo;
     networking::unique_notify_handle m_networkNotifyHandle{};
 };
 

--- a/src/windows/common/NatNetworking.h
+++ b/src/windows/common/NatNetworking.h
@@ -18,7 +18,7 @@ namespace wsl::core {
 class NatNetworking final : public INetworkingEngine
 {
 public:
-    NatNetworking(HCS_SYSTEM system, wsl::windows::common::hcs::unique_hcn_network&& network, GnsChannel&& gnsChannel, Config& config, wil::unique_socket&& dnsHvsocket);
+    NatNetworking(HCS_SYSTEM system, wsl::windows::common::hcs::unique_hcn_network&& network, GnsChannel&& gnsChannel, Config& config, wil::unique_socket&& dnsHvsocket, LPCWSTR dnsOptions = LX_INIT_RESOLVCONF_FULL_HEADER);
     ~NatNetworking() override;
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.
@@ -72,6 +72,9 @@ private:
     // If true, DNS settings are retrieved from host adapters (mirrored mode)
     // rather than using the shared access DNS proxy
     bool m_useMirrorDnsSettings = false;
+
+    // Options/header for /etc/resolv.conf
+    LPCWSTR m_dnsOptions = nullptr;
 
     GnsChannel m_gnsChannel;
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;

--- a/src/windows/common/NatNetworking.h
+++ b/src/windows/common/NatNetworking.h
@@ -18,7 +18,13 @@ namespace wsl::core {
 class NatNetworking final : public INetworkingEngine
 {
 public:
-    NatNetworking(HCS_SYSTEM system, wsl::windows::common::hcs::unique_hcn_network&& network, GnsChannel&& gnsChannel, Config& config, wil::unique_socket&& dnsHvsocket, LPCWSTR dnsOptions = LX_INIT_RESOLVCONF_FULL_HEADER);
+    NatNetworking(
+        HCS_SYSTEM system,
+        wsl::windows::common::hcs::unique_hcn_network&& network,
+        GnsChannel&& gnsChannel,
+        Config& config,
+        wil::unique_socket&& dnsHvsocket,
+        LPCWSTR dnsOptions = LX_INIT_RESOLVCONF_FULL_HEADER);
     ~NatNetworking() override;
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -13,7 +13,7 @@ namespace wsl::core {
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(GnsChannel&& gnsChannel, bool enableLocalhostRelay, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
+    VirtioNetworking(GnsChannel&& gnsChannel, bool enableLocalhostRelay, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
     ~VirtioNetworking();
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.
@@ -49,12 +49,12 @@ private:
     std::optional<GnsPortTrackerChannel> m_gnsPortTrackerChannel;
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
     bool m_enableLocalhostRelay;
+    LPCWSTR m_dnsOptions = nullptr;
     GUID m_localhostAdapterId;
     GUID m_adapterId;
 
     std::optional<ULONGLONG> m_interfaceLuid;
     ULONG m_networkMtu = 0;
-    networking::DnsUpdateHelper m_dnsUpdateHelper;
     networking::DnsInfo m_trackedDnsSettings;
 
     // Note: this field must be destroyed first to stop the callbacks before any other field is destroyed.

--- a/src/windows/common/WslCoreHostDnsInfo.cpp
+++ b/src/windows/common/WslCoreHostDnsInfo.cpp
@@ -105,12 +105,6 @@ wsl::core::networking::DnsInfo wsl::core::networking::HostDnsInfo::GetDnsTunneli
     return dnsInfo;
 }
 
-std::vector<wsl::core::networking::IpAdapterAddress> wsl::core::networking::HostDnsInfo::GetAdapterAddresses()
-{
-    std::lock_guard<std::mutex> lock(m_lock);
-    return m_addresses;
-}
-
 std::vector<std::string> wsl::core::networking::HostDnsInfo::GetDnsServerStrings(
     _In_ const PIP_ADAPTER_DNS_SERVER_ADDRESS& FirstDnsServer, _In_ USHORT IpFamilyFilter, _In_ USHORT MaxValues)
 {
@@ -233,7 +227,7 @@ std::vector<std::string> wsl::core::networking::HostDnsInfo::GetInterfaceDnsSuff
 
 wsl::core::networking::DnsInfo wsl::core::networking::HostDnsInfo::GetDnsSettings(_In_ DnsSettingsFlags Flags)
 {
-    std::vector<IpAdapterAddress> Addresses = GetAdapterAddresses();
+    std::vector<IpAdapterAddress> Addresses = AdapterAddresses::GetCurrent();
 
     auto RemoveFilter = [&](const IpAdapterAddress& Address) {
         // Ignore interfaces that are not currently "up".
@@ -326,12 +320,6 @@ wsl::core::networking::DnsInfo wsl::core::networking::HostDnsInfo::GetDnsSetting
     return DnsSettings;
 }
 
-void wsl::core::networking::HostDnsInfo::UpdateNetworkInformation()
-{
-    std::lock_guard<std::mutex> lock(m_lock);
-    m_addresses = AdapterAddresses::GetCurrent();
-}
-
 std::string wsl::core::networking::GenerateResolvConf(_In_ const DnsInfo& Info)
 {
     std::string contents{};
@@ -345,7 +333,10 @@ std::string wsl::core::networking::GenerateResolvConf(_In_ const DnsInfo& Info)
             contents += c_asciiNewLine;
         }
 
-        // Add domain information if it is available.
+        // Add DNS suffix information using 'search' directive.
+        // Per resolv.conf(5): "The domain directive is an obsolete name for the search directive
+        // that handles one search list entry only."
+        // See: https://man7.org/linux/man-pages/man5/resolv.conf.5.html
         if (!Info.Domains.empty())
         {
             contents += "search ";
@@ -497,28 +488,21 @@ wsl::core::networking::DnsSuffixRegistryWatcher::DnsSuffixRegistryWatcher(Regist
     m_registryWatchers.swap(localRegistryWatchers);
 }
 
-wsl::shared::hns::DNS wsl::core::networking::BuildDnsNotification(const DnsInfo& settings, bool useLinuxDomainEntry)
+wsl::shared::hns::DNS wsl::core::networking::BuildDnsNotification(const DnsInfo& settings, PCWSTR options)
 {
     wsl::shared::hns::DNS dnsNotification{};
-    dnsNotification.Options = LX_INIT_RESOLVCONF_FULL_HEADER;
+    if (options)
+    {
+        dnsNotification.Options = options;
+    }
+
     dnsNotification.ServerList = wsl::shared::string::MultiByteToWide(wsl::shared::string::Join(settings.Servers, ','));
 
-    if (useLinuxDomainEntry && !settings.Domains.empty())
-    {
-        // Use 'domain' entry for single DNS suffix (typically used when mirroring host DNS without tunneling)
-        dnsNotification.Domain = wsl::shared::string::MultiByteToWide(settings.Domains.front());
-    }
-    else
-    {
-        // Use 'search' entry for DNS suffix list
-        dnsNotification.Search = wsl::shared::string::MultiByteToWide(wsl::shared::string::Join(settings.Domains, ','));
-    }
+    // Use 'search' entry for DNS suffix list.
+    // Per resolv.conf(5): "The domain directive is an obsolete name for the search directive
+    // that handles one search list entry only."
+    // See: https://man7.org/linux/man-pages/man5/resolv.conf.5.html
+    dnsNotification.Search = wsl::shared::string::MultiByteToWide(wsl::shared::string::Join(settings.Domains, ','));
 
     return dnsNotification;
-}
-
-wsl::core::networking::DnsInfo wsl::core::networking::DnsUpdateHelper::GetCurrentDnsSettings(DnsSettingsFlags flags)
-{
-    m_hostDnsInfo.UpdateNetworkInformation();
-    return m_hostDnsInfo.GetDnsSettings(flags);
 }

--- a/src/windows/service/exe/LxssInstance.cpp
+++ b/src/windows/service/exe/LxssInstance.cpp
@@ -784,9 +784,6 @@ try
     // Impersonate the service.
     auto runAsSelf = wil::run_as_self();
 
-    // Update the instance's DNS information.
-    m_dnsInfo.UpdateNetworkInformation();
-
     // Update the resolv.conf file if it has changed.
     _UpdateNetworkConfigurationFiles(false);
     return;
@@ -799,7 +796,7 @@ void LxssInstance::_UpdateNetworkConfigurationFiles(_In_ bool UpdateAlways)
     wsl::core::networking::DnsSettingsFlags flags = wsl::core::networking::DnsSettingsFlags::IncludeIpv6Servers;
     WI_SetFlagIf(flags, wsl::core::networking::DnsSettingsFlags::IncludeVpn, m_enableVpnDetection);
 
-    const auto dnsSettings = m_dnsInfo.GetDnsSettings(flags);
+    const auto dnsSettings = wsl::core::networking::HostDnsInfo::GetDnsSettings(flags);
     std::string fileContents = GenerateResolvConf(dnsSettings);
     std::lock_guard<std::mutex> lock(m_resolvConfLock);
     if (!UpdateAlways && (fileContents == m_lastResolvConfContents))

--- a/src/windows/service/exe/LxssInstance.h
+++ b/src/windows/service/exe/LxssInstance.h
@@ -225,11 +225,6 @@ private:
     LxssIpTables m_ipTables;
 
     /// <summary>
-    /// Class for querying host dns information.
-    /// </summary>
-    wsl::core::networking::HostDnsInfo m_dnsInfo;
-
-    /// <summary>
     /// Settings for updating /etc/resolv.conf.
     /// </summary>
     bool m_enableVpnDetection;

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -577,7 +577,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             else if (m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)
             {
                 m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
-                    std::move(gnsChannel), m_vmConfig.EnableLocalhostRelay, m_guestDeviceManager, m_userToken);
+                    std::move(gnsChannel), m_vmConfig.EnableLocalhostRelay, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::Bridged)
             {

--- a/src/windows/service/exe/WslMirroredNetworking.cpp
+++ b/src/windows/service/exe/WslMirroredNetworking.cpp
@@ -434,8 +434,7 @@ void wsl::core::networking::WslMirroredNetworkManager::ProcessDNSChange()
     }
     else
     {
-        m_hostDnsInfo.UpdateNetworkInformation();
-        m_dnsInfo = m_hostDnsInfo.GetDnsSettings(
+        m_dnsInfo = wsl::core::networking::HostDnsInfo::GetDnsSettings(
             wsl::core::networking::DnsSettingsFlags::IncludeVpn | wsl::core::networking::DnsSettingsFlags::IncludeIpv6Servers |
             wsl::core::networking::DnsSettingsFlags::IncludeAllSuffixes);
     }

--- a/src/windows/service/exe/WslMirroredNetworking.h
+++ b/src/windows/service/exe/WslMirroredNetworking.h
@@ -224,9 +224,6 @@ private:
     _Guarded_by_(m_networkLock) DnsInfo m_trackedDnsInfo;
     // The current DNS info on the host
     _Guarded_by_(m_networkLock) DnsInfo m_dnsInfo;
-    // m_hostDnsInfo is an optimization used to avoid allocating a large buffer every time we call
-    // GetAdaptersAddresses when querying host DNS info
-    _Guarded_by_(m_networkLock) HostDnsInfo m_hostDnsInfo;
 
     std::wstring m_dnsTunnelingIpAddress;
 

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -1037,7 +1037,6 @@ class NetworkTests
 
         wsl::shared::hns::DNS dns;
         dns.ServerList = L"1.1.1.1,1.1.1.2";
-        dns.Domain = L"microsoft.com";
         dns.Search = L"foo.microsoft.com,bar.microsoft.com";
         dns.Options = LX_INIT_RESOLVCONF_FULL_HEADER;
         RunGns(dns, ModifyRequestType::Update, GuestEndpointResourceType::DNS);
@@ -1047,7 +1046,6 @@ class NetworkTests
         const std::wstring expected = std::wstring(LX_INIT_RESOLVCONF_FULL_HEADER) +
                                       L"nameserver 1.1.1.1\n"
                                       L"nameserver 1.1.1.2\n"
-                                      L"domain microsoft.com\n"
                                       L"search foo.microsoft.com bar.microsoft.com\n";
         VERIFY_ARE_EQUAL(expected, out.c_str());
     }

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4610,6 +4610,9 @@ class VirtioProxyTests
         const std::wregex pattern(L"(.|\\n)*nameserver [0-9. ]+(.|\\n)*");
 
         VERIFY_IS_TRUE(std::regex_match(out, pattern));
+
+        // Verify that /etc/resolv.conf contains a 'search' line with DNS suffixes
+        VERIFY_IS_TRUE(out.find(L"search ") != std::wstring::npos);
     }
 
     TEST_METHOD(GuestPortIsReleased)


### PR DESCRIPTION
This PR refactors HostDnsInfo to make GetDnsSettings a static method, removing unnecessary state (cached adapter addresses, mutex, UpdateNetworkInformation(), and the DnsUpdateHelper class) since the cache was being populated and immediately consumed without reuse. It also standardizes on the search directive for DNS suffixes instead of the obsolete domain directive, per resolv.conf(5).

Additionally the option to supply a header for /etc/resolv.conf was added to virtioproxy and NAT networking modes.