### PR TITLE
bug: update MountWindowsFolderImpl to use WSLA_FORK::Process

### DIFF
--- a/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/WSLAVirtualMachine.cpp
@@ -1191,7 +1191,7 @@ try
     auto shareNameUtf8 = shared::string::WideToMultiByte(shareName);
     if (!FeatureEnabled(WslaFeatureFlagsVirtioFs))
     {
-        auto [_, __, channel] = Fork(WSLA_FORK::Thread);
+        auto [_, __, channel] = Fork(WSLA_FORK::Process);
 
         WSLA_CONNECT message;
         message.HostPort = LX_INIT_UTILITY_VM_PLAN9_PORT;
@@ -1258,8 +1258,6 @@ HRESULT WSLAVirtualMachine::UnmountWindowsFolder(_In_ LPCSTR LinuxPath)
 void WSLAVirtualMachine::MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_ LPCSTR DriversMountpoint)
 {
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_CONFIG_VALUE), !FeatureEnabled(WslaFeatureFlagsGPU));
-
-    auto [channel, _, __] = Fork(WSLA_FORK::Thread);
 
     auto windowsPath = wil::GetWindowsDirectoryW<std::wstring>();
 


### PR DESCRIPTION
This change resolves two issues:
1. Switch MountWindowsFolderImpl WSLA_FORK::Process instead of WSLA_FORK::Process so file descriptors are automatically cleaned up when the child process exits. Otherwise a bunch of socket file descriptors are leaked.
2. Remove an unneeded thread creation from MountGpuLibraries.