### PR TITLE
cleanup: fix typos and duplicated enum in wslaservice.idl

### DIFF
--- a/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
@@ -601,7 +601,7 @@ void HcsVirtualMachine::OnExit(const HCS_EVENT* Event)
 
     const auto exitStatus = wsl::shared::FromJson<wsl::windows::common::hcs::SystemExitStatus>(Event->EventData);
 
-    auto reason = WSLAlVirtualMachineTerminationReasonUnknown;
+    auto reason = WSLAVirtualMachineTerminationReasonUnknown;
 
     if (exitStatus.ExitType.has_value())
     {
@@ -615,7 +615,7 @@ void HcsVirtualMachine::OnExit(const HCS_EVENT* Event)
             reason = WSLAVirtualMachineTerminationReasonCrashed;
             break;
         default:
-            reason = WSLAlVirtualMachineTerminationReasonUnknown;
+            reason = WSLAVirtualMachineTerminationReasonUnknown;
             break;
         }
     }

--- a/src/windows/wslaservice/exe/WSLAContainer.cpp
+++ b/src/windows/wslaservice/exe/WSLAContainer.cpp
@@ -572,7 +572,7 @@ WSLA_CONTAINER_STATE WSLAContainerImpl::State() noexcept
 {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 
-    if (m_state == WslaContainerStateRunning && m_initProcessControl && m_initProcessControl->GetState().first != WSLAProcessStateRunning)
+    if (m_state == WslaContainerStateRunning && m_initProcessControl && m_initProcessControl->GetState().first != WslaProcessStateRunning)
     {
         m_state = WslaContainerStateExited;
     }

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -35,17 +35,9 @@ struct _WSLA_VERSION {
     ULONG Revision;
 } WSLA_VERSION;
 
-
-typedef enum _WSLAProcessState
-{
-    WSLAProcessStateUnknown,
-    WSLAProcessStateRunning,
-    WSLAProcessStateExited
-} WSLAProcessState;
-
 typedef enum _WSLAVirtualMachineTerminationReason
 {
-    WSLAlVirtualMachineTerminationReasonUnknown,
+    WSLAVirtualMachineTerminationReasonUnknown,
     WSLAVirtualMachineTerminationReasonShutdown,
     WSLAVirtualMachineTerminationReasonCrashed,
 } WSLAVirtualMachineTerminationReason;
@@ -200,7 +192,7 @@ struct WSLA_CONTAINER_NETWORK
 typedef enum _WSLAContainerFlags
 {
     WSLAContainerFlagsNone = 0,
-    WSLAContainerFlagsRm = 1, // Delete the container when it exists. TODO: Implement.
+    WSLAContainerFlagsRm = 1, // Delete the container when it exits. TODO: Implement.
     WSLAContainerFlagsGpu = 2, // Enable GPU access. TODO: implement.
     WSLAContainerFlagsInit = 4, // Run the container under an init process.
 } WSLAContainerFlags;


### PR DESCRIPTION
I noticed a few minor typos and an enum that was duplicated (with the wrong enum type being used in one case).