### PR TITLE
Disable the PmemVhds testcase

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1711,6 +1711,9 @@ class WSLATests
     {
         WSL2_TEST_ONLY();
 
+        // TODO: Remove once test failure is fixed.
+        SKIP_TEST_UNSTABLE();
+
         // Test with SCSI boot VHDs.
         {
             auto settings = GetDefaultSessionSettings(L"pmem-vhd-test");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change disables the PmemVhds testcase since it's failing and blocking pull request. 

I'm investigating the test failure in https://github.com/microsoft/WSL/pull/14244 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
