### PR TITLE
Track `bind` syscall when port is 0

### DIFF
--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -119,9 +119,16 @@ void GnsPortTracker::Run()
 
             if (bindCall->PortZeroBind.has_value())
             {
-                std::lock_guard lock(m_deferredMutex);
-                m_deferredQueue.push_back(std::move(bindCall->PortZeroBind.value()));
-                m_deferredCv.notify_one();
+                try
+                {
+                    std::lock_guard lock(m_deferredMutex);
+                    m_deferredQueue.push_back(std::move(bindCall->PortZeroBind.value()));
+                    m_deferredCv.notify_one();
+                }
+                catch (const std::exception& e)
+                {
+                    GNS_LOG_ERROR("Failed to queue port-0 bind for deferred resolution, {}", e.what());
+                }
             }
         }
 
@@ -521,10 +528,15 @@ wil::unique_fd GnsPortTracker::DuplicateSocketFd(pid_t Pid, int SocketFd)
 }
 
 void GnsPortTracker::TrackPort(PortAllocation allocation)
+try
 {
     // Use insert_or_assign so the deallocation timeout is refreshed if the same
     // port key is already present (emplace would silently keep the old entry).
     m_allocatedPorts.insert_or_assign(std::move(allocation), std::make_optional(time(nullptr) + c_bind_timeout_seconds));
+}
+catch (const std::exception& e)
+{
+    GNS_LOG_ERROR("Failed to track port allocation, {}", e.what());
 }
 
 void GnsPortTracker::RunDeferredResolve()

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -600,6 +600,7 @@ void GnsPortTracker::ResolvePortZeroBind(DeferredPortLookup lookup)
         }
         else
         {
+            GNS_LOG_ERROR("Port-0 bind: unexpected address family ({}) for pid {}", resolvedFamily, lookup.Pid);
             return;
         }
 

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -14,6 +14,14 @@
 #include "GnsPortTracker.h"
 #include "lxinitshared.h"
 
+// pidfd_open (Linux 5.3) and pidfd_getfd (Linux 5.6) may not be defined in older headers.
+#ifndef SYS_pidfd_open
+#define SYS_pidfd_open 434
+#endif
+#ifndef SYS_pidfd_getfd
+#define SYS_pidfd_getfd 438
+#endif
+
 constexpr size_t c_bind_timeout_seconds = 60;
 constexpr auto c_sock_diag_refresh_delay = std::chrono::milliseconds(500);
 constexpr auto c_sock_diag_poll_timeout = std::chrono::milliseconds(10);
@@ -114,6 +122,21 @@ void GnsPortTracker::Run()
             catch (const std::exception& e)
             {
                 GNS_LOG_ERROR("Failed to complete bind request, {}", e.what());
+            }
+
+            // If this was a port-0 bind, the kernel should have assigned an ephemeral port.
+            // This check might be susceptible to races, but it's a best effort to resolve the 
+            // actual port in the case of port-0 binds so that it can be tracked properly.
+            if (bindCall->PortZeroBind.has_value())
+            {
+                try
+                {
+                    ResolvePortZeroBind(bindCall->PortZeroBind.value());
+                }
+                catch (const std::exception& e)
+                {
+                    GNS_LOG_ERROR("Failed to resolve port-0 bind for pid {}, {}", bindCall->PortZeroBind->Pid, e.what());
+                }
             }
         }
 
@@ -300,7 +323,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::ReadNextRequest()
     catch (const std::exception& e)
     {
         GNS_LOG_ERROR("Fetch to read bind() call info with ID {}lu for pid {}, {}", callInfo.id, callInfo.pid, e.what());
-        return {{{}, callInfo.id}};
+        return {{{}, {}, callInfo.id}};
     }
 }
 
@@ -310,14 +333,14 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
     auto ParseSocket = [&](int Socket, size_t AddressPtr, size_t AddressLength) -> std::optional<BindCall> {
         if (AddressLength < sizeof(sockaddr))
         {
-            return {{{}, CallId}}; // Invalid sockaddr. Let it go through.
+            return {{{}, {}, CallId}}; // Invalid sockaddr. Let it go through.
         }
 
         auto networkNamespace = std::filesystem::read_symlink(std::format("/proc/{}/ns/net", Pid)).string();
         if (networkNamespace != m_networkNamespace)
         {
             GNS_LOG_INFO("Skipping bind() call for pid {} in network namespace {}", Pid, networkNamespace.c_str());
-            return {{{}, CallId}}; // Different network namespace. Let it go through.
+            return {{{}, {}, CallId}}; // Different network namespace. Let it go through.
         }
 
         auto processMemory = m_seccompDispatcher->ReadProcessMemory(CallId, Pid, AddressPtr, AddressLength);
@@ -331,7 +354,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
         if ((address.sa_family != AF_INET && address.sa_family != AF_INET6) ||
             (address.sa_family == AF_INET6 && AddressLength < sizeof(sockaddr_in6)))
         {
-            return {{{}, CallId}}; // This is a non IP call, or invalid sockaddr_in6. Let it go through
+            return {{{}, {}, CallId}}; // This is a non IP call, or invalid sockaddr_in6. Let it go through
         }
 
         // Read the port.  The port *happens* to be in the same spot in memory for both sockaddr_in
@@ -343,7 +366,22 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
         in_port_t port = ntohs(inAddr->sin_port);
         if (port == 0)
         {
-            return {{{}, CallId}}; // If port is 0, just let the call go through
+            // Port 0 means the kernel will assign an ephemeral port. We can't know
+            // the port until after the bind() completes, so capture the socket info
+            // for a deferred lookup after the syscall is allowed through.
+            try
+            {
+                const int protocol = GetSocketProtocol(Pid, Socket);
+                if (!m_seccompDispatcher->ValidateCookie(CallId))
+                {
+                    return {{{}, {}, CallId}};
+                }
+                return {{{}, DeferredPortLookup{Pid, Socket, static_cast<int>(address.sa_family), protocol}, CallId}};
+            }
+            catch (const std::exception&)
+            {
+                return {{{}, {}, CallId}}; // Can't determine protocol, just let it through
+            }
         }
 
         in6_addr storedAddress = {};
@@ -370,7 +408,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
             throw RuntimeErrorWithSourceLocation(std::format("Invalid call id {}", CallId));
         }
 
-        return {{{PortAllocation(port, address.sa_family, protocol, storedAddress)}, CallId}};
+        return {{{PortAllocation(port, address.sa_family, protocol, storedAddress)}, {}, CallId}};
     };
 #ifdef __x86_64__
     if (Arch & __AUDIT_ARCH_64BIT)
@@ -384,7 +422,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
     {
         if (Arguments[0] != SYS_BIND)
         {
-            return {{{}, CallId}}; // Not a bind call, just let the call go through
+            return {{{}, {}, CallId}}; // Not a bind call, just let the call go through
         }
         // Grab the first 3 parameters
         auto processMemory = m_seccompDispatcher->ReadProcessMemory(CallId, Pid, Arguments[1], sizeof(uint32_t) * 3);
@@ -440,6 +478,92 @@ int GnsPortTracker::GetSocketProtocol(int pid, int fd)
     }
 
     throw RuntimeErrorWithSourceLocation(std::format("Unexpected IP socket protocol: {}", protocol));
+}
+
+void GnsPortTracker::ResolvePortZeroBind(const DeferredPortLookup& lookup)
+{
+    // Duplicate the socket fd from the target process into our address space.
+    // We cannot use open("/proc/pid/fd/N") for sockets because the symlink target
+    // (socket:[inode]) is not a valid filesystem path. Use pidfd_getfd() instead.
+    wil::unique_fd pidFd(static_cast<int>(syscall(SYS_pidfd_open, lookup.Pid, 0u)));
+    if (!pidFd)
+    {
+        GNS_LOG_INFO("Port-0 bind: pidfd_open failed for pid {} (errno {})", lookup.Pid, errno);
+        return;
+    }
+
+    wil::unique_fd sockFd(static_cast<int>(syscall(SYS_pidfd_getfd, pidFd.get(), lookup.SocketFd, 0u)));
+    if (!sockFd)
+    {
+        GNS_LOG_INFO("Port-0 bind: pidfd_getfd failed for pid {} fd {} (errno {})", lookup.Pid, lookup.SocketFd, errno);
+        return;
+    }
+
+    // The bind() syscall is being completed asynchronously on the seccomp dispatcher
+    // thread after CompleteRequest() unblocks it. Poll getsockname() briefly until
+    // the kernel assigns a port.
+    constexpr int maxRetries = 10;
+    constexpr auto retryDelay = std::chrono::milliseconds(100);
+
+    in_port_t port = 0;
+    in6_addr address = {};
+
+    for (int attempt = 0; attempt < maxRetries; ++attempt)
+    {
+        if (attempt > 0)
+        {
+            std::this_thread::sleep_for(retryDelay);
+        }
+
+        sockaddr_storage storage{};
+        socklen_t addrLen = sizeof(storage);
+        if (getsockname(sockFd.get(), reinterpret_cast<sockaddr*>(&storage), &addrLen) != 0)
+        {
+            GNS_LOG_ERROR("Port-0 bind: getsockname failed for pid {} fd {} (errno {})", lookup.Pid, lookup.SocketFd, errno);
+            return;
+        }
+
+        if (storage.ss_family == AF_INET)
+        {
+            const auto* sin = reinterpret_cast<const sockaddr_in*>(&storage);
+            port = ntohs(sin->sin_port);
+            address.s6_addr32[0] = sin->sin_addr.s_addr;
+        }
+        else if (storage.ss_family == AF_INET6)
+        {
+            const auto* sin6 = reinterpret_cast<const sockaddr_in6*>(&storage);
+            port = ntohs(sin6->sin6_port);
+            memcpy(address.s6_addr32, sin6->sin6_addr.s6_addr32, sizeof(address.s6_addr32));
+        }
+        else
+        {
+            return;
+        }
+
+        if (port != 0)
+        {
+            break;
+        }
+    }
+
+    if (port == 0)
+    {
+        GNS_LOG_INFO("Port-0 bind: kernel did not assign a port for pid {} fd {} after retries", lookup.Pid, lookup.SocketFd);
+        return;
+    }
+
+    PortAllocation allocation(port, lookup.Family, lookup.Protocol, address);
+    const auto result = HandleRequest(allocation);
+    if (result == 0)
+    {
+        m_allocatedPorts.emplace(std::make_pair(std::move(allocation), std::make_optional(time(nullptr) + c_bind_timeout_seconds)));
+        GNS_LOG_INFO(
+            "Port-0 bind resolved: family ({}) port ({}) protocol ({}) for pid {}",
+            lookup.Family,
+            port,
+            lookup.Protocol,
+            lookup.Pid);
+    }
 }
 
 std::ostream& operator<<(std::ostream& out, const GnsPortTracker::PortAllocation& entry)

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -562,7 +562,7 @@ void GnsPortTracker::ResolvePortZeroBind(DeferredPortLookup lookup)
     // The bind() syscall is being completed asynchronously on the seccomp dispatcher
     // thread after CompleteRequest() unblocks it. Poll getsockname() briefly until
     // the kernel assigns a port.
-    constexpr int maxRetries = 10;
+    constexpr int maxRetries = 25;
     constexpr auto retryDelay = std::chrono::milliseconds(100);
 
     in_port_t port = 0;
@@ -611,7 +611,7 @@ void GnsPortTracker::ResolvePortZeroBind(DeferredPortLookup lookup)
 
     if (port == 0)
     {
-        GNS_LOG_INFO("Port-0 bind: kernel did not assign a port for pid {} after retries", lookup.Pid);
+        GNS_LOG_ERROR("Port-0 bind: kernel did not assign a port for pid {} after retries", lookup.Pid);
         return;
     }
 

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -2,7 +2,6 @@
 
 #include <filesystem>
 #include <optional>
-#include <regex>
 #include <iostream>
 #include <linux/audit.h> /* Definition of AUDIT_* constants */
 #include <linux/sock_diag.h>
@@ -336,7 +335,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::ReadNextRequest()
     }
     catch (const std::exception& e)
     {
-        GNS_LOG_ERROR("Fetch to read bind() call info with ID {}lu for pid {}, {}", callInfo.id, callInfo.pid, e.what());
+        GNS_LOG_ERROR("Failed to read bind() call info with ID {} for pid {}, {}", callInfo.id, callInfo.pid, e.what());
         return {{{}, {}, callInfo.id}};
     }
 }
@@ -468,7 +467,7 @@ int GnsPortTracker::GetSocketProtocol(int pid, int fd)
 {
     const auto path = std::format("/proc/{}/fd/{}", pid, fd);
 
-    // Because there's a race between the time where the buffer size is determined and
+    // Because there's a race between the time where the buffer size is determined
     // and the actual getxattr() call, retry until the buffer size is big enough
     std::string protocol;
     int result = -1;
@@ -617,12 +616,12 @@ void GnsPortTracker::ResolvePortZeroBind(DeferredPortLookup lookup)
     }
 
     PortAllocation allocation(port, resolvedFamily, lookup.Protocol, address);
+    GNS_LOG_INFO(
+        "Port-0 bind resolved: family ({}) port ({}) protocol ({}) for pid {}", resolvedFamily, port, lookup.Protocol, lookup.Pid);
     {
         std::lock_guard lock(m_resolvedMutex);
         m_resolvedQueue.push_back(std::move(allocation));
     }
-    GNS_LOG_INFO(
-        "Port-0 bind resolved: family ({}) port ({}) protocol ({}) for pid {}", resolvedFamily, port, lookup.Protocol, lookup.Pid);
 }
 
 std::ostream& operator<<(std::ostream& out, const GnsPortTracker::PortAllocation& entry)

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -8,19 +8,12 @@
 #include <linux/sock_diag.h>
 #include <linux/inet_diag.h>
 #include <linux/net.h>
+#include <sys/syscall.h>
 #include <sys/xattr.h>
 #include "common.h" // Needs to be included before sal.h before of __reserved macro
 #include "NetlinkTransactionError.h"
 #include "GnsPortTracker.h"
 #include "lxinitshared.h"
-
-// pidfd_open (Linux 5.3) and pidfd_getfd (Linux 5.6) may not be defined in older headers.
-#ifndef SYS_pidfd_open
-#define SYS_pidfd_open 434
-#endif
-#ifndef SYS_pidfd_getfd
-#define SYS_pidfd_getfd 438
-#endif
 
 constexpr size_t c_bind_timeout_seconds = 60;
 constexpr auto c_sock_diag_refresh_delay = std::chrono::milliseconds(500);
@@ -81,6 +74,7 @@ void GnsPortTracker::Run()
     // for port deallocation
 
     std::thread{std::bind(&GnsPortTracker::RunPortRefresh, this)}.detach();
+    std::thread{std::bind(&GnsPortTracker::RunDeferredResolve, this)}.detach();
 
     auto future = std::make_optional(m_allocatedPortsRefresh.get_future());
     std::optional<PortRefreshResult> refreshResult;
@@ -106,7 +100,7 @@ void GnsPortTracker::Run()
                 result = HandleRequest(allocationRequest);
                 if (result == 0)
                 {
-                    m_allocatedPorts.emplace(std::make_pair(allocationRequest, std::make_optional(time(nullptr) + c_bind_timeout_seconds)));
+                    TrackPort(allocationRequest);
                     GNS_LOG_INFO(
                         "Tracking bind call: family ({}) port ({}) protocol ({})",
                         allocationRequest.Family,
@@ -124,19 +118,11 @@ void GnsPortTracker::Run()
                 GNS_LOG_ERROR("Failed to complete bind request, {}", e.what());
             }
 
-            // If this was a port-0 bind, the kernel should have assigned an ephemeral port.
-            // This check might be susceptible to races, but it's a best effort to resolve the 
-            // actual port in the case of port-0 binds so that it can be tracked properly.
             if (bindCall->PortZeroBind.has_value())
             {
-                try
-                {
-                    ResolvePortZeroBind(bindCall->PortZeroBind.value());
-                }
-                catch (const std::exception& e)
-                {
-                    GNS_LOG_ERROR("Failed to resolve port-0 bind for pid {}, {}", bindCall->PortZeroBind->Pid, e.what());
-                }
+                std::lock_guard lock(m_deferredMutex);
+                m_deferredQueue.push_back(std::move(bindCall->PortZeroBind.value()));
+                m_deferredCv.notify_one();
             }
         }
 
@@ -157,11 +143,13 @@ void GnsPortTracker::Run()
         }
 
         // Only look at bound ports if there's something to deallocate to avoid wasting cycles
-        if (refreshResult.has_value() && !m_allocatedPorts.empty())
-        {
-            future = m_allocatedPortsRefresh.get_future();
-            refreshResult->Resume(); // This will resume the sock_diag thread
-            refreshResult.reset();
+        if (refreshResult.has_value()) {
+            std::lock_guard lock(m_portsMutex);
+            if (!m_allocatedPorts.empty()) {
+                future = m_allocatedPortsRefresh.get_future();
+                refreshResult->Resume(); // This will resume the sock_diag thread
+                refreshResult.reset();
+            }
         }
     }
 }
@@ -233,33 +221,41 @@ void GnsPortTracker::OnRefreshAllocatedPorts(const std::set<PortAllocation>& Por
     // - The port has been seen to be allocated (if so, then the timeout is empty)
     // - The timeout has expired
 
-    for (auto it = m_allocatedPorts.begin(); it != m_allocatedPorts.end();)
+    std::vector<PortAllocation> toDeallocate;
     {
-        if (Ports.find(it->first) == Ports.end())
+        std::lock_guard lock(m_portsMutex);
+        for (auto it = m_allocatedPorts.begin(); it != m_allocatedPorts.end();)
         {
-            if (!it->second.has_value() || it->second.value() < Timestamp)
+            if (Ports.find(it->first) == Ports.end())
             {
-                auto result = RequestPort(it->first, false);
-                if (result != 0)
+                if (!it->second.has_value() || it->second.value() < Timestamp)
                 {
-                    std::cerr << "GnsPortTracker: Failed to deallocate port " << it->first << ", " << result << std::endl;
+                    toDeallocate.push_back(it->first);
+                    GNS_LOG_INFO(
+                        "No longer tracking bind call: family ({}) port ({}) protocol ({})",
+                        it->first.Family,
+                        it->first.Port,
+                        it->first.Protocol);
+                    it = m_allocatedPorts.erase(it);
+                    continue;
                 }
-
-                GNS_LOG_INFO(
-                    "No longer tracking bind call: family ({}) port ({}) protocol ({})",
-                    it->first.Family,
-                    it->first.Port,
-                    it->first.Protocol);
-                it = m_allocatedPorts.erase(it);
-                continue;
             }
-        }
-        else
-        {
-            it->second.reset(); // The port is known to be allocated, remove the timeout
-        }
+            else
+            {
+                it->second.reset(); // The port is known to be allocated, remove the timeout
+            }
 
-        it++;
+            it++;
+        }
+    }
+
+    for (const auto& port : toDeallocate)
+    {
+        auto result = RequestPort(port, false);
+        if (result != 0)
+        {
+            std::cerr << "GnsPortTracker: Failed to deallocate port " << port << ", " << result << std::endl;
+        }
     }
 }
 
@@ -287,10 +283,13 @@ int GnsPortTracker::HandleRequest(const PortAllocation& Port)
     // decide if bind() should succeed or not
     // Note: Returning 0 will also cause the port's timeout to be updated
 
-    if (m_allocatedPorts.contains(Port))
     {
-        GNS_LOG_INFO("Request for a port that's already reserved (family {}, port {}, protocol {})", Port.Family, Port.Port, Port.Protocol);
-        return 0;
+        std::lock_guard lock(m_portsMutex);
+        if (m_allocatedPorts.contains(Port))
+        {
+            GNS_LOG_INFO("Request for a port that's already reserved (family {}, port {}, protocol {})", Port.Family, Port.Port, Port.Protocol);
+            return 0;
+        }
     }
 
     // Ask the host for this port otherwise
@@ -367,16 +366,22 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
         if (port == 0)
         {
             // Port 0 means the kernel will assign an ephemeral port. We can't know
-            // the port until after the bind() completes, so capture the socket info
-            // for a deferred lookup after the syscall is allowed through.
+            // the port until after the bind() completes, so duplicate the socket fd
+            // now (while the process is still stopped by seccomp) and defer the
+            // getsockname() lookup to after CompleteRequest() unblocks it.
             try
             {
                 const int protocol = GetSocketProtocol(Pid, Socket);
+                auto dupFd = DuplicateSocketFd(Pid, Socket);
+                if (!dupFd)
+                {
+                    return {{{}, {}, CallId}};
+                }
                 if (!m_seccompDispatcher->ValidateCookie(CallId))
                 {
                     return {{{}, {}, CallId}};
                 }
-                return {{{}, DeferredPortLookup{Pid, Socket, static_cast<int>(address.sa_family), protocol}, CallId}};
+                return {{{}, DeferredPortLookup{Pid, std::move(dupFd), static_cast<int>(address.sa_family), protocol}, CallId}};
             }
             catch (const std::exception&)
             {
@@ -480,24 +485,65 @@ int GnsPortTracker::GetSocketProtocol(int pid, int fd)
     throw RuntimeErrorWithSourceLocation(std::format("Unexpected IP socket protocol: {}", protocol));
 }
 
-void GnsPortTracker::ResolvePortZeroBind(const DeferredPortLookup& lookup)
+wil::unique_fd GnsPortTracker::DuplicateSocketFd(pid_t Pid, int SocketFd)
 {
     // Duplicate the socket fd from the target process into our address space.
     // We cannot use open("/proc/pid/fd/N") for sockets because the symlink target
     // (socket:[inode]) is not a valid filesystem path. Use pidfd_getfd() instead.
-    wil::unique_fd pidFd(static_cast<int>(syscall(SYS_pidfd_open, lookup.Pid, 0u)));
+    wil::unique_fd pidFd(static_cast<int>(syscall(SYS_pidfd_open, Pid, 0u)));
     if (!pidFd)
     {
-        GNS_LOG_INFO("Port-0 bind: pidfd_open failed for pid {} (errno {})", lookup.Pid, errno);
-        return;
+        GNS_LOG_INFO("Port-0 bind: pidfd_open failed for pid {} (errno {})", Pid, errno);
+        return {};
     }
 
-    wil::unique_fd sockFd(static_cast<int>(syscall(SYS_pidfd_getfd, pidFd.get(), lookup.SocketFd, 0u)));
-    if (!sockFd)
+    wil::unique_fd dupFd(static_cast<int>(syscall(SYS_pidfd_getfd, pidFd.get(), SocketFd, 0u)));
+    if (!dupFd)
     {
-        GNS_LOG_INFO("Port-0 bind: pidfd_getfd failed for pid {} fd {} (errno {})", lookup.Pid, lookup.SocketFd, errno);
-        return;
+        GNS_LOG_INFO("Port-0 bind: pidfd_getfd failed for pid {} fd {} (errno {})", Pid, SocketFd, errno);
     }
+
+    return dupFd;
+}
+
+void GnsPortTracker::TrackPort(PortAllocation allocation)
+{
+    // Use insert_or_assign so the deallocation timeout is refreshed if the same
+    // port key is already present (emplace would silently keep the old entry).
+    std::lock_guard lock(m_portsMutex);
+    m_allocatedPorts.insert_or_assign(std::move(allocation), std::make_optional(time(nullptr) + c_bind_timeout_seconds));
+}
+
+void GnsPortTracker::RunDeferredResolve()
+{
+    UtilSetThreadName("GnsPortZero");
+
+    for (;;)
+    {
+        DeferredPortLookup lookup{0, {}, 0, 0};
+        {
+            std::unique_lock lock(m_deferredMutex);
+            m_deferredCv.wait(lock, [&] { return !m_deferredQueue.empty(); });
+            lookup = std::move(m_deferredQueue.front());
+            m_deferredQueue.pop_front();
+        }
+
+        try
+        {
+            ResolvePortZeroBind(std::move(lookup));
+        }
+        catch (const std::exception& e)
+        {
+            GNS_LOG_ERROR("Failed to resolve port-0 bind for pid {}, {}", lookup.Pid, e.what());
+        }
+    }
+}
+
+void GnsPortTracker::ResolvePortZeroBind(DeferredPortLookup lookup)
+{
+    // The socket fd was already duplicated (via pidfd_getfd) while the target process
+    // was stopped by seccomp, so it remains valid even if the process has closed or
+    // reused the original fd number.
 
     // The bind() syscall is being completed asynchronously on the seccomp dispatcher
     // thread after CompleteRequest() unblocks it. Poll getsockname() briefly until
@@ -507,6 +553,7 @@ void GnsPortTracker::ResolvePortZeroBind(const DeferredPortLookup& lookup)
 
     in_port_t port = 0;
     in6_addr address = {};
+    int resolvedFamily = 0;
 
     for (int attempt = 0; attempt < maxRetries; ++attempt)
     {
@@ -517,11 +564,13 @@ void GnsPortTracker::ResolvePortZeroBind(const DeferredPortLookup& lookup)
 
         sockaddr_storage storage{};
         socklen_t addrLen = sizeof(storage);
-        if (getsockname(sockFd.get(), reinterpret_cast<sockaddr*>(&storage), &addrLen) != 0)
+        if (getsockname(lookup.DuplicatedSocketFd.get(), reinterpret_cast<sockaddr*>(&storage), &addrLen) != 0)
         {
-            GNS_LOG_ERROR("Port-0 bind: getsockname failed for pid {} fd {} (errno {})", lookup.Pid, lookup.SocketFd, errno);
+            GNS_LOG_ERROR("Port-0 bind: getsockname failed for pid {} (errno {})", lookup.Pid, errno);
             return;
         }
+
+        resolvedFamily = static_cast<int>(storage.ss_family);
 
         if (storage.ss_family == AF_INET)
         {
@@ -548,18 +597,18 @@ void GnsPortTracker::ResolvePortZeroBind(const DeferredPortLookup& lookup)
 
     if (port == 0)
     {
-        GNS_LOG_INFO("Port-0 bind: kernel did not assign a port for pid {} fd {} after retries", lookup.Pid, lookup.SocketFd);
+        GNS_LOG_INFO("Port-0 bind: kernel did not assign a port for pid {} after retries", lookup.Pid);
         return;
     }
 
-    PortAllocation allocation(port, lookup.Family, lookup.Protocol, address);
+    PortAllocation allocation(port, resolvedFamily, lookup.Protocol, address);
     const auto result = HandleRequest(allocation);
     if (result == 0)
     {
-        m_allocatedPorts.emplace(std::make_pair(std::move(allocation), std::make_optional(time(nullptr) + c_bind_timeout_seconds)));
+        TrackPort(std::move(allocation));
         GNS_LOG_INFO(
             "Port-0 bind resolved: family ({}) port ({}) protocol ({}) for pid {}",
-            lookup.Family,
+            resolvedFamily,
             port,
             lookup.Protocol,
             lookup.Pid);

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -142,10 +142,35 @@ void GnsPortTracker::Run()
             }
         }
 
+        // Process any port-0 binds that the background thread has resolved.
+        std::deque<PortAllocation> resolved;
+        {
+            std::lock_guard lock(m_resolvedMutex);
+            resolved.swap(m_resolvedQueue);
+        }
+        for (auto& allocation : resolved)
+        {
+            const auto result = HandleRequest(allocation);
+            if (result == 0)
+            {
+                TrackPort(std::move(allocation));
+            }
+            else
+            {
+                GNS_LOG_ERROR(
+                    "Failed to register resolved port-0 bind: family ({}) port ({}) protocol ({}), error {}",
+                    allocation.Family,
+                    allocation.Port,
+                    allocation.Protocol,
+                    result);
+            }
+        }
+
         // Only look at bound ports if there's something to deallocate to avoid wasting cycles
-        if (refreshResult.has_value()) {
-            std::lock_guard lock(m_portsMutex);
-            if (!m_allocatedPorts.empty()) {
+        if (refreshResult.has_value())
+        {
+            if (!m_allocatedPorts.empty())
+            {
                 future = m_allocatedPortsRefresh.get_future();
                 refreshResult->Resume(); // This will resume the sock_diag thread
                 refreshResult.reset();
@@ -221,41 +246,34 @@ void GnsPortTracker::OnRefreshAllocatedPorts(const std::set<PortAllocation>& Por
     // - The port has been seen to be allocated (if so, then the timeout is empty)
     // - The timeout has expired
 
-    std::vector<PortAllocation> toDeallocate;
+    for (auto it = m_allocatedPorts.begin(); it != m_allocatedPorts.end();)
     {
-        std::lock_guard lock(m_portsMutex);
-        for (auto it = m_allocatedPorts.begin(); it != m_allocatedPorts.end();)
+        if (Ports.find(it->first) == Ports.end())
         {
-            if (Ports.find(it->first) == Ports.end())
+            if (!it->second.has_value() || it->second.value() < Timestamp)
             {
-                if (!it->second.has_value() || it->second.value() < Timestamp)
+                auto result = RequestPort(it->first, false);
+                if (result != 0)
                 {
-                    toDeallocate.push_back(it->first);
-                    GNS_LOG_INFO(
-                        "No longer tracking bind call: family ({}) port ({}) protocol ({})",
-                        it->first.Family,
-                        it->first.Port,
-                        it->first.Protocol);
-                    it = m_allocatedPorts.erase(it);
-                    continue;
+                    std::cerr << "GnsPortTracker: Failed to deallocate port " << it->first << ", " << result << std::endl;
                 }
-            }
-            else
-            {
-                it->second.reset(); // The port is known to be allocated, remove the timeout
-            }
 
-            it++;
+                GNS_LOG_INFO(
+                    "No longer tracking bind call: family ({}) port ({}) protocol ({})",
+                    it->first.Family,
+                    it->first.Port,
+                    it->first.Protocol);
+
+                it = m_allocatedPorts.erase(it);
+                continue;
+            }
         }
-    }
-
-    for (const auto& port : toDeallocate)
-    {
-        auto result = RequestPort(port, false);
-        if (result != 0)
+        else
         {
-            std::cerr << "GnsPortTracker: Failed to deallocate port " << port << ", " << result << std::endl;
+            it->second.reset(); // The port is known to be allocated, remove the timeout
         }
+
+        it++;
     }
 }
 
@@ -283,13 +301,10 @@ int GnsPortTracker::HandleRequest(const PortAllocation& Port)
     // decide if bind() should succeed or not
     // Note: Returning 0 will also cause the port's timeout to be updated
 
+    if (m_allocatedPorts.contains(Port))
     {
-        std::lock_guard lock(m_portsMutex);
-        if (m_allocatedPorts.contains(Port))
-        {
-            GNS_LOG_INFO("Request for a port that's already reserved (family {}, port {}, protocol {})", Port.Family, Port.Port, Port.Protocol);
-            return 0;
-        }
+        GNS_LOG_INFO("Request for a port that's already reserved (family {}, port {}, protocol {})", Port.Family, Port.Port, Port.Protocol);
+        return 0;
     }
 
     // Ask the host for this port otherwise
@@ -381,7 +396,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
                 {
                     return {{{}, {}, CallId}};
                 }
-                return {{{}, DeferredPortLookup{Pid, std::move(dupFd), static_cast<int>(address.sa_family), protocol}, CallId}};
+                return {{{}, DeferredPortLookup{Pid, std::move(dupFd), protocol}, CallId}};
             }
             catch (const std::exception&)
             {
@@ -467,7 +482,7 @@ int GnsPortTracker::GetSocketProtocol(int pid, int fd)
 
     if (result < 0)
     {
-        RuntimeErrorWithSourceLocation(std::format("Failed to read protocol for socket: {}, {}", path, errno));
+        throw RuntimeErrorWithSourceLocation(std::format("Failed to read protocol for socket: {}, {}", path, errno));
     }
 
     // In case the size of the attribute shrunk between the two getxattr calls
@@ -510,7 +525,6 @@ void GnsPortTracker::TrackPort(PortAllocation allocation)
 {
     // Use insert_or_assign so the deallocation timeout is refreshed if the same
     // port key is already present (emplace would silently keep the old entry).
-    std::lock_guard lock(m_portsMutex);
     m_allocatedPorts.insert_or_assign(std::move(allocation), std::make_optional(time(nullptr) + c_bind_timeout_seconds));
 }
 
@@ -520,7 +534,7 @@ void GnsPortTracker::RunDeferredResolve()
 
     for (;;)
     {
-        DeferredPortLookup lookup{0, {}, 0, 0};
+        DeferredPortLookup lookup{0, {}, 0};
         {
             std::unique_lock lock(m_deferredMutex);
             m_deferredCv.wait(lock, [&] { return !m_deferredQueue.empty(); });
@@ -528,13 +542,14 @@ void GnsPortTracker::RunDeferredResolve()
             m_deferredQueue.pop_front();
         }
 
+        const auto pid = lookup.Pid;
         try
         {
             ResolvePortZeroBind(std::move(lookup));
         }
         catch (const std::exception& e)
         {
-            GNS_LOG_ERROR("Failed to resolve port-0 bind for pid {}, {}", lookup.Pid, e.what());
+            GNS_LOG_ERROR("Failed to resolve port-0 bind for pid {}, {}", pid, e.what());
         }
     }
 }
@@ -602,17 +617,12 @@ void GnsPortTracker::ResolvePortZeroBind(DeferredPortLookup lookup)
     }
 
     PortAllocation allocation(port, resolvedFamily, lookup.Protocol, address);
-    const auto result = HandleRequest(allocation);
-    if (result == 0)
     {
-        TrackPort(std::move(allocation));
-        GNS_LOG_INFO(
-            "Port-0 bind resolved: family ({}) port ({}) protocol ({}) for pid {}",
-            resolvedFamily,
-            port,
-            lookup.Protocol,
-            lookup.Pid);
+        std::lock_guard lock(m_resolvedMutex);
+        m_resolvedQueue.push_back(std::move(allocation));
     }
+    GNS_LOG_INFO(
+        "Port-0 bind resolved: family ({}) port ({}) protocol ({}) for pid {}", resolvedFamily, port, lookup.Protocol, lookup.Pid);
 }
 
 std::ostream& operator<<(std::ostream& out, const GnsPortTracker::PortAllocation& entry)

--- a/src/linux/init/GnsPortTracker.h
+++ b/src/linux/init/GnsPortTracker.h
@@ -98,11 +98,10 @@ public:
     {
         pid_t Pid;
         wil::unique_fd DuplicatedSocketFd; // Duplicated via pidfd_getfd while process was stopped
-        int Family;
         int Protocol;
 
-        DeferredPortLookup(pid_t Pid, wil::unique_fd DuplicatedSocketFd, int Family, int Protocol) :
-            Pid(Pid), DuplicatedSocketFd(std::move(DuplicatedSocketFd)), Family(Family), Protocol(Protocol)
+        DeferredPortLookup(pid_t Pid, wil::unique_fd DuplicatedSocketFd, int Protocol) :
+            Pid(Pid), DuplicatedSocketFd(std::move(DuplicatedSocketFd)), Protocol(Protocol)
         {
         }
 
@@ -155,9 +154,6 @@ private:
 
     void TrackPort(PortAllocation allocation);
 
-    // Protects m_allocatedPorts which is accessed from both the main Run() loop
-    // and the background RunDeferredResolve() thread.
-    std::mutex m_portsMutex;
     std::map<PortAllocation, std::optional<time_t>> m_allocatedPorts;
     std::shared_ptr<wsl::shared::SocketChannel> m_hvSocketChannel;
     NetlinkChannel m_channel;
@@ -173,6 +169,11 @@ private:
     std::mutex m_deferredMutex;
     std::condition_variable m_deferredCv;
     std::deque<DeferredPortLookup> m_deferredQueue;
+
+    // Resolved port-0 allocations posted by the background RunDeferredResolve thread
+    // for the main Run() loop to process (keeps SocketChannel access single-threaded).
+    std::mutex m_resolvedMutex;
+    std::deque<PortAllocation> m_resolvedQueue;
 };
 
 std::ostream& operator<<(std::ostream& out, const GnsPortTracker::PortAllocation& portAllocation);

--- a/src/linux/init/GnsPortTracker.h
+++ b/src/linux/init/GnsPortTracker.h
@@ -1,7 +1,9 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 #pragma once
+#include <deque>
 #include <map>
+#include <mutex>
 #include <set>
 #include <utility>
 #include <optional>
@@ -95,9 +97,19 @@ public:
     struct DeferredPortLookup
     {
         pid_t Pid;
-        int SocketFd;
+        wil::unique_fd DuplicatedSocketFd; // Duplicated via pidfd_getfd while process was stopped
         int Family;
         int Protocol;
+
+        DeferredPortLookup(pid_t Pid, wil::unique_fd DuplicatedSocketFd, int Family, int Protocol) :
+            Pid(Pid), DuplicatedSocketFd(std::move(DuplicatedSocketFd)), Family(Family), Protocol(Protocol)
+        {
+        }
+
+        DeferredPortLookup(DeferredPortLookup&&) = default;
+        DeferredPortLookup& operator=(DeferredPortLookup&&) = default;
+        DeferredPortLookup(const DeferredPortLookup&) = delete;
+        DeferredPortLookup& operator=(const DeferredPortLookup&) = delete;
     };
 
     struct BindCall
@@ -135,8 +147,17 @@ private:
 
     static int GetSocketProtocol(int Pid, int Fd);
 
-    void ResolvePortZeroBind(const DeferredPortLookup& lookup);
+    static wil::unique_fd DuplicateSocketFd(pid_t Pid, int SocketFd);
 
+    void ResolvePortZeroBind(DeferredPortLookup lookup);
+
+    void RunDeferredResolve();
+
+    void TrackPort(PortAllocation allocation);
+
+    // Protects m_allocatedPorts which is accessed from both the main Run() loop
+    // and the background RunDeferredResolve() thread.
+    std::mutex m_portsMutex;
     std::map<PortAllocation, std::optional<time_t>> m_allocatedPorts;
     std::shared_ptr<wsl::shared::SocketChannel> m_hvSocketChannel;
     NetlinkChannel m_channel;
@@ -148,6 +169,10 @@ private:
     std::shared_ptr<SecCompDispatcher> m_seccompDispatcher;
 
     std::string m_networkNamespace;
+
+    std::mutex m_deferredMutex;
+    std::condition_variable m_deferredCv;
+    std::deque<DeferredPortLookup> m_deferredQueue;
 };
 
 std::ostream& operator<<(std::ostream& out, const GnsPortTracker::PortAllocation& portAllocation);

--- a/src/linux/init/GnsPortTracker.h
+++ b/src/linux/init/GnsPortTracker.h
@@ -92,9 +92,18 @@ public:
         }
     };
 
+    struct DeferredPortLookup
+    {
+        pid_t Pid;
+        int SocketFd;
+        int Family;
+        int Protocol;
+    };
+
     struct BindCall
     {
         std::optional<PortAllocation> Request;
+        std::optional<DeferredPortLookup> PortZeroBind;
         std::uint64_t CallId;
     };
 
@@ -125,6 +134,8 @@ private:
     void CompleteRequest(uint64_t Id, int Result);
 
     static int GetSocketProtocol(int Pid, int Fd);
+
+    void ResolvePortZeroBind(const DeferredPortLookup& lookup);
 
     std::map<PortAllocation, std::optional<time_t>> m_allocatedPorts;
     std::shared_ptr<wsl::shared::SocketChannel> m_hvSocketChannel;

--- a/src/linux/init/GnsPortTracker.h
+++ b/src/linux/init/GnsPortTracker.h
@@ -138,8 +138,6 @@ private:
 
     int RequestPort(const PortAllocation& Port, bool Allocate);
 
-    int ClosePort(const PortAllocation& Port);
-
     int HandleRequest(const PortAllocation& Request);
 
     void CompleteRequest(uint64_t Id, int Result);

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2067,13 +2067,18 @@ class NetworkTests
             auto pos = outputView.find("listening on");
             if (pos != std::string_view::npos)
             {
+                // Limit the search to just the "listening on" line to avoid
+                // matching colons in subsequent debug lines socat may emit.
+                auto lineEnd = outputView.find('\n', pos);
+                auto line = outputView.substr(pos, lineEnd != std::string_view::npos ? lineEnd - pos : std::string_view::npos);
+
                 // Find the last ':' before the port digits. For IPv6, socat outputs
                 // "listening on AF=10 :::PORT", so using find() would match the
                 // first colon in the address instead of the port separator.
-                auto colonPos = outputView.rfind(':');
-                if (colonPos != std::string_view::npos && colonPos > pos)
+                auto colonPos = line.rfind(':');
+                if (colonPos != std::string_view::npos)
                 {
-                    auto portStr = outputView.substr(colonPos + 1);
+                    auto portStr = line.substr(colonPos + 1);
                     auto end = portStr.find_first_not_of("0123456789");
                     if (end != std::string_view::npos)
                     {

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2028,14 +2028,12 @@ class NetworkTests
     static std::tuple<unique_kill_process, uint16_t> BindGuestPortZero(bool Ipv6 = false)
     {
         auto [stdErrRead, stdErrWrite] = CreateSubprocessPipe(false, true);
-        auto [stdOutRead, stdOutWrite] = CreateSubprocessPipe(false, true);
         const std::wstring protocol = Ipv6 ? L"TCP6-LISTEN:0" : L"TCP4-LISTEN:0";
         const std::wstring wslCmd = L"socat -dd " + protocol + L" STDOUT";
         auto cmd = LxssGenerateWslCommandLine(wslCmd.data());
 
-        auto process = LxsstuStartProcess(cmd.data(), nullptr, stdOutWrite.get(), stdErrWrite.get());
+        auto process = LxsstuStartProcess(cmd.data(), nullptr, nullptr, stdErrWrite.get());
         stdErrWrite.reset();
-        stdOutWrite.reset();
 
         // Parse the assigned port from socat's debug output.
         // socat -dd prints a line like: "... listening on AF=2 0.0.0.0:PORT"
@@ -2046,8 +2044,19 @@ class NetworkTests
 
         while (!found)
         {
+            // Grow the buffer if full to avoid zero-byte reads and infinite loops.
+            if (writeOffset == output.size())
+            {
+                output.resize(output.size() * 2);
+            }
+
             DWORD bytesRead = 0;
             if (!ReadFile(stdErrRead.get(), output.data() + writeOffset, static_cast<DWORD>(output.size() - writeOffset), &bytesRead, nullptr))
+            {
+                break;
+            }
+
+            if (bytesRead == 0)
             {
                 break;
             }
@@ -2058,15 +2067,20 @@ class NetworkTests
             auto pos = outputView.find("listening on");
             if (pos != std::string_view::npos)
             {
-                // Find the last ':' after "listening on" to extract the port
-                auto colonPos = outputView.rfind(':');
-                if (colonPos != std::string_view::npos && colonPos > pos)
+                // Find the first ':' after "listening on" to extract the port
+                auto colonPos = outputView.find(':', pos);
+                if (colonPos != std::string_view::npos)
                 {
                     auto portStr = outputView.substr(colonPos + 1);
                     auto end = portStr.find_first_not_of("0123456789");
                     if (end != std::string_view::npos)
                     {
                         portStr = portStr.substr(0, end);
+                    }
+
+                    if (portStr.empty())
+                    {
+                        continue;
                     }
 
                     assignedPort = static_cast<uint16_t>(std::stoi(std::string(portStr)));

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2023,6 +2023,113 @@ class NetworkTests
         return std::tuple(std::move(process), std::move(read));
     }
 
+    // Bind port 0 in the guest and return the process handle and the kernel-assigned port.
+    // Uses socat's -dd output to extract the actual port from the "listening on" line.
+    static std::tuple<unique_kill_process, uint16_t> BindGuestPortZero(bool Ipv6 = false)
+    {
+        auto [stdErrRead, stdErrWrite] = CreateSubprocessPipe(false, true);
+        auto [stdOutRead, stdOutWrite] = CreateSubprocessPipe(false, true);
+        const std::wstring protocol = Ipv6 ? L"TCP6-LISTEN:0" : L"TCP4-LISTEN:0";
+        const std::wstring wslCmd = L"socat -dd " + protocol + L" STDOUT";
+        auto cmd = LxssGenerateWslCommandLine(wslCmd.data());
+
+        auto process = LxsstuStartProcess(cmd.data(), nullptr, stdOutWrite.get(), stdErrWrite.get());
+        stdErrWrite.reset();
+        stdOutWrite.reset();
+
+        // Parse the assigned port from socat's debug output.
+        // socat -dd prints a line like: "... listening on AF=2 0.0.0.0:PORT"
+        std::string output(512, '\0');
+        DWORD writeOffset = 0;
+        uint16_t assignedPort = 0;
+        bool found = false;
+
+        while (!found)
+        {
+            DWORD bytesRead = 0;
+            if (!ReadFile(stdErrRead.get(), output.data() + writeOffset, static_cast<DWORD>(output.size() - writeOffset), &bytesRead, nullptr))
+            {
+                break;
+            }
+
+            writeOffset += bytesRead;
+            LogInfo("output %hs", output.c_str());
+            std::string_view outputView(output.data(), writeOffset);
+            auto pos = outputView.find("listening on");
+            if (pos != std::string_view::npos)
+            {
+                // Find the last ':' after "listening on" to extract the port
+                auto colonPos = outputView.rfind(':');
+                if (colonPos != std::string_view::npos && colonPos > pos)
+                {
+                    auto portStr = outputView.substr(colonPos + 1);
+                    auto end = portStr.find_first_not_of("0123456789");
+                    if (end != std::string_view::npos)
+                    {
+                        portStr = portStr.substr(0, end);
+                    }
+
+                    assignedPort = static_cast<uint16_t>(std::stoi(std::string(portStr)));
+                    found = true;
+                }
+            }
+        }
+
+        VERIFY_IS_TRUE(found);
+        VERIFY_IS_TRUE(assignedPort > 0);
+        LogInfo("Port-0 bind resolved to port %u", assignedPort);
+
+        return {std::move(process), assignedPort};
+    }
+
+    static void VerifyPortZeroBindIsTracked(bool verifyRelease = true)
+    {
+        // Make sure the VM doesn't time out while we wait for async port resolution
+        WslKeepAlive keepAlive;
+
+        // Bind port 0 in the guest - the kernel assigns an ephemeral port.
+        // The port tracker intercepts the bind() via seccomp and defers lookup
+        // to a background thread that resolves the actual port via getsockname().
+        auto [guestProcess, assignedPort] = BindGuestPortZero();
+
+        // The port-0 resolution is asynchronous (deferred to a background thread).
+        // Retry until the host port tracker registers the port, blocking the host bind.
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&assignedPort]() {
+                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                THROW_LAST_ERROR_IF(!sock);
+
+                SOCKADDR_IN addr{};
+                addr.sin_family = AF_INET;
+                addr.sin_port = htons(assignedPort);
+                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) != SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::seconds(30)));
+
+        if (!verifyRelease)
+        {
+            return;
+        }
+
+        // Kill the guest process so the port tracker releases the port.
+        guestProcess.reset();
+
+        // Retry until the host can bind the port again, confirming it was released.
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&assignedPort]() {
+                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                THROW_LAST_ERROR_IF(!sock);
+
+                SOCKADDR_IN addr{};
+                addr.sin_family = AF_INET;
+                addr.sin_port = htons(assignedPort);
+                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) == SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::minutes(2)));
+    }
+
     template <typename T>
     static void VerifyNotBound(T& Address, int AddressFamily, int Protocol)
     {
@@ -3853,6 +3960,17 @@ class MirroredTests
         auto udpPort = NetworkTests::BindGuestPort(L"UDP4-LISTEN:0", true);
     }
 
+    TEST_METHOD(PortZeroBindIsTracked)
+    {
+        MIRRORED_NETWORKING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+        WaitForMirroredStateInLinux();
+
+        // TODO: debug port release on mirrored.
+        NetworkTests::VerifyPortZeroBindIsTracked(false);
+    }
+
     TEST_METHOD(ExplicitEphemeralBind)
     {
         MIRRORED_NETWORKING_TEST_ONLY();
@@ -4680,6 +4798,15 @@ class VirtioProxyTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
 
         NetworkTests::VerifyDnsResolutionRecordTypes();
+    }
+
+    TEST_METHOD(PortZeroBindIsTracked)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+
+        NetworkTests::VerifyPortZeroBindIsTracked();
     }
 
     TEST_METHOD(HttpProxySimple)

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2067,9 +2067,11 @@ class NetworkTests
             auto pos = outputView.find("listening on");
             if (pos != std::string_view::npos)
             {
-                // Find the first ':' after "listening on" to extract the port
-                auto colonPos = outputView.find(':', pos);
-                if (colonPos != std::string_view::npos)
+                // Find the last ':' before the port digits. For IPv6, socat outputs
+                // "listening on AF=10 :::PORT", so using find() would match the
+                // first colon in the address instead of the port separator.
+                auto colonPos = outputView.rfind(':');
+                if (colonPos != std::string_view::npos && colonPos > pos)
                 {
                     auto portStr = outputView.substr(colonPos + 1);
                     auto end = portStr.find_first_not_of("0123456789");
@@ -3981,7 +3983,11 @@ class MirroredTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
         WaitForMirroredStateInLinux();
 
-        // TODO: debug port release on mirrored.
+        // Skip port-release verification in mirrored mode. The host reserves a contiguous
+        // ephemeral port range via HcnReserveGuestNetworkServicePortRange that no Windows
+        // process can bind for the lifetime of the VM. Port-0 binds resolve to ports within
+        // this range, so even after the guest releases the port the host still cannot bind
+        // it — the range-level reservation remains, making release unverifiable.
         NetworkTests::VerifyPortZeroBindIsTracked(false);
     }
 


### PR DESCRIPTION
With mirrored and virtio networking, we observed an issue when trying to connect to VSCode remote instance inside a WSL environment. The issue is that VSCode will call bind with the localhost IP address with port 0 specified. This indicates to the kernel that it should assign any available ephemeral port to the requesting process.

In WSL's port tracker, we ignore bind syscalls where the port is 0 because the kernel will assign one when the syscall completes. When the port is not 0, we send a PortMappingRequest to the host, which will create a new host-side socket bound to the specified local address and port where incoming connections can be listened to.

To address the issue, we should still track the bind syscall when the port is 0, but follow-up after the syscall has been completed. We do this by duplicating the socket that was created and calling getsockname to check was port has been assigned. Then we can send the same PortMappingRequest to the host.