### PR TITLE
wsla: wrap SIGKILL fallback in try/catch in Terminate()

### DIFF
--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -1003,8 +1003,12 @@ try
         catch (...)
         {
             LOG_CAUGHT_EXCEPTION();
-            m_dockerdProcess->Get().Signal(WSLASignalSIGKILL);
-            exitCode = m_dockerdProcess->Wait(10 * 1000);
+            try
+            {
+                m_dockerdProcess->Get().Signal(WSLASignalSIGKILL);
+                exitCode = m_dockerdProcess->Wait(10 * 1000);
+            }
+            CATCH_LOG();
         }
 
         WSL_LOG("DockerdExit", TraceLoggingValue(exitCode, "code"));


### PR DESCRIPTION
Inside the catch(...) handler for the SIGTERM wait, Signal(SIGKILL) and Wait(10s) can both throw. If they do, the exception exits Terminate() via CATCH_RETURN(), skipping VM unmount/reset and leaving m_terminated = false.

Wrap the fallback kill path in its own try/CATCH_LOG() so VM cleanup always proceeds.