### PR TITLE
Make ForEachSession enforce noexcept lambdas

### DIFF
--- a/src/windows/wslaservice/exe/WSLASessionManager.cpp
+++ b/src/windows/wslaservice/exe/WSLASessionManager.cpp
@@ -56,18 +56,18 @@ void WSLASessionManagerImpl::CreateSession(const WSLA_SESSION_SETTINGS* Settings
     std::lock_guard lock(m_wslaSessionsLock);
 
     // Check for an existing session first.
-    auto result = ForEachSession<HRESULT>([&](auto& entry, const wil::com_ptr<IWSLASession>& session) -> std::optional<HRESULT> {
-        if (wsl::shared::string::IsEqual(entry.DisplayName.c_str(), Settings->DisplayName))
+    auto result = ForEachSession<HRESULT>([&](auto& entry, const wil::com_ptr<IWSLASession>& session) noexcept -> std::optional<HRESULT> {
+        if (!wsl::shared::string::IsEqual(entry.DisplayName.c_str(), Settings->DisplayName))
         {
-            RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS), WI_IsFlagClear(Flags, WSLASessionFlagsOpenExisting));
-
-            THROW_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
-
-            session.copy_to(WslaSession);
-            return S_OK;
+            return {};
         }
 
-        return std::optional<HRESULT>{};
+        RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS), WI_IsFlagClear(Flags, WSLASessionFlagsOpenExisting));
+
+        RETURN_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
+
+        session.copy_to(WslaSession);
+        return S_OK;
     });
 
     if (result.has_value())
@@ -111,17 +111,16 @@ void WSLASessionManagerImpl::CreateSession(const WSLA_SESSION_SETTINGS* Settings
 void WSLASessionManagerImpl::OpenSession(ULONG Id, IWSLASession** Session)
 {
     auto tokenInfo = GetCallingProcessTokenInfo();
-    auto result = ForEachSession<HRESULT>([&](auto& entry, const wil::com_ptr<IWSLASession>& session) {
-        if (entry.SessionId == Id)
+    auto result = ForEachSession<HRESULT>([&](auto& entry, const wil::com_ptr<IWSLASession>& session) noexcept -> std::optional<HRESULT> {
+        if (entry.SessionId != Id)
         {
-            THROW_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
-            session.copy_to(Session);
-            return std::make_optional(S_OK);
+            return {};
         }
-        else
-        {
-            return std::optional<HRESULT>{};
-        }
+
+        RETURN_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
+
+        session.copy_to(Session);
+        return S_OK;
     });
 
     THROW_IF_FAILED_MSG(result.value_or(HRESULT_FROM_WIN32(ERROR_NOT_FOUND)), "Session '%lu' not found", Id);
@@ -131,17 +130,16 @@ void WSLASessionManagerImpl::OpenSessionByName(LPCWSTR DisplayName, IWSLASession
 {
     auto tokenInfo = GetCallingProcessTokenInfo();
 
-    auto result = ForEachSession<HRESULT>([&](auto& entry, const wil::com_ptr<IWSLASession>& session) {
-        if (wsl::shared::string::IsEqual(entry.DisplayName.c_str(), DisplayName))
+    auto result = ForEachSession<HRESULT>([&](auto& entry, const wil::com_ptr<IWSLASession>& session) noexcept -> std::optional<HRESULT> {
+        if (!wsl::shared::string::IsEqual(entry.DisplayName.c_str(), DisplayName))
         {
-            THROW_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
-            session.copy_to(Session);
-            return std::make_optional(S_OK);
+            return {};
         }
-        else
-        {
-            return std::optional<HRESULT>{};
-        }
+
+        RETURN_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
+
+        session.copy_to(Session);
+        return S_OK;
     });
 
     THROW_IF_FAILED_MSG(result.value_or(HRESULT_FROM_WIN32(ERROR_NOT_FOUND)), "Session '%ls' not found", DisplayName);
@@ -151,9 +149,12 @@ void WSLASessionManagerImpl::ListSessions(_Out_ WSLA_SESSION_INFORMATION** Sessi
 {
     std::vector<WSLA_SESSION_INFORMATION> sessionInfo;
 
-    ForEachSession<void>([&](auto& entry, const auto&) {
+    ForEachSession<void>([&](auto& entry, const auto&) noexcept {
         wil::unique_hlocal_string sidString;
-        THROW_IF_WIN32_BOOL_FALSE(ConvertSidToStringSidW(entry.Owner.TokenInfo->User.Sid, &sidString));
+        if (!LOG_IF_WIN32_BOOL_FALSE(ConvertSidToStringSidW(entry.Owner.TokenInfo->User.Sid, &sidString)))
+        {
+            return;
+        }
 
         auto& it = sessionInfo.emplace_back(WSLA_SESSION_INFORMATION{.SessionId = entry.SessionId, .CreatorPid = entry.CreatorPid});
         wcscpy_s(it.Sid, _countof(it.Sid), sidString.get());

--- a/src/windows/wslaservice/exe/WSLASessionManager.cpp
+++ b/src/windows/wslaservice/exe/WSLASessionManager.cpp
@@ -66,7 +66,8 @@ void WSLASessionManagerImpl::CreateSession(const WSLA_SESSION_SETTINGS* Settings
 
         RETURN_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
 
-        session.copy_to(WslaSession);
+        RETURN_IF_FAILED(wil::com_copy_to_nothrow(session, WslaSession));
+
         return S_OK;
     });
 
@@ -119,7 +120,8 @@ void WSLASessionManagerImpl::OpenSession(ULONG Id, IWSLASession** Session)
 
         RETURN_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
 
-        session.copy_to(Session);
+        RETURN_IF_FAILED(wil::com_copy_to_nothrow(session, Session));
+
         return S_OK;
     });
 
@@ -138,7 +140,8 @@ void WSLASessionManagerImpl::OpenSessionByName(LPCWSTR DisplayName, IWSLASession
 
         RETURN_IF_FAILED(CheckTokenAccess(entry, tokenInfo));
 
-        session.copy_to(Session);
+        RETURN_IF_FAILED(wil::com_copy_to_nothrow(session, Session));
+
         return S_OK;
     });
 

--- a/src/windows/wslaservice/exe/WSLASessionManager.cpp
+++ b/src/windows/wslaservice/exe/WSLASessionManager.cpp
@@ -150,15 +150,16 @@ void WSLASessionManagerImpl::ListSessions(_Out_ WSLA_SESSION_INFORMATION** Sessi
     std::vector<WSLA_SESSION_INFORMATION> sessionInfo;
 
     ForEachSession<void>([&](auto& entry, const auto&) noexcept {
-        wil::unique_hlocal_string sidString;
-        if (!LOG_IF_WIN32_BOOL_FALSE(ConvertSidToStringSidW(entry.Owner.TokenInfo->User.Sid, &sidString)))
+        try
         {
-            return;
-        }
+            wil::unique_hlocal_string sidString;
+            THROW_IF_WIN32_BOOL_FALSE(ConvertSidToStringSidW(entry.Owner.TokenInfo->User.Sid, &sidString));
 
-        auto& it = sessionInfo.emplace_back(WSLA_SESSION_INFORMATION{.SessionId = entry.SessionId, .CreatorPid = entry.CreatorPid});
-        wcscpy_s(it.Sid, _countof(it.Sid), sidString.get());
-        wcscpy_s(it.DisplayName, _countof(it.DisplayName), entry.DisplayName.c_str());
+            auto& it = sessionInfo.emplace_back(WSLA_SESSION_INFORMATION{.SessionId = entry.SessionId, .CreatorPid = entry.CreatorPid});
+            wcscpy_s(it.Sid, _countof(it.Sid), sidString.get());
+            wcscpy_s(it.DisplayName, _countof(it.DisplayName), entry.DisplayName.c_str());
+        }
+        CATCH_LOG()
     });
 
     auto output = wil::make_unique_cotaskmem<WSLA_SESSION_INFORMATION[]>(sessionInfo.size());

--- a/src/windows/wslaservice/exe/WSLASessionManager.h
+++ b/src/windows/wslaservice/exe/WSLASessionManager.h
@@ -39,6 +39,7 @@ Abstract:
 #include <string>
 #include <vector>
 #include <mutex>
+#include <type_traits>
 
 namespace wslutil = wsl::windows::common::wslutil;
 
@@ -83,6 +84,13 @@ private:
     inline auto ForEachSession(const auto& Routine)
     {
         std::lock_guard lock(m_wslaSessionsLock);
+
+        // Enforce noexcept: remove_if leaves the container in an unspecified
+        // (partially-moved) state if the predicate throws. Callers must handle
+        // errors via return values, not exceptions.
+        static_assert(
+            std::is_nothrow_invocable_v<decltype(Routine), SessionEntry&, wil::com_ptr<IWSLASession>&>,
+            "ForEachSession routine must be noexcept to preserve container invariants during remove_if");
 
         using TResult = std::conditional_t<std::is_same_v<T, void>, nullptr_t, std::optional<T>>;
         TResult result{};


### PR DESCRIPTION
ForEachSession uses std::ranges::remove_if which leaves the container in an unspecified (partially-moved) state if the predicate throws. Previously, callers used THROW_IF_FAILED inside lambdas which could corrupt m_sessions.

Add static_assert(is_nothrow_invocable_v) to enforce noexcept at compile time. Update all 4 callers to return errors via the result optional instead of throwing:

- CreateSession: return CheckTokenAccess HRESULT directly
- OpenSession: return CheckTokenAccess HRESULT directly
- OpenSessionByName: return CheckTokenAccess HRESULT directly
- ListSessions: LOG_IF_WIN32_BOOL_FALSE + skip entry on SID conversion failure