### PR TITLE
Fix potential long delay in wslaservice termination

### DIFF
--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -1012,6 +1012,7 @@ try
         m_virtualMachine.reset();
     }
 
+    m_terminated = true;
     return S_OK;
 }
 CATCH_RETURN();
@@ -1079,7 +1080,7 @@ void WSLASession::OnContainerDeleted(const WSLAContainerImpl* Container)
 
 HRESULT WSLASession::GetState(_Out_ WSLASessionState* State)
 {
-    *State = m_sessionTerminatingEvent.is_signaled() ? WSLASessionStateTerminated : WSLASessionStateRunning;
+    *State = m_terminated ? WSLASessionStateTerminated : WSLASessionStateRunning;
     return S_OK;
 }
 

--- a/src/windows/wslasession/WSLASession.h
+++ b/src/windows/wslasession/WSLASession.h
@@ -118,6 +118,7 @@ private:
     std::optional<ServiceRunningProcess> m_dockerdProcess;
     WSLAFeatureFlags m_featureFlags{};
     std::function<void()> m_destructionCallback;
+    std::atomic<bool> m_terminated{false};
 };
 
 } // namespace wsl::windows::service::wsla

--- a/src/windows/wslasession/WSLASessionReference.cpp
+++ b/src/windows/wslasession/WSLASessionReference.cpp
@@ -52,14 +52,16 @@ HRESULT wsla::WSLASessionReference::OpenSession(_Out_ IWSLASession** Session)
 HRESULT wsla::WSLASessionReference::Terminate()
 try
 {
-    // Attempt to open a running session and forward the termination request.
-    // If the session is no longer available or not running, treat it as already terminated.
+    // Resolve the weak reference directly (bypassing OpenSession which checks GetState).
+    // We want to terminate regardless of session state.
     Microsoft::WRL::ComPtr<IWSLASession> session;
-    if (SUCCEEDED(OpenSession(&session)))
+    RETURN_IF_FAILED(m_weakSession->Resolve(__uuidof(IWSLASession), reinterpret_cast<IInspectable**>(session.GetAddressOf())));
+
+    if (session)
     {
         return session->Terminate();
     }
 
-    return S_OK; // Session already gone
+    return S_OK; // Session already released
 }
 CATCH_RETURN()


### PR DESCRIPTION
This change resolves a potential long delay when stopping the wslaservice. Previously, the GetState method would acquire the session lock, which could be locked behind a long-running operation. Instead, check the signal status of the terminating event which can be safely done without the lock held.