### PR TITLE
Fix invalid behavior in docker IO relay when a read spans across multiple streams

### DIFF
--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -1610,7 +1610,7 @@ void DockerIORelayHandle::Collect()
 
 HANDLE DockerIORelayHandle::GetHandle() const
 {
-    if (ActiveHandle != nullptr && !PendingBuffer.empty())
+    if (ActiveHandle != nullptr && ActiveHandle->GetState() == IOHandleStatus::Pending)
     {
         return ActiveHandle->GetHandle();
     }

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -1512,9 +1512,10 @@ DockerIORelayHandle::DockerIORelayHandle(HandleWrapper&& ReadHandle, HandleWrapp
 void DockerIORelayHandle::Schedule()
 {
     WI_ASSERT(State == IOHandleStatus::Standby);
+    WI_ASSERT(Read->GetState() != IOHandleStatus::Pending);
 
     // If we have an active handle and a buffer, try to flush that first.
-    if (ActiveHandle != nullptr)
+    if (ActiveHandle != nullptr && !PendingBuffer.empty())
     {
         // Push the data to the selected handle.
         DWORD bytesToWrite = std::min(static_cast<DWORD>(RemainingBytes), static_cast<DWORD>(PendingBuffer.size()));
@@ -1535,16 +1536,21 @@ void DockerIORelayHandle::Schedule()
         }
         else if (ActiveHandle->GetState() == IOHandleStatus::Completed)
         {
-            // Switch back to reading if we've written all bytes for this chunk.
-            ActiveHandle = nullptr;
+            if (RemainingBytes == 0)
+            {
+                // Switch back to reading if we've written all bytes for this chunk.
+                ActiveHandle = nullptr;
 
-            ProcessNextHeader();
+                ProcessNextHeader();
+            }
         }
     }
     else
     {
         if (Read->GetState() == IOHandleStatus::Completed)
         {
+            LOG_HR_IF(E_UNEXPECTED, ActiveHandle != nullptr);
+
             // No more data to read, we're done.
             State = IOHandleStatus::Completed;
             return;
@@ -1563,21 +1569,26 @@ void DockerIORelayHandle::Collect()
 {
     WI_ASSERT(State == IOHandleStatus::Pending);
 
-    if (ActiveHandle != nullptr)
+    if (ActiveHandle != nullptr && ActiveHandle->GetState() == IOHandleStatus::Pending)
     {
         // Complete the write.
         ActiveHandle->Collect();
 
         // If the write is completed, switch back to reading.
-        if (ActiveHandle->GetState() == IOHandleStatus::Completed)
+        if (RemainingBytes == 0)
         {
-            ActiveHandle = nullptr;
+            if (ActiveHandle->GetState() == IOHandleStatus::Completed)
+            {
+                ActiveHandle = nullptr;
+            }
         }
 
         // Transition back to standby if there's still data to read.
         // Otherwise switch to Completed since everything is done.
         if (Read->GetState() == IOHandleStatus::Completed)
         {
+            LOG_HR_IF(E_UNEXPECTED, RemainingBytes != 0);
+
             State = IOHandleStatus::Completed;
         }
         else
@@ -1587,6 +1598,8 @@ void DockerIORelayHandle::Collect()
     }
     else
     {
+        WI_ASSERT(Read->GetState() == IOHandleStatus::Pending);
+
         // Complete the read.
         Read->Collect();
 
@@ -1597,7 +1610,7 @@ void DockerIORelayHandle::Collect()
 
 HANDLE DockerIORelayHandle::GetHandle() const
 {
-    if (ActiveHandle != nullptr)
+    if (ActiveHandle != nullptr && !PendingBuffer.empty())
     {
         return ActiveHandle->GetHandle();
     }

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -3911,7 +3911,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest(input, "", ""); }), E_INVALIDARG);
         }
 
-        // Validate that behavior is correct if a read spans accross multiple streams.
+        // Validate that behavior is correct if a read spans across multiple streams.
         {
             std::vector<char> input;
 

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -3910,6 +3910,19 @@ class WSLATests
 
             VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest(input, "", ""); }), E_INVALIDARG);
         }
+
+        // Validate that behavior is correct if a read spans accross multiple streams.
+        {
+            std::vector<char> input;
+
+            std::string largeStdout(LX_RELAY_BUFFER_SIZE + 150, 'a');
+            std::string largeStderr(LX_RELAY_BUFFER_SIZE + 12, 'b');
+            insert(input, 1, largeStdout);
+            insert(input, 2, largeStderr);
+            insert(input, 1, "regularStdout");
+
+            runTest(input, largeStdout + "regularStdout", largeStderr);
+        }
     }
 
     TEST_METHOD(ContainerRecoveryFromStorage)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a logic error in the docker IO relay that could occur if read spans accross multiple streams.

This is based on the issue found by @benhillis  in #14331.

I have validated that the new test case fails without the fix 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
