### PR TITLE
Fix leaked tracking reference when a process outlives its container

### DIFF
--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -311,19 +311,30 @@ WSLAContainerImpl::~WSLAContainerImpl()
         TraceLoggingValue(m_id.c_str(), "Id"),
         TraceLoggingValue((int)m_state, "State"));
 
+    // Copy processes references so their callback can be removed without holding m_lock.
+    auto* initProcessControl = m_initProcessControl;
+    auto processes = m_processes;
+
     // Remove container callback from any outstanding processes.
     {
         std::lock_guard lock(m_lock);
 
         if (m_initProcessControl)
         {
-            m_initProcessControl->OnContainerReleased();
+            m_initProcessControl = nullptr;
         }
 
-        for (auto& process : m_processes)
-        {
-            process->OnContainerReleased();
-        }
+        m_processes.clear();
+    }
+
+    if (initProcessControl)
+    {
+        initProcessControl->OnContainerReleased();
+    }
+
+    for (auto& process : m_processes)
+    {
+        process->OnContainerReleased();
     }
 
     m_containerEvents.Reset();

--- a/src/windows/wslasession/WSLAProcessControl.cpp
+++ b/src/windows/wslasession/WSLAProcessControl.cpp
@@ -95,6 +95,10 @@ void DockerContainerProcessControl::OnContainerReleased()
     std::lock_guard lock{m_lock};
     m_container = nullptr;
 
+    // N.B. The caller might keep a reference to the process even after the container is released.
+    // If that happens, make sure that the state tracking can't outlive the session.
+    m_trackingReference.Reset();
+
     // Signal the exit event to prevent callers from being blocked on it.
     if (!m_exitEvent.is_signaled())
     {
@@ -157,6 +161,10 @@ void DockerExecProcessControl::OnContainerReleased()
 
     WI_ASSERT(m_container != nullptr);
     m_container = nullptr;
+
+    // N.B. The caller might keep a reference to the process even after the container is released.
+    // If that happens, make sure that the state tracking can't outlive the session.
+    m_trackingReference.Reset();
 
     // Signal the exit event to prevent callers being blocked on it.
     if (!m_exitEvent.is_signaled())

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -826,7 +826,7 @@ void CreateProcessCrashReport(DWORD Pid, LPCWSTR ImageName, LPCWSTR EventName)
 void CreateWerReports()
 {
     static const std::set<std::wstring, wsl::shared::string::CaseInsensitiveCompare> WslProcesses{
-        L"wsl.exe", L"wslhost.exe", L"wslrelay.exe", L"wslservice.exe", L"wslg.exe", L"vmcompute.exe", L"vmwp.exe"};
+        L"wsl.exe", L"wslhost.exe", L"wslrelay.exe", L"wslservice.exe", L"wslg.exe", L"vmcompute.exe", L"vmwp.exe", L"wslaservice.exe", L"wslasession.exe"};
 
     auto PrivilegeState = wsl::windows::common::security::AcquirePrivilege(SE_DEBUG_NAME);
     const std::wstring EventName = L"WslTestHang-" + g_pipelineBuildId;

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -826,7 +826,15 @@ void CreateProcessCrashReport(DWORD Pid, LPCWSTR ImageName, LPCWSTR EventName)
 void CreateWerReports()
 {
     static const std::set<std::wstring, wsl::shared::string::CaseInsensitiveCompare> WslProcesses{
-        L"wsl.exe", L"wslhost.exe", L"wslrelay.exe", L"wslservice.exe", L"wslg.exe", L"vmcompute.exe", L"vmwp.exe", L"wslaservice.exe", L"wslasession.exe"};
+        L"wsl.exe",
+        L"wslhost.exe",
+        L"wslrelay.exe",
+        L"wslservice.exe",
+        L"wslg.exe",
+        L"vmcompute.exe",
+        L"vmwp.exe",
+        L"wslaservice.exe",
+        L"wslasession.exe"};
 
     auto PrivilegeState = wsl::windows::common::security::AcquirePrivilege(SE_DEBUG_NAME);
     const std::wstring EventName = L"WslTestHang-" + g_pipelineBuildId;

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -826,15 +826,7 @@ void CreateProcessCrashReport(DWORD Pid, LPCWSTR ImageName, LPCWSTR EventName)
 void CreateWerReports()
 {
     static const std::set<std::wstring, wsl::shared::string::CaseInsensitiveCompare> WslProcesses{
-        L"wsl.exe",
-        L"wslhost.exe",
-        L"wslrelay.exe",
-        L"wslservice.exe",
-        L"wslg.exe",
-        L"vmcompute.exe",
-        L"vmwp.exe",
-        L"wslaservice.exe",
-        L"wslasession.exe"};
+        L"wsl.exe", L"wslhost.exe", L"wslrelay.exe", L"wslservice.exe", L"wslg.exe", L"vmcompute.exe", L"vmwp.exe"};
 
     auto PrivilegeState = wsl::windows::common::security::AcquirePrivilege(SE_DEBUG_NAME);
     const std::wstring EventName = L"WslTestHang-" + g_pipelineBuildId;

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2074,6 +2074,26 @@ class WSLATests
             ValidateProcessOutput(process, {{1, "www-data\n"}});
         }
 
+        // Validate that the container behaves correctly if the caller keeps a reference to an init process during termination.
+        {
+            WSLAContainerLauncher launcher("debian:latest", "test-init-ref", {"/bin/cat"}, {}, {}, WSLAProcessFlagsStdin);
+
+            auto container = launcher.Launch(*m_defaultSession);
+            auto process = container.GetInitProcess();
+
+            VERIFY_ARE_EQUAL(process.State(), WslaProcessStateRunning);
+
+            // Terminate the session.
+            ResetTestSession();
+
+            WSLA_PROCESS_STATE processState{};
+            int exitCode{};
+            VERIFY_ARE_EQUAL(process.Get().GetState(&processState, &exitCode), HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE));
+
+            WSLA_CONTAINER_STATE state{};
+            VERIFY_ARE_EQUAL(container.Get().GetState(&state), HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE));
+        }
+
         // Validate error handling when the username / group doesn't exist
         {
             WSLAContainerLauncher launcher("debian:latest", "test-no-missing-user", {"groups"});

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2079,6 +2079,14 @@ class WSLATests
             WSLAContainerLauncher launcher("debian:latest", "test-init-ref", {"/bin/cat"}, {}, {}, WSLAProcessFlagsStdin);
 
             auto container = launcher.Launch(*m_defaultSession);
+            auto containerId = container.Id();
+
+            auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+                wil::com_ptr<IWSLAContainer> openedContainer;
+                VERIFY_SUCCEEDED(m_defaultSession->OpenContainer(containerId.c_str(), &openedContainer));
+                VERIFY_SUCCEEDED(openedContainer->Delete());
+            });
+
             auto process = container.GetInitProcess();
 
             VERIFY_ARE_EQUAL(process.State(), WslaProcessStateRunning);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a potential crash that can be caused by a `ContainerTrackingReference` outliving the session if a process reference is kept after a container is released. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
