### PR TITLE
Enable VS 2026 solution generation and improve ARM64 developer experience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,20 @@ set(CMAKE_SYSTEM_VERSION 10.0.26100.0)
 project(wsl)
 
 # Rationalize TARGET_PLATFORM
+# When neither CMAKE_GENERATOR_PLATFORM nor TARGET_PLATFORM is set, default to the host architecture.
+if("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "" AND "${TARGET_PLATFORM}" STREQUAL "")
+    if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "ARM64")
+        set(TARGET_PLATFORM "arm64")
+    else()
+        set(TARGET_PLATFORM "x64")
+    endif()
+    message(STATUS "No platform specified, defaulting to '${TARGET_PLATFORM}' based on host architecture.")
+endif()
+
 if("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "arm64" OR "${TARGET_PLATFORM}" STREQUAL "arm64")
     set(TARGET_PLATFORM "arm64")
     set(TEST_DISTRO_PLATFORM "arm64")
-elseif("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64|amd64|" OR "${TARGET_PLATFORM}" MATCHES "x64|amd64|")
+elseif("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64|amd64" OR "${TARGET_PLATFORM}" MATCHES "x64|amd64")
     set(TARGET_PLATFORM "x64")
     set(TEST_DISTRO_PLATFORM "amd64")
 else()
@@ -258,18 +268,31 @@ else()
     message(FATAL_ERROR "Unsupported platform: '${TARGET_PLATFORM}'")
 endif()
 
-# Determine the Visual Studio installation directory which contains LLVM tools
-# N.B. The version is set to VS2022 to ensure local runs match pipeline behavior
-# Require that Clang be installed in the product to potentially de-deduplicate
-execute_process(
-    COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -version "[17.0,18.0)" -products * -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
-    OUTPUT_VARIABLE VS_INSTALL_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    COMMAND_ERROR_IS_FATAL ANY
-)
+# Determine the Visual Studio installation directory which contains LLVM tools.
+# Supported versions: VS2022 and VS2026.
+# Prefer VS2022 to keep local clang-format output aligned with pipeline expectations.
+function(find_vs_install_dir VERSION_RANGE OUTPUT_VAR)
+    execute_process(
+        COMMAND "${VSWHERE_SOURCE_DIR}/vswhere.exe" -version "${VERSION_RANGE}" -products * -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath -prerelease -latest
+        OUTPUT_VARIABLE _vs_install_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+
+    set(${OUTPUT_VAR} "${_vs_install_dir}" PARENT_SCOPE)
+endfunction()
+
+find_vs_install_dir("[17.0,18.0)" VS_INSTALL_DIR)
 
 if (NOT VS_INSTALL_DIR)
-    message(FATAL_ERROR "Could not determine Visual Studio 2022 installation directory.")
+    find_vs_install_dir("[18.0,19.0)" VS_INSTALL_DIR)
+    if (VS_INSTALL_DIR)
+        message(WARNING "Visual Studio 2022 was not found; using Visual Studio 2026 instead. clang-format output may differ from pipeline expectations.")
+    endif()
+endif()
+
+if (NOT VS_INSTALL_DIR)
+    message(FATAL_ERROR "Could not determine Visual Studio installation directory.")
 endif()
 
 if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "AMD64")

--- a/doc/docs/dev-loop.md
+++ b/doc/docs/dev-loop.md
@@ -18,7 +18,33 @@ The following tools are required to build WSL:
     - .NET WinUI app development tools
 
 - Building WSL requires support for symbolic links. To ensure this capability, enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) in Windows Settings or execute the build process with Administrator privileges.
-    
+
+### ARM64 development
+
+When building on ARM64 Windows, the [WiX](https://wixtoolset.org/) toolset (`wix.exe`) requires the **x64 .NET 6.0 runtime** because it is an x64 binary. The ARM64 .NET runtime alone is not sufficient.
+
+To install the x64 .NET 6.0 runtime, run the following commands in PowerShell:
+
+```powershell
+# Download the official dotnet-install script
+Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile "$env:TEMP\dotnet-install.ps1"
+
+# Install the x64 .NET 6.0 runtime
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\dotnet-install.ps1" -Channel 6.0 -Runtime dotnet -Architecture x64 -InstallDir "C:\Program Files\dotnet\x64"
+```
+
+Then set the `DOTNET_ROOT_X64` environment variable so the runtime is discoverable:
+
+```powershell
+# Set for the current session
+$env:DOTNET_ROOT_X64 = "C:\Program Files\dotnet\x64"
+
+# Set permanently for your user
+[System.Environment]::SetEnvironmentVariable("DOTNET_ROOT_X64", "C:\Program Files\dotnet\x64", "User")
+```
+
+> **Note:** You may need to restart VS Code or open a new terminal for the environment variable to take effect.
+
 ## Building WSL
 
 Once you have cloned the repository, generate the Visual Studio solution by running:


### PR DESCRIPTION
- Auto-detect host architecture when TARGET_PLATFORM and CMAKE_GENERATOR_PLATFORM are unset, defaulting to ARM64 on ARM64 hosts
- Fix trailing '|' in platform regex that made the else branch unreachable
- Refactor Visual Studio detection to prefer VS2022 and fall back to VS2026 with a clang-format warning
- Document x64 .NET 6.0 runtime setup required for WiX on ARM64
