### PR TITLE
WSLA: Fix container destructor iterating cleared member instead of local copy

### DIFF
--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -309,20 +309,15 @@ WSLAContainerImpl::~WSLAContainerImpl()
         TraceLoggingValue(m_id.c_str(), "Id"),
         TraceLoggingValue((int)m_state, "State"));
 
-    // Copy processes references so their callback can be removed without holding m_lock.
-    auto* initProcessControl = m_initProcessControl;
-    auto processes = m_processes;
+    // Snapshot and clear process references under the lock.
+    // Callbacks are then invoked without holding m_lock.
+    decltype(m_processes) processes;
+    decltype(m_initProcessControl) initProcessControl = nullptr;
 
-    // Remove container callback from any outstanding processes.
     {
         std::lock_guard lock(m_lock);
-
-        if (m_initProcessControl)
-        {
-            m_initProcessControl = nullptr;
-        }
-
-        m_processes.clear();
+        initProcessControl = std::exchange(m_initProcessControl, nullptr);
+        processes = std::exchange(m_processes, {});
     }
 
     if (initProcessControl)

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -330,7 +330,7 @@ WSLAContainerImpl::~WSLAContainerImpl()
         initProcessControl->OnContainerReleased();
     }
 
-    for (auto& process : m_processes)
+    for (auto& process : processes)
     {
         process->OnContainerReleased();
     }

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2993,6 +2993,29 @@ class WSLATests
         }
     }
 
+    TEST_METHOD(ExecContainerDelete)
+    {
+        WSL2_TEST_ONLY();
+        SKIP_TEST_ARM64();
+
+        WSLAContainerLauncher launcher(
+            "debian:latest", "test-exec-dtor", {"sleep", "99999"}, {}, WSLA_CONTAINER_NETWORK_TYPE::WSLA_CONTAINER_NETWORK_NONE);
+
+        auto container = launcher.Launch(*m_defaultSession);
+
+        auto process = WSLAProcessLauncher({}, {"sleep", "99999"}).Launch(container.Get());
+        auto exitEvent = process.GetExitEvent();
+
+        // Destroy the container (Stop + Delete + release COM reference).
+        VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
+        VERIFY_SUCCEEDED(container.Get().Delete());
+        container.Reset();
+
+        // The exec process exit event must be signaled within a reasonable timeout.
+        VERIFY_IS_TRUE(exitEvent.wait(30 * 1000));
+        VERIFY_ARE_EQUAL(process.GetExitCode(), 128 + WSLASignalSIGKILL);
+    }
+
     void ExpectHttpResponse(LPCWSTR Url, std::optional<int> expectedCode)
     {
         const winrt::Windows::Web::Http::Filters::HttpBaseProtocolFilter filter;


### PR DESCRIPTION
In ~WSLAContainerImpl(), m_processes is copied to a local variable 'processes' and then m_processes is cleared under the lock. However, the for loop that calls OnContainerReleased() iterated m_processes (now empty) instead of the local copy 'processes'.

This meant OnContainerReleased() was never called on exec'd processes when a container was destroyed, causing clients waiting on those processes to hang indefinitely.
