### PR TITLE
Fix WSLASession.exe crash if the WSLAVirtualMachine throws an exception in its constructor

### DIFF
--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -95,6 +95,7 @@ try
 
     // Create the VM.
     m_virtualMachine.emplace(Vm, Settings);
+    m_virtualMachine->Initialize();
 
     // Make sure that everything is destroyed correctly if an exception is thrown.
     auto errorCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_FAILED(Terminate()); });

--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -95,10 +95,11 @@ try
 
     // Create the VM.
     m_virtualMachine.emplace(Vm, Settings);
-    m_virtualMachine->Initialize();
 
     // Make sure that everything is destroyed correctly if an exception is thrown.
     auto errorCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_FAILED(Terminate()); });
+
+    m_virtualMachine->Initialize();
 
     // Configure storage.
     ConfigureStorage(*Settings, tokenInfo->User.Sid);

--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -39,6 +39,11 @@ WSLAVirtualMachine::WSLAVirtualMachine(_In_ IWSLAVirtualMachine* Vm, _In_ const 
     m_bootTimeoutMs(Settings->BootTimeoutMs),
     m_rootVhdType(Settings->RootVhdTypeOverride ? Settings->RootVhdTypeOverride : "ext4")
 {
+    // N.B. The constructor should not run any operation that could throw, so the destructor runs on failure.
+}
+
+void WSLAVirtualMachine::Initialize()
+{
     THROW_IF_FAILED(m_vm->GetId(&m_vmId));
 
     // Establish a socket channel with mini_init in the VM.

--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -39,7 +39,7 @@ WSLAVirtualMachine::WSLAVirtualMachine(_In_ IWSLAVirtualMachine* Vm, _In_ const 
     m_bootTimeoutMs(Settings->BootTimeoutMs),
     m_rootVhdType(Settings->RootVhdTypeOverride ? Settings->RootVhdTypeOverride : "ext4")
 {
-    // N.B. The constructor should not run any operation that could throw, so the destructor runs on failure.
+    // N.B. The constructor should not run any operation that could throw, so the destructor runs even if the VM fails to boot.
 }
 
 void WSLAVirtualMachine::Initialize()

--- a/src/windows/wslasession/WSLAVirtualMachine.h
+++ b/src/windows/wslasession/WSLAVirtualMachine.h
@@ -57,6 +57,8 @@ public:
     WSLAVirtualMachine(_In_ IWSLAVirtualMachine* Vm, _In_ const WSLA_SESSION_INIT_SETTINGS* Settings);
     ~WSLAVirtualMachine();
 
+    void Initialize();
+
     void MapPort(_In_ int Family, _In_ short WindowsPort, _In_ short LinuxPort);
     void UnmapPort(_In_ int Family, _In_ short WindowsPort, _In_ short LinuxPort);
     void Unmount(_In_ const char* Path);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a crash in wslasession.exe. If the somethings goes wrong in the boot process, WSLAVirtualMachine can throw an exception in its constructor, which causes the object to be destroyed without running its destructor, which causes a crash because the process exit thread isn't properly joined. 

This change solves this by moving all the logic into a separate method, similarly to what we do for other classes

After this change, the pmem tests fails with E_FAIL, which is the expected behavior for a mount failure.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
