### PR TITLE
Fix race condition between OpenContainer() and ReleaseResources()

### DIFF
--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -472,14 +472,6 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
     {
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
         std::lock_guard<std::recursive_mutex> lock(m_lock);
-        if (m_state != WslaContainerStateRunning)
-        {
-            // Don't run the deletion logic if the container is already in a stopped / deleted state.
-            // This can happen if Delete() is called by the user.
-            return;
-        }
-
-        m_state = WslaContainerStateExited;
 
         // Notify all processes that the container has exited.
         // N.B. The exec callback isn't always sent to execed processes, so do this to avoid 'stuck' processes.
@@ -489,6 +481,15 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
         }
 
         m_processes.clear();
+
+        // Don't run the deletion logic if the container is already in a stopped / deleted state.
+        // This can happen if Delete() is called by the user.
+        if (m_state != WslaContainerStateRunning)
+        {
+            return;
+        }
+
+        m_state = WslaContainerStateExited;
 
         if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
         {

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -462,7 +462,7 @@ void WSLAContainerImpl::Start(WSLAContainerStartFlags Flags)
     }
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to start container '%hs'", m_id.c_str());
 
-    m_state = WslaContainerStateRunning;
+    Transition(WslaContainerStateRunning);
     cleanup.release();
 }
 
@@ -472,6 +472,8 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
     {
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
         std::lock_guard<std::recursive_mutex> lock(m_lock);
+
+        auto previousState = Transition(WslaContainerStateExited);
 
         // Notify all processes that the container has exited.
         // N.B. The exec callback isn't always sent to execed processes, so do this to avoid 'stuck' processes.
@@ -484,16 +486,12 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
 
         // Don't run the deletion logic if the container is already in a stopped / deleted state.
         // This can happen if Delete() is called by the user.
-        if (m_state != WslaContainerStateRunning)
+        if (previousState == WslaContainerStateRunning)
         {
-            return;
-        }
-
-        m_state = WslaContainerStateExited;
-
-        if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
-        {
-            Delete();
+            if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
+            {
+                Delete();
+            }
         }
     }
 
@@ -538,7 +536,7 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONGLONG TimeoutSeconds)
         }
     }
 
-    m_state = WslaContainerStateExited;
+    Transition(WslaContainerStateExited);
 
     if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
     {
@@ -566,7 +564,7 @@ void WSLAContainerImpl::Delete()
 
     ReleaseResources();
 
-    m_state = WslaContainerStateDeleted;
+    Transition(WslaContainerStateDeleted);
 }
 
 WSLA_CONTAINER_STATE WSLAContainerImpl::State() noexcept
@@ -1116,6 +1114,21 @@ void WSLAContainerImpl::ReleaseResources()
     }
 
     m_mappedPorts.clear();
+}
+
+__requires_lock_held(m_lock) WSLA_CONTAINER_STATE WSLAContainerImpl::Transition(WSLA_CONTAINER_STATE State) noexcept
+{
+    auto previousState = m_state;
+
+    WSL_LOG(
+        "ContainerStateChange",
+        TraceLoggingValue(static_cast<int>(previousState), "PreviousState"),
+        TraceLoggingValue(static_cast<int>(State), "NewState"),
+        TraceLoggingValue(m_id.c_str(), "ID"));
+
+    m_state = State;
+
+    return previousState;
 }
 
 WSLAContainer::WSLAContainer(WSLAContainerImpl* impl, std::function<void(const WSLAContainerImpl*)>&& OnDeleted) :

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -473,7 +473,7 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
         std::lock_guard<std::recursive_mutex> lock(m_lock);
 
-        auto previousState = Transition(WslaContainerStateExited);
+        auto previousState = m_state;
 
         // Notify all processes that the container has exited.
         // N.B. The exec callback isn't always sent to execed processes, so do this to avoid 'stuck' processes.
@@ -488,6 +488,7 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
         // This can happen if Delete() is called by the user.
         if (previousState == WslaContainerStateRunning)
         {
+            Transition(WslaContainerStateExited);
             if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
             {
                 Delete();
@@ -1116,19 +1117,18 @@ void WSLAContainerImpl::ReleaseResources()
     m_mappedPorts.clear();
 }
 
-__requires_lock_held(m_lock) WSLA_CONTAINER_STATE WSLAContainerImpl::Transition(WSLA_CONTAINER_STATE State) noexcept
+__requires_lock_held(m_lock) void WSLAContainerImpl::Transition(WSLA_CONTAINER_STATE State) noexcept
 {
-    auto previousState = m_state;
+    // N.B. A deleted container cannot transition back to any other state.
+    WI_ASSERT(m_state != WslaContainerStateDeleted);
 
     WSL_LOG(
         "ContainerStateChange",
-        TraceLoggingValue(static_cast<int>(previousState), "PreviousState"),
+        TraceLoggingValue(static_cast<int>(m_state), "PreviousState"),
         TraceLoggingValue(static_cast<int>(State), "NewState"),
         TraceLoggingValue(m_id.c_str(), "ID"));
 
     m_state = State;
-
-    return previousState;
 }
 
 WSLAContainer::WSLAContainer(WSLAContainerImpl* impl, std::function<void(const WSLAContainerImpl*)>&& OnDeleted) :

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -359,9 +359,13 @@ const std::string& WSLAContainerImpl::Name() const noexcept
     return m_name;
 }
 
-IWSLAContainer& WSLAContainerImpl::ComWrapper()
+void WSLAContainerImpl::CopyTo(IWSLAContainer** Container)
 {
-    return *m_comWrapper.Get();
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+
+    THROW_HR_IF_MSG(RPC_E_DISCONNECTED, m_comWrapper == nullptr, "Container '%hs' is being released", m_id.c_str());
+
+    THROW_IF_FAILED(m_comWrapper.CopyTo(Container));
 }
 
 void WSLAContainerImpl::Attach(ULONG* Stdin, ULONG* Stdout, ULONG* Stderr)
@@ -468,6 +472,13 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
     {
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
         std::lock_guard<std::recursive_mutex> lock(m_lock);
+        if (m_state != WslaContainerStateRunning)
+        {
+            // Don't run the deletion logic if the container is already in a stopped / deleted state.
+            // This can happen if Delete() is called by the user.
+            return;
+        }
+
         m_state = WslaContainerStateExited;
 
         // Notify all processes that the container has exited.
@@ -1068,6 +1079,8 @@ std::unique_ptr<RelayedProcessIO> WSLAContainerImpl::CreateRelayedProcessIO(wil:
 
 void WSLAContainerImpl::ReleaseResources()
 {
+    WSL_LOG("ReleaseContainerResources", TraceLoggingValue(m_id.c_str(), "ID"));
+
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 
     // Disconnect the COM wrapper so no new RPC calls can reach this container.

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -70,7 +70,7 @@ public:
     const std::string& Name() const noexcept;
     WSLA_CONTAINER_STATE State() noexcept;
 
-    __requires_lock_held(m_lock) WSLA_CONTAINER_STATE Transition(WSLA_CONTAINER_STATE State) noexcept;
+    __requires_lock_held(m_lock) void Transition(WSLA_CONTAINER_STATE State) noexcept;
 
     void OnProcessReleased(DockerExecProcessControl* process);
 

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -70,6 +70,9 @@ public:
     const std::string& Name() const noexcept;
     WSLA_CONTAINER_STATE State() noexcept;
 
+    __requires_lock_held(m_lock)
+    WSLA_CONTAINER_STATE Transition(WSLA_CONTAINER_STATE State) noexcept;
+
     void OnProcessReleased(DockerExecProcessControl* process);
 
     const std::string& ID() const noexcept;

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -70,8 +70,7 @@ public:
     const std::string& Name() const noexcept;
     WSLA_CONTAINER_STATE State() noexcept;
 
-    __requires_lock_held(m_lock)
-    WSLA_CONTAINER_STATE Transition(WSLA_CONTAINER_STATE State) noexcept;
+    __requires_lock_held(m_lock) WSLA_CONTAINER_STATE Transition(WSLA_CONTAINER_STATE State) noexcept;
 
     void OnProcessReleased(DockerExecProcessControl* process);
 

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -64,7 +64,7 @@ public:
     void Logs(WSLALogsFlags Flags, ULONG* Stdout, ULONG* Stderr, ULONGLONG Since, ULONGLONG Until, ULONGLONG Tail);
     void GetLabels(WSLA_LABEL_INFORMATION** Labels, ULONG* Count);
 
-    IWSLAContainer& ComWrapper();
+    void CopyTo(IWSLAContainer** Container);
 
     const std::string& Image() const noexcept;
     const std::string& Name() const noexcept;

--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -926,8 +926,12 @@ try
             E_UNEXPECTED, it == m_containers.end(), "Resolved container ID (%hs -> %hs) not found", Id, inspectResult.Id.c_str());
     }
 
-    (*it)->CopyTo(Container);
-    return S_OK;
+    auto result = wil::ResultFromException([&]() { (*it)->CopyTo(Container); });
+
+    // Return ERROR_NOT_FOUND if the container was found, but is being deleted for consistency.
+    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), result == RPC_E_DISCONNECTED);
+    
+    return result;
 }
 CATCH_RETURN();
 

--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -930,7 +930,7 @@ try
 
     // Return ERROR_NOT_FOUND if the container was found, but is being deleted for consistency.
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), result == RPC_E_DISCONNECTED);
-    
+
     return result;
 }
 CATCH_RETURN();

--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -870,7 +870,7 @@ try
             m_dockerClient.value(),
             m_ioRelay));
 
-        THROW_IF_FAILED(it->ComWrapper().QueryInterface(__uuidof(IWSLAContainer), (void**)Container));
+        it->CopyTo(Container);
 
         return S_OK;
     }
@@ -926,7 +926,7 @@ try
             E_UNEXPECTED, it == m_containers.end(), "Resolved container ID (%hs -> %hs) not found", Id, inspectResult.Id.c_str());
     }
 
-    THROW_IF_FAILED((*it)->ComWrapper().QueryInterface(__uuidof(IWSLAContainer), (void**)Container));
+    (*it)->CopyTo(Container);
     return S_OK;
 }
 CATCH_RETURN();

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -4315,6 +4315,8 @@ class WSLATests
             }
 
             auto container = OpenContainer(m_defaultSession.get(), "test-auto-remove");
+            auto id = container.Id();
+
             VERIFY_SUCCEEDED(container.Get().Start(WSLAContainerStartFlagsNone));
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
 
@@ -4323,6 +4325,11 @@ class WSLATests
 
             wil::com_ptr<IWSLAContainer> notFound;
             VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer(id.c_str(), &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+
+            wil::unique_cotaskmem_array_ptr<WSLA_CONTAINER> containers;
+            VERIFY_SUCCEEDED(m_defaultSession->ListContainers(&containers, containers.size_address<ULONG>()));
+            VERIFY_ARE_EQUAL(containers.size(), 0);
         }
     }
 };

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -3883,6 +3883,7 @@ class WSLATests
             WSLAContainerLauncher launcher("debian:latest", "logs-test-4", {"/bin/bash", "-c", "echo -n OK"});
             auto container = launcher.Launch(*m_defaultSession);
             auto initProcess = container.GetInitProcess();
+            ValidateProcessOutput(initProcess, {{1, "OK"}});
 
             // Testing would with more granularity would be difficult, but these flags are just forwarded to docker,
             // so validate that they're wired correctly.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a race condition between WSLASession opening a container and the container being released.

If OpenContainer() tries to access the COMWrapper while ReleaseResources() is running, ComWrapper() can return a null / invalid pointer, which crashes wslasession.exe

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
