### PR TITLE
wslc: defer path initialization to avoid crash before main()

### DIFF
--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -18,13 +18,16 @@ Abstract:
 namespace wsl::windows::wslc::models {
 SessionOptions SessionOptions::Default()
 {
+    // Use a function-local static to defer path initialization until first use.
+    static const std::filesystem::path defaultPath = {wsl::windows::common::filesystem::GetLocalAppDataPath(nullptr) / "wsla"};
+
     // TODO: Have a configuration file for those.
     SessionOptions options{};
     options.m_sessionSettings.DisplayName = L"wsla-cli";
     options.m_sessionSettings.CpuCount = 4;
     options.m_sessionSettings.MemoryMb = 2048;
     options.m_sessionSettings.BootTimeoutMs = 30 * 1000;
-    options.m_sessionSettings.StoragePath = m_defaultPath.c_str();
+    options.m_sessionSettings.StoragePath = defaultPath.c_str();
     options.m_sessionSettings.MaximumStorageSizeMb = 10000; // 10GB.
     options.m_sessionSettings.NetworkingMode = WSLANetworkingModeVirtioProxy;
     return options;

--- a/src/windows/wslc/services/SessionModel.h
+++ b/src/windows/wslc/services/SessionModel.h
@@ -38,6 +38,5 @@ struct SessionOptions
 
 private:
     WSLA_SESSION_SETTINGS m_sessionSettings{};
-    inline static std::filesystem::path m_defaultPath = {wsl::windows::common::filesystem::GetLocalAppDataPath(nullptr) / "wsla"};
 };
 } // namespace wsl::windows::wslc::models


### PR DESCRIPTION
SessionOptions::m_defaultPath was an inline static member initialized during static initialization via SHGetKnownFolderPath. If that call fails, the process terminates with no error message before main() runs.

Move to a function-local static in Default(), deferring initialization to first use where exceptions can be caught and reported.
