### PR TITLE
Remove invalid asserts from WslMirroredNetworking.cpp

### DIFF
--- a/src/windows/service/exe/WslMirroredNetworking.cpp
+++ b/src/windows/service/exe/WslMirroredNetworking.cpp
@@ -2565,7 +2565,6 @@ void __stdcall wsl::core::networking::WslMirroredNetworkManager::HcnServiceConne
     auto* const manager = static_cast<WslMirroredNetworkManager*>(Context);
 
     const auto lock = manager->m_networkLock.lock_exclusive();
-    WI_ASSERT(manager->m_state == State::Started);
     if (manager->m_state == State::Stopped)
     {
         return;
@@ -2591,7 +2590,6 @@ try
     auto* const manager = static_cast<WslMirroredNetworkManager*>(Context);
 
     const auto lock = manager->m_networkLock.lock_exclusive();
-    WI_ASSERT(manager->m_state == State::Started);
     if (manager->m_state == State::Stopped)
     {
         return;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change removes two invalid asserts from `src/windows/service/exe/WslMirroredNetworking.cpp` 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
