### PR TITLE
Disable the process creation cursor animation by default

### DIFF
--- a/src/windows/common/SubProcess.cpp
+++ b/src/windows/common/SubProcess.cpp
@@ -46,8 +46,8 @@ std::wstring ReadFileContent(wil::unique_hfile& Handle)
 }
 } // namespace
 
-SubProcess::SubProcess(LPCWSTR ApplicationName, LPCWSTR CommandLine, DWORD Flags) :
-    m_applicationName(ApplicationName), m_commandLine(CommandLine), m_flags(Flags)
+SubProcess::SubProcess(LPCWSTR ApplicationName, LPCWSTR CommandLine, DWORD Flags, DWORD StartupFlags) :
+    m_applicationName(ApplicationName), m_commandLine(CommandLine), m_flags(Flags), m_startupFlags(StartupFlags)
 {
 }
 
@@ -159,7 +159,7 @@ wil::unique_handle SubProcess::Start()
 
     STARTUPINFOEX StartupInfo{};
     StartupInfo.StartupInfo.cb = sizeof(StartupInfo);
-    StartupInfo.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    StartupInfo.StartupInfo.dwFlags = STARTF_USESTDHANDLES | m_startupFlags;
 
     // N.B. Passing a pseudoconsole requires all standard handles to be null
     if (m_pseudoConsole == nullptr)

--- a/src/windows/common/SubProcess.h
+++ b/src/windows/common/SubProcess.h
@@ -29,7 +29,7 @@ public:
         std::wstring Stderr;
     };
 
-    SubProcess(LPCWSTR ApplicationName, LPCWSTR CommandLine, DWORD Flags = CREATE_UNICODE_ENVIRONMENT);
+    SubProcess(LPCWSTR ApplicationName, LPCWSTR CommandLine, DWORD Flags = CREATE_UNICODE_ENVIRONMENT, DWORD StartupFlags = STARTF_FORCEOFFFEEDBACK);
 
     void SetStdHandles(HANDLE Stdin, HANDLE Stdout, HANDLE Stderr);
     void SetPseudoConsole(HPCON Console);
@@ -58,6 +58,7 @@ private:
     LPCWSTR m_desktop = nullptr;
     HANDLE m_token = nullptr;
     DWORD m_flags = 0;
+    DWORD m_startupFlags = 0;
 
     HANDLE m_stdIn = nullptr;
     HANDLE m_stdOut = nullptr;

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -194,7 +194,9 @@ CreateProcessResult CreateProcess(_In_ CreateProcessParsed* Parsed, _In_ HANDLE 
     wsl::windows::common::helpers::SetHandleInheritable(StdOut);
     wsl::windows::common::helpers::SetHandleInheritable(StdErr);
 
-    wsl::windows::common::SubProcess process(Parsed->ApplicationName.c_str(), Parsed->CommandLine(), CREATE_UNICODE_ENVIRONMENT);
+    // N.B. Passing StartupFlags = 0 so that the cursor feedback is set to its default behavior.
+    // See: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+    wsl::windows::common::SubProcess process(Parsed->ApplicationName.c_str(), Parsed->CommandLine(), CREATE_UNICODE_ENVIRONMENT, 0);
 
     CreateProcessResult Result{};
     if (Parsed->CreatePseudoconsole)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This sets the `STARTF_FORCEOFFFEEDBACK` by default whenever we create new Windows processes. 

This particularly useful during testing, since it prevents the cursor from jumping between "normal" and "process creation pending" state back and forth. 

The flag is left untouched when creating interop processes, since this path can create interactive GUI processes on behalf of the user


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
