### PR TITLE
Add support for restarting a stopped container

### DIFF
--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -543,6 +543,15 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
     {
         return;
     }
+    else if (m_state != WslaContainerStateRunning)
+    {
+        THROW_HR_IF_MSG(
+            HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
+            m_state != WslaContainerStateRunning,
+            "Cannot stop container '%hs', state: %i",
+            m_id.c_str(),
+            m_state);
+    }
 
     try
     {
@@ -584,7 +593,6 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
         auto io = m_wslaSession.CreateIOContext();
         io.AddHandle(std::make_unique<EventHandle>(m_stoppedNotifiedEvent.get()), MultiHandleWait::CancelOnCompleted);
 
-        // Drop the exclusive lock. No class fields can be accessed after this.
         lock.reset();
 
         io.Run({60s});

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -40,7 +40,10 @@ using wsl::windows::service::wsla::WSLASession;
 using wsl::windows::service::wsla::WSLAVirtualMachine;
 using wsl::windows::service::wsla::WSLAVolumeMount;
 
+using namespace wsl::windows::common::relay;
 using namespace wsl::windows::common::docker_schema;
+using namespace std::chrono_literals;
+
 namespace wsla_schema = wsl::windows::common::wsla_schema;
 
 using DockerInspectContainer = wsl::windows::common::docker_schema::InspectContainer;
@@ -444,7 +447,7 @@ void WSLAContainerImpl::Start(WSLAContainerStartFlags Flags)
 
     THROW_HR_IF_MSG(
         HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
-        m_state != WslaContainerStateCreated,
+        m_state != WslaContainerStateCreated && m_state != WslaContainerStateExited,
         "Cannot start container '%hs', state: %i",
         m_name.c_str(),
         m_state);
@@ -477,6 +480,8 @@ void WSLAContainerImpl::Start(WSLAContainerStartFlags Flags)
         m_initProcessControl = nullptr;
     });
 
+    m_stoppedNotifiedEvent.ResetEvent();
+
     try
     {
         m_dockerClient.StartContainer(m_id);
@@ -491,6 +496,8 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
 {
     if (event == ContainerEvent::Stop)
     {
+        m_stoppedNotifiedEvent.SetEvent();
+
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
         auto lock = m_lock.lock_exclusive();
         auto previousState = m_state;
@@ -567,6 +574,20 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
     if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
     {
         DeleteExclusiveLockHeld();
+    }
+    else
+    {
+        // Wait for the stop notification to arrive before returning.
+        // This is required so that a caller that Stops() and immediately calls Start() again doesn't see the container
+        // switch back to 'stopped' state due to the delayed event notification.
+
+        auto io = m_wslaSession.CreateIOContext();
+        io.AddHandle(std::make_unique<EventHandle>(m_stoppedNotifiedEvent.get()), MultiHandleWait::CancelOnCompleted);
+
+        // Drop the exclusive lock. No class fields can be accessed after this.
+        lock.reset();
+
+        io.Run({60s});
     }
 }
 

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -593,8 +593,6 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
         auto io = m_wslaSession.CreateIOContext();
         io.AddHandle(std::make_unique<EventHandle>(m_stoppedNotifiedEvent.get()), MultiHandleWait::CancelOnCompleted);
 
-        lock.reset();
-
         io.Run({60s});
     }
 }

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -128,6 +128,8 @@ private:
     __guarded_by(m_processesLock) std::vector<DockerExecProcessControl*> m_processes;
     __guarded_by(m_processesLock) Microsoft::WRL::ComPtr<WSLAProcess> m_initProcess;
     __guarded_by(m_processesLock) DockerContainerProcessControl* m_initProcessControl = nullptr;
+
+    wil::unique_event m_stoppedNotifiedEvent{wil::EventOptions::ManualReset};
     DockerHTTPClient& m_dockerClient;
     WSLA_CONTAINER_STATE m_state = WslaContainerStateInvalid;
     WSLASession& m_wslaSession;

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2686,7 +2686,7 @@ class WSLATests
             }
         }
 
-        // Validate that containers can be restarted after being explicitely stopped.
+        // Validate that containers can be restarted after being explicitly stopped.
         {
             WSLAContainerLauncher launcher("debian:latest", "test-stop-start-2", {"sleep", "99999"});
             auto container = launcher.Launch(*m_defaultSession);
@@ -2895,7 +2895,10 @@ class WSLATests
             WSLAContainerLauncher launcher(
                 "debian:latest", "test-container-2", {"sleep", "99999"}, {}, WSLA_CONTAINER_NETWORK_TYPE::WSLA_CONTAINER_NETWORK_HOST);
 
-            auto container = launcher.Launch(*m_defaultSession);
+            auto container = launcher.Create(*m_defaultSession);
+
+            // Validate that a created container cannot be stopped.
+            VERIFY_ARE_EQUAL(container.Get().Stop(WSLASignalSIGKILL, 0), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
 
             // Verify that the container is in running state.
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2653,6 +2653,79 @@ class WSLATests
         }
     }
 
+    TEST_METHOD(ContainerStartAfterStop)
+    {
+        WSL2_TEST_ONLY();
+
+        {
+            WSLAContainerLauncher launcher("debian:latest", "test-stop-start", {"echo", "OK"});
+            auto container = launcher.Launch(*m_defaultSession);
+            auto process = container.GetInitProcess();
+
+            ValidateProcessOutput(process, {{1, "OK\n"}});
+
+            {
+                // Validate that the container can be restarted.
+                VERIFY_ARE_EQUAL(container.Get().Start(WSLAContainerStartFlagsAttach), S_OK);
+                auto restartedProcess = container.GetInitProcess();
+                ValidateProcessOutput(restartedProcess, {{1, "OK\n"}});
+            }
+
+            {
+                // Validate that the container can be restarted without the attach flag.
+                VERIFY_ARE_EQUAL(container.Get().Start(WSLAContainerStartFlagsNone), S_OK);
+                auto restartedProcess = container.GetInitProcess();
+                VERIFY_ARE_EQUAL(restartedProcess.Wait(), 0);
+
+                wil::unique_handle stdoutLogs;
+                wil::unique_handle stderrLogs;
+                VERIFY_SUCCEEDED(container.Get().Logs(WSLALogsFlagsNone, (ULONG*)&stdoutLogs, (ULONG*)&stderrLogs, 0, 0, 0));
+
+                ValidateHandleOutput(stdoutLogs.get(), "OK\nOK\nOK\n");
+                ValidateHandleOutput(stderrLogs.get(), "");
+            }
+        }
+
+        // Validate that containers can be restarted after being explicitely stopped.
+        {
+            WSLAContainerLauncher launcher("debian:latest", "test-stop-start-2", {"sleep", "99999"});
+            auto container = launcher.Launch(*m_defaultSession);
+
+            VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
+            VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
+            VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
+
+            VERIFY_SUCCEEDED(container.Get().Start(WSLAContainerStartFlagsNone));
+            VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
+
+            auto initProcess = container.GetInitProcess();
+            initProcess.Get().Signal(WSLASignalSIGKILL);
+            VERIFY_ARE_EQUAL(initProcess.Wait(), WSLASignalSIGKILL + 128);
+
+            VERIFY_SUCCEEDED(container.Get().Start(WSLAContainerStartFlagsNone));
+            VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
+
+            VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
+            VERIFY_SUCCEEDED(container.Get().Delete());
+
+            // Validate that deleted containers can't be started.
+            VERIFY_ARE_EQUAL(container.Get().Start(WSLAContainerStartFlagsNone), RPC_E_DISCONNECTED);
+        }
+
+        // Validate restart behavior for a container with the autorm flag set
+        {
+            WSLAContainerLauncher launcher("debian:latest", "test-stop-start-3", {"sleep", "99999"});
+            launcher.SetContainerFlags(WSLAContainerFlagsRm);
+            auto container = launcher.Launch(*m_defaultSession);
+
+            VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
+            VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
+
+            // Validate that deleted containers can't be started.
+            VERIFY_ARE_EQUAL(container.Get().Start(WSLAContainerStartFlagsNone), RPC_E_DISCONNECTED);
+        }
+    }
+
     TEST_METHOD(OpenContainer)
     {
         WSL2_TEST_ONLY();
@@ -3304,7 +3377,8 @@ class WSLATests
             ValidateProcessOutput(
                 process,
                 {{1,
-                  "OCI runtime exec failed: exec failed: unable to start container process: chdir to cwd (\"/notfound\") set in "
+                  "OCI runtime exec failed: exec failed: unable to start container process: chdir to cwd (\"/notfound\") set "
+                  "in "
                   "config.json failed: no such file or directory: unknown\r\n"}},
                 126);
         }

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -3377,8 +3377,7 @@ class WSLATests
             ValidateProcessOutput(
                 process,
                 {{1,
-                  "OCI runtime exec failed: exec failed: unable to start container process: chdir to cwd (\"/notfound\") set "
-                  "in "
+                  "OCI runtime exec failed: exec failed: unable to start container process: chdir to cwd (\"/notfound\") set in "
                   "config.json failed: no such file or directory: unknown\r\n"}},
                 126);
         }

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2901,6 +2901,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.Get().Stop(WSLASignalSIGKILL, 0), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
 
             // Verify that the container is in running state.
+            VERIFY_SUCCEEDED(container.Get().Start(WSLAContainerStartFlagsNone));
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGTERM, 0));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds support for started a container in an exited state. This effectively allows containers to be restarted as many times as the caller wants. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
