### PR TITLE
wslc bug: container retry path discards newly-created container

### DIFF
--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -84,8 +84,7 @@ static wsl::windows::common::RunningWSLAContainer CreateInternal(
         PrintMessage(L"Image '%hs' not found, pulling", stderr, image.c_str());
         ImageService imageService;
         imageService.Pull(session, image, callback);
-        auto [retryResult, _] = containerLauncher.CreateNoThrow(*session.Get());
-        result = retryResult;
+        std::tie(result, runningContainer) = containerLauncher.CreateNoThrow(*session.Get());
     }
 
     THROW_IF_FAILED(result);

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -84,7 +84,7 @@ static wsl::windows::common::RunningWSLAContainer CreateInternal(
         PrintMessage(L"Image '%hs' not found, pulling", stderr, image.c_str());
         ImageService imageService;
         imageService.Pull(session, image, callback);
-        std::tie(result, runningContainer) = containerLauncher.CreateNoThrow(*session.Get());
+        return containerLauncher.Create(*session.Get());
     }
 
     THROW_IF_FAILED(result);


### PR DESCRIPTION
When CreateNoThrow fails with WSLA_E_IMAGE_NOT_FOUND and the image is pulled and retried, the retry result was bound to a scoped variable '_' that was destroyed at the end of the if-block. The outer 'runningContainer' remained empty from the first failed call, causing a dereference of an empty optional.