### PR TITLE
Switch GetExitEvent COM interface to use handle marshalling and fix potential handle truncation in ClientRunningWSLAProcess.

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -645,18 +645,7 @@ try
     RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), internalType->process);
     RETURN_HR_IF_NULL(E_POINTER, exitEvent);
 
-    *exitEvent = nullptr;
-
-    ULONG ulongHandle = 0;
-
-    HRESULT hr = internalType->process->GetExitEvent(&ulongHandle);
-
-    if (SUCCEEDED_LOG(hr))
-    {
-        *exitEvent = ULongToHandle(ulongHandle);
-    }
-
-    return hr;
+    return internalType->process->GetExitEvent(exitEvent);
 }
 CATCH_RETURN();
 

--- a/src/windows/common/WSLAProcessLauncher.cpp
+++ b/src/windows/common/WSLAProcessLauncher.cpp
@@ -216,16 +216,16 @@ ClientRunningWSLAProcess::ClientRunningWSLAProcess(wil::com_ptr<IWSLAProcess>&& 
 
 wil::unique_handle ClientRunningWSLAProcess::GetStdHandle(int Index)
 {
-    wil::unique_handle handle;
-    THROW_IF_FAILED_MSG(m_process->GetStdHandle(Index, reinterpret_cast<ULONG*>(&handle)), "Failed to get handle: %i", Index);
+    ULONG handle{};
+    THROW_IF_FAILED_MSG(m_process->GetStdHandle(Index, &handle), "Failed to get handle: %i", Index);
 
-    return handle;
+    return wil::unique_handle{ULongToHandle(handle)};
 }
 
 wil::unique_event ClientRunningWSLAProcess::GetExitEvent()
 {
-    wil::unique_event event;
-    THROW_IF_FAILED(m_process->GetExitEvent(reinterpret_cast<ULONG*>(&event)));
+    wil::unique_event event{};
+    THROW_IF_FAILED(m_process->GetExitEvent(&event));
 
     return event;
 }

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -271,7 +271,7 @@ enum WSLA_PROCESS_STATE
 interface IWSLAProcess : IUnknown
 {
     HRESULT Signal([in] int Signal);
-    HRESULT GetExitEvent([out] ULONG* EventHandle);
+    HRESULT GetExitEvent([out, system_handle(sh_event)] HANDLE* EventHandle);
     HRESULT GetStdHandle([in] ULONG Index, [out] ULONG* Handle);
     HRESULT GetPid([out] int* Pid);
     HRESULT GetState([out] enum WSLA_PROCESS_STATE* State, [out] int* Code);

--- a/src/windows/wslasession/WSLAProcess.cpp
+++ b/src/windows/wslasession/WSLAProcess.cpp
@@ -31,10 +31,10 @@ try
 }
 CATCH_RETURN();
 
-HRESULT WSLAProcess::GetExitEvent(ULONG* Event)
+HRESULT WSLAProcess::GetExitEvent(HANDLE* Event)
 try
 {
-    *Event = HandleToUlong(common::wslutil::DuplicateHandleToCallingProcess(m_control->GetExitEvent().get(), SYNCHRONIZE));
+    *Event = wsl::windows::common::helpers::DuplicateHandle(m_control->GetExitEvent().get(), 0, FALSE, SYNCHRONIZE);
     return S_OK;
 }
 CATCH_RETURN();

--- a/src/windows/wslasession/WSLAProcess.cpp
+++ b/src/windows/wslasession/WSLAProcess.cpp
@@ -34,7 +34,7 @@ CATCH_RETURN();
 HRESULT WSLAProcess::GetExitEvent(HANDLE* Event)
 try
 {
-    *Event = wsl::windows::common::helpers::DuplicateHandle(m_control->GetExitEvent().get(), 0, FALSE, SYNCHRONIZE);
+    *Event = wsl::windows::common::helpers::DuplicateHandle(m_control->GetExitEvent().get(), SYNCHRONIZE, FALSE, 0);
     return S_OK;
 }
 CATCH_RETURN();

--- a/src/windows/wslasession/WSLAProcess.h
+++ b/src/windows/wslasession/WSLAProcess.h
@@ -30,7 +30,7 @@ public:
     WSLAProcess& operator=(const WSLAProcess&) = delete;
 
     IFACEMETHOD(Signal)(_In_ int Signal) override;
-    IFACEMETHOD(GetExitEvent)(_Out_ ULONG* Event) override;
+    IFACEMETHOD(GetExitEvent)(_Out_ HANDLE* Event) override;
     IFACEMETHOD(GetStdHandle)(_In_ ULONG Index, _Out_ ULONG* Handle) override;
     IFACEMETHOD(GetPid)(_Out_ int* Pid) override;
     IFACEMETHOD(GetState)(_Out_ WSLA_PROCESS_STATE* State, _Out_ int* Code) override;


### PR DESCRIPTION
This change updates the GetExitEvent API to use system handle marshalling since the handle type is always known (an event handle). It also resolves a minor potential issue with casting HANDLE values to a ULONG in the GetStdHandle method.