### PR TITLE
Add Clang requirement to vswhere usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,8 +260,9 @@ endif()
 
 # Determine the Visual Studio installation directory which contains LLVM tools
 # N.B. The version is set to VS2022 to ensure local runs match pipeline behavior
+# Require that Clang be installed in the product to potentially de-deduplicate
 execute_process(
-    COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -version "[17.0,18.0)" -products * -property installationPath
+    COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -version "[17.0,18.0)" -products * -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
     OUTPUT_VARIABLE VS_INSTALL_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY
@@ -278,7 +279,7 @@ else()
 endif()
 
 if (NOT EXISTS ${LLVM_INSTALL_DIR})
-    message(FATAL_ERROR "C++ Clang Compiler for Windows is not installed. Please install it from the Visual Studio Installer.")
+    message(FATAL_ERROR "C++ Clang Compiler for Windows is not installed at ${LLVM_INSTALL_DIR}. Please install it from the Visual Studio Installer.")
 endif()
 
 # Generate the clang-format script which contains a path to clang-format.exe


### PR DESCRIPTION
## Summary of the Pull Request
Add a requirement that the VS product have Clang installed when detecting with vswhere.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
If multiple products in the version range are installed, the invocation of vswhere will output multiple lines with each install path, breaking the rest of the cmake setup.  This change adds a requirement that the product have Clang, which is what the later `if (NOT EXISTS ${LLVM_INSTALL_DIR})` is testing for (although even that check is incorrect as this directory can exist without actually containing clang.exe due to alternate components).

Also adds the `LLVM_INSTALL_DIR` that does not exist to the error message, making it easier to see why it was unhappy.

## Validation Steps Performed
Was able to build with both VS 2022 Enterprise and the VS Build tools products installed.