### PR TITLE
wsla: narrow Stop() timeout from LONGLONG to LONG

### DIFF
--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -375,7 +375,7 @@ typedef enum _WSLALogsFlags
 interface IWSLAContainer : IUnknown
 {
     HRESULT Attach([out] ULONG* StdIn, [out] ULONG* StdOut, [out] ULONG* StdErr);
-    HRESULT Stop([in] WSLASignal Signal, [in] LONGLONG TimeoutSeconds);
+    HRESULT Stop([in] WSLASignal Signal, [in] LONG TimeoutSeconds);
     HRESULT Start([in] WSLAContainerStartFlags Flags);
     HRESULT Delete(); // TODO: Look into lifetime logic.
     HRESULT Export([in] ULONG TarHandle);

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -505,7 +505,7 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
         TraceLoggingValue((int)event, "Event"));
 }
 
-void WSLAContainerImpl::Stop(WSLASignal Signal, LONGLONG TimeoutSeconds)
+void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
 {
     std::lock_guard lock(m_lock);
 
@@ -1226,7 +1226,7 @@ HRESULT WSLAContainer::Exec(const WSLA_PROCESS_OPTIONS* Options, IWSLAProcess** 
     return CallImpl(&WSLAContainerImpl::Exec, Options, Process);
 }
 
-HRESULT WSLAContainer::Stop(_In_ WSLASignal Signal, _In_ LONGLONG TimeoutSeconds)
+HRESULT WSLAContainer::Stop(_In_ WSLASignal Signal, _In_ LONG TimeoutSeconds)
 {
     COMServiceExecutionContext context;
 

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -57,7 +57,7 @@ public:
     void Start(WSLAContainerStartFlags Flags);
 
     void Attach(ULONG* Stdin, ULONG* Stdout, ULONG* Stderr);
-    void Stop(_In_ WSLASignal Signal, _In_ LONGLONG TimeoutSeconds);
+    void Stop(_In_ WSLASignal Signal, _In_ LONG TimeoutSeconds);
     void Delete();
     void Export(ULONG TarHandle);
     void GetState(_Out_ WSLA_CONTAINER_STATE* State);
@@ -148,7 +148,7 @@ public:
     WSLAContainer(WSLAContainerImpl* impl, std::function<void(const WSLAContainerImpl*)>&& OnDeleted);
 
     IFACEMETHOD(Attach)(_Out_ ULONG* Stdin, _Out_ ULONG* Stdout, _Out_ ULONG* Stderr) override;
-    IFACEMETHOD(Stop)(_In_ WSLASignal Signal, _In_ LONGLONG TimeoutSeconds) override;
+    IFACEMETHOD(Stop)(_In_ WSLASignal Signal, _In_ LONG TimeoutSeconds) override;
     IFACEMETHOD(Delete)() override;
     IFACEMETHOD(Export)(_In_ ULONG TarHandle) override;
     IFACEMETHOD(GetState)(_Out_ WSLA_CONTAINER_STATE* State) override;

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -44,10 +44,10 @@ struct CreateContainerResult
 
 struct StopContainerOptions
 {
-    static constexpr LONGLONG DefaultTimeout = -1;
+    static constexpr LONG DefaultTimeout = -1;
 
     WSLASignal Signal = WSLASignalSIGTERM;
-    LONGLONG Timeout = DefaultTimeout;
+    LONG Timeout = DefaultTimeout;
 };
 
 struct KillContainerOptions

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -95,7 +95,7 @@ static wsl::windows::common::RunningWSLAContainer CreateInternal(
     return std::move(*runningContainer);
 }
 
-static void StopInternal(IWSLAContainer& container, WSLASignal signal = WSLASignalNone, LONGLONG timeout = -1)
+static void StopInternal(IWSLAContainer& container, WSLASignal signal = WSLASignalNone, LONG timeout = -1)
 {
     THROW_IF_FAILED(container.Stop(signal, timeout)); // TODO: Error message
 }

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -236,7 +236,7 @@ void StopContainers(CLIExecutionContext& context)
 
     if (context.Args.Contains(ArgType::Time))
     {
-        options.Timeout = validation::GetIntegerFromString<LONGLONG>(context.Args.Get<ArgType::Time>());
+        options.Timeout = validation::GetIntegerFromString<LONG>(context.Args.Get<ArgType::Time>());
     }
 
     for (const auto& id : containersToStop)


### PR DESCRIPTION
LONGLONG allows values > ULONG_MAX which silently truncate to 0 when cast to ULONG for the Docker API, causing an immediate kill with no grace period. LONG (max ~68 years) is more than sufficient and eliminates the truncation risk. Negative values still serve as the 'no timeout / use default' sentinel.