### PR TITLE
Revert "Enable detection cmake script for Visual Studio 2026 and pre-release versions of Visual Studio"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ endif()
 # N.B. The version is set to VS2022 to ensure local runs match pipeline behavior
 # Require that Clang be installed in the product to potentially de-deduplicate
 execute_process(
-    COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -version "[17.0,19.0)" -products * -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath -prerelease
+    COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -version "[17.0,18.0)" -products * -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
     OUTPUT_VARIABLE VS_INSTALL_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY


### PR DESCRIPTION
Reverts microsoft/WSL#14160

This causes issues when multiple versions of Visual Studio are installed.