### PR TITLE
Fix FindIDL.cmake to correctly reference IDL_P variable instead of empty IDL_C var

### DIFF
--- a/cmake/FindIDL.cmake
+++ b/cmake/FindIDL.cmake
@@ -24,7 +24,7 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
         set(IDL_I ${OUTPUT_DIR}/${IDL_NAME}_i_${TARGET_PLATFORM}.c)
         set(IDL_P ${OUTPUT_DIR}/${IDL_NAME}_p_${TARGET_PLATFORM}.c)
         set(IDL_DLLDATA ${OUTPUT_DIR}/dlldata_${TARGET_PLATFORM}.c)
-        set(MIDL_OUTPUT ${IDL_HEADER} ${IDL_I} ${IDL_C} ${IDL_DLLDATA})
+        set(MIDL_OUTPUT ${IDL_HEADER} ${IDL_I} ${IDL_P} ${IDL_DLLDATA})
 
         add_custom_command(
             OUTPUT ${MIDL_OUTPUT} ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}


### PR DESCRIPTION
The _p_x64.c proxy source wasn't listed as a MIDL output or marked as generated. So during a parallel build, cl.exe saw the old _p_x64.c already on disk and compiled it immediately — before MIDL had a chance to regenerate it.