### PR TITLE
Add support for container DNS options (DnsOptions)

### DIFF
--- a/src/windows/common/WSLAContainerLauncher.cpp
+++ b/src/windows/common/WSLAContainerLauncher.cpp
@@ -131,6 +131,11 @@ void WSLAContainerLauncher::SetDnsSearchDomains(std::vector<std::string>&& DnsSe
     m_dnsSearchDomains = std::move(DnsSearchDomains);
 }
 
+void WSLAContainerLauncher::SetDnsOptions(std::vector<std::string>&& DnsOptions)
+{
+    m_dnsOptions = std::move(DnsOptions);
+}
+
 void wsl::windows::common::WSLAContainerLauncher::AddVolume(const std::wstring& HostPath, const std::string& ContainerPath, bool ReadOnly)
 {
     // Store a copy of the path strings to the launcher to ensure the pointers in WSLA_VOLUME remain valid.
@@ -231,6 +236,17 @@ std::pair<HRESULT, std::optional<RunningWSLAContainer>> WSLAContainerLauncher::C
     if (!dnsSearchDomainsStorage.empty())
     {
         options.DnsSearchDomains = {dnsSearchDomainsStorage.data(), static_cast<ULONG>(dnsSearchDomainsStorage.size())};
+    }
+
+    std::vector<const char*> dnsOptionsStorage;
+    for (const auto& e : m_dnsOptions)
+    {
+        dnsOptionsStorage.push_back(e.c_str());
+    }
+
+    if (!dnsOptionsStorage.empty())
+    {
+        options.DnsOptions = {dnsOptionsStorage.data(), static_cast<ULONG>(dnsOptionsStorage.size())};
     }
 
     if (!m_workingDirectory.empty())

--- a/src/windows/common/WSLAContainerLauncher.h
+++ b/src/windows/common/WSLAContainerLauncher.h
@@ -74,6 +74,7 @@ public:
     void SetDomainname(std::string&& Domainame);
     void SetDnsServers(std::vector<std::string>&& DnsServers);
     void SetDnsSearchDomains(std::vector<std::string>&& DnsSearchDomains);
+    void SetDnsOptions(std::vector<std::string>&& DnsOptions);
 
     using WSLAProcessLauncher::SetUser;
     using WSLAProcessLauncher::SetWorkingDirectory;
@@ -93,6 +94,7 @@ private:
     std::string m_domainname;
     std::vector<std::string> m_dnsServers;
     std::vector<std::string> m_dnsSearchDomains;
+    std::vector<std::string> m_dnsOptions;
     std::vector<WSLA_LABEL> m_labels;
     std::deque<std::string> m_labelKeys;
     std::deque<std::string> m_labelValues;

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -74,8 +74,9 @@ struct HostConfig
     bool Init{};
     std::optional<std::vector<std::string>> Dns;
     std::optional<std::vector<std::string>> DnsSearch;
+    std::optional<std::vector<std::string>> DnsOptions;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(HostConfig, Mounts, PortBindings, NetworkMode, Init, Dns, DnsSearch);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(HostConfig, Mounts, PortBindings, NetworkMode, Init, Dns, DnsSearch, DnsOptions);
 };
 
 struct CreateContainer

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -229,6 +229,7 @@ struct WSLA_CONTAINER_OPTIONS
 
     WSLAStringArray DnsServers;
     WSLAStringArray DnsSearchDomains;
+    WSLAStringArray DnsOptions;
 
     ULONGLONG ShmSize;
     struct WSLA_CONTAINER_NETWORK ContainerNetwork;

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -836,6 +836,17 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Create(
         request.HostConfig.DnsSearch = StringArrayToVector(containerOptions.DnsSearchDomains);
     }
 
+    if (containerOptions.DnsOptions.Count > 0)
+    {
+        THROW_HR_IF_NULL_MSG(
+            E_INVALIDARG,
+            containerOptions.DnsOptions.Values,
+            "DnsOptions.Values is null with Count=%lu",
+            containerOptions.DnsOptions.Count);
+
+        request.HostConfig.DnsOptions = StringArrayToVector(containerOptions.DnsOptions);
+    }
+
     if (containerOptions.InitProcessOptions.User != nullptr)
     {
         request.User = containerOptions.InitProcessOptions.User;

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2131,6 +2131,30 @@ class WSLATests
             ValidateProcessOutput(process, {}, 0);
         }
 
+        // Validate that custom DNS options are correctly wired.
+        {
+            WSLAContainerLauncher launcher(
+                "debian:latest", "test-dns-options", {"/bin/grep", "-iF", "timeout:1", "/etc/resolv.conf"});
+
+            launcher.SetDnsOptions({"timeout:1"});
+
+            auto container = launcher.Launch(*m_defaultSession);
+            auto process = container.GetInitProcess();
+            ValidateProcessOutput(process, {}, 0);
+        }
+
+        // Validate that multiple DNS options are correctly wired.
+        {
+            WSLAContainerLauncher launcher(
+                "debian:latest", "test-dns-options-multiple", {"/bin/grep", "-iF", "timeout:2", "/etc/resolv.conf"});
+
+            launcher.SetDnsOptions({"timeout:1", "timeout:2"});
+
+            auto container = launcher.Launch(*m_defaultSession);
+            auto process = container.GetInitProcess();
+            ValidateProcessOutput(process, {}, 0);
+        }
+
         // Validate that the username is correctly wired.
         {
             WSLAContainerLauncher launcher("debian:latest", "test-username", {"whoami"});


### PR DESCRIPTION

## Summary of the Pull Request
Add support for configuring DNS options in the container create flow by wiring DnsOptions through container_options to HostConfig.DnsOptions.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
This change adds support for container DNS options by wiring DnsOptions from container_options to HostConfig.DnsOptions in the Docker create request. DNS options are only set when explicitly provided, preserving Docker’s default behavior otherwise.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
Validated by creating containers with and without DNS options configured and verifying the expected entries in /etc/resolv.conf. Confirmed that when no DNS options are provided, the container uses Docker’s default DNS behavior.
