### PR TITLE
Fix 4 code bugs: substr off-by-one, HANDLE* cast, TOCTOU GetLastError, sun_path overflow

### DIFF
--- a/src/windows/service/exe/LxssHttpProxy.cpp
+++ b/src/windows/service/exe/LxssHttpProxy.cpp
@@ -327,12 +327,12 @@ try
     if (openBracket != ::std::wstring::npos)
     {
         const auto closeBracket = portRemoved.find_first_of(L"]");
-        if (closeBracket == ::std::wstring::npos || (openBracket + 1 >= closeBracket - 1))
+        if (closeBracket == ::std::wstring::npos || (openBracket + 1 >= closeBracket))
         {
             // no other of below checks can contain brackets
             return UnsupportedProxyReason::Supported;
         }
-        portRemoved = portRemoved.substr(openBracket + 1, closeBracket - 1);
+        portRemoved = portRemoved.substr(openBracket + 1, closeBracket - openBracket - 1);
     }
 
     in6_addr addrV6{};


### PR DESCRIPTION
* LxssHttpProxy.cpp: IPv6 substr extraction used wrong length calculation. substr(openBracket+1, closeBracket-1) is incorrect when openBracket > 0; fixed to substr(openBracket+1, closeBracket-openBracket-1). Also fixed empty-address guard to check closeBracket (not closeBracket-1).

* LxssUserSession.cpp: Two instances of reinterpret_cast<HANDLE*> in ScopedMultiRelay construction should be reinterpret_cast<HANDLE> (without the pointer). Other identical callsites in the same file already use the correct cast.

* LxssUserSession.cpp: GetLastError() was called unconditionally after CreateFileW, even on success. A stale ERROR_SHARING_VIOLATION from a prior API call could cause a false throw. Fixed to only check GetLastError() when CreateFileW fails (!vhd).

* plan9.cpp: sun_path bounds check used > instead of >= leaving no room for null terminator. Also added a post-split check to ensure the child name fits after splitting parent/child for long paths.