### PR TITLE
Fix data race on IORelay::m_exit between Stop() and Run() threads

### DIFF
--- a/src/windows/wslasession/IORelay.h
+++ b/src/windows/wslasession/IORelay.h
@@ -39,7 +39,7 @@ private:
     std::vector<std::unique_ptr<common::relay::OverlappedIOHandle>> m_pendingHandles;
 
     std::thread m_thread;
-    bool m_exit = false;
+    std::atomic<bool> m_exit = false;
 };
 
 } // namespace wsl::windows::service::wsla


### PR DESCRIPTION
m_exit is written by Stop() (called from any thread) and read by Run() (on the IO relay thread) without synchronization. This is a data race under the C++ memory model. Change m_exit to std::atomic<bool>.
