### PR TITLE
init: fix variable shadowing, uninitialized bool, symlink check, open mode, and signal mask

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -64,15 +64,13 @@ struct WSLAState
 static WSLAState g_state;
 
 int CreateCaptureCrashSymlink()
+try
 {
-    if (symlink("/wsl-init", "/" LX_INIT_WSL_CAPTURE_CRASH) < 0)
-    {
-        LOG_ERROR("symlink({}, {}) failed {}", "/wsl-init", "/" LX_INIT_WSL_CAPTURE_CRASH, errno);
-        return errno;
-    }
+    THROW_LAST_ERROR_IF(symlink("/wsl-init", "/" LX_INIT_WSL_CAPTURE_CRASH) < 0);
 
     return 0;
 }
+CATCH_RETURN_ERRNO()
 
 void WSLAEnableCrashDumpCollection()
 {
@@ -142,54 +140,6 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_CONNECT& 
     {
         result = fd.release();
     }
-}
-
-void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_OPEN& Message, const gsl::span<gsl::byte>& Buffer)
-{
-    int32_t result = EINVAL;
-
-    auto sendResult = wil::scope_exit([&]() { Channel.SendResultMessage(result); });
-
-    auto path = wsl::shared::string::FromMessageBuffer<WSLA_OPEN>(Buffer);
-    int flags = 0;
-
-    WI_SetFlagIf(flags, O_APPEND, WI_IsFlagSet(Message.Flags, WslaOpenFlagsAppend));
-    WI_SetFlagIf(flags, O_TRUNC, !WI_IsFlagSet(Message.Flags, WslaOpenFlagsAppend) && WI_IsFlagSet(Message.Flags, WslaOpenFlagsWrite));
-    WI_SetFlagIf(flags, O_CREAT, WI_IsFlagSet(Message.Flags, WslaOpenFlagsCreate));
-    if (WI_IsFlagSet(Message.Flags, WslaOpenFlagsRead) && WI_IsFlagSet(Message.Flags, WslaOpenFlagsWrite))
-    {
-        WI_SetFlag(flags, O_RDWR);
-    }
-    else if (WI_IsFlagSet(Message.Flags, WslaOpenFlagsRead))
-    {
-        static_assert(O_RDONLY == 0);
-    }
-    else if (WI_IsFlagSet(Message.Flags, WslaOpenFlagsWrite))
-    {
-        WI_SetFlag(flags, O_WRONLY);
-    }
-    else
-    {
-        LOG_ERROR("Invalid WSLA_OPEN flags: {}", Message.Flags);
-        return; // Return -EINVAL if no opening flags are passed.
-    }
-
-    wil::unique_fd fd = open(path, flags);
-    if (!fd)
-    {
-        result = errno;
-        LOG_ERROR("open({}, {}) failed: {}", path, flags, result);
-        return;
-    }
-
-    if (dup2(fd.get(), Message.Fd) < 0)
-    {
-        result = errno;
-        LOG_ERROR("dup2({}, {}) failed: {}", fd.get(), Message.Fd, result);
-        return;
-    }
-
-    result = 0;
 }
 
 void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_UNIX_CONNECT& Message, const gsl::span<gsl::byte>& Buffer)
@@ -510,6 +460,8 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_FORK& Mes
             {
                 sigset_t SignalMask;
                 sigemptyset(&SignalMask);
+                THROW_LAST_ERROR_IF(sigprocmask(SIG_SETMASK, &SignalMask, nullptr) < 0);
+
                 try
                 {
                     childLogic();
@@ -839,7 +791,7 @@ void ProcessMessage(wsl::shared::SocketChannel& Channel, LX_MESSAGE_TYPE Type, c
 {
     try
     {
-        HandleMessage<WSLA_GET_DISK, WSLA_MOUNT, WSLA_EXEC, WSLA_FORK, WSLA_CONNECT, WSLA_SIGNAL, WSLA_TTY_RELAY, WSLA_PORT_RELAY, WSLA_OPEN, WSLA_UNMOUNT, WSLA_DETACH, WSLA_ACCEPT, WSLA_WATCH_PROCESSES, WSLA_UNIX_CONNECT>(
+        HandleMessage<WSLA_GET_DISK, WSLA_MOUNT, WSLA_EXEC, WSLA_FORK, WSLA_CONNECT, WSLA_SIGNAL, WSLA_TTY_RELAY, WSLA_PORT_RELAY, WSLA_UNMOUNT, WSLA_DETACH, WSLA_ACCEPT, WSLA_WATCH_PROCESSES, WSLA_UNIX_CONNECT>(
             Channel, Type, Buffer);
     }
     catch (...)

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -342,7 +342,7 @@ try
             long long int const ReclaimThreshold = (get_nprocs() * sysconf(_SC_CLK_TCK) * SleepDuration / std::chrono::seconds(1)) / 200; // 0.5%
             long long int ReclaimWindow[20] = {}; // 10 minutes
             long long int ReclaimWindowLength = COUNT_OF(ReclaimWindow);
-            bool ReclaimIdling;
+            bool ReclaimIdling = false;
 
             //
             // Fall back to drop cache if the required cgroup path is not present.
@@ -429,7 +429,7 @@ try
                 if (PageReportingOrder != 0 && (Start - Stop) > IdleThreshold)
                 {
                     std::this_thread::sleep_for(std::chrono::seconds(1));
-                    const long long int Stop = GetUserCpuTime();
+                    Stop = GetUserCpuTime();
                     THROW_LAST_ERROR_IF(Stop == -1);
                     if ((Stop - Start) < IdleThreshold)
                     {

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -395,7 +395,6 @@ typedef enum _LX_MESSAGE_TYPE
     LxMessageWSLAMapPort,
     LxMessageWSLAConnectRelay,
     LxMessageWSLAPortRelay,
-    LxMessageWSLAOpen,
     LxMessageWSLAUnmount,
     LxMessageWSLADetach,
     LxMessageWSLATerminalChanged,
@@ -506,7 +505,6 @@ inline auto ToString(LX_MESSAGE_TYPE messageType)
         X(LxMessageWSLAMapPort)
         X(LxMessageWSLAConnectRelay)
         X(LxMessageWSLAPortRelay)
-        X(LxMessageWSLAOpen)
         X(LxMessageWSLAUnmount)
         X(LxMessageWSLADetach)
         X(LxMessageWSLATerminalChanged)
@@ -1710,37 +1708,6 @@ struct WSLA_CONNECT
     MESSAGE_HEADER Header;
     uint32_t HostPort{};
     PRETTY_PRINT(FIELD(Header), FIELD(HostPort));
-};
-
-enum WslaOpenFlags // Must match FileDescriptorType.
-{
-    WslaOpenFlagsNone = 0,
-    WslaOpenFlagsRead = 4,
-    WslaOpenFlagsWrite = 8,
-    WslaOpenFlagsAppend = 16,
-    WslaOpenFlagsCreate = 32
-};
-
-struct WSLA_OPEN
-{
-    static inline auto Type = LxMessageWSLAOpen;
-    using TResponse = RESULT_MESSAGE<int32_t>;
-    DECLARE_MESSAGE_CTOR(WSLA_OPEN);
-
-    MESSAGE_HEADER Header;
-    uint32_t Flags{};
-    int32_t Fd{};
-    char Buffer[];
-
-    PRETTY_PRINT(FIELD(Header), FIELD(Flags), FIELD(Fd), FIELD(Buffer));
-};
-
-enum WSLAOpenFlags
-{
-    WSLAOpenFlagsUnknown,
-    WSLAOpenFlagsRunning,
-    WSLAOpenFlagsExited,
-    WSLAOpenFlagsSignaled
 };
 
 struct WSLA_SIGNAL


### PR DESCRIPTION
- Fix variable shadowing: inner 'Stop' declaration in main.cpp shadowed the outer variable, preventing idle detection from working correctly.
- Fix uninitialized bool: ReclaimIdling was used before being assigned.
- Fix CreateCaptureCrashSymlink: use THROW_LAST_ERROR_IF/CATCH_RETURN_ERRNO to match idiomatic error handling in the codebase.
- Fix missing sigprocmask call: child process after fork did not reset the signal mask, inheriting the parent's blocked signals.
- Remove WSLA_OPEN message type and handler: dead code with no callers.