### PR TITLE
Remove stale wslaclient.dll copy from test VM setup script

### DIFF
--- a/tools/test/setup-vm-for-tests.ps1
+++ b/tools/test/setup-vm-for-tests.ps1
@@ -140,7 +140,6 @@ Invoke-Command -Session $Session -ArgumentList $RemoteFolder -ScriptBlock {
 Copy-Item -ToSession $Session -Path "$Bin/installer.msix"  -Destination $RemoteFolder -Force
 Copy-Item -ToSession $Session -Path "$Bin/wsltests.dll"  -Destination $RemoteFolder -Force
 Copy-Item -ToSession $Session -Path "$Bin/testplugin.dll"  -Destination $RemoteFolder -Force
-Copy-Item -ToSession $Session -Path "$Bin/wslaclient.dll"  -Destination $RemoteFolder -Force
 Copy-Item -ToSession $Session -Path "$PSScriptRoot/test-setup.ps1"  -Destination $RemoteFolder -Force
 Copy-Item -ToSession $Session -Path "$PSScriptRoot/run-tests.ps1"  -Destination $RemoteFolder -Force
 Copy-Item -ToSession $Session -Path "$PSScriptRoot/../../test/linux/unit_tests" -Destination $RemoteFolder -Recurse -Force


### PR DESCRIPTION
## Summary

- `wslaclient.dll` was deleted in #14213 but `setup-vm-for-tests.ps1` was not updated, causing the script to fail when setting up a VM for tests.
- Removes the stale `Copy-Item` line for `wslaclient.dll`.

## Test plan

- [ ] Run `setup-vm-for-tests.ps1` and verify it completes without error