### PR TITLE
wslc: Fix PullImageCallback crash when stdout is redirected

### DIFF
--- a/src/windows/wslc/services/PullImageCallback.cpp
+++ b/src/windows/wslc/services/PullImageCallback.cpp
@@ -21,9 +21,14 @@ Abstract:
 namespace wsl::windows::wslc::services {
 using namespace wsl::shared;
 
-ChangeTerminalMode::ChangeTerminalMode(HANDLE console, bool cursorVisible)
+ChangeTerminalMode::ChangeTerminalMode(HANDLE console, bool cursorVisible) : m_console(console)
 {
-    m_console = console;
+    if (!wsl::windows::common::wslutil::IsConsoleHandle(console))
+    {
+        m_console = nullptr;
+        return;
+    }
+
     THROW_IF_WIN32_BOOL_FALSE(GetConsoleCursorInfo(console, &m_originalCursorInfo));
     CONSOLE_CURSOR_INFO newCursorInfo = m_originalCursorInfo;
     newCursorInfo.bVisible = cursorVisible;
@@ -32,7 +37,10 @@ ChangeTerminalMode::ChangeTerminalMode(HANDLE console, bool cursorVisible)
 
 ChangeTerminalMode::~ChangeTerminalMode()
 {
-    LOG_IF_WIN32_BOOL_FALSE(SetConsoleCursorInfo(m_console, &m_originalCursorInfo));
+    if (m_console)
+    {
+        LOG_IF_WIN32_BOOL_FALSE(SetConsoleCursorInfo(m_console, &m_originalCursorInfo));
+    }
 }
 
 auto PullImageCallback::MoveToLine(SHORT line)
@@ -54,6 +62,11 @@ HRESULT PullImageCallback::OnProgress(LPCSTR status, LPCSTR id, ULONGLONG curren
 {
     try
     {
+        if (!m_terminalMode.IsConsole())
+        {
+            return S_OK;
+        }
+
         if (id == nullptr || *id == '\0') // Print all 'global' statuses on their own line
         {
             wprintf(L"%hs\n", status);

--- a/src/windows/wslc/services/PullImageCallback.h
+++ b/src/windows/wslc/services/PullImageCallback.h
@@ -24,7 +24,10 @@ public:
     ChangeTerminalMode(HANDLE console, bool cursorVisible);
     ~ChangeTerminalMode();
 
-    bool IsConsole() const { return m_console != nullptr; }
+    bool IsConsole() const
+    {
+        return m_console != nullptr;
+    }
 
 private:
     HANDLE m_console{};

--- a/src/windows/wslc/services/PullImageCallback.h
+++ b/src/windows/wslc/services/PullImageCallback.h
@@ -24,6 +24,8 @@ public:
     ChangeTerminalMode(HANDLE console, bool cursorVisible);
     ~ChangeTerminalMode();
 
+    bool IsConsole() const { return m_console != nullptr; }
+
 private:
     HANDLE m_console{};
     CONSOLE_CURSOR_INFO m_originalCursorInfo{};


### PR DESCRIPTION
ChangeTerminalMode's constructor calls GetConsoleCursorInfo, which throws ERROR_INVALID_HANDLE when stdout is redirected (e.g., '> file' or '| findstr'), crashing 'wslc container create' and 'wslc container run'.

Add an IsConsoleHandle() check at the top of the ChangeTerminalMode constructor. When the handle is not a real console, set m_console to nullptr and return early, skipping all console API calls. The destructor already guards its SetConsoleCursorInfo restore with an m_console check.

Added an IsConsole() accessor so PullImageCallback::OnProgress can skip progress display when stdout is not a console, returning S_OK silently.

This follows the same pattern used by ConsoleProgressBar, which checks IsConsoleHandle in its constructor and no-ops its Print method.
