### PR TITLE
Fix AcceptEx stack buffer use-after-free in PortRelay

### DIFF
--- a/src/windows/wslrelay/localhost.cpp
+++ b/src/windows/wslrelay/localhost.cpp
@@ -339,6 +339,7 @@ struct PortRelay
     bool Pending = false;
     wil::unique_socket PendingSocket;
     int Family;
+    CHAR AcceptBuffer[2 * sizeof(SOCKADDR_STORAGE)]{};
 
     PortRelay(wil::unique_socket&& ListenSocket, uint32_t LinuxPort, uint32_t RelayPort, int Family) :
         ListenSocket(std::move(ListenSocket)), LinuxPort(LinuxPort), RelayPort(RelayPort), Family(Family)
@@ -408,7 +409,7 @@ struct PortRelay
         WI_VERIFY(!Pending);
 
         PendingSocket.reset(WSASocket(Family, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED));
-        CHAR AcceptBuffer[2 * sizeof(SOCKADDR_STORAGE)]{};
+        memset(AcceptBuffer, 0, sizeof(AcceptBuffer));
         DWORD BytesReturned{};
         if (!AcceptEx(ListenSocket.get(), PendingSocket.get(), AcceptBuffer, 0, sizeof(SOCKADDR_STORAGE), sizeof(SOCKADDR_STORAGE), &BytesReturned, &Overlapped))
         {


### PR DESCRIPTION
Move AcceptBuffer from stack-local variable in ScheduleAccept() to a member of the PortRelay struct. When AcceptEx returns WSA_IO_PENDING, the function returns and the stack frame is destroyed, but the OS still writes address data into AcceptBuffer on completion - causing a write to freed stack memory.

This matches the pattern used by SingleAcceptHandle in relay.hpp, which correctly stores AcceptBuffer as a class member.
