### PR TITLE
wsla: add null-pointer safety to COM interfaces

### DIFF
--- a/src/windows/wslaservice/exe/WSLASessionManager.cpp
+++ b/src/windows/wslaservice/exe/WSLASessionManager.cpp
@@ -51,6 +51,10 @@ WSLASessionManagerImpl::~WSLASessionManagerImpl()
 
 void WSLASessionManagerImpl::CreateSession(const WSLA_SESSION_SETTINGS* Settings, WSLASessionFlags Flags, IWSLASession** WslaSession)
 {
+    // Ensure that the session display name is non-null and not too long.
+    THROW_HR_IF(E_INVALIDARG, Settings->DisplayName == nullptr);
+    THROW_HR_IF(E_INVALIDARG, wcslen(Settings->DisplayName) >= std::size(WSLA_SESSION_INFORMATION{}.DisplayName));
+
     auto tokenInfo = GetCallingProcessTokenInfo();
 
     std::lock_guard lock(m_wslaSessionsLock);

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -381,7 +381,7 @@ interface IWSLAContainer : IUnknown
     HRESULT Export([in] ULONG TarHandle);
     HRESULT GetState([out] enum WSLA_CONTAINER_STATE* State);
     HRESULT GetInitProcess([out] IWSLAProcess** Process);
-    HRESULT Exec([in] const struct WSLA_PROCESS_OPTIONS* Options, [out] IWSLAProcess** Process);
+    HRESULT Exec([in, ref] const struct WSLA_PROCESS_OPTIONS* Options, [out] IWSLAProcess** Process);
     HRESULT Inspect([out] LPSTR* Output);
     HRESULT Logs([in] WSLALogsFlags Flags, [out] ULONG* Stdout, [out] ULONG* Stderr, [in] ULONGLONG Since, [in] ULONGLONG Until, [in] ULONGLONG Tail);
     HRESULT GetId([out, string] WSLAContainerId Id);
@@ -448,23 +448,23 @@ interface IWSLASession : IUnknown
 
     // Container management.
     HRESULT CreateContainer([in] const struct WSLA_CONTAINER_OPTIONS* Options, [out] IWSLAContainer** Container);
-    HRESULT OpenContainer([in] LPCSTR Id, [out] IWSLAContainer** Container);
+    HRESULT OpenContainer([in, ref] LPCSTR Id, [out] IWSLAContainer** Container);
     HRESULT ListContainers([out, size_is(, *Count)] struct WSLA_CONTAINER** Images, [out] ULONG* Count);
 
     // Create a process at the VM level. This is meant for debugging.
-    HRESULT CreateRootNamespaceProcess([in] LPCSTR Executable, [in] const struct WSLA_PROCESS_OPTIONS* Options, [out] IWSLAProcess** Process, [out] int* Errno);
+    HRESULT CreateRootNamespaceProcess([in, ref] LPCSTR Executable, [in, ref] const struct WSLA_PROCESS_OPTIONS* Options, [out] IWSLAProcess** Process, [out] int* Errno);
 
     // TODO: an OpenProcess() method can be added later if needed.
 
     // Disk management.
-    HRESULT FormatVirtualDisk([in] LPCWSTR Path);
+    HRESULT FormatVirtualDisk([in, ref] LPCWSTR Path);
 
     // Terminate the VM and containers.
     HRESULT Terminate();
 
     // Used only for testing. TODO: Think about moving them to a dedicated testing-only interface.
-    HRESULT MountWindowsFolder([in] LPCWSTR WindowsPath, [in] LPCSTR LinuxPath, [in] BOOL ReadOnly);
-    HRESULT UnmountWindowsFolder([in] LPCSTR LinuxPath);
+    HRESULT MountWindowsFolder([in, ref] LPCWSTR WindowsPath, [in, ref] LPCSTR LinuxPath, [in] BOOL ReadOnly);
+    HRESULT UnmountWindowsFolder([in, ref] LPCSTR LinuxPath);
     HRESULT MapVmPort([in] int Family, [in] short WindowsPort, [in] short LinuxPort);
     HRESULT UnmapVmPort([in] int Family, [in] short WindowsPort, [in] short LinuxPort);
 
@@ -562,7 +562,7 @@ interface IWSLASessionManager : IUnknown
     HRESULT CreateSession([in] const struct WSLA_SESSION_SETTINGS* Settings, WSLASessionFlags Flags, [out] IWSLASession** Session);
     HRESULT ListSessions([out, size_is(, *SessionsCount)] struct WSLA_SESSION_INFORMATION** Sessions, [out] ULONG* SessionsCount);
     HRESULT OpenSession([in] ULONG Id, [out] IWSLASession** Session);
-    HRESULT OpenSessionByName([in] LPCWSTR DisplayName, [out] IWSLASession** Session);
+    HRESULT OpenSessionByName([in, ref] LPCWSTR DisplayName, [out] IWSLASession** Session);
 }
 
 cpp_quote("#define WSLA_E_BASE (0x0600)")

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -559,7 +559,7 @@ interface IWSLASessionManager : IUnknown
     HRESULT GetVersion([out] WSLA_VERSION* Version);
 
     // Session management.
-    HRESULT CreateSession([in] const struct WSLA_SESSION_SETTINGS* Settings, WSLASessionFlags Flags, [out] IWSLASession** Session);
+    HRESULT CreateSession([in, ref] const struct WSLA_SESSION_SETTINGS* Settings, WSLASessionFlags Flags, [out] IWSLASession** Session);
     HRESULT ListSessions([out, size_is(, *SessionsCount)] struct WSLA_SESSION_INFORMATION** Sessions, [out] ULONG* SessionsCount);
     HRESULT OpenSession([in] ULONG Id, [out] IWSLASession** Session);
     HRESULT OpenSessionByName([in, ref] LPCWSTR DisplayName, [out] IWSLASession** Session);

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -49,10 +49,10 @@ std::vector<std::string> StringArrayToVector(const WSLAStringArray& array)
     {
         return {};
     }
-    else
-    {
-        return {&array.Values[0], &array.Values[array.Count]};
-    }
+
+    THROW_HR_IF_NULL_MSG(E_INVALIDARG, array.Values, "StringArray.Values is null with Count=%lu", array.Count);
+
+    return {&array.Values[0], &array.Values[array.Count]};
 }
 
 // TODO: Determine when ports should be mapped and unmapped (at container creation, start, stop or delete).
@@ -889,6 +889,11 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Create(
     std::vector<WSLAVolumeMount> volumes;
     volumes.reserve(containerOptions.VolumesCount);
 
+    if (containerOptions.VolumesCount > 0)
+    {
+        THROW_HR_IF_NULL_MSG(E_INVALIDARG, containerOptions.Volumes, "Volumes is null with VolumesCount=%lu", containerOptions.VolumesCount);
+    }
+
     for (ULONG i = 0; i < containerOptions.VolumesCount; i++)
     {
         GUID volumeId;
@@ -896,6 +901,9 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Create(
 
         auto parentVMPath = std::format("/mnt/{}", wsl::shared::string::GuidToString<char>(volumeId));
         auto volume = containerOptions.Volumes[i];
+
+        THROW_HR_IF_NULL_MSG(E_INVALIDARG, volume.HostPath, "Volumes[%lu].HostPath is null", i);
+        THROW_HR_IF_NULL_MSG(E_INVALIDARG, volume.ContainerPath, "Volumes[%lu].ContainerPath is null", i);
 
         volumes.push_back(WSLAVolumeMount{volume.HostPath, parentVMPath, volume.ContainerPath, static_cast<bool>(volume.ReadOnly)});
 

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -52,7 +52,15 @@ std::vector<std::string> StringArrayToVector(const WSLAStringArray& array)
 
     THROW_HR_IF_NULL_MSG(E_INVALIDARG, array.Values, "StringArray.Values is null with Count=%lu", array.Count);
 
-    return {&array.Values[0], &array.Values[array.Count]};
+    std::vector<std::string> result;
+    result.reserve(array.Count);
+    for (ULONG i = 0; i < array.Count; i += 1)
+    {
+        THROW_HR_IF_NULL_MSG(E_INVALIDARG, array.Values[i], "StringArray.Values[%lu] is null", i);
+        result.emplace_back(array.Values[i]);
+    }
+
+    return result;
 }
 
 // TODO: Determine when ports should be mapped and unmapped (at container creation, start, stop or delete).

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -333,6 +333,14 @@ class WSLATests
             VERIFY_ARE_EQUAL(sessionManager->CreateSession(&settings, WSLASessionFlagsNone, &session), E_INVALIDARG);
         }
 
+        // Reject DisplayName at exact boundary (no room for null terminator).
+        {
+            std::wstring boundaryName(std::size(WSLA_SESSION_INFORMATION{}.DisplayName), L'x');
+            auto settings = GetDefaultSessionSettings(boundaryName.c_str());
+            wil::com_ptr<IWSLASession> session;
+            VERIFY_ARE_EQUAL(sessionManager->CreateSession(&settings, WSLASessionFlagsNone, &session), E_INVALIDARG);
+        }
+
         // Reject too long DisplayName.
         {
             std::wstring longName(std::size(WSLA_SESSION_INFORMATION{}.DisplayName) + 1, L'x');

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -320,6 +320,28 @@ class WSLATests
         VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
     }
 
+    TEST_METHOD(CreateSessionValidation)
+    {
+        WSL2_TEST_ONLY();
+
+        auto sessionManager = OpenSessionManager();
+
+        // Reject NULL DisplayName.
+        {
+            auto settings = GetDefaultSessionSettings(nullptr);
+            wil::com_ptr<IWSLASession> session;
+            VERIFY_ARE_EQUAL(sessionManager->CreateSession(&settings, WSLASessionFlagsNone, &session), E_INVALIDARG);
+        }
+
+        // Reject too long DisplayName.
+        {
+            std::wstring longName(std::size(WSLA_SESSION_INFORMATION{}.DisplayName) + 1, L'x');
+            auto settings = GetDefaultSessionSettings(longName.c_str());
+            wil::com_ptr<IWSLASession> session;
+            VERIFY_ARE_EQUAL(sessionManager->CreateSession(&settings, WSLASessionFlagsNone, &session), E_INVALIDARG);
+        }
+    }
+
     void ExpectImagePresent(IWSLASession& Session, const char* Image, bool Present = true)
     {
         wil::unique_cotaskmem_array_ptr<WSLA_IMAGE_INFORMATION> images;


### PR DESCRIPTION
Fix multiple crash vectors where null pointers passed through COM/RPC interfaces (which use pointer_default(unique) in the IDL) could cause undefined behavior or crashes.

IDL changes - mark parameters as [ref] to enforce non-null at the RPC marshaling boundary:
- IWSLASessionManager::OpenSessionByName (DisplayName)
- IWSLAContainer::Exec (Options)
- IWSLASession::OpenContainer (Id)
- IWSLASession::CreateRootNamespaceProcess (Executable, Options)
- IWSLASession::FormatVirtualDisk (Path)
- IWSLASession::MountWindowsFolder (WindowsPath, LinuxPath)
- IWSLASession::UnmountWindowsFolder (LinuxPath)

Runtime validation for cases not enforceable via IDL:
- CreateSession: reject null/oversized DisplayName with E_INVALIDARG
- StringArrayToVector: reject null Values with non-zero Count
- Container Create: reject null Volumes array, HostPath, ContainerPath

Tests:
- Add CreateSessionValidation test for null and oversized DisplayName