### PR TITLE
Fix container stop/kill timeout: ULONG(-1) wraps to UINT_MAX instead of meaning 'no timeout'

### DIFF
--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -39,10 +39,10 @@ struct CreateContainerResult
 
 struct StopContainerOptions
 {
-    static constexpr ULONG DefaultTimeout = -1;
+    static constexpr LONGLONG DefaultTimeout = -1;
 
     int Signal = WSLASignalSIGTERM;
-    ULONG Timeout = DefaultTimeout;
+    LONGLONG Timeout = DefaultTimeout;
 };
 
 struct KillContainerOptions

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -92,7 +92,7 @@ static wsl::windows::common::RunningWSLAContainer CreateInternal(
     return std::move(*runningContainer);
 }
 
-static void StopInternal(IWSLAContainer& container, int signal = WSLASignalNone, ULONG timeout = -1)
+static void StopInternal(IWSLAContainer& container, int signal = WSLASignalNone, LONGLONG timeout = -1)
 {
     THROW_IF_FAILED(container.Stop(static_cast<WSLASignal>(signal), timeout)); // TODO: Error message
 }


### PR DESCRIPTION
StopContainerOptions::DefaultTimeout was 'static constexpr ULONG = -1', which wraps to 4294967295. This value flows through StopInternal() to the COM Stop(WSLASignal, LONGLONG) method, where it becomes positive LONGLONG 4294967295 so Docker receives a 136-year timeout instead of using its own default timeout.

This breaks 'wslc kill' (which should send SIGKILL with Docker's default short timeout) and force-delete (same pattern). The container never terminates promptly.

Fix: change DefaultTimeout, Timeout, and StopInternal parameter from ULONG to LONGLONG so that -1 remains negative and correctly triggers the 'no timeout' code path.