### PR TITLE
cleanup: minor DuplicateHandle helper hygene

### DIFF
--- a/src/windows/common/Dmesg.cpp
+++ b/src/windows/common/Dmesg.cpp
@@ -18,7 +18,7 @@ Abstract:
 DmesgCollector::DmesgCollector(GUID VmId, const wil::unique_event& ExitEvent, bool EnableTelemetry, bool EnableDebugConsole, const std::wstring& Com1PipeName) :
     m_com1PipeName(Com1PipeName), m_runtimeId(VmId), m_debugConsole(EnableDebugConsole), m_telemetry(EnableTelemetry)
 {
-    m_exitEvent.reset(wsl::windows::common::helpers::DuplicateHandle(ExitEvent.get()));
+    m_exitEvent.reset(wsl::windows::common::wslutil::DuplicateHandle(ExitEvent.get()));
     m_overlappedEvent.create(wil::EventOptions::ManualReset);
     m_overlapped.hEvent = m_overlappedEvent.get();
     m_threadExit.create(wil::EventOptions::ManualReset);

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -266,16 +266,6 @@ wsl::windows::common::helpers::unique_proc_attribute_list wsl::windows::common::
     return List;
 }
 
-[[nodiscard]] HANDLE wsl::windows::common::helpers::DuplicateHandle(_In_ HANDLE Handle, _In_ DWORD DesiredAccess, _In_ BOOL InheritHandle, _In_ DWORD Options)
-{
-    // N.B. This function does not return a wil::unique_handle so that the caller
-    //      can pick its own desired type (e.g. wil::unique_event).
-    HANDLE Result;
-    THROW_IF_WIN32_BOOL_FALSE(::DuplicateHandle(GetCurrentProcess(), Handle, GetCurrentProcess(), &Result, DesiredAccess, InheritHandle, Options));
-
-    return Result;
-}
-
 std::vector<gsl::byte> wsl::windows::common::helpers::GenerateConfigurationMessage(
     _In_ const std::wstring& DistributionName,
     _In_ ULONG FixedDrivesBitmap,

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -118,8 +118,6 @@ void CreateConsole(_In_ LPCWSTR ConsoleTitle = nullptr);
 
 unique_proc_attribute_list CreateProcThreadAttributeList(_In_ DWORD AttributeCount);
 
-[[nodiscard]] HANDLE DuplicateHandle(_In_ HANDLE Handle, _In_ DWORD DesiredAccess = 0, _In_ BOOL InheritHandle = FALSE, _In_ DWORD Options = DUPLICATE_SAME_ACCESS);
-
 std::vector<gsl::byte> GenerateConfigurationMessage(
     _In_ const std::wstring& DistributionName,
     _In_ ULONG FixedDrivesBitmap = 0,

--- a/src/windows/common/svccomm.cpp
+++ b/src/windows/common/svccomm.cpp
@@ -194,7 +194,7 @@ void SpawnWslHost(_In_ HANDLE ServerPort, _In_ const GUID& DistroId, _In_opt_ LP
 {
     wsl::windows::common::helpers::SetHandleInheritable(ServerPort);
     const auto RegistrationComplete = wil::unique_event(wil::EventOptions::None);
-    const wil::unique_handle ParentProcess{wsl::windows::common::wslutil::DuplicateHandle(GetCurrentProcess(), 0, TRUE)};
+    const wil::unique_handle ParentProcess{wsl::windows::common::wslutil::DuplicateHandle(GetCurrentProcess(), std::nullopt, TRUE)};
     THROW_LAST_ERROR_IF(!ParentProcess);
 
     const wil::unique_handle Process{wsl::windows::common::helpers::LaunchInteropServer(

--- a/src/windows/common/svccomm.cpp
+++ b/src/windows/common/svccomm.cpp
@@ -176,7 +176,7 @@ void InitializeInterop(_In_ HANDLE ServerPort, _In_ const GUID& DistroId)
     // Create a thread to handle interop requests.
     //
 
-    wil::unique_handle WorkerThreadSeverPort{wsl::windows::common::helpers::DuplicateHandle(ServerPort)};
+    wil::unique_handle WorkerThreadSeverPort{wsl::windows::common::wslutil::DuplicateHandle(ServerPort)};
     std::thread([WorkerThreadSeverPort = std::move(WorkerThreadSeverPort)]() mutable {
         wsl::windows::common::wslutil::SetThreadDescription(L"Interop");
         wsl::windows::common::interop::WorkerThread(std::move(WorkerThreadSeverPort));
@@ -194,7 +194,7 @@ void SpawnWslHost(_In_ HANDLE ServerPort, _In_ const GUID& DistroId, _In_opt_ LP
 {
     wsl::windows::common::helpers::SetHandleInheritable(ServerPort);
     const auto RegistrationComplete = wil::unique_event(wil::EventOptions::None);
-    const wil::unique_handle ParentProcess{wsl::windows::common::helpers::DuplicateHandle(GetCurrentProcess(), 0, TRUE)};
+    const wil::unique_handle ParentProcess{wsl::windows::common::wslutil::DuplicateHandle(GetCurrentProcess(), 0, TRUE)};
     THROW_LAST_ERROR_IF(!ParentProcess);
 
     const wil::unique_handle Process{wsl::windows::common::helpers::LaunchInteropServer(

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -574,15 +574,36 @@ std::wstring wsl::windows::common::wslutil::DownloadFile(std::wstring_view Url, 
     return file.Path().c_str();
 }
 
-[[nodiscard]] HANDLE wsl::windows::common::wslutil::DuplicateHandleFromCallingProcess(_In_ HANDLE handleInTarget)
+[[nodiscard]] HANDLE wsl::windows::common::wslutil::DuplicateHandle(_In_ HANDLE Handle, _In_ std::optional<DWORD> DesiredAccess, _In_ BOOL InheritHandle)
+{
+    HANDLE newHandle;
+    THROW_IF_WIN32_BOOL_FALSE(::DuplicateHandle(
+        GetCurrentProcess(), Handle, GetCurrentProcess(), &newHandle, DesiredAccess.value_or(0), InheritHandle, DesiredAccess.has_value() ? 0 : DUPLICATE_SAME_ACCESS));
+
+    return newHandle;
+}
+
+[[nodiscard]] HANDLE wsl::windows::common::wslutil::DuplicateHandleFromCallingProcess(_In_ HANDLE Handle)
 {
     const wil::unique_handle caller = OpenCallingProcess(PROCESS_DUP_HANDLE);
     THROW_LAST_ERROR_IF(!caller);
 
-    HANDLE handle;
-    THROW_IF_WIN32_BOOL_FALSE(DuplicateHandle(caller.get(), handleInTarget, GetCurrentProcess(), &handle, 0, FALSE, DUPLICATE_SAME_ACCESS));
+    HANDLE newHandle;
+    THROW_IF_WIN32_BOOL_FALSE(::DuplicateHandle(caller.get(), Handle, GetCurrentProcess(), &newHandle, 0, FALSE, DUPLICATE_SAME_ACCESS));
 
-    return handle;
+    return newHandle;
+}
+
+[[nodiscard]] HANDLE wsl::windows::common::wslutil::DuplicateHandleToCallingProcess(_In_ HANDLE Handle, _In_ std::optional<DWORD> Permissions)
+{
+    const wil::unique_handle caller = OpenCallingProcess(PROCESS_DUP_HANDLE);
+    THROW_LAST_ERROR_IF(!caller);
+
+    HANDLE newHandle;
+    THROW_IF_WIN32_BOOL_FALSE(::DuplicateHandle(
+        GetCurrentProcess(), Handle, caller.get(), &newHandle, Permissions.value_or(0), FALSE, Permissions.has_value() ? 0 : DUPLICATE_SAME_ACCESS));
+
+    return newHandle;
 }
 
 void wsl::windows::common::wslutil::EnforceFileLimit(LPCWSTR Path, size_t Limit, const std::function<bool(const std::filesystem::directory_entry&)>& pred)

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -594,14 +594,14 @@ std::wstring wsl::windows::common::wslutil::DownloadFile(std::wstring_view Url, 
     return newHandle;
 }
 
-[[nodiscard]] HANDLE wsl::windows::common::wslutil::DuplicateHandleToCallingProcess(_In_ HANDLE Handle, _In_ std::optional<DWORD> Permissions)
+[[nodiscard]] HANDLE wsl::windows::common::wslutil::DuplicateHandleToCallingProcess(_In_ HANDLE Handle, _In_ std::optional<DWORD> DesiredAccess)
 {
     const wil::unique_handle caller = OpenCallingProcess(PROCESS_DUP_HANDLE);
     THROW_LAST_ERROR_IF(!caller);
 
     HANDLE newHandle;
     THROW_IF_WIN32_BOOL_FALSE(::DuplicateHandle(
-        GetCurrentProcess(), Handle, caller.get(), &newHandle, Permissions.value_or(0), FALSE, Permissions.has_value() ? 0 : DUPLICATE_SAME_ACCESS));
+        GetCurrentProcess(), Handle, caller.get(), &newHandle, DesiredAccess.value_or(0), FALSE, DesiredAccess.has_value() ? 0 : DUPLICATE_SAME_ACCESS));
 
     return newHandle;
 }

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -101,7 +101,11 @@ GUID CreateV5Uuid(const GUID& namespaceGuid, const std::span<const std::byte> na
 
 std::wstring DownloadFile(std::wstring_view Url, std::wstring Filename);
 
-[[nodiscard]] HANDLE DuplicateHandleFromCallingProcess(_In_ HANDLE handleInTarget);
+[[nodiscard]] HANDLE DuplicateHandle(_In_ HANDLE Handle, _In_ std::optional<DWORD> DesiredAccess = std::nullopt, _In_ BOOL InheritHandle = FALSE);
+
+[[nodiscard]] HANDLE DuplicateHandleFromCallingProcess(_In_ HANDLE Handle);
+
+[[nodiscard]] HANDLE DuplicateHandleToCallingProcess(_In_ HANDLE Handle, _In_ std::optional<DWORD> Permissions = {});
 
 void EnforceFileLimit(LPCWSTR Folder, size_t limit, const std::function<bool(const std::filesystem::directory_entry&)>& pred);
 

--- a/src/windows/service/exe/GuestTelemetryLogger.cpp
+++ b/src/windows/service/exe/GuestTelemetryLogger.cpp
@@ -51,7 +51,7 @@ void GuestTelemetryLogger::Start(const wil::unique_event& ExitEvent)
 
     THROW_LAST_ERROR_IF(!pipe);
 
-    wil::unique_handle exitEvent(wsl::windows::common::helpers::DuplicateHandle(ExitEvent.get()));
+    wil::unique_handle exitEvent(wsl::windows::common::wslutil::DuplicateHandle(ExitEvent.get()));
     m_thread = std::thread([Self = shared_from_this(), Pipe = std::move(pipe), ExitEvent = std::move(exitEvent)]() {
         try
         {

--- a/src/windows/service/exe/Lifetime.cpp
+++ b/src/windows/service/exe/Lifetime.cpp
@@ -132,7 +132,7 @@ void LifetimeManager::RegisterCallback(_In_ ULONG64 ClientKey, _In_ const std::f
         if (proc == client->clientProcesses.end())
         {
             OwnedProcess newProcess{};
-            newProcess.process.reset(wsl::windows::common::helpers::DuplicateHandle(ClientProcess));
+            newProcess.process.reset(wsl::windows::common::wslutil::DuplicateHandle(ClientProcess));
             newProcess.InitializeListenForTermination(s_OnClientProcessTerminated, this);
             client->clientProcesses.emplace_back(std::move(newProcess));
             client->clientProcesses.back().ListenForTermination();


### PR DESCRIPTION
There were DuplicateHandle helper functions declared in two separate source files. This change moves all the DuplicateHandle helpers into wslutil and modifies the standard helper to be more functionally similar to the existing DuplicateHandleFromCallingProcess helper.

I've also brought the DuplicateHandleToCallingProcess helper from the wsla feature branch to make the merge more clean.