### PR TITLE
Add container ID to WSLA_CONTAINER so the CLI doesn't require a WslaContainer reference during simple wslc container list

### DIFF
--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -115,7 +115,6 @@ struct WSLA_REGISTRY_AUTHENTICATION_INFORMATION
     // TODO: Details TBD.
 };
 
-
 struct WSLA_IMAGE_INFORMATION
 {
     char Image[WSLA_MAX_IMAGE_NAME_LENGTH + 1];
@@ -240,10 +239,13 @@ enum WSLA_CONTAINER_STATE
     WslaContainerStateDeleted = 4,
 };
 
+typedef char WSLAContainerId[WSLA_CONTAINER_ID_LENGTH + 1] ;
+
 struct WSLA_CONTAINER
 {
     char Name[WSLA_MAX_CONTAINER_NAME_LENGTH + 1];
     char Image[WSLA_MAX_IMAGE_NAME_LENGTH + 1];
+    WSLAContainerId Id;
     enum WSLA_CONTAINER_STATE State;
 
     // TODO: Add creation timestamp and other fields that the command line tool might want to display.
@@ -360,7 +362,6 @@ typedef enum _WSLALogsFlags
     WSLALogsFlagsTimestamps = 2,
 } WSLALogsFlags;
 
-typedef char WSLAContainerId[WSLA_CONTAINER_ID_LENGTH + 1] ;
 
 [
     uuid(7577FE8D-DE85-471E-B870-11669986F332),

--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -949,6 +949,7 @@ try
     {
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Image, e->Image().c_str()) != 0);
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Name, e->Name().c_str()) != 0);
+        THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Id, e->ID().c_str()) != 0);
         e->GetState(&output[index].State);
         index++;
     }

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -187,8 +187,7 @@ std::vector<ContainerInformation> ContainerService::List(Session& session)
 {
     std::vector<ContainerInformation> result;
     wil::unique_cotaskmem_array_ptr<WSLA_CONTAINER> containers;
-    ULONG count = 0;
-    THROW_IF_FAILED(session.Get()->ListContainers(&containers, &count));
+    THROW_IF_FAILED(session.Get()->ListContainers(&containers, containers.size_address<ULONG>()));
     for (const auto& current : containers)
     {
         ContainerInformation entry;

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -189,23 +189,14 @@ std::vector<ContainerInformation> ContainerService::List(Session& session)
     wil::unique_cotaskmem_array_ptr<WSLA_CONTAINER> containers;
     ULONG count = 0;
     THROW_IF_FAILED(session.Get()->ListContainers(&containers, &count));
-    for (auto ptr = containers.get(), end = containers.get() + count; ptr != end; ++ptr)
+    for (const auto& current : containers)
     {
-        const WSLA_CONTAINER& current = *ptr;
-
-        wil::com_ptr<IWSLAContainer> container;
-        THROW_IF_FAILED(session.Get()->OpenContainer(current.Name, &container));
-
-        wil::unique_cotaskmem_ansistring output;
-        THROW_IF_FAILED(container->Inspect(&output));
-        auto inspect = wsl::shared::FromJson<InspectContainer>(output.get());
-
         ContainerInformation entry;
         entry.Name = current.Name;
         entry.Image = current.Image;
         entry.State = current.State;
-        entry.Id = inspect.Id;
-        result.push_back(entry);
+        entry.Id = current.Id;
+        result.emplace_back(std::move(entry));
     }
 
     return result;

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2329,6 +2329,7 @@ class WSLATests
                 VERIFY_ARE_EQUAL(expectedName, containers[i].Name);
                 VERIFY_ARE_EQUAL(expectedImage, containers[i].Image);
                 VERIFY_ARE_EQUAL(expectedState, containers[i].State);
+                VERIFY_ARE_EQUAL(strlen(containers[i].Id), WSLA_CONTAINER_ID_LENGTH);
             }
         };
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds ID to the list of returned fields when listing a container, which fixes list for containers without names and allows a simpler implementation of the simple case for List() 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
