### PR TITLE
Correctly handle empty arguments when creating processes

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -642,12 +642,12 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_EXEC& Mes
 {
     auto Executable = wsl::shared::string::FromSpan(Buffer, Message.ExecutableIndex);
     auto ArgumentArray = wsl::shared::string::ArrayFromSpan(Buffer, Message.CommandLineIndex);
-    ArgumentArray.push_back(nullptr);
+    auto ArgumentPointers = wsl::shared::string::StringPointersFromArray(ArgumentArray, true);
 
     auto EnvironmentArray = wsl::shared::string::ArrayFromSpan(Buffer, Message.EnvironmentIndex);
-    EnvironmentArray.push_back(nullptr);
+    auto EnvironmentPointers = wsl::shared::string::StringPointersFromArray(EnvironmentArray, true);
 
-    execve(Executable, (char* const*)(ArgumentArray.data()), (char* const*)(EnvironmentArray.data()));
+    execve(Executable, (char* const*)(ArgumentPointers.data()), (char* const*)(EnvironmentPointers.data()));
 
     // Only reached if exec() fails
     Channel.SendResultMessage<int32_t>(errno);

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -166,22 +166,53 @@ inline const char* FromMessageBuffer(const gsl::span<gsl::byte>& Span)
     return FromSpan(Span, offsetof(T, Buffer));
 }
 
-inline std::vector<const char*> ArrayFromSpan(gsl::span<gsl::byte> Span, size_t Offset = 0)
+inline std::vector<const char*> StringPointersFromArray(const std::vector<std::string>& Strings, bool insertNull)
+{
+    std::vector<const char*> result(Strings.size());
+    std::transform(Strings.begin(), Strings.end(), result.begin(), [](const std::string& str) { return str.c_str(); });
+
+    if (insertNull)
+    {
+        result.push_back(nullptr);
+    }
+
+    return result;
+}
+
+inline std::vector<std::string> ArrayFromSpan(gsl::span<const gsl::byte> Span, size_t Offset = 0)
 {
     THROW_INVALID_ARG_IF(Span.size() < Offset);
 
     Span = Span.subspan(Offset);
 
-    auto StringSpan = gsl::make_span<char>(reinterpret_cast<char*>(Span.data()), Span.size());
+    std::vector<std::string> Result;
 
-    std::vector<const char*> Result;
+    auto it = Span.begin();
 
-    auto it = StringSpan.begin();
+    auto readSize = [&]() {
+        THROW_INVALID_ARG_IF(Span.end() - it < sizeof(int32_t));
 
-    while (*it != '\0')
+        auto size = *reinterpret_cast<const int32_t*>(&*it);
+        it += sizeof(int32_t);
+
+        return size;
+    };
+
+    while (true)
     {
-        Result.push_back(&*it);
-        it += strlen(&*it) + 1;
+        auto size = readSize();
+        if (size == -1)
+        {
+            break;
+        }
+
+        THROW_INVALID_ARG_IF(size < 0);
+        THROW_INVALID_ARG_IF(size > Span.end() - it);
+
+        const char* begin = reinterpret_cast<const char*>(&*it);
+        Result.emplace_back(begin, size);
+
+        it += size;
     }
 
     return Result;

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -209,7 +209,8 @@ void WSLAVirtualMachine::Start()
     wil::unique_handle dmesgOutput;
     dmesgOutput = std::move(m_settings.DmesgHandle);
 
-    m_dmesgCollector = DmesgCollector::Create(m_vmId, m_vmExitEvent, true, false, L"", true, std::move(dmesgOutput));
+    m_dmesgCollector = DmesgCollector::Create(
+        m_vmId, m_vmExitEvent, true, false, L"", FeatureEnabled(WslaFeatureFlagsEarlyBootDmesg), std::move(dmesgOutput));
 
     if (FeatureEnabled(WslaFeatureFlagsEarlyBootDmesg))
     {

--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -209,8 +209,7 @@ void WSLAVirtualMachine::Start()
     wil::unique_handle dmesgOutput;
     dmesgOutput = std::move(m_settings.DmesgHandle);
 
-    m_dmesgCollector = DmesgCollector::Create(
-        m_vmId, m_vmExitEvent, true, false, L"", FeatureEnabled(WslaFeatureFlagsEarlyBootDmesg), std::move(dmesgOutput));
+    m_dmesgCollector = DmesgCollector::Create(m_vmId, m_vmExitEvent, true, false, L"", true, std::move(dmesgOutput));
 
     if (FeatureEnabled(WslaFeatureFlagsEarlyBootDmesg))
     {

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1132,6 +1132,14 @@ class WSLATests
             ResetTestSession();
             VERIFY_ARE_EQUAL(process.Get().Signal(WSLASignalSIGKILL), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
         }
+
+        // Validate that empty arguments are correctly handled.
+        {
+            WSLAProcessLauncher launcher({"/usr/bin/echo"}, {"/usr/bin/echo", "foo", "", "bar"});
+
+            auto process = launcher.Launch(*m_defaultSession);
+            ValidateProcessOutput(process, {{1, "foo  bar\n"}}); // expect two spaces for the empty argument.
+        }
     }
 
     TEST_METHOD(CrashDumpCollection)
@@ -1360,6 +1368,15 @@ class WSLATests
             auto container = launcher.Launch(*m_defaultSession);
             auto process = container.GetInitProcess();
             ValidateProcessOutput(process, {{1, "nobody\n"}});
+        }
+
+        // Validate that empty arguments are correctly handled.
+        {
+            WSLAContainerLauncher launcher("debian:latest", "test-empty-args", {"echo", "foo", "", "bar"});
+
+            auto container = launcher.Launch(*m_defaultSession);
+            auto process = container.GetInitProcess();
+            ValidateProcessOutput(process, {{1, "foo  bar\n"}}); // Expect two spaces for the empty argument.
         }
 
         // Validate error paths
@@ -1874,6 +1891,14 @@ class WSLATests
             auto process = WSLAProcessLauncher({}, {"/bin/sh", "-c", "echo $testenv"}, {{"testenv=testvalue"}}).Launch(container.Get());
 
             ValidateProcessOutput(process, {{1, "testvalue\n"}});
+        }
+
+        // Validate that empty arguments are correctly handled.
+        {
+            WSLAProcessLauncher launcher({}, {"echo", "foo", "", "bar"});
+
+            auto process = launcher.Launch(container.Get());
+            ValidateProcessOutput(process, {{1, "foo  bar\n"}}); // Expect two spaces for the empty argument.
         }
 
         // Validate that an exec'd command returns when the container is stopped.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the init protocol to correctly handle empty strings in array. 

This change also test coverage for empty arguments at the VM, container and exec level

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
