### PR TITLE
Fix print-fatal-signals being immediately disabled after enabling

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -914,6 +914,7 @@ int WSLAEntryPoint(int Argc, char* Argv[])
     //
     // Enable dump collection when processes crash.
     //
+
     WSLAEnableCrashDumpCollection();
 
     //
@@ -921,11 +922,6 @@ int WSLAEntryPoint(int Argc, char* Argv[])
     //
 
     if (WriteToFile("/proc/sys/kernel/print-fatal-signals", "1\n") < 0)
-    {
-        return -1;
-    }
-
-    if (WriteToFile("/proc/sys/kernel/print-fatal-signals", "0\n") < 0)
     {
         return -1;
     }


### PR DESCRIPTION
The code wrote '1' to enable fatal signal logging, then immediately wrote '0' to the same sysctl, disabling it. Remove the second write so fatal signal logging actually stays enabled as intended.

