### PR TITLE
Fix grammar, typos, and formatting in docs and source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Thank you in advance for your contribution! We appreciate your help in making WS
 ## Notes for collecting WSL logs
 
 ### Important: Reporting BSODs and Security issues
-**Do not open GitHub issues for Windows crashes (BSODs) or security issues.**. Instead, send Windows crashes or other security-related issues to secure@microsoft.com.
+**Do not open GitHub issues for Windows crashes (BSODs) or security issues.** Instead, send Windows crashes or other security-related issues to secure@microsoft.com.
 See the `10) Reporting a Windows crash (BSOD)` section below for detailed instructions.
 
 ### Reporting issues in Windows Console or WSL text rendering/user experience

--- a/distributions/validate.py
+++ b/distributions/validate.py
@@ -2,7 +2,6 @@ import requests
 import json
 import sys
 import hashlib
-import base64
 import difflib
 from urllib.request import urlretrieve
 from xml.etree import ElementTree

--- a/doc/docs/debugging.md
+++ b/doc/docs/debugging.md
@@ -41,7 +41,7 @@ Notable ETL providers:
 - `Microsoft.Windows.Plan9.Server`: Logs from the Windows plan9 server (used when accessing /mnt/ shares and running Windows)
 
 
-On the Linux side, the easiest way to access logs is to look at `dmesg` or use the debug console, which can enabled by writing:
+On the Linux side, the easiest way to access logs is to look at `dmesg` or use the debug console, which can be enabled by writing:
 
 ```
 [wsl2]
@@ -65,7 +65,7 @@ Once started, just use `dir /path/to/wsl/source` in gdb to connect the source fi
 
 ## Root namespace debugging
 
-Some WSL process such as `gns` or `mini_init` aren't accessible from within WSL distributions. To attach a debugger to those, use the debug shell via:
+Some WSL processes such as `gns` or `mini_init` aren't accessible from within WSL distributions. To attach a debugger to those, use the debug shell via:
 
 ```
 wsl --debug-shell

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -7,4 +7,4 @@ For user documentation, including installation and configuration, see [https://l
 
 To get started developing (building, testing and deploying), see [Getting started](dev-loop.md).
 
-To learn more about how WSL works, see [technical documentation](technical-documentation/index.md)
+To learn more about how WSL works, see [technical documentation](technical-documentation/index.md).

--- a/doc/docs/technical-documentation/boot-process.md
+++ b/doc/docs/technical-documentation/boot-process.md
@@ -64,7 +64,7 @@ See `src/windows/common/hcs_schema.h` for more details on the HCS JSON schema.
 
 Part of the JSON configuration includes:
 
-- The kernel: WSL will use its built-in kernel, usually installed `C:/Program Files/WSL/tools/kernel`, or a custom kernel if overridden via [.wslconfig](https://learn.microsoft.com/windows/wsl/wsl-config)
+- The kernel: WSL will use its built-in kernel, usually installed in `C:\Program Files\WSL\tools\kernel`, or a custom kernel if overridden via [.wslconfig](https://learn.microsoft.com/windows/wsl/wsl-config)
 - The initramfs: WSL uses its own initramfs (usually installed in `C:\Program Files\WSL\tools\initrd.img`). It's an image that only contains the [mini_init](mini_init.md) binary
 - The resources accessible to the virtual machine such as CPU, RAM, GPU, etc
 
@@ -88,13 +88,13 @@ After applying all the configuration requested by [wslservice.exe](wslservice.ex
 
 ## Starting a Linux distribution
 
-To start a new distribution, [wslservice.exe](wslservice.exe.md) sends a `LxMiniInitMessageLaunchInit` message to [mini_init](mini_init.md), which then mounts the distribution vhd and starts [init](init.md). See ([init](init.md) for more details on WSL2 distributions configuration)
+To start a new distribution, [wslservice.exe](wslservice.exe.md) sends a `LxMiniInitMessageLaunchInit` message to [mini_init](mini_init.md), which then mounts the distribution vhd and starts [init](init.md). See [init](init.md) for more details on WSL2 distributions configuration.
 
-Once running, [wslservice.exe](wslservice.exe.md) can then send a `LxInitMessageCreateSession` message to start a new [session leader](session-leader.md) inside that distribution, which can be used to launch linux processes
+Once running, [wslservice.exe](wslservice.exe.md) can then send a `LxInitMessageCreateSession` message to start a new [session leader](session-leader.md) inside that distribution, which can be used to launch Linux processes
 
-## Relaying the linux process's input and output to Windows
+## Relaying the Linux process's input and output to Windows
 
-Once the user's linux process has been created, [wslservice.exe](wslservice.exe.md) can return from `CreateLxProcess()` back to [wsl.exe](wsl.exe.md). In the case of WSL2, [wsl.exe](wsl.exe.md) receives the following HANDLES: 
+Once the user's Linux process has been created, [wslservice.exe](wslservice.exe.md) can return from `CreateLxProcess()` back to [wsl.exe](wsl.exe.md). In the case of WSL2, [wsl.exe](wsl.exe.md) receives the following HANDLES: 
 
 - STDIN
 - STDOUT
@@ -104,7 +104,7 @@ Once the user's linux process has been created, [wslservice.exe](wslservice.exe.
 
 The `STDIN`, `STDOUT` and `STDERR` handles are used to relay input and output from the Linux process to the Windows terminal. Depending on the type of handle (terminal, pipe, file, ...), [wsl.exe](wsl.exe.md) will apply different relaying logics (see `src/windows/common/relay.cpp`) to achieve the best compatibility between Windows & Linux. 
 
-The `Control channel` is used to notify the linux process of a change in the terminal (for instance when [wsl.exe's](wsl.exe.md) terminal window is resized) so these changes can be applied to the Linux process as well. 
+The `Control channel` is used to notify the Linux process of a change in the terminal (for instance when [wsl.exe's](wsl.exe.md) terminal window is resized) so these changes can be applied to the Linux process as well. 
 
 The `Interop channel` has two usages: 
 

--- a/doc/docs/technical-documentation/drvfs.md
+++ b/doc/docs/technical-documentation/drvfs.md
@@ -8,7 +8,7 @@ Within a distribution, WSL separates between Linux processes that have been crea
 
 This is done by having two separate [mount namespaces](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html) within the distribution. One of them offers an elevated access to Windows drives, and the other offers a non-elevated access to Windows drives.
 
-When a Linux process is created, [wslservice.exe](wslservice.exe.md) determines its elevation status, and then tell [init](init.md) to create the process in the appropriate mount namespace.
+When a Linux process is created, [wslservice.exe](wslservice.exe.md) determines its elevation status, and then tells [init](init.md) to create the process in the appropriate mount namespace.
 
 ## Mounting a Windows drive
 
@@ -18,7 +18,7 @@ When a [session leader](session-leader.md) is created, [wslservice.exe](wslservi
 
 When the WSL distribution is created, [wslservice.exe](wslservice.exe.md) uses the `LX_INIT_CONFIGURATION_INFORMATION` message to indicate whether the process that created the distribution is elevated or not. Based on this, [init](init.md) will mount either the elevated, or un-elevated version of the plan9 server.
 
-Later when the first command is created in the namespace that hasn't been mounted yet, (either elevated, or non-elevated), [wslservice.exe](wslservice.exe.md) sends a `LxInitMessageRemountDrvfs` to [init](init.md), which tell `init` to mount the other namespace. 
+Later when the first command is created in the namespace that hasn't been mounted yet, (either elevated, or non-elevated), [wslservice.exe](wslservice.exe.md) sends a `LxInitMessageRemountDrvfs` to [init](init.md), which tells `init` to mount the other namespace. 
 
 See: `src/windows/service/exe/WslCoreInstance.cpp` and `src/linux/drvfs.cpp`. 
 
@@ -32,4 +32,4 @@ mount -t drvfs C: /tmp/my-mount-point
 
 Internally, this is handled by `/usr/sbin/mount.drvfs`, which is a symlink to `/init`. When `/init` starts, it looks at `argv[0]` to determine which entrypoint to run. If `argv[0]` is `mount.drvfs`, then `/init` runs the `mount.drvfs` entrypoint (see `MountDrvfsEntry()` in `src/linux/init/drvfs.cpp`).
 
-Depending on the distribution configuration, `mount.drvfs` will either mount the drive as `drvfs` (WSL1), or  `plan9`, `virtio-plan9` or `virtiofs` (WSL), depending on [.wslconfig](https://learn.microsoft.com/windows/wsl/wsl-config).
+Depending on the distribution configuration, `mount.drvfs` will either mount the drive as `drvfs` (WSL1), or `plan9`, `virtio-plan9` or `virtiofs` (WSL), depending on [.wslconfig](https://learn.microsoft.com/windows/wsl/wsl-config).

--- a/doc/docs/technical-documentation/index.md
+++ b/doc/docs/technical-documentation/index.md
@@ -1,6 +1,6 @@
 # WSL Overview
 
-WSL is comprised of a set of executables, API's and protocols. This page offers an overview of the different components, and how they're connected.
+WSL is comprised of a set of executables, APIs and protocols. This page offers an overview of the different components, and how they're connected.
 Click on any component to get more details.
 
 

--- a/doc/docs/technical-documentation/init.md
+++ b/doc/docs/technical-documentation/init.md
@@ -29,7 +29,7 @@ Once started, the `init` process performs various initialization tasks such as:
 
 ## Running the distribution
 
-Once ready, `init` establishes either an `lxbus` (WSL1) or an  `hvsocket` (WSL2) connection to [wslservice](wslservice.exe.md). This channel is used to transmit various commands to `init` (see `src/shared/inc/lxinitshared.h`), such as:
+Once ready, `init` establishes either an `lxbus` (WSL1) or an `hvsocket` (WSL2) connection to [wslservice](wslservice.exe.md). This channel is used to transmit various commands to `init` (see `src/shared/inc/lxinitshared.h`), such as:
 
 - `LxInitMessageInitialize`: Configure the distribution
 - `LxInitMessageCreateSession`: Create a new session leader. See [session leader](session-leader.md)

--- a/doc/docs/technical-documentation/localhost.md
+++ b/doc/docs/technical-documentation/localhost.md
@@ -1,6 +1,6 @@
 # Localhost
 
-`localhost` is a WSL2 linux process, created by [mini_init](mini_init.md). Its role is to forward network traffic between the WSL2 virtual machine, and Windows.
+`localhost` is a WSL2 Linux process, created by [mini_init](mini_init.md). Its role is to forward network traffic between the WSL2 virtual machine, and Windows.
 
 
 ## NAT networking 

--- a/doc/docs/technical-documentation/plan9.md
+++ b/doc/docs/technical-documentation/plan9.md
@@ -1,6 +1,6 @@
 # Plan 9
 
-Plan9 is a linux process that hosts a plan9 filesystem server for WSL1 and WSL2 distributions. It's created by [init](init.md) in each distribution.
+Plan9 is a Linux process that hosts a plan9 filesystem server for WSL1 and WSL2 distributions. It's created by [init](init.md) in each distribution.
 
 ## WSL 1 
 

--- a/doc/docs/technical-documentation/relay.md
+++ b/doc/docs/technical-documentation/relay.md
@@ -1,6 +1,6 @@
 # Relay
 
-Relay is a WSL2 linux process created by a [session leader](session-leader.md). Its job is to create a linux process on behalf of the user, and relay its output back to Windows. 
+Relay is a WSL2 Linux process created by a [session leader](session-leader.md). Its job is to create a Linux process on behalf of the user, and relay its output back to Windows. 
 
 ## Creating a user process
 
@@ -10,7 +10,7 @@ These channels are used to:
 
 - Relay standard file descriptors (stdin, stdout, stderr)
 - Relay information about the terminal (for instance when the terminal window is resized from Windows)
-- Notify Windows when the linux process exits
+- Notify Windows when the Linux process exits
 
 Once those channels are configured, the `relay` forks() into two processes: 
 

--- a/doc/docs/technical-documentation/session-leader.md
+++ b/doc/docs/technical-documentation/session-leader.md
@@ -21,6 +21,6 @@ When running in a WSL1 distribution, the session leader forks(), and uses the ch
 - The current directory
 - The standard file descriptors (stdin, stdout, stderr)
 
-## Creating a WSL2 process
+### Creating a WSL2 process
 
 When running in a WSL2 distribution, the session leader forks() to create a [relay](relay.md) process, which is responsible for creating the user process and relaying its output back to [wsl.exe](wsl.exe.md)

--- a/doc/docs/technical-documentation/systemd.md
+++ b/doc/docs/technical-documentation/systemd.md
@@ -13,7 +13,7 @@ After launching `/sbin/init`, [init](init.md) waits for systemd to be ready by w
 
 ## User sessions
 
-When systemd is enabled, WSL tries synchronizes launching processes with systemd user sessions. This is currently done by launching `login -f <user>` to start the associated systemd user session.
+When systemd is enabled, WSL tries to synchronize launching processes with systemd user sessions. This is currently done by launching `login -f <user>` to start the associated systemd user session.
 
 ## Additional systemd configuration 
 

--- a/doc/docs/technical-documentation/wslhost.exe.md
+++ b/doc/docs/technical-documentation/wslhost.exe.md
@@ -16,7 +16,7 @@ See: `src/windows/common/notifications.cpp`
 
 ## Background processes 
 
-When [wsl.exe](wsl.exe.md) terminates before the associated Linux processes terminates, `wslhost.exe` takes over the lifetime of the Linux process. 
+When [wsl.exe](wsl.exe.md) terminates before the associated Linux process terminates, `wslhost.exe` takes over the lifetime of the Linux process. 
 
 This allows Linux processes to keep running Windows commands and access the terminal even after the associated `wsl.exe` terminates. 
 

--- a/intune/WSL.admx
+++ b/intune/WSL.admx
@@ -31,7 +31,7 @@
       </disabledValue>
     </policy>
 
-   <policy name="AllowWSL1" class="Machine" displayName="$(string.AllowWSL1)" explainText="$(string.AllowWSL1Explain)" key="Software\Policies\WSL" valueName="AllowWSL1">
+    <policy name="AllowWSL1" class="Machine" displayName="$(string.AllowWSL1)" explainText="$(string.AllowWSL1Explain)" key="Software\Policies\WSL" valueName="AllowWSL1">
       <parentCategory ref="WSL" />
       <supportedOn ref="windows:SUPPORTED_Windows10" />
       <enabledValue>
@@ -42,7 +42,7 @@
       </disabledValue>
     </policy>
 
-   <policy name="CustomKernelUserSettingConfigurable" class="Machine" displayName="$(string.CustomKernelUserSettingConfigurable)" explainText="$(string.CustomKernelExplain)" key="Software\Policies\WSL" valueName="AllowKernelUserSetting">
+    <policy name="CustomKernelUserSettingConfigurable" class="Machine" displayName="$(string.CustomKernelUserSettingConfigurable)" explainText="$(string.CustomKernelExplain)" key="Software\Policies\WSL" valueName="AllowKernelUserSetting">
       <parentCategory ref="WSL" />
       <supportedOn ref="windows:SUPPORTED_Windows10" />
       <enabledValue>

--- a/intune/en-US/WSL.adml
+++ b/intune/en-US/WSL.adml
@@ -5,13 +5,13 @@
   <description>Windows Subsystem for Linux</description>
   <resources>
     <stringTable>
-        <string id="WindowsSubsystemForLinux">Windows Subsystem For Linux</string>
+        <string id="WindowsSubsystemForLinux">Windows Subsystem for Linux</string>
 
-        <string id="AllowWSL">Allow the Windows Subsystem For Linux</string>
-        <string id="AllowWSLExplain">When set to disabled, this policy disables access to the Windows Subsystem For Linux for all users on the machine.</string>
+        <string id="AllowWSL">Allow the Windows Subsystem for Linux</string>
+        <string id="AllowWSLExplain">When set to disabled, this policy disables access to the Windows Subsystem for Linux for all users on the machine.</string>
 
-        <string id="AllowInboxWSL">Allow the Inbox version of the Windows Subsystem For Linux</string>
-        <string id="AllowInboxWSLExplain">When set to disabled, this policy disables the inbox version (optional component) of the Windows Subsystem For Linux. If this policy is disabled, only the store version of WSL can be used.</string>
+        <string id="AllowInboxWSL">Allow the Inbox version of the Windows Subsystem for Linux</string>
+        <string id="AllowInboxWSLExplain">When set to disabled, this policy disables the inbox version (optional component) of the Windows Subsystem for Linux. If this policy is disabled, only the store version of WSL can be used.</string>
 
         <string id="AllowWSL1">Allow WSL1</string>
         <string id="AllowWSL1Explain">When set to disabled, this policy disables WSL1. When disabled, only WSL2 distributions can be used.</string>

--- a/localization/strings/en-GB/Resources.resw
+++ b/localization/strings/en-GB/Resources.resw
@@ -722,7 +722,7 @@ The system may need to be restarted so the changes can take effect.</value>
     <value>Bridged networking requires wsl2.vmSwitch to be set.</value>
   </data>
   <data name="MessageCouldFetchDistributionList" xml:space="preserve">
-    <value>Failed to fetch the list distribution from '{}'. {}</value>
+    <value>Failed to fetch the distribution list from '{}'. {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageFailedToAttachDisk" xml:space="preserve">
@@ -1055,7 +1055,7 @@ Falling back to NAT networking.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageCorruptedDistroRegistration" xml:space="preserve">
-    <value>Failed to read property '{}' from distribution {} </value>
+    <value>Failed to read property '{}' from distribution {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessagePassVhdFlag" xml:space="preserve">

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -722,7 +722,7 @@ The system may need to be restarted so the changes can take effect.</value>
     <value>Bridged networking requires wsl2.vmSwitch to be set.</value>
   </data>
   <data name="MessageCouldFetchDistributionList" xml:space="preserve">
-    <value>Failed to fetch the list distribution from '{}'. {}</value>
+    <value>Failed to fetch the distribution list from '{}'. {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageFailedToAttachDisk" xml:space="preserve">
@@ -1055,7 +1055,7 @@ Falling back to NAT networking.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageCorruptedDistroRegistration" xml:space="preserve">
-    <value>Failed to read property '{}' from distribution {} </value>
+    <value>Failed to read property '{}' from distribution {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessagePassVhdFlag" xml:space="preserve">

--- a/src/windows/inc/WmiService.h
+++ b/src/windows/inc/WmiService.h
@@ -760,7 +760,7 @@ public:
     }
 
     // Allows for executing a WMI query against the WMI service for an enumeration of WMI objects.
-    // Assumes the query of of the WQL query language.
+    // Assumes the query is of the WQL query language.
     const WmiEnumerate& query(_In_ PCWSTR query)
     {
         THROW_IF_FAILED(m_wbemServices->ExecQuery(

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -1407,13 +1407,13 @@ class UnitTests
 
             ValidateErrorMessage(
                 L"--install -d ubuntu",
-                L"Failed to fetch the list distribution from 'http://127.0.0.1:6666'. " +
+                L"Failed to fetch the distribution list from 'http://127.0.0.1:6666'. " +
                     GetSystemErrorString(HRESULT_FROM_WIN32(WININET_E_CANNOT_CONNECT)),
                 L"Wsl/InstallDistro/WININET_E_CANNOT_CONNECT");
 
             ValidateErrorMessage(
                 L"--list --online",
-                L"Failed to fetch the list distribution from 'http://127.0.0.1:6666'. " +
+                L"Failed to fetch the distribution list from 'http://127.0.0.1:6666'. " +
                     GetSystemErrorString(HRESULT_FROM_WIN32(WININET_E_CANNOT_CONNECT)),
                 L"Wsl/WININET_E_CANNOT_CONNECT");
         }


### PR DESCRIPTION
Some minor formatting / grammar error fixes in the docs and source.