### PR TITLE
Exit early if m_cancel is set in MultiHandleWait::Run()

### DIFF
--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -962,9 +962,9 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
     while (!m_handles.empty() && !m_cancel)
     {
         // Schedule IO on each handle until all are either pending, or completed.
-        for (size_t i = 0; i < m_handles.size(); i++)
+        for (size_t i = 0; i < m_handles.size() && !m_cancel; i++)
         {
-            while (m_handles[i].second->GetState() == IOHandleStatus::Standby)
+            while (m_handles[i].second->GetState() == IOHandleStatus::Standby && !m_cancel)
             {
                 try
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a potential starvation of an IO is cancelled but a specific handle keeps getting synchronous IO. This is solved by simply exiting the first two loops if `m_cancel` is set 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
