### PR TITLE
Fix ContainerTrackingReference move constructor double-unregister

### DIFF
--- a/src/windows/wslasession/ContainerEventTracker.cpp
+++ b/src/windows/wslasession/ContainerEventTracker.cpp
@@ -48,6 +48,13 @@ void ContainerEventTracker::ContainerTrackingReference::Reset()
     }
 }
 
+ContainerEventTracker::ContainerTrackingReference::ContainerTrackingReference(ContainerTrackingReference&& other) noexcept :
+    m_id(other.m_id), m_tracker(other.m_tracker)
+{
+    other.m_tracker = nullptr;
+    other.m_id = {};
+}
+
 ContainerEventTracker::ContainerTrackingReference::~ContainerTrackingReference()
 {
     Reset();

--- a/src/windows/wslasession/ContainerEventTracker.h
+++ b/src/windows/wslasession/ContainerEventTracker.h
@@ -43,7 +43,7 @@ public:
 
         ContainerTrackingReference() = default;
         ContainerTrackingReference(ContainerEventTracker* tracker, size_t id);
-        ContainerTrackingReference(ContainerTrackingReference&&) = default;
+        ContainerTrackingReference(ContainerTrackingReference&& other) noexcept;
         ~ContainerTrackingReference();
 
         ContainerTrackingReference& operator=(ContainerTrackingReference&&);


### PR DESCRIPTION
The defaulted move constructor copies m_tracker and m_id but doesn't null the source's m_tracker. Both the moved-from and moved-to objects then call Reset() in their destructors, causing a double-unregister from the event tracker. This can corrupt the callback vector.

The move assignment operator already handled this correctly by nulling the source. Apply the same pattern to the move constructor.
