### PR TITLE
Fix cmake configuration failure when both VS 2022 and 2026 are installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,10 @@ if (NOT VS_INSTALL_DIR)
     message(FATAL_ERROR "Could not determine Visual Studio 2022 installation directory.")
 endif()
 
+# Pick the first line returned from vswhere, in case multiple versions are returned.
+# TODO: Remove this and require VS 2026 once the CI supports it.
+string(REGEX MATCH "([^\n\r]+)" VS_INSTALL_DIR "${VS_INSTALL_DIR}")
+
 if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
     set(LLVM_INSTALL_DIR "${VS_INSTALL_DIR}/VC/Tools/Llvm/x64/bin")
 else()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a cmake configuration issue that happens if both VS 2022 and 2026 are installed. 

Sample failure: 

```
CMake Error at CMakeLists.txt:297 (message):
  C++ Clang Compiler for Windows is not installed at C:\Program
  Files\Microsoft Visual Studio\2022\Enterprise

  C:\Program Files\Microsoft Visual
  Studio\18\Enterprise/VC/Tools/Llvm/x64/bin.  Please install it from the
  Visual Studio Installer.
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
