### PR TITLE
virtiofs: exit QueryVirtiofsMountSource early if virtiofs disabled

### DIFF
--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -679,12 +679,7 @@ try
     //
 
     Config.FeatureFlags = Message->FeatureFlags;
-    char FeatureFlagsString[10];
-    snprintf(FeatureFlagsString, sizeof(FeatureFlagsString), "%x", Config.FeatureFlags.value());
-    if (setenv(WSL_FEATURE_FLAGS_ENV, FeatureFlagsString, 1) < 0)
-    {
-        LOG_ERROR("setenv failed {}", errno);
-    }
+    UtilSetFeatureFlags(Config.FeatureFlags.value());
 
     //
     // Determine the default UID which can be specified in /etc/wsl.conf.
@@ -2413,7 +2408,7 @@ try
 
             NewMountOptions = MountEntry.MountOptions;
             NewMountOptions += ',';
-            if (WSL_USE_VIRTIO_9P(Config))
+            if (WSL_USE_VIRTIO_9P())
             {
                 //
                 // Check if the existing mount is a drvfs mount that needs to be remounted.
@@ -2446,7 +2441,7 @@ try
                 NewMountOptions += ',';
             }
 
-            MountPlan9Share(NewSource, MountEntry.MountPoint, NewMountOptions.c_str(), Message->Admin, Config);
+            MountPlan9Share(NewSource, MountEntry.MountPoint, NewMountOptions.c_str(), Message->Admin);
         }
         else if (strcmp(MountEntry.FileSystemType, VIRTIO_FS_TYPE) == 0)
         {

--- a/src/linux/init/config.h
+++ b/src/linux/init/config.h
@@ -23,8 +23,8 @@ Abstract:
 #include "SocketChannel.h"
 #include "WslDistributionConfig.h"
 
-#define WSL_USE_VIRTIO_9P(_Config) (WI_IsFlagSet(UtilGetFeatureFlags((_Config)), LxInitFeatureVirtIo9p))
-#define WSL_USE_VIRTIO_FS(_Config) (WI_IsFlagSet(UtilGetFeatureFlags((_Config)), LxInitFeatureVirtIoFs))
+#define WSL_USE_VIRTIO_9P() (WI_IsFlagSet(UtilGetFeatureFlags(), LxInitFeatureVirtIo9p))
+#define WSL_USE_VIRTIO_FS() (WI_IsFlagSet(UtilGetFeatureFlags(), LxInitFeatureVirtIoFs))
 #define WSLG_SHARED_FOLDER "wslg"
 
 #define INIT_MAKE_SECURITY(_uid, _gid, _mode) {_uid, _gid, _mode}

--- a/src/linux/init/drvfs.h
+++ b/src/linux/init/drvfs.h
@@ -23,7 +23,7 @@ int MountDrvfs(const char* Source, const char* Target, const char* Options, std:
 
 int MountDrvfsEntry(int Argc, char* Argv[]);
 
-int MountPlan9Share(const char* Source, const char* Target, const char* Options, bool Admin, const wsl::linux::WslDistributionConfig& Config, int* ExitCode = nullptr);
+int MountPlan9Share(const char* Source, const char* Target, const char* Options, bool Admin, int* ExitCode = nullptr);
 
 int MountPlan9(const char* Source, const char* Target, const char* Options, std::optional<bool> Admin, const wsl::linux::WslDistributionConfig& Config, int* ExitCode);
 

--- a/src/linux/init/util.h
+++ b/src/linux/init/util.h
@@ -223,7 +223,9 @@ std::optional<std::string> UtilGetEnv(const char* Name, char* Environment);
 
 std::string UtilGetEnvironmentVariable(const char* Name);
 
-int UtilGetFeatureFlags(const wsl::linux::WslDistributionConfig& Config);
+int UtilGetFeatureFlags();
+
+void UtilSetFeatureFlags(int FeatureFlags, bool UpdateEnv = true);
 
 std::optional<LX_MINI_INIT_NETWORKING_MODE> UtilGetNetworkingMode(void);
 


### PR DESCRIPTION
While experimenting with virtiofs and pmem I noticed that our path translation logic would query the service for the source of the non-drvfs virtiofs shares (for example the wslg shared memory mount in the system distro). This caused an error to be printed in kmesg.

This change ensures that non-drvfs virtiofs shares are skipped by QueryVirtiofsMountSource by only querying the service if virtiofs is enabled, and the tag is a GUID.