### PR TITLE
Improved VirtioProxy networking and VirtioFS posix compatibility

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.1.10-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.1.14-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -11,14 +11,15 @@ using namespace wsl::shared;
 using namespace wsl::windows::common::stringify;
 using wsl::core::VirtioNetworking;
 
+static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
 VirtioNetworking::VirtioNetworking(
-    GnsChannel&& gnsChannel, bool enableLocalhostRelay, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
+    GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
     m_guestDeviceManager(std::move(guestDeviceManager)),
     m_userToken(std::move(userToken)),
     m_gnsChannel(std::move(gnsChannel)),
-    m_enableLocalhostRelay(enableLocalhostRelay),
+    m_flags(flags),
     m_dnsOptions(dnsOptions)
 {
 }
@@ -27,95 +28,22 @@ VirtioNetworking::~VirtioNetworking()
 {
     // Unregister the network notification callback to prevent it from using the GNS channel.
     m_networkNotifyHandle.reset();
+
     // Stop the GNS channel to unblock any stuck communications with the guest.
     m_gnsChannel.Stop();
 }
 
 void VirtioNetworking::Initialize()
 {
-    m_networkSettings = GetHostEndpointSettings();
+    // Initialize adapter state.
+    RefreshGuestConnection();
 
-    // TODO: Determine gateway MAC address
-    std::wstringstream device_options;
-    auto client_ip = m_networkSettings->PreferredIpAddress.AddressString;
-    if (!client_ip.empty())
-    {
-        if (device_options.tellp() > 0)
-        {
-            device_options << L";";
-        }
-        device_options << L"client_ip=" << client_ip;
-    }
-
-    if (!m_networkSettings->MacAddress.empty())
-    {
-        if (device_options.tellp() > 0)
-        {
-            device_options << L";";
-        }
-        device_options << L"client_mac=" << m_networkSettings->MacAddress;
-    }
-
-    std::wstring default_route = m_networkSettings->GetBestGatewayAddressString();
-    if (!default_route.empty())
-    {
-        if (device_options.tellp() > 0)
-        {
-            device_options << L";";
-        }
-        device_options << L"gateway_ip=" << default_route;
-    }
-
-    // Get initial DNS settings for device options.
-    auto initialDns = networking::HostDnsInfo::GetDnsSettings(networking::DnsSettingsFlags::IncludeVpn);
-    if (!initialDns.Servers.empty())
-    {
-        if (device_options.tellp() > 0)
-        {
-            device_options << L";";
-        }
-        device_options << L"nameservers=" << wsl::shared::string::MultiByteToWide(wsl::shared::string::Join(initialDns.Servers, ','));
-    }
-
-    auto lock = m_lock.lock_exclusive();
-
-    // Add virtio net adapter to guest
-    m_adapterId = m_guestDeviceManager->AddGuestDevice(
-        VIRTIO_NET_DEVICE_ID, VIRTIO_NET_CLASS_ID, L"eth0", nullptr, device_options.str().c_str(), 0, m_userToken.get());
-
-    hns::HNSEndpoint endpointProperties;
-    endpointProperties.ID = m_adapterId;
-    endpointProperties.IPAddress = m_networkSettings->PreferredIpAddress.AddressString;
-    endpointProperties.PrefixLength = m_networkSettings->PreferredIpAddress.PrefixLength;
-    m_gnsChannel.SendEndpointState(endpointProperties);
-
-    // N.B. The MAC address is advertised with the virtio device so doesn't need to be explicitly set.
-
-    // Send the default route to gns
-    if (!default_route.empty())
-    {
-        wsl::shared::hns::Route route;
-        route.NextHop = default_route;
-        route.DestinationPrefix = LX_INIT_DEFAULT_ROUTE_PREFIX;
-        route.Family = AF_INET;
-
-        hns::ModifyGuestEndpointSettingRequest<hns::Route> request;
-        request.RequestType = hns::ModifyRequestType::Add;
-        request.ResourceType = hns::GuestEndpointResourceType::Route;
-        request.Settings = route;
-        m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId);
-    }
-
-    // Send the initial DNS configuration to GNS and track it.
-    m_trackedDnsSettings = initialDns;
-    SendDnsUpdate(initialDns);
-
-    if (m_enableLocalhostRelay)
+    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::LocalhostRelay))
     {
         SetupLoopbackDevice();
     }
 
-    THROW_IF_WIN32_ERROR(NotifyNetworkConnectivityHintChange(&VirtioNetworking::OnNetworkConnectivityChange, this, true, &m_networkNotifyHandle));
+    THROW_IF_WIN32_ERROR(NotifyNetworkConnectivityHintChange(&VirtioNetworking::OnNetworkConnectivityChange, this, TRUE, &m_networkNotifyHandle));
 }
 
 void VirtioNetworking::SetupLoopbackDevice()
@@ -129,22 +57,21 @@ void VirtioNetworking::SetupLoopbackDevice()
         0,
         m_userToken.get());
 
-    hns::HNSEndpoint endpointProperties;
-    endpointProperties.ID = m_localhostAdapterId;
     // The loopback gateway (see LX_INIT_IPV4_LOOPBACK_GATEWAY_ADDRESS) is 169.254.73.152, so assign loopback0 an
     // address of 169.254.73.153 with a netmask of 30 so that the only addresses associated with this adapter are
     // itself and the gateway.
+    // N.B. The MAC address is advertised with the virtio device so doesn't need to be explicitly set.
+    hns::HNSEndpoint endpointProperties;
+    endpointProperties.ID = m_localhostAdapterId.value();
     endpointProperties.IPAddress = L"169.254.73.153";
     endpointProperties.PrefixLength = 30;
     endpointProperties.PortFriendlyName = c_loopbackDeviceName;
     m_gnsChannel.SendEndpointState(endpointProperties);
 
-    // N.B. The MAC address is advertised with the virtio device so doesn't need to be explicitly set.
-
     hns::CreateDeviceRequest createLoopbackDevice;
     createLoopbackDevice.deviceName = c_loopbackDeviceName;
     createLoopbackDevice.type = hns::DeviceType::Loopback;
-    createLoopbackDevice.lowerEdgeAdapterId = m_localhostAdapterId;
+    createLoopbackDevice.lowerEdgeAdapterId = m_localhostAdapterId.value();
     constexpr auto loopbackType = GnsMessageType(createLoopbackDevice);
     m_gnsChannel.SendNetworkDeviceMessage(loopbackType, ToJsonW(createLoopbackDevice).c_str());
 }
@@ -175,7 +102,7 @@ HRESULT VirtioNetworking::HandlePortNotification(const SOCKADDR_INET& addr, int 
         }
     }
 
-    if (m_enableLocalhostRelay && (unspecified || loopback))
+    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::LocalhostRelay) && (unspecified || loopback))
     {
         SOCKADDR_INET localAddr = addr;
         if (!loopback)
@@ -191,13 +118,14 @@ HRESULT VirtioNetworking::HandlePortNotification(const SOCKADDR_INET& addr, int 
             }
         }
         result = ModifyOpenPorts(c_loopbackDeviceName, localAddr, protocol, allocate);
-        LOG_HR_IF_MSG(E_FAIL, result != S_OK, "Failure adding localhost relay port %d", localAddr.Ipv4.sin_port);
+        LOG_HR_IF_MSG(
+            E_FAIL, result != S_OK, "Failure adding localhost relay port %d", INETADDR_PORT(reinterpret_cast<const SOCKADDR*>(&localAddr)));
     }
 
     if (!loopback)
     {
-        const int localResult = ModifyOpenPorts(L"eth0", addr, protocol, allocate);
-        LOG_HR_IF_MSG(E_FAIL, localResult != S_OK, "Failure adding relay port %d", addr.Ipv4.sin_port);
+        const int localResult = ModifyOpenPorts(c_eth0DeviceName, addr, protocol, allocate);
+        LOG_HR_IF_MSG(E_FAIL, localResult != S_OK, "Failure adding relay port %d", INETADDR_PORT(reinterpret_cast<const SOCKADDR*>(&addr)));
         if (result == 0)
         {
             result = localResult;
@@ -238,8 +166,7 @@ int VirtioNetworking::ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET&
         }
         else
         {
-            wchar_t addrStr[16]; // "000.000.000.000" + null terminator
-            RtlIpv4AddressToStringW(&addr.Ipv4.sin_addr, addrStr);
+            const auto addrStr = wsl::windows::common::string::SockAddrInetToWstring(addr);
             portString += std::format(L";listen_addr={}", addrStr);
         }
 
@@ -251,57 +178,128 @@ int VirtioNetworking::ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET&
 
 void NETIOAPI_API_ VirtioNetworking::OnNetworkConnectivityChange(PVOID context, NL_NETWORK_CONNECTIVITY_HINT hint)
 {
-    static_cast<VirtioNetworking*>(context)->RefreshGuestConnection(hint);
+    static_cast<VirtioNetworking*>(context)->RefreshGuestConnection();
 }
 
-void VirtioNetworking::RefreshGuestConnection(NL_NETWORK_CONNECTIVITY_HINT connectivityHint) noexcept
+void VirtioNetworking::RefreshGuestConnection() noexcept
 try
 {
-    auto lock = m_lock.lock_exclusive();
-    UpdateMtu();
+    // Query current networking information before acquiring the lock.
+    m_networkSettings = GetHostEndpointSettings();
 
-    // Check for DNS changes and send update if needed.
-    auto currentDns = networking::HostDnsInfo::GetDnsSettings(networking::DnsSettingsFlags::IncludeVpn);
+    // TODO: Determine gateway MAC address
+    std::wstringstream device_options;
+    auto client_ip = m_networkSettings->PreferredIpAddress.AddressString;
+    if (!client_ip.empty())
+    {
+        if (device_options.tellp() > 0)
+        {
+            device_options << L";";
+        }
+        device_options << L"client_ip=" << client_ip;
+    }
+
+    if (!m_networkSettings->MacAddress.empty())
+    {
+        if (device_options.tellp() > 0)
+        {
+            device_options << L";";
+        }
+        device_options << L"client_mac=" << m_networkSettings->MacAddress;
+    }
+
+    std::wstring default_route = m_networkSettings->GetBestGatewayAddressString();
+    if (!default_route.empty())
+    {
+        if (device_options.tellp() > 0)
+        {
+            device_options << L";";
+        }
+        device_options << L"gateway_ip=" << default_route;
+    }
+
+    const auto newDeviceOptions = device_options.str();
+
+    networking::DnsInfo currentDns{};
+    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))
+    {
+        currentDns = networking::HostDnsInfo::GetDnsTunnelingSettings(default_route);
+    }
+    else
+    {
+        currentDns = networking::HostDnsInfo::GetDnsSettings(networking::DnsSettingsFlags::IncludeVpn);
+    }
+
+    const auto minMtu = GetMinimumConnectedInterfaceMtu();
+
+    // Acquire the lock and perform device updates.
+    auto lock = m_lock.lock_exclusive();
+    if (newDeviceOptions != m_trackedDeviceOptions)
+    {
+        m_trackedDeviceOptions = newDeviceOptions;
+
+        // Add virtio net adapter to guest. If the adapter already exists update adapter state.
+        if (!m_adapterId.has_value())
+        {
+            m_adapterId = m_guestDeviceManager->AddGuestDevice(
+                VIRTIO_NET_DEVICE_ID, VIRTIO_NET_CLASS_ID, c_eth0DeviceName, nullptr, newDeviceOptions.c_str(), 0, m_userToken.get());
+        }
+        else
+        {
+            const auto server = m_guestDeviceManager->GetRemoteFileSystem(VIRTIO_NET_CLASS_ID, c_defaultDeviceTag);
+            if (server)
+            {
+                LOG_IF_FAILED(server->AddSharePath(c_eth0DeviceName, newDeviceOptions.c_str(), 0));
+            }
+        }
+
+        // N.B. The MAC address is advertised with the virtio device so doesn't need to be explicitly set.
+        hns::HNSEndpoint endpointProperties;
+        endpointProperties.ID = m_adapterId.value();
+        endpointProperties.IPAddress = m_networkSettings->PreferredIpAddress.AddressString;
+        endpointProperties.PrefixLength = m_networkSettings->PreferredIpAddress.PrefixLength;
+        m_gnsChannel.SendEndpointState(endpointProperties);
+
+        // Send the default route to GNS.
+        if (!default_route.empty())
+        {
+            wsl::shared::hns::Route route;
+            route.NextHop = default_route;
+            route.DestinationPrefix = LX_INIT_DEFAULT_ROUTE_PREFIX;
+            route.Family = AF_INET;
+
+            hns::ModifyGuestEndpointSettingRequest<hns::Route> request;
+            request.RequestType = hns::ModifyRequestType::Add;
+            request.ResourceType = hns::GuestEndpointResourceType::Route;
+            request.Settings = route;
+            m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId.value());
+        }
+    }
+
+    // Send DNS update if needed.
     if (currentDns != m_trackedDnsSettings)
     {
         m_trackedDnsSettings = currentDns;
-        SendDnsUpdate(currentDns);
+        hns::ModifyGuestEndpointSettingRequest<hns::DNS> notification{};
+        notification.RequestType = hns::ModifyRequestType::Update;
+        notification.ResourceType = hns::GuestEndpointResourceType::DNS;
+        notification.Settings = networking::BuildDnsNotification(currentDns, m_dnsOptions);
+        m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId.value());
     }
-}
-CATCH_LOG();
 
-void VirtioNetworking::SendDnsUpdate(const networking::DnsInfo& dnsSettings)
-{
-    hns::ModifyGuestEndpointSettingRequest<hns::DNS> notification{};
-    notification.RequestType = hns::ModifyRequestType::Update;
-    notification.ResourceType = hns::GuestEndpointResourceType::DNS;
-    notification.Settings = networking::BuildDnsNotification(dnsSettings, m_dnsOptions);
-    m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId);
-}
-
-void VirtioNetworking::UpdateMtu()
-{
-    const auto minMtu = GetMinimumConnectedInterfaceMtu();
-
-    // Only send the update if the MTU changed.
+    // Send MTU update if needed.
     if (minMtu && minMtu.value() != m_networkMtu)
     {
         m_networkMtu = minMtu.value();
-
         hns::ModifyGuestEndpointSettingRequest<hns::NetworkInterface> notification{};
         notification.ResourceType = hns::GuestEndpointResourceType::Interface;
         notification.RequestType = hns::ModifyRequestType::Update;
         notification.Settings.Connected = true;
         notification.Settings.NlMtu = m_networkMtu;
-
-        WSL_LOG(
-            "VirtioNetworking::UpdateMtu",
-            TraceLoggingValue(m_adapterId, "endpointId"),
-            TraceLoggingValue(m_networkMtu, "virtioMtu"));
-
-        m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId);
+        m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId.value());
     }
 }
+CATCH_LOG();
 
 void VirtioNetworking::TraceLoggingRundown() noexcept
 {
@@ -316,107 +314,4 @@ void VirtioNetworking::FillInitialConfiguration(LX_MINI_INIT_NETWORKING_CONFIGUR
     message.DisableIpv6 = false;
     message.EnableDhcpClient = false;
     message.PortTrackerType = LX_MINI_INIT_PORT_TRACKER_TYPE::LxMiniInitPortTrackerTypeMirrored;
-}
-
-std::optional<ULONGLONG> VirtioNetworking::FindVirtioInterfaceLuid(const SOCKADDR_INET& VirtioAddress, const NL_NETWORK_CONNECTIVITY_HINT& currentConnectivityHint)
-{
-    constexpr ULONGLONG maxTimeToWaitMs = 10 * 1000;
-    constexpr ULONG timeToSleepMs = 100;
-    const auto startTickCount = GetTickCount64();
-
-    NET_LUID VirtioLuid{};
-    for (;;)
-    {
-        unique_address_table addressTable;
-        THROW_IF_WIN32_ERROR(GetUnicastIpAddressTable(AF_INET, &addressTable));
-        for (const auto& address : wil::make_range(addressTable.get()->Table, addressTable.get()->NumEntries))
-        {
-            if (VirtioAddress == address.Address)
-            {
-                VirtioLuid.Value = address.InterfaceLuid.Value;
-                break;
-            }
-
-            WSL_LOG(
-                "VirtioNetworking::FindVirtioInterfaceLuid [IP Address comparison mismatch]",
-                TraceLoggingValue(wsl::windows::common::string::SockAddrInetToString(VirtioAddress).c_str(), "VirtioAddress"),
-                TraceLoggingValue(
-                    wsl::windows::common::string::SockAddrInetToString(address.Address).c_str(), "enumeratedAddress"));
-        }
-
-        if (VirtioLuid.Value != 0)
-        {
-            break;
-        }
-
-        // give up if something is just broken and taking too long
-        if (GetTickCount64() - startTickCount >= maxTimeToWaitMs)
-        {
-            break;
-        }
-        // else sleep and try again shortly
-        Sleep(timeToSleepMs);
-        // bail if connectivity on the host has completely changed
-        NL_NETWORK_CONNECTIVITY_HINT latestConnectivityHint{};
-        GetNetworkConnectivityHint(&latestConnectivityHint);
-        if (latestConnectivityHint != currentConnectivityHint)
-        {
-            WSL_LOG("VirtioNetworking::FindVirtioInterfaceLuid [connectivity changed while waiting for the Virtio interface]");
-            THROW_WIN32_MSG(ERROR_RETRY, "connectivity changed while waiting for the Virtio interface");
-        }
-    }
-
-    if (VirtioLuid.Value == 0)
-    {
-        WSL_LOG(
-            "VirtioNetworking::FindVirtioInterfaceLuid [IP address not found]",
-            TraceLoggingValue(VirtioLuid.Value, "VirtioInterfaceLuid"),
-            TraceLoggingValue(wsl::windows::common::string::SockAddrInetToString(VirtioAddress).c_str(), "VirtioIPAddress"));
-        return {};
-    }
-
-    WSL_LOG(
-        "VirtioNetworking::FindVirtioInterfaceLuid [waiting for Virtio interface to be connected]",
-        TraceLoggingValue(VirtioLuid.Value, "VirtioInterfaceLuid"),
-        TraceLoggingValue(wsl::windows::common::string::SockAddrInetToString(VirtioAddress).c_str(), "VirtioIPAddress"));
-
-    bool ipv4Connected = false;
-    for (;;)
-    {
-        unique_interface_table interfaceTable{};
-        THROW_IF_WIN32_ERROR(::GetIpInterfaceTable(AF_UNSPEC, &interfaceTable));
-        // we only track the IPv4 interface because we only Virtio IPv4 to the container
-        for (auto index = 0ul; index < interfaceTable.get()->NumEntries; ++index)
-        {
-            const auto& ipInterface = interfaceTable.get()->Table[index];
-            if (ipInterface.Family == AF_INET && !!ipInterface.Connected && ipInterface.InterfaceLuid.Value == VirtioLuid.Value)
-            {
-                ipv4Connected = true;
-                break;
-            }
-        }
-        if (ipv4Connected)
-        {
-            break;
-        }
-
-        // give up if something is just broken and taking too long
-        if (GetTickCount64() - startTickCount >= maxTimeToWaitMs)
-        {
-            break;
-        }
-        // else sleep and try again shortly
-        Sleep(timeToSleepMs);
-        // bail if connectivity on the host has completely changed
-        NL_NETWORK_CONNECTIVITY_HINT latestConnectivityHint{};
-        GetNetworkConnectivityHint(&latestConnectivityHint);
-        if (latestConnectivityHint != currentConnectivityHint)
-        {
-            WSL_LOG("VirtioNetworking::FindVirtioInterfaceLuid [connectivity changed while waiting for the Virtio interface]");
-            THROW_WIN32_MSG(ERROR_RETRY, "connectivity changed while waiting for the Virtio interface");
-        }
-    }
-
-    // return zero if it's not connected yet so we can retry the next cycle
-    return ipv4Connected ? VirtioLuid.Value : std::optional<ULONGLONG>();
 }

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -10,10 +10,18 @@
 
 namespace wsl::core {
 
+enum class VirtioNetworkingFlags
+{
+    None = 0x0,
+    LocalhostRelay = 0x1,
+    DnsTunneling = 0x2,
+};
+DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
+
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(GnsChannel&& gnsChannel, bool enableLocalhostRelay, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
+    VirtioNetworking(GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
     ~VirtioNetworking();
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.
@@ -28,18 +36,13 @@ public:
     void FillInitialConfiguration(LX_MINI_INIT_NETWORKING_CONFIGURATION& message) override;
     void StartPortTracker(wil::unique_socket&& socket) override;
 
-    void StartLegacyPortTracker(wil::unique_socket&& socket);
-
 private:
     static void NETIOAPI_API_ OnNetworkConnectivityChange(PVOID context, NL_NETWORK_CONNECTIVITY_HINT hint);
-    static std::optional<ULONGLONG> FindVirtioInterfaceLuid(const SOCKADDR_INET& virtioAddress, const NL_NETWORK_CONNECTIVITY_HINT& currentConnectivityHint);
 
     HRESULT HandlePortNotification(const SOCKADDR_INET& addr, int protocol, bool allocate) const noexcept;
     int ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET& addr, _In_ int protocol, _In_ bool isOpen) const;
-    void RefreshGuestConnection(NL_NETWORK_CONNECTIVITY_HINT hint) noexcept;
+    void RefreshGuestConnection() noexcept;
     void SetupLoopbackDevice();
-    void SendDnsUpdate(const networking::DnsInfo& dnsSettings);
-    void UpdateMtu();
 
     mutable wil::srwlock m_lock;
 
@@ -48,13 +51,13 @@ private:
     GnsChannel m_gnsChannel;
     std::optional<GnsPortTrackerChannel> m_gnsPortTrackerChannel;
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
-    bool m_enableLocalhostRelay;
+    VirtioNetworkingFlags m_flags = VirtioNetworkingFlags::None;
     LPCWSTR m_dnsOptions = nullptr;
-    GUID m_localhostAdapterId;
-    GUID m_adapterId;
+    std::optional<GUID> m_localhostAdapterId;
+    std::optional<GUID> m_adapterId;
 
-    std::optional<ULONGLONG> m_interfaceLuid;
     ULONG m_networkMtu = 0;
+    std::wstring m_trackedDeviceOptions;
     networking::DnsInfo m_trackedDnsSettings;
 
     // Note: this field must be destroyed first to stop the callbacks before any other field is destroyed.

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -576,8 +576,10 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)
             {
+                wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::None;
+                WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::LocalhostRelay, m_vmConfig.EnableLocalhostRelay);
                 m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
-                    std::move(gnsChannel), m_vmConfig.EnableLocalhostRelay, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);
+                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::Bridged)
             {
@@ -1929,7 +1931,9 @@ bool WslCoreVm::InitializeDrvFsLockHeld(_In_ HANDLE UserToken)
 
 bool WslCoreVm::IsDnsTunnelingSupported() const
 {
-    WI_ASSERT(m_vmConfig.NetworkingMode == NetworkingMode::Nat || m_vmConfig.NetworkingMode == NetworkingMode::Mirrored);
+    WI_ASSERT(
+        m_vmConfig.NetworkingMode == NetworkingMode::Nat || m_vmConfig.NetworkingMode == NetworkingMode::Mirrored ||
+        m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy);
 
     return SUCCEEDED_LOG(wsl::core::networking::DnsResolver::LoadDnsResolverMethods());
 }

--- a/test/linux/unit_tests/drvfs.c
+++ b/test/linux/unit_tests/drvfs.c
@@ -1422,13 +1422,6 @@ Return Value:
 
     int Result;
 
-    if (g_LxtFsInfo.FsType == LxtFsTypeVirtioFs)
-    {
-        LxtLogInfo("TODO: debug this test on virtiofs.");
-        Result = 0;
-        goto ErrorExit;
-    }
-
     LxtCheckResult(LxtFsDeleteLoopCommon(DRVFS_DELETELOOP_PREFIX));
 
 ErrorExit:

--- a/test/linux/unit_tests/fscommon.c
+++ b/test/linux/unit_tests/fscommon.c
@@ -3405,13 +3405,6 @@ Return Value:
 
     int Result;
 
-    if (g_LxtFsInfo.FsType == LxtFsTypeVirtioFs)
-    {
-        LxtLogInfo("TODO: debug this test on virtiofs");
-        Result = 0;
-        goto ErrorExit;
-    }
-
     LxtCheckResult(LxtFsDeleteLoopCommon(FS_DELETELOOP_TEST_DIR));
 
 ErrorExit:
@@ -3777,16 +3770,9 @@ int FsCommonTestNoatimeFlag(PLXT_ARGS Args)
     // Plan 9 and virtiofs do not forward O_NOATIME to the server.
     //
 
-    if (g_LxtFsInfo.FsType == LxtFsTypePlan9)
+    if (g_LxtFsInfo.FsType == LxtFsTypePlan9 || g_LxtFsInfo.FsType == LxtFsTypeVirtioFs)
     {
-        LxtLogInfo("Test not supported on Plan 9.");
-        Result = 0;
-        goto ErrorExit;
-    }
-
-    if (g_LxtFsInfo.FsType == LxtFsTypeVirtioFs)
-    {
-        LxtLogInfo("Test not supported on virtiofs.");
+        LxtLogInfo("This test is not supported for plan9 or virtiofs.");
         Result = 0;
         goto ErrorExit;
     }

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -178,33 +178,6 @@ class NetworkTests
     friend class BridgedTests;
     friend class VirtioProxyTests;
 
-    static std::wstring SockaddrToString(const SOCKADDR_INET* sockAddr)
-    {
-        constexpr auto ipv4AddressStringLength = 16;
-        constexpr auto ipv6AddressStringLength = 48;
-
-        std::wstring address(std::max(ipv4AddressStringLength, ipv6AddressStringLength), L'\0');
-
-        switch (sockAddr->si_family)
-        {
-        case AF_INET:
-        {
-            RtlIpv4AddressToStringW(&sockAddr->Ipv4.sin_addr, address.data());
-            break;
-        }
-        case AF_INET6:
-        {
-            RtlIpv6AddressToStringW(&sockAddr->Ipv6.sin6_addr, address.data());
-            break;
-        }
-        default:
-            break;
-        }
-
-        address.resize(std::wcslen(address.data()));
-        return address;
-    }
-
     struct IpAddress
     {
         std::wstring Address;
@@ -243,7 +216,7 @@ class NetworkTests
                 }
             }
 
-            return SockaddrToString(address) + L"/" + std::to_wstring(PrefixLength);
+            return wsl::windows::common::string::SockAddrInetToWstring(*address) + L"/" + std::to_wstring(PrefixLength);
         }
     };
 
@@ -812,7 +785,7 @@ class NetworkTests
         }
         else
         {
-            LogSkipped("Host does not have IPv4 internet connectivity. Skipping IPv4 DNS tests.");
+            LogInfo("Host does not have IPv4 internet connectivity. Skipping IPv4 DNS tests.");
         }
 
         if (HostHasInternetConnectivity(AF_INET6))
@@ -823,7 +796,7 @@ class NetworkTests
         }
         else
         {
-            LogSkipped("Host does not have IPv6 internet connectivity. Skipping IPv6 DNS tests.");
+            LogInfo("Host does not have IPv6 internet connectivity. Skipping IPv6 DNS tests.");
         }
     }
 


### PR DESCRIPTION
This change updates WSL to use a new version of the Microsoft.WSL.DeviceHost package (version 1.1.14-0) which contains the following changes:
1. DNS tunneling support for virtio proxy networking
3. UDP timeout support for virtio proxy networking
4. Improvements to virtiofs posix compatibility