### PR TITLE
Use latest version of Visual Studio if multiple versions are present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ endif()
 # N.B. The version is set to VS2022 to ensure local runs match pipeline behavior
 # Require that Clang be installed in the product to potentially de-deduplicate
 execute_process(
-    COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -version "[17.0,19.0)" -products * -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath -prerelease
+    COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -prerelease -latest -version "[17.0,19.0)" -products * -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
     OUTPUT_VARIABLE VS_INSTALL_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY


### PR DESCRIPTION
#14160 broke cmake files generation if multiple versions of Visual Studio are installed. This change adds the "-latest" flag so the most recent version is used.