### PR TITLE
Correctly detect Exec() failures and set the process exit code

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -144,6 +144,15 @@ struct InspectContainer
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectContainer, Id, Name, Created, Image, State, Config, HostConfig);
 };
 
+struct InspectExec
+{
+    std::optional<int> Pid{};
+    std::optional<int> ExitCode{};
+    bool Running{};
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectExec, Pid, ExitCode, Running);
+};
+
 struct Image
 {
     std::string Id;

--- a/src/windows/wslasession/DockerHTTPClient.cpp
+++ b/src/windows/wslasession/DockerHTTPClient.cpp
@@ -273,6 +273,19 @@ std::string DockerHTTPClient::InspectContainer(const std::string& Id)
     return response;
 }
 
+std::string DockerHTTPClient::InspectExec(const std::string& Id)
+{
+    auto url = URL::Create("/exec/{}/json", Id);
+    auto [code, response] = SendRequestAndReadResponse(verb::get, url);
+
+    if (code < 200 || code >= 300)
+    {
+        throw DockerHTTPException(code, verb::get, url.Get(), "", response);
+    }
+
+    return response;
+}
+
 wil::unique_socket DockerHTTPClient::AttachContainer(const std::string& Id)
 {
     std::map<boost::beast::http::field, std::string> headers{

--- a/src/windows/wslasession/DockerHTTPClient.h
+++ b/src/windows/wslasession/DockerHTTPClient.h
@@ -102,6 +102,7 @@ public:
     void DeleteContainer(const std::string& Id);
     void SignalContainer(const std::string& Id, int Signal);
     std::string InspectContainer(const std::string& Id);
+    std::string InspectExec(const std::string& Id);
     wil::unique_socket AttachContainer(const std::string& Id);
     void ResizeContainerTty(const std::string& Id, ULONG Rows, ULONG Columns);
     wil::unique_socket ContainerLogs(const std::string& Id, WSLALogsFlags Flags, ULONGLONG Since, ULONGLONG Until, ULONGLONG Tail);

--- a/src/windows/wslasession/WSLAProcess.cpp
+++ b/src/windows/wslasession/WSLAProcess.cpp
@@ -34,7 +34,7 @@ CATCH_RETURN();
 HRESULT WSLAProcess::GetExitEvent(ULONG* Event)
 try
 {
-    *Event = HandleToUlong(common::wslutil::DuplicateHandleToCallingProcess(m_control->GetExitEvent(), SYNCHRONIZE));
+    *Event = HandleToUlong(common::wslutil::DuplicateHandleToCallingProcess(m_control->GetExitEvent().get(), SYNCHRONIZE));
     return S_OK;
 }
 CATCH_RETURN();
@@ -69,7 +69,7 @@ wil::unique_handle WSLAProcess::GetStdHandle(int Index)
 
 HANDLE WSLAProcess::GetExitEvent()
 {
-    return m_control->GetExitEvent();
+    return m_control->GetExitEvent().get();
 }
 
 HRESULT WSLAProcess::GetPid(int* Pid)

--- a/src/windows/wslasession/WSLAProcessControl.h
+++ b/src/windows/wslasession/WSLAProcessControl.h
@@ -32,7 +32,7 @@ public:
     virtual void ResizeTty(ULONG Rows, ULONG Columns) = 0;
     virtual int GetPid() const = 0;
     std::pair<WSLA_PROCESS_STATE, int> GetState() const;
-    HANDLE GetExitEvent() const;
+    const wil::unique_event& GetExitEvent() const;
 
 protected:
     wil::unique_event m_exitEvent{wil::EventOptions::ManualReset};
@@ -68,11 +68,15 @@ public:
     int GetPid() const override;
     void OnContainerReleased();
 
+    void SetPid(int Pid);
+    void SetExitCode(int ExitCode);
+
 private:
     void OnEvent(ContainerEvent Event, std::optional<int> ExitCode);
 
-    std::mutex m_lock;
+    mutable std::mutex m_lock;
     std::string m_id;
+    std::optional<int> m_pid{};
     DockerHTTPClient& m_client;
     WSLAContainerImpl* m_container{};
     ContainerEventTracker::ContainerTrackingReference m_trackingReference;

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2785,9 +2785,6 @@ class WSLATests
 
         {
             WSLAProcessLauncher launcher({}, {"/not-found"});
-            auto [result, _] = launcher.LaunchNoThrow(container.Get());
-
-            VERIFY_SUCCEEDED(result);
 
             auto process = launcher.Launch(container.Get());
             ValidateProcessOutput(
@@ -2803,10 +2800,6 @@ class WSLATests
             WSLAProcessLauncher launcher({}, {"/bin/cat"});
             launcher.SetWorkingDirectory("/notfound");
 
-            auto [result, _] = launcher.LaunchNoThrow(container.Get());
-
-            VERIFY_SUCCEEDED(result);
-
             auto process = launcher.Launch(container.Get());
             ValidateProcessOutput(
                 process,
@@ -2820,10 +2813,6 @@ class WSLATests
         {
             WSLAProcessLauncher launcher({}, {"/bin/cat"});
             launcher.SetUser("does-not-exist");
-
-            auto [result, _] = launcher.LaunchNoThrow(container.Get());
-
-            VERIFY_SUCCEEDED(result);
 
             auto process = launcher.Launch(container.Get());
             ValidateProcessOutput(process, {{1, "unable to find user does-not-exist: no matching entries in passwd file\r\n"}}, 126);

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -196,11 +196,11 @@ class WSLATests
         if (result.Code != expectedResult)
         {
             LogError(
-                "Comman didn't return expected code (%i). ExitCode: %i, Stdout: '%hs', Stderr: '%hs'",
+                "Command didn't return expected code (%i). ExitCode: %i, Stdout: '%hs', Stderr: '%hs'",
                 expectedResult,
                 result.Code,
-                result.Output[1].c_str(),
-                result.Output[2].c_str());
+                EscapeString(result.Output[1]).c_str(),
+                EscapeString(result.Output[2]).c_str());
 
             return;
         }
@@ -216,7 +216,11 @@ class WSLATests
 
             if (it->second != expected)
             {
-                LogError("Unexpected output on fd %i. Expected: '%hs', Actual: '%hs'", fd, expected.c_str(), it->second.c_str());
+                LogError(
+                    "Unexpected output on fd %i. Expected: '%hs', Actual: '%hs'",
+                    fd,
+                    EscapeString(expected).c_str(),
+                    EscapeString(it->second).c_str());
             }
         }
     }
@@ -2778,27 +2782,38 @@ class WSLATests
         }
 
         // Validate that launching a non-existing command returns the correct error.
-        // TODO: Uncomment once exec launch errors are handled.
 
-        /*
         {
             WSLAProcessLauncher launcher({}, {"/not-found"});
             auto [result, _] = launcher.LaunchNoThrow(container.Get());
 
-            VERIFY_ARE_EQUAL(result, E_FAIL);
+            VERIFY_SUCCEEDED(result);
 
-            ValidateCOMErrorMessage(L"TODO");
+            auto process = launcher.Launch(container.Get());
+            ValidateProcessOutput(
+                process,
+                {{1,
+                  "OCI runtime exec failed: exec failed: unable to start container process: exec: \"/not-found\": stat "
+                  "/not-found: no such file or directory: unknown\r\n"}},
+                126);
         }
 
         // Validate that setting invalid current directory returns the correct error.
         {
             WSLAProcessLauncher launcher({}, {"/bin/cat"});
             launcher.SetWorkingDirectory("/notfound");
+
             auto [result, _] = launcher.LaunchNoThrow(container.Get());
 
-            VERIFY_ARE_EQUAL(result, E_FAIL);
+            VERIFY_SUCCEEDED(result);
 
-            ValidateCOMErrorMessage(L"TODO");
+            auto process = launcher.Launch(container.Get());
+            ValidateProcessOutput(
+                process,
+                {{1,
+                  "OCI runtime exec failed: exec failed: unable to start container process: chdir to cwd (\"/notfound\") set in "
+                  "config.json failed: no such file or directory: unknown\r\n"}},
+                126);
         }
 
         // Validate that invalid usernames are correctly handled.
@@ -2808,11 +2823,15 @@ class WSLATests
 
             auto [result, _] = launcher.LaunchNoThrow(container.Get());
 
-            VERIFY_ARE_EQUAL(result, E_FAIL);
-            ValidateCOMErrorMessage(L"Not found");
-        }
+            VERIFY_SUCCEEDED(result);
 
-        */
+            auto process = launcher.Launch(container.Get());
+            ValidateProcessOutput(
+                process,
+                {{1,
+                  "unable to find user does-not-exist: no matching entries in passwd file\r\n"}},
+                126);
+        }
 
         // Validate that an exec'd command returns when the container is stopped.
         {

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2826,11 +2826,7 @@ class WSLATests
             VERIFY_SUCCEEDED(result);
 
             auto process = launcher.Launch(container.Get());
-            ValidateProcessOutput(
-                process,
-                {{1,
-                  "unable to find user does-not-exist: no matching entries in passwd file\r\n"}},
-                126);
+            ValidateProcessOutput(process, {{1, "unable to find user does-not-exist: no matching entries in passwd file\r\n"}}, 126);
         }
 
         // Validate that an exec'd command returns when the container is stopped.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to wait for an exec instance to either running or failed before returning the process to the caller. This allows us to correctly handle failed execs

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
