### PR TITLE
wsla: update TerminationCallback test to not hang forever on failure

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -742,6 +742,7 @@ class WSLATests
         session.reset();
         auto future = promise.get_future();
         auto result = future.wait_for(std::chrono::seconds(30));
+        VERIFY_ARE_EQUAL(result, std::future_status::ready);
         auto [reason, details] = future.get();
         VERIFY_ARE_EQUAL(reason, WSLAVirtualMachineTerminationReasonShutdown);
         VERIFY_ARE_NOT_EQUAL(details, L"");


### PR DESCRIPTION
Minor test fix to prevent TerminationCallback from hanging forever if the callback isn't received.