### PR TITLE
Don't try to read from the early console if EarlyBootDmesg is disabled

### DIFF
--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -209,7 +209,8 @@ void WSLAVirtualMachine::Start()
     wil::unique_handle dmesgOutput;
     dmesgOutput = std::move(m_settings.DmesgHandle);
 
-    m_dmesgCollector = DmesgCollector::Create(m_vmId, m_vmExitEvent, true, false, L"", true, std::move(dmesgOutput));
+    m_dmesgCollector = DmesgCollector::Create(
+        m_vmId, m_vmExitEvent, true, false, L"", FeatureEnabled(WslaFeatureFlagsEarlyBootDmesg), std::move(dmesgOutput));
 
     if (FeatureEnabled(WslaFeatureFlagsEarlyBootDmesg))
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

This change updates the dmesg collector to not try to read from the early boot serial if early boot logging is disabled. 

This avoids creating an essentially useless thread, and this error when the session terminates: 

```
Microsoft.Windows.Wsla	Error	01-30-2026 17:12:19.969	"HRESULTString: 	E_ABORT
code: 	E_ABORT
failurecount: 	1
functon: 	wsl::windows::common::helpers::ConnectPipe
hr: 	0x80004004
```

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
