### PR TITLE
WSLA:  impersonate user token before EnforceVmSavedStateFileLimit

### DIFF
--- a/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
@@ -752,6 +752,8 @@ void HcsVirtualMachine::CreateVmSavedStateFile(HANDLE InUserToken)
 
 void HcsVirtualMachine::EnforceVmSavedStateFileLimit()
 {
+    auto runAsUser = wil::impersonate_token(m_userToken.get());
+
     auto pred = [](const auto& e) {
         return WI_IsFlagSet(GetFileAttributes(e.path().c_str()), FILE_ATTRIBUTE_TEMPORARY) && e.path().has_extension() &&
                e.path().extension() == SAVED_STATE_FILE_EXTENSION && e.path().has_filename() &&


### PR DESCRIPTION
OnCrash runs on an HCS callback thread as SYSTEM. It calls EnforceVmSavedStateFileLimit which enumerates and deletes files in m_crashDumpFolder (a user temp directory) without impersonating. A malicious user could place a symlink/junction at the crash dump folder path, causing SYSTEM to delete arbitrary files.

All other methods that touch m_crashDumpFolder (CollectCrashDumps, CreateVmSavedStateFile, WriteCrashLog) correctly impersonate via wil::impersonate_token. Add the same guard here.