### PR TITLE
Fix container export files not getting cleaned up.

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1186,11 +1186,16 @@ class WSLATests
             // Load the exported container to verify it's valid.
             {
                 std::filesystem::path containerTar = L"HelloWorldExported.tar";
+
                 wil::unique_handle containerTarFileHandle{CreateFileW(
                     containerTar.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
                 VERIFY_IS_FALSE(INVALID_HANDLE_VALUE == containerTarFileHandle.get());
-                auto cleanup =
-                    wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(containerTar.c_str())); });
+
+                auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+                    containerTarFileHandle.reset();
+                    LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(containerTar.c_str()));
+                });
+
                 LARGE_INTEGER fileSize{};
                 VERIFY_SUCCEEDED(m_defaultSession->LoadImage(HandleToULong(containerTarFileHandle.get()), nullptr, fileSize.QuadPart));
                 // Verify that the image is in the list of images.
@@ -1202,13 +1207,17 @@ class WSLATests
                 VERIFY_IS_TRUE(result.Output[1].find("Hello from Docker!") != std::string::npos);
 
                 // Stop and delete the above container and try to export.
-
                 std::filesystem::path imageTarFile = L"HelloWorldExportError.tar";
+
                 wil::unique_handle contTarFileHandle{CreateFileW(
                     imageTarFile.c_str(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr)};
                 VERIFY_IS_FALSE(INVALID_HANDLE_VALUE == contTarFileHandle.get());
-                auto cleanfile =
-                    wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(imageTarFile.c_str())); });
+
+                auto cleanfile = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+                    contTarFileHandle.reset();
+                    LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(imageTarFile.c_str()));
+                });
+
                 VERIFY_IS_TRUE(GetFileSizeEx(contTarFileHandle.get(), &fileSize));
                 VERIFY_ARE_EQUAL(fileSize.QuadPart, 0);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Ensure file handles are closed before deleting temp tar files in WSLATests.cpp by resetting wil::unique_handle in cleanup lambdas, preventing file deletion failures due to open handles.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
