### PR TITLE
wsla: Gracefully half-close hvsocket when unix socket closes in relay

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -245,8 +245,15 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_UNIX_CONN
             }
             else if (bytesRead == 0)
             {
-                // Unix socket has been closed.
+                // Unix socket has been closed. Gracefully half-close the
+                // hvsocket so the Windows side receives a clean EOF instead
+                // of ERROR_BROKEN_PIPE.
                 pollDescriptors[0].fd = -1;
+                if (shutdown(Channel.Socket(), SHUT_WR) < 0)
+                {
+                    LOG_ERROR("shutdown({}, SHUT_WR) failed {}", Channel.Socket(), errno);
+                }
+
                 break;
             }
             else if (UtilWriteBuffer(Channel.Socket(), relayBuffer.data(), bytesRead) < 0)


### PR DESCRIPTION
Add shutdown(SHUT_WR) on the hvsocket when the unix socket (e.g. docker.sock) closes, matching the reverse direction. Without this, the Windows side gets ERROR_BROKEN_PIPE instead of clean EOF, causing E_INVALIDARG in the HTTP chunked parser.

I believe this is the cause of spurious test failures in the wslcsdk tests.