### PR TITLE
wslc: Propagate process exit code correctly

### DIFF
--- a/src/windows/wslc/core/CLIExecutionContext.h
+++ b/src/windows/wslc/core/CLIExecutionContext.h
@@ -14,6 +14,7 @@ Abstract:
 #pragma once
 #include "ArgumentTypes.h"
 #include "ExecutionContextData.h"
+#include <optional>
 
 namespace wsl::windows::wslc::execution {
 // The context within which all commands execute.
@@ -35,5 +36,9 @@ struct CLIExecutionContext : public wsl::windows::common::ExecutionContext
 
     // Map of data stored in the context.
     DataMap Data;
+
+    // Process exit code set by tasks like Run/Exec. When set, CoreMain returns this
+    // instead of the HRESULT, enabling `wslc run ... && echo success` patterns.
+    std::optional<int> ExitCode;
 };
 } // namespace wsl::windows::wslc::execution

--- a/src/windows/wslc/core/Main.cpp
+++ b/src/windows/wslc/core/Main.cpp
@@ -79,7 +79,7 @@ try
         // A command exception means there was an input failure. Display the help
         // along with the error message to help the user correct their input.
         command->OutputHelp(&ce);
-        return E_INVALIDARG;
+        return 1;
     }
     // Any other type of error unrelated to the command parsing.
     catch (...)
@@ -105,11 +105,16 @@ try
         }
     }
 
-    return result;
+    if (context.ExitCode.has_value())
+    {
+        return context.ExitCode.value();
+    }
+
+    return FAILED(result) ? 1 : 0;
 }
 catch (...)
 {
-    return E_UNEXPECTED;
+    return 1;
 }
 } // namespace wsl::windows::wslc
 

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -59,7 +59,7 @@ void ExecContainer(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Session));
     WI_ASSERT(context.Args.Contains(ArgType::ContainerId));
     WI_ASSERT(context.Data.Contains(Data::ContainerOptions));
-    auto result = ContainerService::Exec(
+    context.ExitCode = ContainerService::Exec(
         context.Data.Get<Data::Session>(), WideToMultiByte(context.Args.Get<ArgType::ContainerId>()), context.Data.Get<Data::ContainerOptions>());
 }
 
@@ -169,7 +169,7 @@ void RunContainer(CLIExecutionContext& context)
     WI_ASSERT(context.Args.Contains(ArgType::ImageId));
     WI_ASSERT(context.Data.Contains(Data::ContainerOptions));
     PullImageCallback callback;
-    ContainerService::Run(
+    context.ExitCode = ContainerService::Run(
         context.Data.Get<Data::Session>(), WideToMultiByte(context.Args.Get<ArgType::ImageId>()), context.Data.Get<Data::ContainerOptions>(), &callback);
 }
 

--- a/src/windows/wslc/tasks/SessionTasks.cpp
+++ b/src/windows/wslc/tasks/SessionTasks.cpp
@@ -30,7 +30,7 @@ namespace wsl::windows::wslc::task {
 void AttachToSession(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Args.Contains(ArgType::SessionId));
-    SessionService::Attach(context.Args.Get<ArgType::SessionId>());
+    context.ExitCode = SessionService::Attach(context.Args.Get<ArgType::SessionId>());
 }
 
 void CreateSession(CLIExecutionContext& context)


### PR DESCRIPTION
Currently the exit codes of the wslc.exe process are not correctly plumbed, or are returning HRESULTS as process exit codes which is non-standard. I'm open to suggestions if this is not the intended way to fix this, let me know!

ContainerService::Run, ContainerService::Exec, and SessionService::Attach all return an int exit code, but the callers in ContainerTasks and SessionTasks discarded the return value. This meant 'wslc run <image> -- /bin/false && echo success' would print 'success' because CoreMain always returned the HRESULT (S_OK) instead of the process exit code.

Add std::optional<int> ExitCode to CLIExecutionContext. Tasks that launch processes store the exit code there, and CoreMain returns it when set.
