### PR TITLE
Add tmpfs mount support for WSLA containers

### DIFF
--- a/src/windows/common/WSLAContainerLauncher.cpp
+++ b/src/windows/common/WSLAContainerLauncher.cpp
@@ -163,6 +163,19 @@ void wsl::windows::common::WSLAContainerLauncher::AddLabel(const std::string& Ke
     m_labels.push_back(label);
 }
 
+void wsl::windows::common::WSLAContainerLauncher::AddTmpfs(const std::string& ContainerPath, const std::string& Options)
+{
+    // Store a copy of the path/options strings to the launcher to ensure the pointers in WSLA_TMPFS_MOUNT remain valid.
+    const auto& containerPath = m_tmpfsContainerPaths.emplace_back(ContainerPath);
+    const auto& options = m_tmpfsOptions.emplace_back(Options);
+
+    WSLA_TMPFS_MOUNT tmpfs{};
+    tmpfs.Destination = containerPath.c_str();
+    tmpfs.Options = options.c_str();
+
+    m_tmpfsMounts.push_back(tmpfs);
+}
+
 std::pair<HRESULT, std::optional<RunningWSLAContainer>> WSLAContainerLauncher::LaunchNoThrow(IWSLASession& Session, WSLAContainerStartFlags Flags)
 {
     auto [result, container] = CreateNoThrow(Session);
@@ -259,6 +272,9 @@ std::pair<HRESULT, std::optional<RunningWSLAContainer>> WSLAContainerLauncher::C
 
     options.LabelsCount = static_cast<ULONG>(m_labels.size());
     options.Labels = m_labels.size() > 0 ? m_labels.data() : nullptr;
+
+    options.TmpfsCount = static_cast<ULONG>(m_tmpfsMounts.size());
+    options.Tmpfs = m_tmpfsMounts.size() > 0 ? m_tmpfsMounts.data() : nullptr;
 
     // TODO: Support volumes, ports, flags, shm size, container networking mode, etc.
     wil::com_ptr<IWSLAContainer> container;

--- a/src/windows/common/WSLAContainerLauncher.h
+++ b/src/windows/common/WSLAContainerLauncher.h
@@ -60,6 +60,7 @@ public:
     void AddVolume(const std::wstring& HostPath, const std::string& ContainerPath, bool ReadOnly);
     void AddPort(uint16_t WindowsPort, uint16_t ContainerPort, int Family);
     void AddLabel(const std::string& Key, const std::string& Value);
+    void AddTmpfs(const std::string& ContainerPath, const std::string& Options);
 
     std::pair<HRESULT, std::optional<RunningWSLAContainer>> CreateNoThrow(IWSLASession& Session);
     RunningWSLAContainer Create(IWSLASession& Session);
@@ -98,5 +99,8 @@ private:
     std::vector<WSLA_LABEL> m_labels;
     std::deque<std::string> m_labelKeys;
     std::deque<std::string> m_labelValues;
+    std::vector<WSLA_TMPFS_MOUNT> m_tmpfsMounts;
+    std::deque<std::string> m_tmpfsContainerPaths;
+    std::deque<std::string> m_tmpfsOptions;
 };
 } // namespace wsl::windows::common

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -76,8 +76,9 @@ struct HostConfig
     std::optional<std::vector<std::string>> Dns;
     std::optional<std::vector<std::string>> DnsSearch;
     std::optional<std::vector<std::string>> DnsOptions;
+    std::map<std::string, std::string> Tmpfs;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(HostConfig, Mounts, PortBindings, NetworkMode, Init, Dns, DnsSearch, DnsOptions);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(HostConfig, Mounts, PortBindings, NetworkMode, Init, Dns, DnsSearch, DnsOptions, Tmpfs);
 };
 
 struct CreateContainer

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -169,6 +169,12 @@ struct WSLA_LABEL
     [string] LPCSTR Value;
 };
 
+struct WSLA_TMPFS_MOUNT
+{
+    LPCSTR Destination;
+    [unique] LPCSTR Options;
+};
+
 struct WSLA_LABEL_INFORMATION
 {
     [string] LPSTR Key;
@@ -232,6 +238,8 @@ struct WSLA_CONTAINER_OPTIONS
 
     ULONGLONG ShmSize;
     struct WSLA_CONTAINER_NETWORK ContainerNetwork;
+    [unique, size_is(TmpfsCount)] const struct WSLA_TMPFS_MOUNT* Tmpfs;
+    ULONG TmpfsCount;
 };
 
 enum WSLA_CONTAINER_STATE

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -794,11 +794,11 @@ WslaInspectContainer WSLAContainerImpl::BuildInspectContainer(const DockerInspec
     }
 
     // Map tmpfs mounts from Docker inspect data.
-    for (const auto& [destination, options] : dockerInspect.HostConfig.Tmpfs)
+    for (const auto& entry : dockerInspect.HostConfig.Tmpfs)
     {
         wsla_schema::InspectMount mountInfo{};
         mountInfo.Type = "tmpfs";
-        mountInfo.Destination = destination;
+        mountInfo.Destination = entry.first;
         // Tmpfs mounts are read-write by default. We currently do not parse tmpfs options
         // (e.g. "ro") for inspect output; Docker enforces actual mount behavior.
         mountInfo.ReadWrite = true;
@@ -928,6 +928,12 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Create(
             const auto& tmpfs = containerOptions.Tmpfs[i];
 
             THROW_HR_IF_NULL_MSG(E_INVALIDARG, tmpfs.Destination, "Tmpfs mount at index %lu has null destination", i);
+
+            THROW_HR_IF_MSG(
+                HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS),
+                request.HostConfig.Tmpfs.contains(tmpfs.Destination),
+                "Duplicate tmpfs destination: '%hs'",
+                tmpfs.Destination);
 
             request.HostConfig.Tmpfs[tmpfs.Destination] = tmpfs.Options != nullptr ? tmpfs.Options : "";
         }

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -781,7 +781,7 @@ WslaInspectContainer WSLAContainerImpl::BuildInspectContainer(const DockerInspec
     }
 
     // Map volume mounts using WSLA's host-side data.
-    wslaInspect.Mounts.reserve(m_mountedVolumes.size());
+    wslaInspect.Mounts.reserve(m_mountedVolumes.size() + dockerInspect.HostConfig.Tmpfs.size());
     for (const auto& volume : m_mountedVolumes)
     {
         wsla_schema::InspectMount mountInfo{};

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -793,6 +793,18 @@ WslaInspectContainer WSLAContainerImpl::BuildInspectContainer(const DockerInspec
         wslaInspect.Mounts.push_back(std::move(mountInfo));
     }
 
+    // Map tmpfs mounts from Docker inspect data.
+    for (const auto& [destination, options] : dockerInspect.HostConfig.Tmpfs)
+    {
+        wsla_schema::InspectMount mountInfo{};
+        mountInfo.Type = "tmpfs";
+        mountInfo.Destination = destination;
+        // Tmpfs mounts are read-write by default. We currently do not parse tmpfs options
+        // (e.g. "ro") for inspect output; Docker enforces actual mount behavior.
+        mountInfo.ReadWrite = true;
+        wslaInspect.Mounts.push_back(std::move(mountInfo));
+    }
+
     return wslaInspect;
 }
 
@@ -905,6 +917,21 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Create(
 
     // Mount volumes.
     auto volumeErrorCleanup = MountVolumes(volumes, virtualMachine);
+
+    // Process tmpfs mounts from container options.
+    if (containerOptions.TmpfsCount > 0)
+    {
+        THROW_HR_IF_NULL_MSG(E_INVALIDARG, containerOptions.Tmpfs, "Tmpfs is null with TmpfsCount=%lu", containerOptions.TmpfsCount);
+
+        for (ULONG i = 0; i < containerOptions.TmpfsCount; i++)
+        {
+            const auto& tmpfs = containerOptions.Tmpfs[i];
+
+            THROW_HR_IF_NULL_MSG(E_INVALIDARG, tmpfs.Destination, "Tmpfs mount at index %lu has null destination", i);
+
+            request.HostConfig.Tmpfs[tmpfs.Destination] = tmpfs.Options != nullptr ? tmpfs.Options : "";
+        }
+    }
 
     // Process port mappings from container options.
     auto [ports, networkMode] = ProcessPortMappings(containerOptions);

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -929,12 +929,6 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Create(
 
             THROW_HR_IF_NULL_MSG(E_INVALIDARG, tmpfs.Destination, "Tmpfs mount at index %lu has null destination", i);
 
-            THROW_HR_IF_MSG(
-                HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS),
-                request.HostConfig.Tmpfs.contains(tmpfs.Destination),
-                "Duplicate tmpfs destination: '%hs'",
-                tmpfs.Destination);
-
             request.HostConfig.Tmpfs[tmpfs.Destination] = tmpfs.Options != nullptr ? tmpfs.Options : "";
         }
     }

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2288,6 +2288,16 @@ class WSLATests
             ValidateProcessOutput(process, {}, 0);
         }
 
+        // Validate that duplicate tmpfs destinations are rejected.
+        {
+            WSLAContainerLauncher launcher("debian:latest", "test-tmpfs-duplicate", {"/bin/cat"});
+            launcher.AddTmpfs("/mnt/wsla-tmpfs-dup", "");
+            launcher.AddTmpfs("/mnt/wsla-tmpfs-dup", "");
+
+            auto [hresult, container] = launcher.LaunchNoThrow(*m_defaultSession);
+            VERIFY_ARE_EQUAL(hresult, HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
+        }
+
         // Validate error paths
         {
             WSLAContainerLauncher launcher("debian:latest", std::string(WSLA_MAX_CONTAINER_NAME_LENGTH + 1, 'a'), {"/bin/cat"});

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -537,6 +537,19 @@ class WSLATests
         }
     }
 
+    void ValidateCOMErrorContains(const std::wstring& Substring)
+    {
+        auto comError = wsl::windows::common::wslutil::GetCOMErrorInfo();
+        VERIFY_IS_TRUE(comError.has_value());
+        VERIFY_IS_NOT_NULL(comError->Message.get());
+
+        if (wcsstr(comError->Message.get(), Substring.c_str()) == nullptr)
+        {
+            LogError("COM error '%ls' does not contain expected substring '%ls'", comError->Message.get(), Substring.c_str());
+            VERIFY_FAIL();
+        }
+    }
+
     HRESULT BuildImageFromContext(const std::filesystem::path& contextDir, const char* imageTag, const char* dockerfilePath = nullptr)
     {
         wil::unique_hfile dockerfileHandle;
@@ -2288,14 +2301,26 @@ class WSLATests
             ValidateProcessOutput(process, {}, 0);
         }
 
-        // Validate that duplicate tmpfs destinations are rejected.
+        // Validate that relative tmpfs paths are rejected by Docker.
         {
-            WSLAContainerLauncher launcher("debian:latest", "test-tmpfs-duplicate", {"/bin/cat"});
-            launcher.AddTmpfs("/mnt/wsla-tmpfs-dup", "");
-            launcher.AddTmpfs("/mnt/wsla-tmpfs-dup", "");
+            WSLAContainerLauncher launcher("debian:latest", "test-tmpfs-relative", {"/bin/cat"});
+            launcher.AddTmpfs("relative-path", "");
 
             auto [hresult, container] = launcher.LaunchNoThrow(*m_defaultSession);
-            VERIFY_ARE_EQUAL(hresult, HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
+            VERIFY_IS_TRUE(FAILED(hresult));
+
+            ValidateCOMErrorContains(L"mount path must be absolute");
+        }
+
+        // Validate that invalid tmpfs options are rejected by Docker.
+        {
+            WSLAContainerLauncher launcher("debian:latest", "test-tmpfs-invalid-opts", {"/bin/cat"});
+            launcher.AddTmpfs("/mnt/wsla-tmpfs", "invalid_option_xyz");
+
+            auto [hresult, container] = launcher.LaunchNoThrow(*m_defaultSession);
+            VERIFY_IS_TRUE(FAILED(hresult));
+
+            ValidateCOMErrorContains(L"tmpfs");
         }
 
         // Validate error paths

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -537,19 +537,6 @@ class WSLATests
         }
     }
 
-    void ValidateCOMErrorContains(const std::wstring& Substring)
-    {
-        auto comError = wsl::windows::common::wslutil::GetCOMErrorInfo();
-        VERIFY_IS_TRUE(comError.has_value());
-        VERIFY_IS_NOT_NULL(comError->Message.get());
-
-        if (wcsstr(comError->Message.get(), Substring.c_str()) == nullptr)
-        {
-            LogError("COM error '%ls' does not contain expected substring '%ls'", comError->Message.get(), Substring.c_str());
-            VERIFY_FAIL();
-        }
-    }
-
     HRESULT BuildImageFromContext(const std::filesystem::path& contextDir, const char* imageTag, const char* dockerfilePath = nullptr)
     {
         wil::unique_hfile dockerfileHandle;
@@ -2307,9 +2294,9 @@ class WSLATests
             launcher.AddTmpfs("relative-path", "");
 
             auto [hresult, container] = launcher.LaunchNoThrow(*m_defaultSession);
-            VERIFY_IS_TRUE(FAILED(hresult));
+            VERIFY_ARE_EQUAL(hresult, E_FAIL);
 
-            ValidateCOMErrorContains(L"mount path must be absolute");
+            ValidateCOMErrorMessage(L"invalid mount path: 'relative-path' mount path must be absolute");
         }
 
         // Validate that invalid tmpfs options are rejected by Docker.
@@ -2318,9 +2305,9 @@ class WSLATests
             launcher.AddTmpfs("/mnt/wsla-tmpfs", "invalid_option_xyz");
 
             auto [hresult, container] = launcher.LaunchNoThrow(*m_defaultSession);
-            VERIFY_IS_TRUE(FAILED(hresult));
+            VERIFY_ARE_EQUAL(hresult, E_FAIL);
 
-            ValidateCOMErrorContains(L"tmpfs");
+            ValidateCOMErrorMessage(L"invalid tmpfs option [\"invalid_option_xyz\"]");
         }
 
         // Validate error paths

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2273,6 +2273,21 @@ class WSLATests
             ValidateProcessOutput(process, {{1, "foo  bar\n"}}); // Expect two spaces for the empty argument.
         }
 
+        // Validate that tmpfs mounts are correctly wired.
+        {
+            WSLAContainerLauncher launcher(
+                "debian:latest",
+                "test-tmpfs",
+                {"/bin/sh", "-c", "mount | grep 'tmpfs on /mnt/wsla-tmpfs1' && mount | grep 'tmpfs on /mnt/wsla-tmpfs2'"});
+
+            launcher.AddTmpfs("/mnt/wsla-tmpfs1", "rw,noexec,nosuid,size=65536k");
+            launcher.AddTmpfs("/mnt/wsla-tmpfs2", "");
+
+            auto container = launcher.Launch(*m_defaultSession);
+            auto process = container.GetInitProcess();
+            ValidateProcessOutput(process, {}, 0);
+        }
+
         // Validate error paths
         {
             WSLAContainerLauncher launcher("debian:latest", std::string(WSLA_MAX_CONTAINER_NAME_LENGTH + 1, 'a'), {"/bin/cat"});
@@ -2777,9 +2792,12 @@ class WSLATests
                 }
 
                 VERIFY_IS_FALSE(it->Type.empty());
-                VERIFY_IS_FALSE(it->Source.empty());
-
                 VERIFY_ARE_EQUAL(it->Type, expectedType);
+
+                if (expectedType != "tmpfs")
+                {
+                    VERIFY_IS_FALSE(it->Source.empty());
+                }
                 VERIFY_ARE_EQUAL(it->ReadWrite, expectedReadWrite);
             }
         };
@@ -2806,6 +2824,7 @@ class WSLATests
             launcher.AddPort(1236, 8001, AF_INET);
             launcher.AddVolume(testFolder.wstring(), "/test-volume", false);
             launcher.AddVolume(testFolderReadOnly.wstring(), "/test-volume-ro", true);
+            launcher.AddTmpfs("/mnt/wsla-tmpfs-inspect", "");
 
             auto container = launcher.Launch(*m_defaultSession);
             auto details = container.Inspect();
@@ -2825,8 +2844,10 @@ class WSLATests
             // Verify port mappings match what we configured.
             expectPorts(details.Ports, {{"8000/tcp", {"1234", "1235"}}, {"8001/tcp", {"1236"}}});
 
-            // Verify volume mounts match what we configured.
-            expectMounts(details.Mounts, {{"/test-volume", "bind", true}, {"/test-volume-ro", "bind", false}});
+            // Verify mounts match what we configured.
+            expectMounts(
+                details.Mounts,
+                {{"/test-volume", "bind", true}, {"/test-volume-ro", "bind", false}, {"/mnt/wsla-tmpfs-inspect", "tmpfs", true}});
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
             VERIFY_SUCCEEDED(container.Get().Delete());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds tmpfs mount support for WSLA containers. Tmpfs mounts are memory-backed filesystems commonly used for temporary data (e.g., /run, /tmp). This change enables callers to specify tmpfs mounts when creating containers via the WSLA API, passes them through to Docker's HostConfig.Tmpfs, and surfaces them in container inspect output.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
**IDL changes (wslaservice.idl)**
- Added WSLA_TMPFS_MOUNT struct with Destination (required) and [unique] Options (nullable) fields
- Added [unique, size_is(TmpfsCount)] Tmpfs and TmpfsCount to WSLA_CONTAINER_OPTIONS, following the existing Volumes/Labels pattern

 **Docker schema (docker_schema.h)**
- Added std::map<std::string, std::string> Tmpfs to HostConfig and registered it with the JSON serialization macro

**Container creation (WSLAContainer.cpp)**
- In Create(): validates Tmpfs array pointer when TmpfsCount > 0, validates each Destination is non-null, handles nullable Options with fallback to "", and populates request.HostConfig.Tmpfs
- In BuildInspectContainer(): iterates dockerInspect.HostConfig.Tmpfs and populates InspectMount entries with Type = "tmpfs", ReadWrite = true

**Client launcher (WSLAContainerLauncher.h/.cpp)**
- Added AddTmpfs(const std::string& ContainerPath, const std::string& Options) following the AddLabel/AddVolume pattern with std::deque for stable LPCSTR pointer storage
- Wired TmpfsCount/Tmpfs into CreateNoThrow() using the existing size() > 0 ? .data() : nullptr pattern

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
