### PR TITLE
Accessibility Bug Fix: After selecting from the navigation list, keyboard focus is not transferred to page content 

### DIFF
--- a/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml
+++ b/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml
@@ -7,13 +7,16 @@
     xmlns:controls="using:WslSettings.Controls"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
 
-    <Grid Margin="{ThemeResource ContentPageMargin}">
+    <Grid Margin="{ThemeResource ContentPageMargin}"
+          IsTabStop="True"
+		  AutomationProperties.LandmarkType="Main"
+		  x:Name="DeveloperPageRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Uid="Settings_DeveloperPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left"/>
+        <TextBlock x:Uid="Settings_DeveloperPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left" AutomationProperties.HeadingLevel="Level1"/>
         <TextBlock x:Uid="Settings_ErrorTryAgainLater" x:Name="Settings_ErrorTryAgainLater" Grid.Row="1" HorizontalAlignment="Left" AutomationProperties.LiveSetting="Assertive"
             Visibility="{x:Bind ViewModel.ErrorVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}"/>
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"

--- a/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml.cs
@@ -3,6 +3,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;
@@ -33,6 +34,7 @@ public sealed partial class DeveloperPage : Page
 
     private void OnPageLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
+        DeveloperPageRoot.Focus(FocusState.Programmatic);
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "CustomKernelPathExpander", "CustomKernelPathTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "CustomKernelModulesPathExpander", "CustomKernelModulesPathTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "CustomSystemDistroPathExpander", "CustomSystemDistroPathTextBox");

--- a/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml.cs
@@ -3,7 +3,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;

--- a/src/windows/wslsettings/Views/Settings/FileSystemPage.xaml
+++ b/src/windows/wslsettings/Views/Settings/FileSystemPage.xaml
@@ -6,13 +6,16 @@
     xmlns:behaviors="using:WslSettings.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
 
-    <Grid Margin="{ThemeResource ContentPageMargin}">
+    <Grid Margin="{ThemeResource ContentPageMargin}"
+          IsTabStop="True"
+		  AutomationProperties.LandmarkType="Main"
+		  x:Name="FileSystemPageRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Uid="Settings_FileSystemPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left"/>
+        <TextBlock x:Uid="Settings_FileSystemPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left" AutomationProperties.HeadingLevel="Level1"/>
         <TextBlock x:Uid="Settings_ErrorTryAgainLater" x:Name="Settings_ErrorTryAgainLater" Grid.Row="1" HorizontalAlignment="Left" AutomationProperties.LiveSetting="Assertive"
             Visibility="{x:Bind ViewModel.ErrorVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}"/>
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"

--- a/src/windows/wslsettings/Views/Settings/FileSystemPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/FileSystemPage.xaml.cs
@@ -4,7 +4,6 @@ using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using System.Diagnostics;
 using WslSettings.Contracts.Services;

--- a/src/windows/wslsettings/Views/Settings/FileSystemPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/FileSystemPage.xaml.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (C) Microsoft Corporation. All rights reserved.
 
 using CommunityToolkit.WinUI.Controls;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using System.Diagnostics;
 using WslSettings.Contracts.Services;
@@ -60,6 +62,7 @@ public sealed partial class FileSystemPage : Page
 
     private void OnPageLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
+        FileSystemPageRoot.Focus(FocusState.Programmatic);
         var expander = this.FindName("DefaultVHDSizeExpander") as SettingsExpander;
         var textBox = this.FindName("DefaultVHDSizeTextBox") as TextBox;
 

--- a/src/windows/wslsettings/Views/Settings/MemAndProcPage.xaml
+++ b/src/windows/wslsettings/Views/Settings/MemAndProcPage.xaml
@@ -6,13 +6,16 @@
     xmlns:behaviors="using:WslSettings.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
 
-    <Grid Margin="{ThemeResource ContentPageMargin}">
+    <Grid Margin="{ThemeResource ContentPageMargin}"
+          IsTabStop="True"
+		  AutomationProperties.LandmarkType="Main"
+		  x:Name="MemAndProcPageRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Uid="Settings_MemAndProcPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left"/>
+        <TextBlock x:Uid="Settings_MemAndProcPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left" AutomationProperties.HeadingLevel="Level1"/>
         <TextBlock x:Uid="Settings_ErrorTryAgainLater" x:Name="Settings_ErrorTryAgainLater" Grid.Row="1" HorizontalAlignment="Left" AutomationProperties.LiveSetting="Assertive"
             Visibility="{x:Bind ViewModel.ErrorVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}"/>
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"

--- a/src/windows/wslsettings/Views/Settings/MemAndProcPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/MemAndProcPage.xaml.cs
@@ -3,7 +3,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;

--- a/src/windows/wslsettings/Views/Settings/MemAndProcPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/MemAndProcPage.xaml.cs
@@ -3,6 +3,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;
@@ -33,6 +34,7 @@ public sealed partial class MemAndProcPage : Page
 
     private void OnPageLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
+        MemAndProcPageRoot.Focus(FocusState.Programmatic);
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "ProcCountExpander", "ProcCountTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "MemorySizeExpander", "MemorySizeTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "SwapSizeExpander", "SwapSizeTextBox");

--- a/src/windows/wslsettings/Views/Settings/NetworkingPage.xaml
+++ b/src/windows/wslsettings/Views/Settings/NetworkingPage.xaml
@@ -6,13 +6,16 @@
     xmlns:behaviors="using:WslSettings.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
 
-    <Grid Margin="{ThemeResource ContentPageMargin}">
+    <Grid Margin="{ThemeResource ContentPageMargin}"
+          IsTabStop="True"
+		  AutomationProperties.LandmarkType="Main"
+		  x:Name="NetworkingPageRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Uid="Settings_NetworkingPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left"/>
+        <TextBlock x:Uid="Settings_NetworkingPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left" AutomationProperties.HeadingLevel="Level1"/>
         <TextBlock x:Uid="Settings_ErrorTryAgainLater" x:Name="Settings_ErrorTryAgainLater" Grid.Row="1" HorizontalAlignment="Left" AutomationProperties.LiveSetting="Assertive"
             Visibility="{x:Bind ViewModel.ErrorVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}"/>
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"

--- a/src/windows/wslsettings/Views/Settings/NetworkingPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/NetworkingPage.xaml.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (C) Microsoft Corporation. All rights reserved.
 
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;
@@ -32,6 +34,7 @@ public sealed partial class NetworkingPage : Page
 
     private void OnPageLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
+        NetworkingPageRoot.Focus(FocusState.Programmatic);
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "IgnoredPortsExpander", "IgnoredPortsTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "InitialAutoProxyTimeoutExpander", "InitialAutoProxyTimeoutTextBox");
     }

--- a/src/windows/wslsettings/Views/Settings/NetworkingPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/NetworkingPage.xaml.cs
@@ -3,7 +3,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;

--- a/src/windows/wslsettings/Views/Settings/OptionalFeaturesPage.xaml
+++ b/src/windows/wslsettings/Views/Settings/OptionalFeaturesPage.xaml
@@ -7,13 +7,16 @@
     xmlns:controls="using:WslSettings.Controls"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
 
-    <Grid Margin="{ThemeResource ContentPageMargin}">
+    <Grid Margin="{ThemeResource ContentPageMargin}"
+          IsTabStop="True"
+		  AutomationProperties.LandmarkType="Main"
+		  x:Name="OptionalFeaturesPageRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Uid="Settings_OptionalFeaturesPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left"/>
+        <TextBlock x:Uid="Settings_OptionalFeaturesPageTitle" Style="{ThemeResource PageHeaderTextBlockStyle}" Margin="{StaticResource MediumSmallBottomMargin}" HorizontalAlignment="Left" AutomationProperties.HeadingLevel="Level1"/>
         <TextBlock x:Uid="Settings_ErrorTryAgainLater" x:Name="Settings_ErrorTryAgainLater" Grid.Row="1" HorizontalAlignment="Left" AutomationProperties.LiveSetting="Assertive"
             Visibility="{x:Bind ViewModel.ErrorVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}"/>
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"

--- a/src/windows/wslsettings/Views/Settings/OptionalFeaturesPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/OptionalFeaturesPage.xaml.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (C) Microsoft Corporation. All rights reserved.
 
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;
@@ -32,6 +34,7 @@ public sealed partial class OptionalFeaturesPage : Page
 
     private void OnPageLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
+        OptionalFeaturesPageRoot.Focus(FocusState.Programmatic);
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "SystemdSettingsExpander", "InitTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "VMIdleTimeoutExpander", "VMIdleTimeoutTextBox");
     }

--- a/src/windows/wslsettings/Views/Settings/OptionalFeaturesPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/OptionalFeaturesPage.xaml.cs
@@ -3,7 +3,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WslSettings.Contracts.Services;
 using WslSettings.ViewModels.Settings;

--- a/src/windows/wslsettings/Views/Settings/ShellPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/ShellPage.xaml.cs
@@ -44,6 +44,7 @@ public sealed partial class ShellPage : Page
         App.MainWindow.SetTitleBar(AppTitleBar);
         App.MainWindow.Activated += MainWindow_Activated;
         AppTitleBarText.Text = "Settings_AppDisplayName".GetLocalized();
+        NavigationFrame.LostFocus += NavigationFrame_LostFocus;
     }
 
     private void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -128,5 +129,24 @@ public sealed partial class ShellPage : Page
         var result = navigationService.GoBack();
 
         args.Handled = result;
+    }
+
+    private void NavigationFrame_LostFocus(object sender, RoutedEventArgs e)
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            var focused = FocusManager.GetFocusedElement(NavigationViewControl.XamlRoot);
+
+            // If focus is transferred to the selected page itself, do nothing
+            if (focused is not NavigationViewItem && focused is not NavigationView)
+            {
+                return;
+            }
+
+            // Restore focus to the selected navigation item
+            var selected = NavigationViewControl.SelectedItem;
+            var container = NavigationViewControl.ContainerFromMenuItem(selected) as Control;
+            container?.Focus(FocusState.Keyboard);
+        });
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Problem: After selecting any list item (e.g., File System) in the navigation menu, keyboard focus is not directly shifting to the revealed content.

Changes
Focus redirection on page load: Each settings page's root Grid is now named and marked as a tab stop with
AutomationProperties.LandmarkType="Main". On page load, focus is programmatically set to the page root via Focus(FocusState.Programmatic), ensuring keyboard focus shifts directly to the revealed content.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Additional Change: 
Focus return to navigation menu: A LostFocus handler on NavigationFrame in ShellPage.xaml.cs detects when focus escapes the page content back to the NavigationView. When this happens, focus is restored to the currently selected navigation item, allowing the user to continue keyboard navigation from the menu.
Heading-level annotations: Page titles are now marked as Level 1 headings for screen reader landmark navigation.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested with the Windows on-screen keyboard:
- Verified focus shifts directly to page content when selecting a navigation item via keyboard
- Verified Tab cycles through all page controls and returns focus to the selected menu item