### PR TITLE
Update CMakeLists to auto add cpp and h files

### DIFF
--- a/src/windows/wslc/CMakeLists.txt
+++ b/src/windows/wslc/CMakeLists.txt
@@ -6,49 +6,20 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks
 )
 
-set(HEADERS
-    core/Exceptions.h
-    core/EnumVariantMap.h
-    arguments/ArgumentDefinitions.h
-    arguments/ArgumentTypes.h
-    arguments/Argument.h
-    arguments/ArgumentParser.h
-    core/Command.h
-    core/CLIExecutionContext.h
-    core/ExecutionContextData.h
-    core/Invocation.h
-    core/TablePrinter.h
-    commands/RootCommand.h
-    commands/ContainerCommand.h
-    commands/DiagCommand.h
-    services/ConsoleService.h
-    services/ContainerModel.h
-    services/ContainerService.h
-    services/ImageService.h
-    services/SessionModel.h
-    services/SessionService.h
-    tasks/Task.h
-    tasks/DiagTasks.h
-    tasks/ContainerTasks.h
+file(GLOB_RECURSE HEADERS CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/arguments/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/commands/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/tasks/*.h
 )
 
-set(SOURCES
-    core/Command.cpp
-    core/Main.cpp
-    arguments/Argument.cpp
-    arguments/ArgumentParser.cpp
-    commands/RootCommand.cpp
-    commands/ContainerCommand.cpp
-    commands/ContainerListCommand.cpp
-    commands/DiagCommand.cpp
-    commands/DiagListCommand.cpp
-    services/ConsoleService.cpp
-    services/ContainerService.cpp
-    services/ImageService.cpp
-    services/SessionModel.cpp
-    services/SessionService.cpp
-    tasks/DiagTasks.cpp
-    tasks/ContainerTasks.cpp
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/arguments/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/commands/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tasks/*.cpp
 )
 
 # Object library for WSLC components.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## 🦞 Summary of the Pull Request
- The change replaces the hardcoded source/header file lists in CMakeLists.txt with scoped recursive globs so new .cpp and .h files in those folders are picked up automatically during reconfigure.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
