### PR TITLE
CLI: Add image command, pull and list

### DIFF
--- a/src/windows/wslc/commands/ImageCommand.cpp
+++ b/src/windows/wslc/commands/ImageCommand.cpp
@@ -1,0 +1,48 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ImageCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+#include "CLIExecutionContext.h"
+#include "ImageCommand.h"
+
+using namespace wsl::windows::wslc::execution;
+
+namespace wsl::windows::wslc {
+// Image Root Command
+std::vector<std::unique_ptr<Command>> ImageCommand::GetCommands() const
+{
+    std::vector<std::unique_ptr<Command>> commands;
+    commands.push_back(std::make_unique<ImagePullCommand>(FullName()));
+    commands.push_back(std::make_unique<ImageListCommand>(FullName()));
+    return commands;
+}
+
+std::vector<Argument> ImageCommand::GetArguments() const
+{
+    return {};
+}
+
+std::wstring ImageCommand::ShortDescription() const
+{
+    return {L"Image command"};
+}
+
+std::wstring ImageCommand::LongDescription() const
+{
+    return {L"Image command"};
+}
+
+void ImageCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    OutputHelp();
+}
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/ImageCommand.h
+++ b/src/windows/wslc/commands/ImageCommand.h
@@ -1,0 +1,72 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ImageCommand.h
+
+Abstract:
+
+    Declaration of command classes and interfaces.
+
+--*/
+#pragma once
+#include "Command.h"
+
+namespace wsl::windows::wslc {
+// Root Image Command
+struct ImageCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"image";
+    ImageCommand(const std::wstring& parent) : Command(CommandName, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+    std::vector<std::unique_ptr<Command>> GetCommands() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
+
+// List Command
+struct ImageListCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"list";
+    ImageListCommand(const std::wstring& parent) : Command(CommandName, {L"ls"}, parent)
+    {
+    }
+
+    // Image list has an alias 'images' off the root, which will collide with the
+    // container list command and its alias off the root. To avoid this, we will use
+    // an override constructor that changes the name and alias of the command for when
+    // it is parented directly to the root.
+    ImageListCommand(const std::wstring& parent, const std::wstring_view name) : Command(name, {}, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
+
+// Pull Command
+struct ImagePullCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"pull";
+    ImagePullCommand(const std::wstring& parent) : Command(CommandName, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/ImageCommand.h
+++ b/src/windows/wslc/commands/ImageCommand.h
@@ -36,6 +36,11 @@ protected:
 struct ImageListCommand final : public Command
 {
     constexpr static std::wstring_view CommandName = L"list";
+
+    // When parented directly to the root, ImageListCommand uses a different name
+    // to avoid colliding with the container list command.
+    constexpr static std::wstring_view RootCommandName = L"images";
+
     ImageListCommand(const std::wstring& parent) : Command(CommandName, {L"ls"}, parent)
     {
     }
@@ -44,7 +49,8 @@ struct ImageListCommand final : public Command
     // container list command and its alias off the root. To avoid this, we will use
     // an override constructor that changes the name and alias of the command for when
     // it is parented directly to the root.
-    ImageListCommand(const std::wstring& parent, const std::wstring_view name) : Command(name, {}, parent)
+    // The bool parameter is used as a tag to select the root-specific name.
+    ImageListCommand(const std::wstring& parent, bool /*rootScoped*/) : Command(RootCommandName, {}, parent)
     {
     }
     std::vector<Argument> GetArguments() const override;

--- a/src/windows/wslc/commands/ImageListCommand.cpp
+++ b/src/windows/wslc/commands/ImageListCommand.cpp
@@ -26,12 +26,7 @@ namespace wsl::windows::wslc {
 // Image List Command
 std::vector<Argument> ImageListCommand::GetArguments() const
 {
-    return {
-        Argument::Create(ArgType::Format),
-        Argument::Create(ArgType::Quiet),
-        Argument::Create(ArgType::Session),
-        Argument::Create(ArgType::Verbose)
-    };
+    return {Argument::Create(ArgType::Format), Argument::Create(ArgType::Quiet), Argument::Create(ArgType::Session), Argument::Create(ArgType::Verbose)};
 }
 
 std::wstring ImageListCommand::ShortDescription() const

--- a/src/windows/wslc/commands/ImageListCommand.cpp
+++ b/src/windows/wslc/commands/ImageListCommand.cpp
@@ -1,0 +1,54 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ImageListCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+
+#include "ImageCommand.h"
+#include "CLIExecutionContext.h"
+#include "ImageTasks.h"
+#include "SessionTasks.h"
+#include "Task.h"
+
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::task;
+using namespace wsl::shared::string;
+
+namespace wsl::windows::wslc {
+// Image List Command
+std::vector<Argument> ImageListCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::Format),
+        Argument::Create(ArgType::Quiet),
+        Argument::Create(ArgType::Session),
+        Argument::Create(ArgType::Verbose)
+    };
+}
+
+std::wstring ImageListCommand::ShortDescription() const
+{
+    return {L"List images."};
+}
+
+std::wstring ImageListCommand::LongDescription() const
+{
+    return {L"Lists images."};
+}
+
+void ImageListCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    context              //
+        << CreateSession //
+        << GetImages     //
+        << ListImages;
+}
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/ImagePullCommand.cpp
+++ b/src/windows/wslc/commands/ImagePullCommand.cpp
@@ -1,0 +1,53 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ImagePullCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+
+#include "ImageCommand.h"
+#include "CLIExecutionContext.h"
+#include "ImageTasks.h"
+#include "SessionTasks.h"
+#include "Task.h"
+
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::task;
+using namespace wsl::shared::string;
+
+namespace wsl::windows::wslc {
+// Image Pull Command
+std::vector<Argument> ImagePullCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::ImageId, true),
+        Argument::Create(ArgType::Scheme),
+        Argument::Create(ArgType::Progress),
+        Argument::Create(ArgType::Session),
+    };
+}
+
+std::wstring ImagePullCommand::ShortDescription() const
+{
+    return {L"Pull images."};
+}
+
+std::wstring ImagePullCommand::LongDescription() const
+{
+    return {L"Pulls images."};
+}
+
+void ImagePullCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    context              //
+        << CreateSession //
+        << PullImage;
+}
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -30,7 +30,7 @@ std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
     commands.push_back(std::make_unique<ContainerCreateCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerDeleteCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerExecCommand>(FullName()));
-    commands.push_back(std::make_unique<ImageListCommand>(FullName(), L"images")); // Aliased to avoid collision.
+    commands.push_back(std::make_unique<ImageListCommand>(FullName(), true));
     commands.push_back(std::make_unique<ContainerInspectCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerKillCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerListCommand>(FullName()));

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -30,7 +30,7 @@ std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
     commands.push_back(std::make_unique<ContainerCreateCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerDeleteCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerExecCommand>(FullName()));
-    commands.push_back(std::make_unique<ImageListCommand>(FullName(), L"images")); // Alaised to avoid collision.
+    commands.push_back(std::make_unique<ImageListCommand>(FullName(), L"images")); // Aliased to avoid collision.
     commands.push_back(std::make_unique<ContainerInspectCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerKillCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerListCommand>(FullName()));

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -30,7 +30,7 @@ std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
     commands.push_back(std::make_unique<ContainerCreateCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerDeleteCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerExecCommand>(FullName()));
-    commands.push_back(std::make_unique<ImageListCommand>(FullName(), L"images"));  // Alaised to avoid collision.
+    commands.push_back(std::make_unique<ImageListCommand>(FullName(), L"images")); // Alaised to avoid collision.
     commands.push_back(std::make_unique<ContainerInspectCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerKillCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerListCommand>(FullName()));

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -15,6 +15,7 @@ Abstract:
 
 // Include all commands that parent to the root.
 #include "ContainerCommand.h"
+#include "ImageCommand.h"
 #include "SessionCommand.h"
 
 using namespace wsl::windows::wslc::execution;
@@ -24,14 +25,17 @@ std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
 {
     std::vector<std::unique_ptr<Command>> commands;
     commands.push_back(std::make_unique<ContainerCommand>(FullName()));
+    commands.push_back(std::make_unique<ImageCommand>(FullName()));
     commands.push_back(std::make_unique<SessionCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerCreateCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerDeleteCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerExecCommand>(FullName()));
+    commands.push_back(std::make_unique<ImageListCommand>(FullName(), L"images"));  // Alaised to avoid collision.
     commands.push_back(std::make_unique<ContainerInspectCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerKillCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerListCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerLogsCommand>(FullName()));
+    commands.push_back(std::make_unique<ImagePullCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerRunCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerStartCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerStopCommand>(FullName()));

--- a/src/windows/wslc/core/ExecutionContextData.h
+++ b/src/windows/wslc/core/ExecutionContextData.h
@@ -14,6 +14,7 @@ Abstract:
 #pragma once
 #include "EnumVariantMap.h"
 #include "ContainerModel.h"
+#include "ImageModel.h"
 #include "SessionModel.h"
 
 #include <string>
@@ -34,6 +35,7 @@ enum class Data : size_t
     Session,
     Containers,
     ContainerOptions,
+    Images,
 
     Max
 };
@@ -47,6 +49,7 @@ namespace details {
     DEFINE_DATA_MAPPING(Session, wsl::windows::wslc::models::Session);
     DEFINE_DATA_MAPPING(Containers, std::vector<wsl::windows::wslc::models::ContainerInformation>);
     DEFINE_DATA_MAPPING(ContainerOptions, wsl::windows::wslc::models::ContainerOptions);
+    DEFINE_DATA_MAPPING(Images, std::vector<wsl::windows::wslc::models::ImageInformation>);
 } // namespace details
 
 struct DataMap : wsl::windows::wslc::EnumBasedVariantMap<Data, wsl::windows::wslc::execution::details::DataMapping>

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -29,7 +29,7 @@ std::vector<ImageInformation> ImageService::List(wsl::windows::wslc::models::Ses
     for (auto ptr = images.get(), end = images.get() + count; ptr != end; ++ptr)
     {
         const WSLA_IMAGE_INFORMATION& image = *ptr;
-        ImageInformation info;
+        ImageInformation info{};
         info.Name = image.Image;
         info.Size = image.Size;
         result.push_back(info);

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -20,8 +20,8 @@ namespace wsl::windows::wslc::services {
 class ImageService
 {
 public:
-    std::vector<wsl::windows::wslc::models::ImageInformation> List(wsl::windows::wslc::models::Session& session);
-    void Pull(wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback);
+    static std::vector<wsl::windows::wslc::models::ImageInformation> List(wsl::windows::wslc::models::Session& session);
+    static void Pull(wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback);
     void Push();
     void Save();
     void Load();

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -1,0 +1,97 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ImageTasks.cpp
+
+Abstract:
+
+    Implementation of image command related execution logic.
+
+--*/
+#include "Argument.h"
+#include "ArgumentValidation.h"
+#include "CLIExecutionContext.h"
+#include "ImageModel.h"
+#include "ImageService.h"
+#include "ImageTasks.h"
+#include "PullImageCallback.h"
+#include "TablePrinter.h"
+#include "Task.h"
+#include <format>
+
+using namespace wsl::shared;
+using namespace wsl::windows::common::string;
+using namespace wsl::windows::common::wslutil;
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::services;
+
+namespace wsl::windows::wslc::task {
+void GetImages(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Session));
+    auto& session = context.Data.Get<Data::Session>();
+    auto images = ImageService::List(session);
+    context.Data.Add<Data::Images>(std::move(images));
+}
+
+void ListImages(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Images));
+    auto& images = context.Data.Get<Data::Images>();
+
+    if (context.Args.Contains(ArgType::Quiet))
+    {
+        // Print only the image ids
+        for (const auto& image : images)
+        {
+            PrintMessage(MultiByteToWide(image.Name));
+        }
+
+        return;
+    }
+
+    FormatType format = FormatType::Table; // Default is table
+    if (context.Args.Contains(ArgType::Format))
+    {
+        format = validation::GetFormatTypeFromString(context.Args.Get<ArgType::Format>());
+    }
+
+    switch (format)
+    {
+    case FormatType::Json:
+    {
+        auto json = ToJson(images);
+        PrintMessage(MultiByteToWide(json));
+        break;
+    }
+    case FormatType::Table:
+    {
+        utils::TablePrinter tablePrinter({L"NAME", L"SIZE (MB)"});
+        for (const auto& image : images)
+        {
+            tablePrinter.AddRow(
+                {wsl::shared::string::MultiByteToWide(image.Name), std::format(L"{:.2f} MB", static_cast<double>(image.Size) / (1024 * 1024))});
+        }
+
+        tablePrinter.Print();
+        break;
+    }
+    default:
+        THROW_HR(E_UNEXPECTED);
+    }
+}
+
+void PullImage(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Session));
+    WI_ASSERT(context.Args.Contains(ArgType::ImageId));
+    auto& session = context.Data.Get<Data::Session>();
+    auto& imageId = context.Args.Get<ArgType::ImageId>();
+
+    PullImageCallback callback;
+    services::ImageService::Pull(session, WideToMultiByte(imageId), &callback);
+}
+} // namespace wsl::windows::wslc::task

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -44,7 +44,7 @@ void ListImages(CLIExecutionContext& context)
 
     if (context.Args.Contains(ArgType::Quiet))
     {
-        // Print only the image ids
+        // Print only the image names.
         for (const auto& image : images)
         {
             PrintMessage(MultiByteToWide(image.Name));
@@ -72,8 +72,7 @@ void ListImages(CLIExecutionContext& context)
         utils::TablePrinter tablePrinter({L"NAME", L"SIZE (MB)"});
         for (const auto& image : images)
         {
-            tablePrinter.AddRow(
-                {MultiByteToWide(image.Name), std::format(L"{:.2f}", static_cast<double>(image.Size) / (1024 * 1024))});
+            tablePrinter.AddRow({MultiByteToWide(image.Name), std::format(L"{:.2f}", static_cast<double>(image.Size) / (1024 * 1024))});
         }
 
         tablePrinter.Print();

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -73,7 +73,7 @@ void ListImages(CLIExecutionContext& context)
         for (const auto& image : images)
         {
             tablePrinter.AddRow(
-                {wsl::shared::string::MultiByteToWide(image.Name), std::format(L"{:.2f} MB", static_cast<double>(image.Size) / (1024 * 1024))});
+                {MultiByteToWide(image.Name), std::format(L"{:.2f}", static_cast<double>(image.Size) / (1024 * 1024))});
         }
 
         tablePrinter.Print();

--- a/src/windows/wslc/tasks/ImageTasks.h
+++ b/src/windows/wslc/tasks/ImageTasks.h
@@ -1,0 +1,23 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ImageTasks.h
+
+Abstract:
+
+    Declaration of image command execution tasks.
+
+--*/
+#pragma once
+#include "CLIExecutionContext.h"
+
+using wsl::windows::wslc::execution::CLIExecutionContext;
+
+namespace wsl::windows::wslc::task {
+void GetImages(CLIExecutionContext& context);
+void ListImages(CLIExecutionContext& context);
+void PullImage(CLIExecutionContext& context);
+} // namespace wsl::windows::wslc::task

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -73,6 +73,17 @@ COMMAND_LINE_TEST_CASE(L"container logs --follow cont1", L"logs", true)
 COMMAND_LINE_TEST_CASE(L"container logs cont1 -f", L"logs", true)
 COMMAND_LINE_TEST_CASE(L"container logs", L"logs", false)
 
+// Image command
+COMMAND_LINE_TEST_CASE(L"image list", L"list", true)
+COMMAND_LINE_TEST_CASE(L"images", L"images", true)                      // Aliased off the root changes the name
+COMMAND_LINE_TEST_CASE(L"image ls", L"list", true)
+COMMAND_LINE_TEST_CASE(L"image list --format json", L"list", true)
+COMMAND_LINE_TEST_CASE(L"image list --format badformat", L"list", false)
+COMMAND_LINE_TEST_CASE(L"image list -v", L"list", true)
+COMMAND_LINE_TEST_CASE(L"image list -q", L"list", true)
+COMMAND_LINE_TEST_CASE(L"image pull ubuntu", L"pull", true)
+COMMAND_LINE_TEST_CASE(L"pull ubuntu", L"pull", true)
+
 // Error cases
 COMMAND_LINE_TEST_CASE(L"invalid command", L"", false)
 COMMAND_LINE_TEST_CASE(L"CONTAINER list", L"list", false)               // We are intentionally case-sensitive

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -75,7 +75,7 @@ COMMAND_LINE_TEST_CASE(L"container logs", L"logs", false)
 
 // Image command
 COMMAND_LINE_TEST_CASE(L"image list", L"list", true)
-COMMAND_LINE_TEST_CASE(L"images", L"images", true)                      // Aliased off the root changes the name
+COMMAND_LINE_TEST_CASE(L"images", L"images", true) // Aliased off the root changes the name
 COMMAND_LINE_TEST_CASE(L"image ls", L"list", true)
 COMMAND_LINE_TEST_CASE(L"image list --format json", L"list", true)
 COMMAND_LINE_TEST_CASE(L"image list --format badformat", L"list", false)

--- a/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
@@ -89,6 +89,12 @@ class WSLCCLIExecutionUnitTests
                 dataMap.Add<Data::ContainerOptions>(std::move(options));
                 handled = true;
             }
+            else if (dataType == Data::Images)
+            {
+                std::vector<wsl::windows::wslc::models::ImageInformation> images;
+                dataMap.Add<Data::Images>(std::move(images));
+                handled = true;
+            }
 
             if (!handled)
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Added image base command, `wslc image`
* Added image pull subcommand, also aliased to the root. `wslc image pull` and `wslc pull`
* Added image list subcommand, aliased to 'ls' in the image command, and 'images' in the root. `wslc image list`, `wslc image ls`, and `wslc images`
* Added unit tests for the above.

This completes the last conversion item from the old infrastructure.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This completes the last remaining conversion items, two commands in the Image command tree, pull and list.

The code follows Container patterns closely, with List being very similar to Container List, and pull using a subset of the Container Create task for pulling the image with progress.

There isn't much to note here other than the new root aliasing that is different from previous aliased commands, as it is actually a different command name in the root to avoid collision with container list. This is how Docker does it so we are following the docker usage pattern here with `wslc image list`, `wslc image ls`, and `wslc images`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Unit tests created and passed
* Manual validation of pull and list, which perform as epected.