### PR TITLE
Add automount.cgroups to WSL_CONF_KEYS in validate-modern.py

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -38,7 +38,8 @@ DISCOURAGED_SYSTEM_UNITS = ['systemd-resolved.service',
 
 WSL1_UNSUPPORTED_XATTRS = ['security.selinux', 'security.ima', 'security.evm']
 
-WSL_CONF_KEYS = ['automount.enabled',
+WSL_CONF_KEYS = ['automount.cgroups',
+                 'automount.enabled',
                  'automount.ldconfig',
                  'automount.mountfstab',
                  'automount.options',


### PR DESCRIPTION
Fixes #13993

The validate-modern.py script was missing the 'automount.cgroups' setting from WSL_CONF_KEYS, causing validation errors when distributions include this setting in their /etc/wsl.conf files.