### PR TITLE
Mask NetworkManager-wait-online.service during boot

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -33,6 +33,7 @@ DISCOURAGED_SYSTEM_UNITS = ['systemd-resolved.service',
                             'systemd-tmpfiles-setup-dev.service',
                             'tmp.mount',
                             'NetworkManager.service',
+                            'NetworkManager-wait-online.service',
                             'networking.service',
                             'hypervkvpd.service']
 

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -333,6 +333,9 @@ int GenerateSystemdUnits(int Argc, char** Argv)
         // That unit can cause systemd boot timeouts since WSL's network interface is unmanaged by systemd.
         THROW_LAST_ERROR_IF(symlink("/dev/null", std::format("{}/systemd-networkd-wait-online.service", installPath).c_str()) < 0);
 
+        // Mask NetworkManager-wait-online.service for the same reason, as it causes timeouts on distros using NetworkManager.
+        THROW_LAST_ERROR_IF(symlink("/dev/null", std::format("{}/NetworkManager-wait-online.service", installPath).c_str()) < 0);
+
         // Only create the wslg unit if both enabled in wsl.conf, and if the wslg folder actually exists.
         if (enableGuiApps && access("/mnt/wslg/runtime-dir", F_OK) == 0)
         {

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -217,6 +217,12 @@ class UnitTests
             LxsstuLaunchWslAndCaptureOutput(L"systemctl status systemd-networkd-wait-online.service  | grep -iF Loaded:");
 
         VERIFY_ARE_EQUAL(out, L"     Loaded: masked (Reason: Unit systemd-networkd-wait-online.service is masked.)\n");
+
+        // Validate that NetworkManager-wait-online.service is masked.
+        auto [outNm, _nm] =
+            LxsstuLaunchWslAndCaptureOutput(L"systemctl status NetworkManager-wait-online.service | grep -iF Loaded:");
+
+        VERIFY_ARE_EQUAL(outNm, L"     Loaded: masked (Reason: Unit NetworkManager-wait-online.service is masked.)\n");
     }
 
     TEST_METHOD(SystemdUser)

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -219,8 +219,8 @@ class UnitTests
         VERIFY_ARE_EQUAL(out, L"     Loaded: masked (Reason: Unit systemd-networkd-wait-online.service is masked.)\n");
 
         // Validate that NetworkManager-wait-online.service is masked.
-        auto [outNm, _nm] =
-            LxsstuLaunchWslAndCaptureOutput(L"systemctl status NetworkManager-wait-online.service | grep -iF Loaded:");
+        auto [outNm, _] =
+            LxsstuLaunchWslAndCaptureOutput(L"systemctl status NetworkManager-wait-online.service  | grep -iF Loaded:");
 
         VERIFY_ARE_EQUAL(outNm, L"     Loaded: masked (Reason: Unit NetworkManager-wait-online.service is masked.)\n");
     }

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -219,7 +219,7 @@ class UnitTests
         VERIFY_ARE_EQUAL(out, L"     Loaded: masked (Reason: Unit systemd-networkd-wait-online.service is masked.)\n");
 
         // Validate that NetworkManager-wait-online.service is masked.
-        auto [outNm, _] =
+        auto [outNm, __] =
             LxsstuLaunchWslAndCaptureOutput(L"systemctl status NetworkManager-wait-online.service  | grep -iF Loaded:");
 
         VERIFY_ARE_EQUAL(outNm, L"     Loaded: masked (Reason: Unit NetworkManager-wait-online.service is masked.)\n");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes #13772. Similar to PR #13611, this masks NetworkManager-wait-online.service to prevent 60-second timeouts during boot since WSL interfaces are unmanaged by NetworkManager. Also added the service to the discouraged units list in validate-modern.py and added a unit test.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/13772
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
