### PR TITLE
Only try to parse into an ErrorResponse if the content-type is json

### DIFF
--- a/src/windows/wslasession/DockerHTTPClient.h
+++ b/src/windows/wslasession/DockerHTTPClient.h
@@ -67,7 +67,7 @@ public:
     bool HasErrorMessage() const
     {
         auto it = m_response.find(boost::beast::http::field::content_type);
-        return it != m_response.end() && it->value() == "application/json";
+        return it != m_response.end() && it->value().starts_with("application/json");
     }
 
     uint16_t StatusCode() const noexcept
@@ -216,7 +216,7 @@ private:
 
         if (response.result_int() < 200 || response.result_int() >= 300)
         {
-            throw DockerHTTPException(std::move(response), std::move(Method), Url.Get(), std::move(requestString), std::move(body));
+            throw DockerHTTPException(std::move(response), Method, Url.Get(), std::move(requestString), std::move(body));
         }
 
         if constexpr (!std::is_same_v<TResponse, void>)

--- a/src/windows/wslasession/DockerHTTPClient.h
+++ b/src/windows/wslasession/DockerHTTPClient.h
@@ -22,7 +22,7 @@ Abstract:
 #include "docker_schema.h"
 
 #define THROW_DOCKER_USER_ERROR_MSG(_Ex, _Msg, ...) \
-    if ((_Ex).StatusCode() >= 400 && (_Ex).StatusCode() <= 500) \
+    if ((_Ex).HasErrorMessage()) \
     { \
         THROW_HR_WITH_USER_ERROR_MSG(E_FAIL, (_Ex).DockerMessage<wsl::windows::common::docker_schema::ErrorResponse>().message, _Msg, __VA_ARGS__); \
     } \
@@ -42,32 +42,44 @@ namespace wsl::windows::service::wsla {
 class DockerHTTPException : public std::runtime_error
 {
 public:
-    DockerHTTPException(uint16_t StatusCode, boost::beast::http::verb Method, const std::string& Url, const std::string& RequestContent, const std::string& ResponseContent) :
+    DockerHTTPException(
+        boost::beast::http::message<false, boost::beast::http::buffer_body>&& Response,
+        boost::beast::http::verb Method,
+        std::string&& Url,
+        std::string&& RequestContent,
+        std::string&& ResponseContent) :
         std::runtime_error(std::format(
-            "HTTP request failed: {} {} -> {} (Request: {}, Response: {})", boost::beast::http::to_string(Method), Url, StatusCode, RequestContent, ResponseContent)),
-        m_statusCode(StatusCode),
-        m_url(Url),
-        m_request(RequestContent),
-        m_response(ResponseContent)
+            "HTTP request failed: {} {} -> {} (Request: {}, Response: {})", boost::beast::http::to_string(Method), Url, Response.result_int(), RequestContent, ResponseContent)),
+        m_response(std::move(Response)),
+        m_url(std::move(Url)),
+        m_request(std::move(RequestContent)),
+        m_responseBody(std::move(ResponseContent))
     {
     }
 
     template <typename T = docker_schema::ErrorResponse>
     T DockerMessage() const
     {
-        return wsl::shared::FromJson<T>(m_response.c_str());
+        return wsl::shared::FromJson<T>(m_responseBody.c_str());
+    }
+
+    // Only try to decode the error message if it's actually json.
+    bool HasErrorMessage() const
+    {
+        auto it = m_response.find(boost::beast::http::field::content_type);
+        return it != m_response.end() && it->value() == "application/json";
     }
 
     uint16_t StatusCode() const noexcept
     {
-        return m_statusCode;
+        return static_cast<uint16_t>(m_response.result());
     }
 
 private:
-    uint16_t m_statusCode{};
+    boost::beast::http::message<false, boost::beast::http::buffer_body> m_response{};
     std::string m_url;
     std::string m_request;
-    std::string m_response;
+    std::string m_responseBody;
 };
 
 class DockerHTTPClient
@@ -92,6 +104,8 @@ public:
         boost::asio::generic::stream_protocol::socket stream;
     };
 
+    using HTTPResponse = boost::beast::http::message<false, boost::beast::http::buffer_body>;
+
     DockerHTTPClient(wsl::shared::SocketChannel&& Channel, HANDLE ExitingEvent, GUID VmId, ULONG ConnectTimeoutMs);
 
     // Container management.
@@ -101,8 +115,8 @@ public:
     void StopContainer(const std::string& Id, std::optional<WSLASignal> Signal, std::optional<ULONG> TimeoutSeconds);
     void DeleteContainer(const std::string& Id);
     void SignalContainer(const std::string& Id, int Signal);
-    std::string InspectContainer(const std::string& Id);
-    std::string InspectExec(const std::string& Id);
+    common::docker_schema::InspectContainer InspectContainer(const std::string& Id);
+    common::docker_schema::InspectExec InspectExec(const std::string& Id);
     wil::unique_socket AttachContainer(const std::string& Id);
     void ResizeContainerTty(const std::string& Id, ULONG Rows, ULONG Columns);
     wil::unique_socket ContainerLogs(const std::string& Id, WSLALogsFlags Flags, ULONGLONG Since, ULONGLONG Until, ULONGLONG Tail);
@@ -131,7 +145,7 @@ public:
 
         DockerHttpResponseHandle(
             HTTPRequestContext& context,
-            std::function<void(const boost::beast::http::message<false, boost::beast::http::buffer_body>&)>&& OnResponseHeader,
+            std::function<void(const HTTPResponse&)>&& OnResponseHeader,
             std::function<void(const gsl::span<char>&)>&& OnResponseBytes,
             std::function<void()>&& OnCompleted = []() {});
 
@@ -183,10 +197,10 @@ private:
     std::unique_ptr<HTTPRequestContext> SendRequestImpl(
         boost::beast::http::verb Method, const URL& Url, const std::string& Body, const std::map<boost::beast::http::field, std::string>& Headers);
 
-    std::pair<uint32_t, std::string> SendRequestAndReadResponse(
+    std::pair<HTTPResponse, std::string> SendRequestAndReadResponse(
         boost::beast::http::verb Method, const URL& Url, const std::string& Body = "");
 
-    std::pair<uint32_t, wil::unique_socket> SendRequest(
+    std::pair<HTTPResponse, wil::unique_socket> SendRequest(
         boost::beast::http::verb Method, const URL& Url, const std::string& Body, const std::map<boost::beast::http::field, std::string>& Headers = {});
 
     template <typename TRequest = common::docker_schema::EmptyRequest, typename TResponse = TRequest::TResponse>
@@ -198,16 +212,16 @@ private:
             requestString = wsl::shared::ToJson(RequestObject);
         }
 
-        auto [statusCode, responseString] = SendRequestAndReadResponse(Method, Url, requestString);
+        auto [response, body] = SendRequestAndReadResponse(Method, Url, requestString);
 
-        if (statusCode < 200 || statusCode >= 300)
+        if (response.result_int() < 200 || response.result_int() >= 300)
         {
-            throw DockerHTTPException(statusCode, Method, Url.Get(), requestString, responseString);
+            throw DockerHTTPException(std::move(response), std::move(Method), Url.Get(), std::move(requestString), std::move(body));
         }
 
         if constexpr (!std::is_same_v<TResponse, void>)
         {
-            return wsl::shared::FromJson<TResponse>(responseString.c_str());
+            return wsl::shared::FromJson<TResponse>(body.c_str());
         }
     }
 

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -671,8 +671,7 @@ void WSLAContainerImpl::Exec(const WSLA_PROCESS_OPTIONS* Options, IWSLAProcess**
 
         do
         {
-            auto inspectJson = m_dockerClient.InspectExec(result.Id);
-            auto state = wsl::shared::FromJson<common::docker_schema::InspectExec>(inspectJson.c_str());
+            auto state = m_dockerClient.InspectExec(result.Id);
             if (state.Running && state.Pid.has_value())
             {
                 control->SetPid(state.Pid.value());
@@ -689,7 +688,7 @@ void WSLAContainerImpl::Exec(const WSLA_PROCESS_OPTIONS* Options, IWSLAProcess**
                     HRESULT_FROM_WIN32(ERROR_TIMEOUT),
                     "Timed out waiting for exec state for '%hs'. Last state: %hs",
                     result.Id.c_str(),
-                    inspectJson.c_str());
+                    wsl::shared::ToJson(state).c_str());
             }
 
         } while (!control->GetExitEvent().wait(100));
@@ -958,8 +957,7 @@ void WSLAContainerImpl::Inspect(LPSTR* Output)
     try
     {
         // Get Docker inspect data
-        auto dockerJson = m_dockerClient.InspectContainer(m_id);
-        auto dockerInspect = wsl::shared::FromJson<DockerInspectContainer>(dockerJson.c_str());
+        auto dockerInspect = m_dockerClient.InspectContainer(m_id);
 
         // Convert to WSLA schema
         auto wslaInspect = BuildInspectContainer(dockerInspect);

--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -912,7 +912,7 @@ try
 
         try
         {
-            inspectResult = wsl::shared::FromJson<docker_schema::InspectContainer>(m_dockerClient->InspectContainer(Id).c_str());
+            inspectResult = m_dockerClient->InspectContainer(Id);
         }
         catch (DockerHTTPException& e)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the HTTP error handling logic to look at the content-type header before attempting to parse into JSON. 

This is the standard way of inspect the response's content and will be more reliable than the previous implementation of trying to guess the content type based on the status code. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
