### PR TITLE
wslc: change default networking mode to virtio proxy

### DIFF
--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -26,7 +26,7 @@ SessionOptions SessionOptions::Default()
     options.m_sessionSettings.BootTimeoutMs = 30 * 1000;
     options.m_sessionSettings.StoragePath = m_defaultPath.c_str();
     options.m_sessionSettings.MaximumStorageSizeMb = 10000; // 10GB.
-    options.m_sessionSettings.NetworkingMode = WSLANetworkingModeNAT;
+    options.m_sessionSettings.NetworkingMode = WSLANetworkingModeVirtioProxy;
     return options;
 }
 


### PR DESCRIPTION
We are expecting to ship with virtio proxy networking mode (not NAT), this change switches wslc.exe to use the right networking mode.