### PR TITLE
WSLA: Set page_reporting_order to the appropriate value

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -3181,4 +3181,20 @@ class WSLATests
             VERIFY_ARE_EQUAL(initProcess.Wait(), 0);
         }
     }
+
+    TEST_METHOD(PageReporting)
+    {
+        WSL2_TEST_ONLY();
+
+        // Determine expected page reporting order based on Windows version.
+        // On Germanium or later: 5 (128k), otherwise: 9 (2MB).
+        const auto windowsVersion = wsl::windows::common::helpers::GetWindowsVersion();
+        int expectedOrder = (windowsVersion.BuildNumber >= wsl::windows::common::helpers::WindowsBuildNumbers::Germanium) ? 5 : 9;
+
+        // Read the actual value from sysfs and verify it matches.
+        auto result =
+            ExpectCommandResult(m_defaultSession.get(), {"/bin/cat", "/sys/module/page_reporting/parameters/page_reporting_order"}, 0);
+
+        VERIFY_ARE_EQUAL(result.Output[1], std::format("{}\n", expectedOrder));
+    }
 };


### PR DESCRIPTION
This change plumbs page reporting order into the WSLA Vm. This value was being calculated but not used.

This value is used by the kernel to determine how large of memory regions it can report as free back to the host. With a smaller page reporting order, that means that our va-backed VM process will be able to release more memory back to the host.