### PR TITLE
wsla: fix test bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ doc/site/
 directory.build.targets
 test-storage/
 *.vhdx
+*.tar

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -191,19 +191,25 @@ public:
 
     wil::unique_hkey OpenKey()
     {
-        return;
+        return wsl::windows::common::registry::CreateKey(m_hive, m_key, KEY_ALL_ACCESS);
     }
 
     RegistryKeyChange(const RegistryKeyChange&) = delete;
     RegistryKeyChange(RegistryKeyChange&& other) = default;
-    const RegistryKeyChange& operator=(RegistryKeyChange&& other)
+    RegistryKeyChange& operator=(RegistryKeyChange&& other)
     {
-        m_hive = std::move(other.m_hive);
-        m_key = std::move(other.m_key);
-        m_value = std::move(other.m_value);
+        if (this != &other)
+        {
+            m_hive = std::move(other.m_hive);
+            m_key = std::move(other.m_key);
+            m_value = std::move(other.m_value);
+            m_originalValue = std::move(other.m_originalValue);
 
-        other.m_hive = nullptr;
-        other.m_key = nullptr;
+            other.m_hive = nullptr;
+            other.m_key = nullptr;
+        }
+
+        return *this;
     }
 
     const RegistryKeyChange& operator=(RegistryKeyChange&) = delete;

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -195,7 +195,13 @@ public:
     }
 
     RegistryKeyChange(const RegistryKeyChange&) = delete;
-    RegistryKeyChange(RegistryKeyChange&& other) = default;
+    RegistryKeyChange(RegistryKeyChange&& other) noexcept :
+        m_hive(other.m_hive), m_key(other.m_key), m_value(std::move(other.m_value)), m_originalValue(std::move(other.m_originalValue))
+    {
+        other.m_hive = nullptr;
+        other.m_key = nullptr;
+    }
+
     RegistryKeyChange& operator=(RegistryKeyChange&& other)
     {
         if (this != &other)

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -111,7 +111,7 @@ class WSLATests
         WSLA_SESSION_SETTINGS settings{};
         settings.DisplayName = Name;
         settings.CpuCount = 4;
-        settings.MemoryMb = 2024;
+        settings.MemoryMb = 2048;
         settings.BootTimeoutMs = 30 * 1000;
         settings.StoragePath = enableStorage ? m_storagePath.c_str() : nullptr;
         settings.MaximumStorageSizeMb = 4096; // 4GB.
@@ -184,7 +184,7 @@ class WSLATests
     }
 
     static RunningWSLAProcess::ProcessResult ExpectCommandResult(
-        IWSLASession* session, const std::vector<std::string>& command, int expectResult, bool expectSignal = false, int timeout = 600000)
+        IWSLASession* session, const std::vector<std::string>& command, int expectResult, int timeout = 600000)
     {
         auto result = RunCommand(session, command, timeout);
 
@@ -235,6 +235,8 @@ class WSLATests
                     fd,
                     EscapeString(expected).c_str(),
                     EscapeString(it->second).c_str());
+
+                return;
             }
         }
     }
@@ -1192,6 +1194,7 @@ class WSLATests
                 auto cleanup =
                     wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(containerTar.c_str())); });
                 LARGE_INTEGER fileSize{};
+                VERIFY_IS_TRUE(GetFileSizeEx(containerTarFileHandle.get(), &fileSize));
                 VERIFY_SUCCEEDED(m_defaultSession->LoadImage(HandleToULong(containerTarFileHandle.get()), nullptr, fileSize.QuadPart));
                 // Verify that the image is in the list of images.
                 ExpectImagePresent(*m_defaultSession, "hello-world:latest");
@@ -4048,7 +4051,7 @@ class WSLATests
 
         // Test duplicate keys
         {
-            std::vector<WSLA_LABEL> labels(2);
+            std::vector<WSLA_LABEL> labels;
             labels.push_back({.Key = "key", .Value = "value"});
             labels.push_back({.Key = "key", .Value = "value2"});
 
@@ -4060,7 +4063,7 @@ class WSLATests
 
             wil::com_ptr<IWSLAContainer> container;
             auto hr = m_defaultSession->CreateContainer(&options, &container);
-            VERIFY_ARE_EQUAL(hr, E_INVALIDARG);
+            VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
         }
 
         // Test wsla metadata key conflict

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -168,7 +168,7 @@ class WslcSdkTests
         WslcSessionSettings sessionSettings;
         VERIFY_SUCCEEDED(WslcSessionInitSettings(c_testSessionName, m_storagePath.c_str(), &sessionSettings));
         VERIFY_SUCCEEDED(WslcSessionSettingsSetCpuCount(&sessionSettings, 4));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetMemory(&sessionSettings, 2024));
+        VERIFY_SUCCEEDED(WslcSessionSettingsSetMemory(&sessionSettings, 2048));
         VERIFY_SUCCEEDED(WslcSessionSettingsSetTimeout(&sessionSettings, 30 * 1000));
 
         WslcVhdRequirements vhdReqs{};


### PR DESCRIPTION
- Add missing GetFileSizeEx in ExportContainer second block
- Fix ContainerLabels duplicate-key false positive (empty vector, correct expected HRESULT)
- Fix RegistryKeyChange move-assignment (return *this, transfer m_originalValue, self-assign guard)
- Fix RegistryKeyChange::OpenKey to return actual key
- Add missing return after content mismatch in ValidateProcessOutput
- Fix MemoryMb 2024 -> 2048 typo in WSLATests and WslcSdkTests
- Remove unused expectSignal parameter from ExpectCommandResult
- Add *.tar to .gigignore 
