### PR TITLE
wsla: do not return sessions via ListSessions that the caller does not have access to

### DIFF
--- a/src/windows/wslaservice/exe/WSLASessionManager.cpp
+++ b/src/windows/wslaservice/exe/WSLASessionManager.cpp
@@ -149,9 +149,15 @@ void WSLASessionManagerImpl::OpenSessionByName(LPCWSTR DisplayName, IWSLASession
 
 void WSLASessionManagerImpl::ListSessions(_Out_ WSLA_SESSION_INFORMATION** Sessions, _Out_ ULONG* SessionsCount)
 {
+    auto tokenInfo = GetCallingProcessTokenInfo();
     std::vector<WSLA_SESSION_INFORMATION> sessionInfo;
 
     ForEachSession<void>([&](auto& entry, const auto&) {
+        if (FAILED(CheckTokenAccess(entry, tokenInfo)))
+        {
+            return;
+        }
+
         wil::unique_hlocal_string sidString;
         THROW_IF_WIN32_BOOL_FALSE(ConvertSidToStringSidW(entry.Owner.TokenInfo->User.Sid, &sidString));
 


### PR DESCRIPTION
ListSessions returned all sessions to any caller without checking access, allowing non-elevated users to enumerate other users' sessions. Fixed by calling CheckTokenAccess to filter results, matching the pattern already used by OpenSession and OpenSessionByName.