### PR TITLE
Fix AttachDisk LUN counter leak on AddVhd failure

### DIFF
--- a/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
@@ -193,8 +193,8 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLA_SESSION_SETTINGS* Settings)
     hcs::Scsi scsiController{};
     if (!FeatureEnabled(WslaFeatureFlagsPmemVhds))
     {
-        auto attachScsiDisk = [&](PCWSTR path, ULONG& lun) {
-            lun = m_nextLun++;
+        auto attachScsiDisk = [&](PCWSTR path) {
+            const ULONG lun = AllocateLun();
             hcs::Attachment disk{};
             disk.Type = hcs::AttachmentType::VirtualDisk;
             disk.Path = path;
@@ -205,12 +205,10 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLA_SESSION_SETTINGS* Settings)
             scsiController.Attachments[std::to_string(lun)] = std::move(disk);
             DiskInfo diskInfo{path};
             m_attachedDisks.emplace(lun, std::move(diskInfo));
-            return lun;
         };
 
-        ULONG rootLun, modulesLun;
-        attachScsiDisk(rootVhdPath.c_str(), rootLun);
-        attachScsiDisk(kernelModulesPath.c_str(), modulesLun);
+        attachScsiDisk(rootVhdPath.c_str());
+        attachScsiDisk(kernelModulesPath.c_str());
     }
     else
     {
@@ -466,6 +464,16 @@ try
     std::lock_guard lock(m_lock);
 
     DiskInfo disk{Path};
+    const ULONG lun = AllocateLun();
+
+    auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+        if (disk.AccessGranted)
+        {
+            hcs::RevokeVmAccess(m_vmIdString.c_str(), disk.Path.c_str());
+        }
+
+        FreeLun(lun);
+    });
 
     auto grantDiskAccess = [&]() {
         auto runAsUser = wil::impersonate_token(m_userToken.get());
@@ -477,8 +485,6 @@ try
     {
         grantDiskAccess();
     }
-
-    const ULONG lun = m_nextLun;
 
     auto result = wil::ResultFromException([&]() { hcs::AddVhd(m_computeSystem.get(), Path, lun, ReadOnly); });
 
@@ -494,10 +500,9 @@ try
 
     m_attachedDisks.emplace(lun, std::move(disk));
 
-    // Only increment after AddVhd succeeds to avoid leaking LUN numbers on failure.
-    m_nextLun++;
-    *Lun = lun;
+    cleanup.release();
 
+    *Lun = lun;
     return S_OK;
 }
 CATCH_RETURN()
@@ -516,6 +521,8 @@ try
     {
         hcs::RevokeVmAccess(m_vmIdString.c_str(), it->second.Path.c_str());
     }
+
+    FreeLun(Lun);
 
     m_attachedDisks.erase(it);
 
@@ -783,4 +790,26 @@ void HcsVirtualMachine::WriteCrashLog(const std::wstring& crashLog)
 
     THROW_IF_WIN32_BOOL_FALSE(SetFileAttributesW(filePath.c_str(), FILE_ATTRIBUTE_TEMPORARY));
     m_crashLogCaptured = true;
+}
+
+ULONG HcsVirtualMachine::AllocateLun()
+{
+    for (ULONG index = 0; index < gsl::narrow_cast<ULONG>(m_lunBitmap.size()); index += 1)
+    {
+        if (!m_lunBitmap[index])
+        {
+            m_lunBitmap[index] = true;
+            return index;
+        }
+    }
+
+    THROW_HR(WSL_E_TOO_MANY_DISKS_ATTACHED);
+}
+
+void HcsVirtualMachine::FreeLun(ULONG Lun)
+{
+    THROW_HR_IF(E_BOUNDS, Lun >= m_lunBitmap.size());
+    THROW_HR_IF(E_INVALIDARG, !m_lunBitmap[Lun]);
+
+    m_lunBitmap[Lun] = false;
 }

--- a/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
@@ -464,7 +464,7 @@ try
     std::lock_guard lock(m_lock);
 
     DiskInfo disk{Path};
-    const ULONG lun = AllocateLun();
+    const ULONG allocatedLun = AllocateLun();
 
     auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
         if (disk.AccessGranted)
@@ -472,7 +472,7 @@ try
             hcs::RevokeVmAccess(m_vmIdString.c_str(), disk.Path.c_str());
         }
 
-        FreeLun(lun);
+        FreeLun(allocatedLun);
     });
 
     auto grantDiskAccess = [&]() {
@@ -486,23 +486,23 @@ try
         grantDiskAccess();
     }
 
-    auto result = wil::ResultFromException([&]() { hcs::AddVhd(m_computeSystem.get(), Path, lun, ReadOnly); });
+    auto result = wil::ResultFromException([&]() { hcs::AddVhd(m_computeSystem.get(), Path, allocatedLun, ReadOnly); });
 
     if (result == HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) && !disk.AccessGranted)
     {
         grantDiskAccess();
-        hcs::AddVhd(m_computeSystem.get(), Path, lun, ReadOnly);
+        hcs::AddVhd(m_computeSystem.get(), Path, allocatedLun, ReadOnly);
     }
     else
     {
         THROW_IF_FAILED(result);
     }
 
-    m_attachedDisks.emplace(lun, std::move(disk));
+    m_attachedDisks.emplace(allocatedLun, std::move(disk));
 
     cleanup.release();
 
-    *Lun = lun;
+    *Lun = allocatedLun;
     return S_OK;
 }
 CATCH_RETURN()
@@ -517,12 +517,12 @@ try
 
     hcs::RemoveScsiDisk(m_computeSystem.get(), Lun);
 
+    FreeLun(Lun);
+
     if (it->second.AccessGranted)
     {
         hcs::RevokeVmAccess(m_vmIdString.c_str(), it->second.Path.c_str());
     }
-
-    FreeLun(Lun);
 
     m_attachedDisks.erase(it);
 

--- a/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
@@ -478,21 +478,25 @@ try
         grantDiskAccess();
     }
 
-    *Lun = m_nextLun++;
+    const ULONG lun = m_nextLun;
 
-    auto result = wil::ResultFromException([&]() { hcs::AddVhd(m_computeSystem.get(), Path, *Lun, ReadOnly); });
+    auto result = wil::ResultFromException([&]() { hcs::AddVhd(m_computeSystem.get(), Path, lun, ReadOnly); });
 
     if (result == HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) && !disk.AccessGranted)
     {
         grantDiskAccess();
-        hcs::AddVhd(m_computeSystem.get(), Path, *Lun, ReadOnly);
+        hcs::AddVhd(m_computeSystem.get(), Path, lun, ReadOnly);
     }
     else
     {
         THROW_IF_FAILED(result);
     }
 
-    m_attachedDisks.emplace(*Lun, std::move(disk));
+    m_attachedDisks.emplace(lun, std::move(disk));
+
+    // Only increment after AddVhd succeeds to avoid leaking LUN numbers on failure.
+    m_nextLun++;
+    *Lun = lun;
 
     return S_OK;
 }

--- a/src/windows/wslaservice/exe/HcsVirtualMachine.h
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.h
@@ -24,6 +24,8 @@ Abstract:
 #include <map>
 #include <thread>
 
+#define MAX_VHD_COUNT 254
+
 namespace wsl::windows::service::wsla {
 
 class HcsVirtualMachine
@@ -46,7 +48,6 @@ private:
     struct DiskInfo
     {
         std::wstring Path;
-        std::string Device;
         bool AccessGranted = false;
     };
 
@@ -60,6 +61,9 @@ private:
     void EnforceVmSavedStateFileLimit();
     void WriteCrashLog(const std::wstring& crashLog);
     void CollectCrashDumps(wil::unique_socket&& listenSocket) const;
+
+    ULONG AllocateLun();
+    void FreeLun(ULONG Lun);
 
     std::recursive_mutex m_lock;
 
@@ -82,7 +86,7 @@ private:
     wil::unique_event m_vmExitEvent{wil::EventOptions::ManualReset};
 
     std::map<ULONG, DiskInfo> m_attachedDisks;
-    ULONG m_nextLun = 0;
+    std::bitset<MAX_VHD_COUNT> m_lunBitmap;
 
     // Shares: key is ShareId, value is nullopt for Plan9 or DeviceInstanceId for VirtioFS
     std::map<GUID, std::optional<GUID>, wsl::windows::common::helpers::GuidLess> m_shares;


### PR DESCRIPTION
This PR resolves an issue where if LUN numbers would be wasted if adding the VHD to the VM fails. It also adjusts the LUN allocation logic to support reuse of LUN numbers of disks are removed from the VM.