### PR TITLE
wsla: move CollectCrashDumps from HcsVirtualMachine to WSLAVirtualMachine

### DIFF
--- a/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
@@ -27,10 +27,8 @@ using helpers::WindowsBuildNumbers;
 using wsl::windows::service::wsla::HcsVirtualMachine;
 
 constexpr auto MAX_VM_CRASH_FILES = 3;
-constexpr auto MAX_CRASH_DUMPS = 10;
 constexpr auto SAVED_STATE_FILE_EXTENSION = L".vmrs";
 constexpr auto SAVED_STATE_FILE_PREFIX = L"saved-state-";
-constexpr auto RECEIVE_TIMEOUT = 30 * 1000;
 
 HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLA_SESSION_SETTINGS* Settings)
 {
@@ -278,16 +276,10 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLA_SESSION_SETTINGS* Settings)
     // Create a listening socket for mini_init to connect to once the VM is running.
     m_listenSocket = wsl::windows::common::hvsocket::Listen(m_vmId, LX_INIT_UTILITY_VM_INIT_PORT);
 
-    // Start crash dump listener
-    auto crashDumpSocket = wsl::windows::common::hvsocket::Listen(m_vmId, LX_INIT_UTILITY_VM_CRASH_DUMP_PORT);
-    THROW_LAST_ERROR_IF(!crashDumpSocket);
-
     // Start the virtual machine
     hcs::StartComputeSystem(m_computeSystem.get(), json.c_str());
 
-    m_crashDumpThread = std::thread{[this, socket = std::move(crashDumpSocket)]() mutable { CollectCrashDumps(std::move(socket)); }};
-
-    // Add GPU to the VM if requested (HCS modify operation)
+    // Add GPU to the VM if requested
     if (FeatureEnabled(WslaFeatureFlagsGPU))
     {
         hcs::ModifySettingRequest<hcs::GpuConfiguration> gpuRequest{};
@@ -352,11 +344,6 @@ HcsVirtualMachine::~HcsVirtualMachine()
             std::filesystem::remove(m_vmSavedStateFile);
         }
         CATCH_LOG()
-    }
-
-    if (m_crashDumpThread.joinable())
-    {
-        m_crashDumpThread.join();
     }
 }
 
@@ -659,72 +646,6 @@ void HcsVirtualMachine::OnCrash(const HCS_EVENT* Event)
     if (!m_crashLogCaptured && !crashReport.CrashLog.empty())
     {
         WriteCrashLog(crashReport.CrashLog);
-    }
-}
-
-void HcsVirtualMachine::CollectCrashDumps(wil::unique_socket&& listenSocket) const
-{
-    wsl::windows::common::wslutil::SetThreadDescription(L"CrashDumpCollection");
-
-    while (!m_vmExitEvent.is_signaled())
-    {
-        try
-        {
-            auto socket = wsl::windows::common::hvsocket::CancellableAccept(listenSocket.get(), INFINITE, m_vmExitEvent.get());
-            if (!socket)
-            {
-                // VM is exiting.
-                break;
-            }
-
-            THROW_LAST_ERROR_IF(
-                setsockopt(listenSocket.get(), SOL_SOCKET, SO_RCVTIMEO, (const char*)&RECEIVE_TIMEOUT, sizeof(RECEIVE_TIMEOUT)) == SOCKET_ERROR);
-
-            auto channel = wsl::shared::SocketChannel{std::move(socket.value()), "crash_dump", m_vmExitEvent.get()};
-
-            const auto& message = channel.ReceiveMessage<LX_PROCESS_CRASH>();
-            const char* process = reinterpret_cast<const char*>(&message.Buffer);
-
-            constexpr auto dumpExtension = ".dmp";
-            constexpr auto dumpPrefix = "wsl-crash";
-
-            auto filename = std::format("{}-{}-{}-{}-{}{}", dumpPrefix, message.Timestamp, message.Pid, process, message.Signal, dumpExtension);
-
-            std::replace_if(filename.begin(), filename.end(), [](auto e) { return !std::isalnum(e) && e != '.' && e != '-'; }, '_');
-
-            auto fullPath = m_crashDumpFolder / filename;
-
-            WSL_LOG(
-                "WSLALinuxCrash",
-                TraceLoggingValue(fullPath.c_str(), "FullPath"),
-                TraceLoggingValue(message.Pid, "Pid"),
-                TraceLoggingValue(message.Signal, "Signal"),
-                TraceLoggingValue(process, "process"));
-
-            auto runAsUser = wil::impersonate_token(m_userToken.get());
-            wsl::windows::common::filesystem::EnsureDirectory(m_crashDumpFolder.c_str());
-
-            // Only delete files that:
-            // - have the temporary flag set
-            // - start with 'wsl-crash'
-            // - end in .dmp
-            //
-            // This logic is here to prevent accidental user file deletion
-            auto pred = [&dumpExtension, &dumpPrefix](const auto& e) {
-                return WI_IsFlagSet(GetFileAttributes(e.path().c_str()), FILE_ATTRIBUTE_TEMPORARY) && e.path().has_extension() &&
-                       e.path().extension() == dumpExtension && e.path().has_filename() &&
-                       e.path().filename().string().find(dumpPrefix) == 0;
-            };
-
-            wsl::windows::common::wslutil::EnforceFileLimit(m_crashDumpFolder.c_str(), MAX_CRASH_DUMPS, pred);
-
-            wil::unique_hfile file{CreateFileW(fullPath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_TEMPORARY, nullptr)};
-            THROW_LAST_ERROR_IF(!file);
-
-            channel.SendResultMessage<std::int32_t>(0);
-            wsl::windows::common::relay::InterruptableRelay(reinterpret_cast<HANDLE>(channel.Socket()), file.get(), nullptr);
-        }
-        CATCH_LOG()
     }
 }
 

--- a/src/windows/wslaservice/exe/HcsVirtualMachine.h
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.h
@@ -22,7 +22,6 @@ Abstract:
 #include "INetworkingEngine.h"
 #include <filesystem>
 #include <map>
-#include <thread>
 
 #define MAX_VHD_COUNT 254
 
@@ -60,7 +59,6 @@ private:
     void CreateVmSavedStateFile(HANDLE UserToken);
     void EnforceVmSavedStateFileLimit();
     void WriteCrashLog(const std::wstring& crashLog);
-    void CollectCrashDumps(wil::unique_socket&& listenSocket) const;
 
     ULONG AllocateLun();
     void FreeLun(ULONG Lun);
@@ -91,7 +89,6 @@ private:
     // Shares: key is ShareId, value is nullopt for Plan9 or DeviceInstanceId for VirtioFS
     std::map<GUID, std::optional<GUID>, wsl::windows::common::helpers::GuidLess> m_shares;
 
-    std::thread m_crashDumpThread;
     std::filesystem::path m_vmSavedStateFile;
     std::filesystem::path m_crashDumpFolder;
     bool m_vmSavedStateCaptured = false;

--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -46,6 +46,12 @@ void WSLAVirtualMachine::Initialize()
 {
     THROW_IF_FAILED(m_vm->GetId(&m_vmId));
 
+    // Start crash dump collection thread.
+    auto crashDumpSocket = hvsocket::Listen(m_vmId, LX_INIT_UTILITY_VM_CRASH_DUMP_PORT);
+    THROW_LAST_ERROR_IF(!crashDumpSocket);
+
+    m_crashDumpThread = std::thread{[this, socket = std::move(crashDumpSocket)]() mutable { CollectCrashDumps(std::move(socket)); }};
+
     // Establish a socket channel with mini_init in the VM.
     wil::unique_socket socket;
     THROW_IF_FAILED(m_vm->AcceptConnection(reinterpret_cast<HANDLE*>(&socket)));
@@ -99,6 +105,11 @@ WSLAVirtualMachine::~WSLAVirtualMachine()
     if (m_processExitThread.joinable())
     {
         m_processExitThread.join();
+    }
+
+    if (m_crashDumpThread.joinable())
+    {
+        m_crashDumpThread.join();
     }
 
     // Clear the state of all remaining processes now that the VM has exited.
@@ -893,4 +904,72 @@ wil::unique_socket WSLAVirtualMachine::ConnectUnixSocket(const char* Path)
     THROW_HR_IF_MSG(E_FAIL, result.Result < 0, "Failed to connect to unix socket: '%hs', %i", Path, result.Result);
 
     return channel.Release();
+}
+
+void WSLAVirtualMachine::CollectCrashDumps(wil::unique_socket&& listenSocket)
+{
+    // No impersonation needed - the session process already runs as the user.
+    wslutil::SetThreadDescription(L"CrashDumpCollection");
+
+    const auto crashDumpFolder = filesystem::GetTempFolderPath(GetCurrentProcessToken()) / L"wsla-crashes";
+
+    while (!m_vmTerminatingEvent.is_signaled())
+    {
+        try
+        {
+            auto socket = hvsocket::CancellableAccept(listenSocket.get(), INFINITE, m_vmTerminatingEvent.get());
+            if (!socket)
+            {
+                // VM is exiting.
+                break;
+            }
+
+            constexpr DWORD timeout = 30 * 1000;
+            THROW_LAST_ERROR_IF(setsockopt(socket->get(), SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout)) == SOCKET_ERROR);
+
+            auto channel = wsl::shared::SocketChannel{std::move(socket.value()), "crash_dump", m_vmTerminatingEvent.get()};
+
+            const auto& message = channel.ReceiveMessage<LX_PROCESS_CRASH>();
+            const char* process = reinterpret_cast<const char*>(&message.Buffer);
+
+            constexpr auto dumpExtension = ".dmp";
+            constexpr auto dumpPrefix = "wsl-crash";
+
+            auto filename = std::format("{}-{}-{}-{}-{}{}", dumpPrefix, message.Timestamp, message.Pid, process, message.Signal, dumpExtension);
+
+            std::replace_if(filename.begin(), filename.end(), [](auto e) { return !std::isalnum(e) && e != '.' && e != '-'; }, '_');
+
+            auto fullPath = crashDumpFolder / filename;
+
+            WSL_LOG(
+                "WSLALinuxCrash",
+                TraceLoggingValue(fullPath.c_str(), "FullPath"),
+                TraceLoggingValue(message.Pid, "Pid"),
+                TraceLoggingValue(message.Signal, "Signal"),
+                TraceLoggingValue(process, "process"));
+
+            filesystem::EnsureDirectory(crashDumpFolder.c_str());
+
+            // Only delete files that:
+            // - have the temporary flag set
+            // - start with 'wsl-crash'
+            // - end in .dmp
+            //
+            // This logic is here to prevent accidental user file deletion
+            auto pred = [&dumpExtension, &dumpPrefix](const auto& e) {
+                return WI_IsFlagSet(GetFileAttributes(e.path().c_str()), FILE_ATTRIBUTE_TEMPORARY) && e.path().has_extension() &&
+                       e.path().extension() == dumpExtension && e.path().has_filename() &&
+                       e.path().filename().string().find(dumpPrefix) == 0;
+            };
+
+            wslutil::EnforceFileLimit(crashDumpFolder.c_str(), 10, pred);
+
+            wil::unique_hfile file{CreateFileW(fullPath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_TEMPORARY, nullptr)};
+            THROW_LAST_ERROR_IF(!file);
+
+            channel.SendResultMessage<std::int32_t>(0);
+            relay::InterruptableRelay(reinterpret_cast<HANDLE>(channel.Socket()), file.get(), nullptr);
+        }
+        CATCH_LOG()
+    }
 }

--- a/src/windows/wslasession/WSLAVirtualMachine.h
+++ b/src/windows/wslasession/WSLAVirtualMachine.h
@@ -19,6 +19,8 @@ Abstract:
 #include "wslaservice.h"
 #include "hcs.hpp"
 #include "WSLAProcess.h"
+#include <thread>
+#include <filesystem>
 
 namespace wsl::windows::service::wsla {
 
@@ -130,6 +132,8 @@ private:
 
     void WatchForExitedProcesses(wsl::shared::SocketChannel& Channel);
 
+    void CollectCrashDumps(wil::unique_socket&& listenSocket);
+
     struct AttachedDisk
     {
         std::filesystem::path Path;
@@ -146,6 +150,7 @@ private:
     std::string m_rootVhdType;
 
     std::thread m_processExitThread;
+    std::thread m_crashDumpThread;
 
     std::set<uint16_t> m_allocatedPorts;
 


### PR DESCRIPTION
This change moves Linux user space crash collect out of the system service and into the wslasession process which runs as the user. This is preferrable because these crashdumps will be written as the user and do not require any impersonation.