### PR TITLE
virtio networking: add support for ipv6

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.1.14-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.1.24-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.5.7-47" />

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -230,13 +230,12 @@ try
     }
 
     UpdateIpv4Address(networkSettings->PreferredIpAddress);
-    UpdateDefaultRoute(default_route, AF_INET);
-
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6))
     {
         UpdateIpv6Address(networkSettings->PreferredIpv6Address);
-        UpdateDefaultRoute(default_route_v6, AF_INET6);
     }
+
+    UpdateDefaultRoute(default_route);
 
     UpdateDnsSettings(currentDns);
     UpdateMtu(minMtu);
@@ -275,10 +274,8 @@ void VirtioNetworking::SetupLoopbackDevice()
     m_gnsChannel.SendNetworkDeviceMessage(loopbackType, ToJsonW(createLoopbackDevice).c_str());
 }
 
-void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family, hns::ModifyRequestType requestType)
+void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, hns::ModifyRequestType requestType)
 {
-    WI_ASSERT(family == AF_INET || WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
-
     if (gateway.empty())
     {
         return;
@@ -286,8 +283,8 @@ void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, ADDRESS_FAM
 
     wsl::shared::hns::Route route;
     route.NextHop = gateway;
-    route.DestinationPrefix = (family == AF_INET) ? LX_INIT_DEFAULT_ROUTE_PREFIX : LX_INIT_DEFAULT_ROUTE_V6_PREFIX;
-    route.Family = family;
+    route.DestinationPrefix = LX_INIT_DEFAULT_ROUTE_PREFIX;
+    route.Family = AF_INET;
 
     hns::ModifyGuestEndpointSettingRequest<hns::Route> request;
     request.RequestType = requestType;
@@ -296,19 +293,16 @@ void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, ADDRESS_FAM
     m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId.value());
 }
 
-void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family)
+void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway)
 {
-    WI_ASSERT(family == AF_INET || WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
-
-    auto& trackedRoute = (family == AF_INET) ? m_trackedDefaultRoute : m_trackedDefaultRouteV6;
-    if (gateway == trackedRoute)
+    if (gateway == m_trackedDefaultRoute)
     {
         return;
     }
 
-    SendDefaultRoute(trackedRoute, family, hns::ModifyRequestType::Remove);
-    trackedRoute = gateway;
-    SendDefaultRoute(gateway, family, hns::ModifyRequestType::Add);
+    SendDefaultRoute(m_trackedDefaultRoute, hns::ModifyRequestType::Remove);
+    m_trackedDefaultRoute = gateway;
+    SendDefaultRoute(gateway, hns::ModifyRequestType::Add);
 }
 
 void VirtioNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
@@ -366,6 +360,7 @@ void VirtioNetworking::SendIpv6Address(const networking::EndpointIpAddress& ipAd
     request.Settings.Address = ipAddress.AddressString;
     request.Settings.Family = ipAddress.Address.si_family;
     request.Settings.OnLinkPrefixLength = ipAddress.PrefixLength;
+    request.Settings.PreferredLifetime = ULONG_MAX;
     m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId.value());
 }
 

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -185,10 +185,8 @@ try
     appendOption(L"gateway_ip", default_route);
     appendOption(L"gateway_mac", networkSettings->GetBestGatewayMacAddress(AF_INET));
 
-    std::wstring default_route_v6{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6))
     {
-        default_route_v6 = networkSettings->GetBestGatewayAddressString(AF_INET6);
         appendOption(L"client_ip_ipv6", networkSettings->PreferredIpv6Address.AddressString);
         appendOption(L"gateway_mac_ipv6", networkSettings->GetBestGatewayMacAddress(AF_INET6));
     }

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -274,7 +274,7 @@ void VirtioNetworking::SetupLoopbackDevice()
 
 void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, hns::ModifyRequestType requestType)
 {
-    if (gateway.empty())
+    if (gateway.empty() || !m_adapterId.has_value())
     {
         return;
     }
@@ -293,7 +293,7 @@ void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, hns::Modify
 
 void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway)
 {
-    if (gateway == m_trackedDefaultRoute)
+    if (gateway == m_trackedDefaultRoute || !m_adapterId.has_value())
     {
         return;
     }
@@ -305,7 +305,7 @@ void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway)
 
 void VirtioNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
 {
-    if (dns == m_trackedDnsSettings)
+    if (dns == m_trackedDnsSettings || !m_adapterId.has_value())
     {
         return;
     }
@@ -321,17 +321,12 @@ void VirtioNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
 
 void VirtioNetworking::UpdateIpv4Address(const networking::EndpointIpAddress& ipAddress)
 {
-    if (ipAddress == m_trackedIpv4Address)
+    if (ipAddress == m_trackedIpv4Address || ipAddress.AddressString.empty() || !m_adapterId.has_value())
     {
         return;
     }
 
     m_trackedIpv4Address = ipAddress;
-
-    if (ipAddress.AddressString.empty())
-    {
-        return;
-    }
 
     // N.B. SendEndpointState triggers SetAdapterConfiguration on the Linux side
     // which brings the interface UP and configures the full adapter state.
@@ -346,7 +341,7 @@ void VirtioNetworking::SendIpv6Address(const networking::EndpointIpAddress& ipAd
 {
     WI_ASSERT(WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
 
-    if (ipAddress.AddressString.empty())
+    if (ipAddress.AddressString.empty() || !m_adapterId.has_value())
     {
         return;
     }
@@ -366,7 +361,7 @@ void VirtioNetworking::UpdateIpv6Address(const networking::EndpointIpAddress& ip
 {
     WI_ASSERT(WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
 
-    if (ipAddress == m_trackedIpv6Address)
+    if (ipAddress == m_trackedIpv6Address || !m_adapterId.has_value())
     {
         return;
     }
@@ -378,7 +373,7 @@ void VirtioNetworking::UpdateIpv6Address(const networking::EndpointIpAddress& ip
 
 void VirtioNetworking::UpdateMtu(std::optional<ULONG> mtu)
 {
-    if (!mtu || mtu.value() == m_networkMtu)
+    if (!mtu || mtu.value() == m_networkMtu || !m_adapterId.has_value())
     {
         return;
     }

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -56,7 +56,7 @@ void VirtioNetworking::TraceLoggingRundown() noexcept
 void VirtioNetworking::FillInitialConfiguration(LX_MINI_INIT_NETWORKING_CONFIGURATION& message)
 {
     message.NetworkingMode = LxMiniInitNetworkingModeVirtioProxy;
-    message.DisableIpv6 = false;
+    message.DisableIpv6 = WI_IsFlagClear(m_flags, VirtioNetworkingFlags::Ipv6);
     message.EnableDhcpClient = false;
     message.PortTrackerType = LX_MINI_INIT_PORT_TRACKER_TYPE::LxMiniInitPortTrackerTypeMirrored;
 }
@@ -78,6 +78,11 @@ void NETIOAPI_API_ VirtioNetworking::OnNetworkConnectivityChange(PVOID context, 
 
 HRESULT VirtioNetworking::HandlePortNotification(const SOCKADDR_INET& addr, int protocol, bool allocate) const noexcept
 {
+    if (addr.si_family == AF_INET6 && WI_IsFlagClear(m_flags, VirtioNetworkingFlags::Ipv6))
+    {
+        return S_OK;
+    }
+
     int result = 0;
     const auto ipAddress = (addr.si_family == AF_INET) ? reinterpret_cast<const void*>(&addr.Ipv4.sin_addr)
                                                        : reinterpret_cast<const void*>(&addr.Ipv6.sin6_addr);
@@ -132,19 +137,12 @@ int VirtioNetworking::ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET&
         LOG_HR_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), "Unsupported bind protocol %d", protocol);
         return 0;
     }
-    else if (addr.si_family == AF_INET6)
-    {
-        // The virtio net adapter does not yet support IPv6 packets, so any traffic would arrive via
-        // IPv4. If the caller wants IPv4 they will also likely listen on an IPv4 address, which will
-        // be handled as a separate callback to this same code.
-        return 0;
-    }
 
     auto lock = m_lock.lock_exclusive();
     const auto server = m_guestDeviceManager->GetRemoteFileSystem(VIRTIO_NET_CLASS_ID, c_defaultDeviceTag);
     if (server)
     {
-        std::wstring portString = std::format(L"tag={};port_number={}", tag, addr.Ipv4.sin_port);
+        std::wstring portString = std::format(L"tag={};port_number={}", tag, INETADDR_PORT(reinterpret_cast<const SOCKADDR*>(&addr)));
         if (protocol == IPPROTO_UDP)
         {
             portString += L";udp";
@@ -187,6 +185,13 @@ try
     appendOption(L"gateway_ip", default_route);
     appendOption(L"gateway_mac", networkSettings->GetBestGatewayMacAddress());
 
+    std::wstring default_route_v6{};
+    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6))
+    {
+        default_route_v6 = networkSettings->GetBestGatewayV6AddressString();
+        appendOption(L"client_ip_ipv6", networkSettings->PreferredIpv6Address.AddressString);
+    }
+
     networking::DnsInfo currentDns{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))
     {
@@ -194,7 +199,9 @@ try
     }
     else
     {
-        currentDns = networking::HostDnsInfo::GetDnsSettings(networking::DnsSettingsFlags::IncludeVpn);
+        wsl::core::networking::DnsSettingsFlags dnsFlags = networking::DnsSettingsFlags::IncludeVpn;
+        WI_SetFlagIf(dnsFlags, networking::DnsSettingsFlags::IncludeIpv6Servers, WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+        currentDns = networking::HostDnsInfo::GetDnsSettings(dnsFlags);
     }
 
     const auto minMtu = GetMinimumConnectedInterfaceMtu();
@@ -221,32 +228,17 @@ try
         }
     }
 
-    // Update IP address if needed.
-    if (!m_networkSettings || networkSettings->PreferredIpAddress != m_networkSettings->PreferredIpAddress)
+    UpdateIpv4Address(networkSettings->PreferredIpAddress);
+    UpdateDefaultRoute(default_route, AF_INET);
+
+    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6))
     {
-        UpdateIpAddress(networkSettings->PreferredIpAddress);
+        UpdateIpv6Address(networkSettings->PreferredIpv6Address);
+        UpdateDefaultRoute(default_route_v6, AF_INET6);
     }
 
-    // Send default route update if needed.
-    if (default_route != m_trackedDefaultRoute)
-    {
-        m_trackedDefaultRoute = default_route;
-        UpdateDefaultRoute(default_route, AF_INET);
-    }
-
-    // Send DNS update if needed.
-    if (currentDns != m_trackedDnsSettings)
-    {
-        m_trackedDnsSettings = currentDns;
-        UpdateDnsSettings(currentDns);
-    }
-
-    // Send MTU update if needed.
-    if (minMtu && minMtu.value() != m_networkMtu)
-    {
-        m_networkMtu = minMtu.value();
-        UpdateMtu(m_networkMtu);
-    }
+    UpdateDnsSettings(currentDns);
+    UpdateMtu(minMtu);
 
     m_networkSettings = std::move(networkSettings);
 }
@@ -282,8 +274,10 @@ void VirtioNetworking::SetupLoopbackDevice()
     m_gnsChannel.SendNetworkDeviceMessage(loopbackType, ToJsonW(createLoopbackDevice).c_str());
 }
 
-void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family)
+void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family, hns::ModifyRequestType requestType)
 {
+    WI_ASSERT(family == AF_INET || WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+
     if (gateway.empty())
     {
         return;
@@ -295,14 +289,36 @@ void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway, ADDRESS_F
     route.Family = family;
 
     hns::ModifyGuestEndpointSettingRequest<hns::Route> request;
-    request.RequestType = hns::ModifyRequestType::Add;
+    request.RequestType = requestType;
     request.ResourceType = hns::GuestEndpointResourceType::Route;
     request.Settings = route;
     m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId.value());
 }
 
+void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family)
+{
+    WI_ASSERT(family == AF_INET || WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+
+    auto& trackedRoute = (family == AF_INET) ? m_trackedDefaultRoute : m_trackedDefaultRouteV6;
+    if (gateway == trackedRoute)
+    {
+        return;
+    }
+
+    SendDefaultRoute(trackedRoute, family, hns::ModifyRequestType::Remove);
+    trackedRoute = gateway;
+    SendDefaultRoute(gateway, family, hns::ModifyRequestType::Add);
+}
+
 void VirtioNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
 {
+    if (dns == m_trackedDnsSettings)
+    {
+        return;
+    }
+
+    m_trackedDnsSettings = dns;
+
     hns::ModifyGuestEndpointSettingRequest<hns::DNS> notification{};
     notification.RequestType = hns::ModifyRequestType::Update;
     notification.ResourceType = hns::GuestEndpointResourceType::DNS;
@@ -310,9 +326,22 @@ void VirtioNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
     m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId.value());
 }
 
-void VirtioNetworking::UpdateIpAddress(const networking::EndpointIpAddress& ipAddress)
+void VirtioNetworking::UpdateIpv4Address(const networking::EndpointIpAddress& ipAddress)
 {
-    // N.B. The MAC address is advertised with the virtio device so doesn't need to be explicitly set.
+    if (ipAddress == m_trackedIpv4Address)
+    {
+        return;
+    }
+
+    m_trackedIpv4Address = ipAddress;
+
+    if (ipAddress.AddressString.empty())
+    {
+        return;
+    }
+
+    // N.B. SendEndpointState triggers SetAdapterConfiguration on the Linux side
+    // which brings the interface UP and configures the full adapter state.
     hns::HNSEndpoint endpointProperties;
     endpointProperties.ID = m_adapterId.value();
     endpointProperties.IPAddress = ipAddress.AddressString;
@@ -320,12 +349,52 @@ void VirtioNetworking::UpdateIpAddress(const networking::EndpointIpAddress& ipAd
     m_gnsChannel.SendEndpointState(endpointProperties);
 }
 
-void VirtioNetworking::UpdateMtu(ULONG mtu)
+void VirtioNetworking::SendIpv6Address(const networking::EndpointIpAddress& ipAddress, hns::ModifyRequestType requestType)
 {
+    WI_ASSERT(WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+
+    if (ipAddress.AddressString.empty())
+    {
+        return;
+    }
+
+    // The HNSEndpoint schema doesn't support IPv6 addresses, so use ModifyGuestEndpointSettingRequest.
+    hns::ModifyGuestEndpointSettingRequest<hns::IPAddress> request;
+    request.RequestType = requestType;
+    request.ResourceType = hns::GuestEndpointResourceType::IPAddress;
+    request.Settings.Address = ipAddress.AddressString;
+    request.Settings.Family = ipAddress.Address.si_family;
+    request.Settings.OnLinkPrefixLength = ipAddress.PrefixLength;
+    m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId.value());
+}
+
+void VirtioNetworking::UpdateIpv6Address(const networking::EndpointIpAddress& ipAddress)
+{
+    WI_ASSERT(WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+
+    if (ipAddress == m_trackedIpv6Address)
+    {
+        return;
+    }
+
+    SendIpv6Address(m_trackedIpv6Address, hns::ModifyRequestType::Remove);
+    m_trackedIpv6Address = ipAddress;
+    SendIpv6Address(ipAddress, hns::ModifyRequestType::Add);
+}
+
+void VirtioNetworking::UpdateMtu(std::optional<ULONG> mtu)
+{
+    if (!mtu || mtu.value() == m_networkMtu)
+    {
+        return;
+    }
+
+    m_networkMtu = mtu.value();
+
     hns::ModifyGuestEndpointSettingRequest<hns::NetworkInterface> notification{};
     notification.ResourceType = hns::GuestEndpointResourceType::Interface;
     notification.RequestType = hns::ModifyRequestType::Update;
     notification.Settings.Connected = true;
-    notification.Settings.NlMtu = mtu;
+    notification.Settings.NlMtu = m_networkMtu;
     m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId.value());
 }

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -183,13 +183,14 @@ try
 
     std::wstring default_route = networkSettings->GetBestGatewayAddressString();
     appendOption(L"gateway_ip", default_route);
-    appendOption(L"gateway_mac", networkSettings->GetBestGatewayMacAddress());
+    appendOption(L"gateway_mac", networkSettings->GetBestGatewayMacAddress(AF_INET));
 
     std::wstring default_route_v6{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6))
     {
-        default_route_v6 = networkSettings->GetBestGatewayV6AddressString();
+        default_route_v6 = networkSettings->GetBestGatewayAddressString(AF_INET6);
         appendOption(L"client_ip_ipv6", networkSettings->PreferredIpv6Address.AddressString);
+        appendOption(L"gateway_mac_ipv6", networkSettings->GetBestGatewayMacAddress(AF_INET6));
     }
 
     networking::DnsInfo currentDns{};

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -15,6 +15,7 @@ enum class VirtioNetworkingFlags
     None = 0x0,
     LocalhostRelay = 0x1,
     DnsTunneling = 0x2,
+    Ipv6 = 0x4,
 };
 DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
 
@@ -43,10 +44,13 @@ private:
     int ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET& addr, _In_ int protocol, _In_ bool isOpen) const;
     void RefreshGuestConnection() noexcept;
     void SetupLoopbackDevice();
+    void SendDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family, wsl::shared::hns::ModifyRequestType requestType);
+    void SendIpv6Address(const networking::EndpointIpAddress& ipAddress, wsl::shared::hns::ModifyRequestType requestType);
     void UpdateDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family);
     void UpdateDnsSettings(const networking::DnsInfo& dns);
-    void UpdateIpAddress(const networking::EndpointIpAddress& ipAddress);
-    void UpdateMtu(ULONG mtu);
+    void UpdateIpv4Address(const networking::EndpointIpAddress& ipAddress);
+    void UpdateIpv6Address(const networking::EndpointIpAddress& ipAddress);
+    void UpdateMtu(std::optional<ULONG> mtu);
 
     mutable wil::srwlock m_lock;
 
@@ -62,7 +66,10 @@ private:
 
     ULONG m_networkMtu = 0;
     std::wstring m_trackedDeviceOptions;
+    networking::EndpointIpAddress m_trackedIpv4Address{};
+    networking::EndpointIpAddress m_trackedIpv6Address{};
     std::wstring m_trackedDefaultRoute;
+    std::wstring m_trackedDefaultRouteV6;
     networking::DnsInfo m_trackedDnsSettings{};
 
     // Note: this field must be destroyed first to stop the callbacks before any other field is destroyed.

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -44,9 +44,9 @@ private:
     int ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET& addr, _In_ int protocol, _In_ bool isOpen) const;
     void RefreshGuestConnection() noexcept;
     void SetupLoopbackDevice();
-    void SendDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family, wsl::shared::hns::ModifyRequestType requestType);
+    void SendDefaultRoute(const std::wstring& gateway, wsl::shared::hns::ModifyRequestType requestType);
     void SendIpv6Address(const networking::EndpointIpAddress& ipAddress, wsl::shared::hns::ModifyRequestType requestType);
-    void UpdateDefaultRoute(const std::wstring& gateway, ADDRESS_FAMILY family);
+    void UpdateDefaultRoute(const std::wstring& gateway);
     void UpdateDnsSettings(const networking::DnsInfo& dns);
     void UpdateIpv4Address(const networking::EndpointIpAddress& ipAddress);
     void UpdateIpv6Address(const networking::EndpointIpAddress& ipAddress);
@@ -69,7 +69,6 @@ private:
     networking::EndpointIpAddress m_trackedIpv4Address{};
     networking::EndpointIpAddress m_trackedIpv6Address{};
     std::wstring m_trackedDefaultRoute;
-    std::wstring m_trackedDefaultRouteV6;
     networking::DnsInfo m_trackedDnsSettings{};
 
     // Note: this field must be destroyed first to stop the callbacks before any other field is destroyed.

--- a/src/windows/common/WslCoreNetworkEndpointSettings.cpp
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.cpp
@@ -24,7 +24,9 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
     return std::make_shared<wsl::core::networking::NetworkSettings>(
         properties.InterfaceConstraint.InterfaceGuid,
         address,
+        EndpointIpAddress{},
         route,
+        EndpointRoute{},
         properties.MacAddress,
         properties.InterfaceConstraint.InterfaceIndex,
         properties.InterfaceConstraint.InterfaceMediaType);
@@ -61,38 +63,78 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
     }
     if (firstIpv4Address)
     {
-        address.Address = *reinterpret_cast<SOCKADDR_INET*>(firstIpv4Address->Address.lpSockaddr);
+        address.Address.Ipv4 = *reinterpret_cast<SOCKADDR_IN*>(firstIpv4Address->Address.lpSockaddr);
         address.AddressString = windows::common::string::SockAddrInetToWstring(address.Address);
         address.PrefixLength = firstIpv4Address->OnLinkPrefixLength;
     }
 
-    EndpointRoute route{};
-    PIP_ADAPTER_GATEWAY_ADDRESS nextGatewayAddress = bestInterface->FirstGatewayAddress;
-    while (nextGatewayAddress && nextGatewayAddress->Address.lpSockaddr->sa_family != AF_INET)
+    // Find the first global-scope (non-link-local) IPv6 unicast address.
+    EndpointIpAddress ipv6Address{};
+    auto nextUnicastAddress = bestInterface->FirstUnicastAddress;
+    while (nextUnicastAddress)
     {
-        nextGatewayAddress = nextGatewayAddress->Next;
+        if (nextUnicastAddress->Address.lpSockaddr->sa_family == AF_INET6)
+        {
+            const auto& sin6 = *reinterpret_cast<SOCKADDR_IN6*>(nextUnicastAddress->Address.lpSockaddr);
+            if (!IN6_IS_ADDR_LINKLOCAL(&sin6.sin6_addr) && !IN6_IS_ADDR_LOOPBACK(&sin6.sin6_addr))
+            {
+                ipv6Address.Address.Ipv6 = sin6;
+                ipv6Address.AddressString = windows::common::string::SockAddrInetToWstring(ipv6Address.Address);
+                ipv6Address.PrefixLength = nextUnicastAddress->OnLinkPrefixLength;
+                break;
+            }
+        }
+        nextUnicastAddress = nextUnicastAddress->Next;
     }
-    if (nextGatewayAddress)
+
+    // Helper to find the first gateway address of a given family.
+    auto findGatewayAddress = [](PIP_ADAPTER_GATEWAY_ADDRESS list, ADDRESS_FAMILY family) -> PIP_ADAPTER_GATEWAY_ADDRESS {
+        while (list && list->Address.lpSockaddr->sa_family != family)
+        {
+            list = list->Next;
+        }
+        return list;
+    };
+
+    // Build IPv4 default route.
+    EndpointRoute route{};
+    const auto v4Gateway = findGatewayAddress(bestInterface->FirstGatewayAddress, AF_INET);
+    if (v4Gateway)
     {
-        route.DestinationPrefix.PrefixLength = 0;
-        IN4ADDR_SETANY(&route.DestinationPrefix.Prefix.Ipv4);
-        route.DestinationPrefixString = LX_INIT_UNSPECIFIED_ADDRESS;
-        route.NextHop = *reinterpret_cast<SOCKADDR_INET*>(nextGatewayAddress->Address.lpSockaddr);
-        route.NextHopString = windows::common::string::SockAddrInetToWstring(route.NextHop);
+        SOCKADDR_INET v4NextHop{};
+        v4NextHop.Ipv4 = *reinterpret_cast<SOCKADDR_IN*>(v4Gateway->Address.lpSockaddr);
+        route = EndpointRoute::DefaultRoute(AF_INET, v4NextHop);
     }
     else if (address.Address.si_family == AF_INET)
     {
-        IN_ADDR default_route{};
-        default_route.s_addr = htonl((ntohl(address.Address.Ipv4.sin_addr.s_addr) & ~((1 << (32 - address.PrefixLength)) - 1)) | 1);
-        route.DestinationPrefix.PrefixLength = 0;
-        IN4ADDR_SETANY(&route.DestinationPrefix.Prefix.Ipv4);
-        route.DestinationPrefixString = LX_INIT_UNSPECIFIED_ADDRESS;
-        IN4ADDR_SETSOCKADDR(&route.NextHop.Ipv4, &default_route, 0);
-        route.NextHopString = windows::common::string::SockAddrInetToWstring(route.NextHop);
+        // Synthesize a gateway from the first host address in the subnet.
+        SOCKADDR_INET gatewayAddr{};
+        gatewayAddr.si_family = AF_INET;
+        const uint32_t hostAddr = ntohl(address.Address.Ipv4.sin_addr.s_addr);
+        const uint32_t mask = (address.PrefixLength == 0) ? 0u : ~((1u << (32u - address.PrefixLength)) - 1u);
+        gatewayAddr.Ipv4.sin_addr.s_addr = htonl((hostAddr & mask) | 1u);
+        route = EndpointRoute::DefaultRoute(AF_INET, gatewayAddr);
+    }
+
+    // Build IPv6 default route.
+    EndpointRoute v6Route{};
+    const auto v6Gateway = findGatewayAddress(bestInterface->FirstGatewayAddress, AF_INET6);
+    if (v6Gateway)
+    {
+        SOCKADDR_INET v6NextHop{};
+        v6NextHop.Ipv6 = *reinterpret_cast<SOCKADDR_IN6*>(v6Gateway->Address.lpSockaddr);
+        v6Route = EndpointRoute::DefaultRoute(AF_INET6, v6NextHop);
     }
 
     return std::make_shared<NetworkSettings>(
-        bestInterface->NetworkGuid, address, route, macAddress, bestInterface->IfIndex, bestInterface->IfType);
+        bestInterface->NetworkGuid,
+        std::move(address),
+        std::move(ipv6Address),
+        std::move(route),
+        std::move(v6Route),
+        std::move(macAddress),
+        bestInterface->IfIndex,
+        bestInterface->IfType);
 }
 
 std::wstring wsl::core::networking::NetworkSettings::GetBestGatewayMacAddress() const

--- a/src/windows/common/WslCoreNetworkEndpointSettings.cpp
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.cpp
@@ -139,16 +139,7 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
 
 std::wstring wsl::core::networking::NetworkSettings::GetBestGatewayMacAddress(ADDRESS_FAMILY addressFamily) const
 {
-    SOCKADDR_INET gatewayAddress{};
-    if (addressFamily == AF_INET)
-    {
-        gatewayAddress = GetBestGatewayAddress();
-    }
-    else if (addressFamily == AF_INET6)
-    {
-        gatewayAddress = GetBestGatewayAddress(AF_INET6);
-    }
-
+    auto gatewayAddress = GetBestGatewayAddress(addressFamily);
     if (gatewayAddress.si_family != addressFamily)
     {
         return {};

--- a/src/windows/common/WslCoreNetworkEndpointSettings.cpp
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.cpp
@@ -137,10 +137,19 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
         bestInterface->IfType);
 }
 
-std::wstring wsl::core::networking::NetworkSettings::GetBestGatewayMacAddress() const
+std::wstring wsl::core::networking::NetworkSettings::GetBestGatewayMacAddress(ADDRESS_FAMILY addressFamily) const
 {
-    auto gatewayAddress = GetBestGatewayAddress();
-    if (gatewayAddress.si_family != AF_INET)
+    SOCKADDR_INET gatewayAddress{};
+    if (addressFamily == AF_INET)
+    {
+        gatewayAddress = GetBestGatewayAddress();
+    }
+    else if (addressFamily == AF_INET6)
+    {
+        gatewayAddress = GetBestGatewayAddress(AF_INET6);
+    }
+
+    if (gatewayAddress.si_family != addressFamily)
     {
         return {};
     }

--- a/src/windows/common/WslCoreNetworkEndpointSettings.h
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.h
@@ -295,6 +295,8 @@ struct NetworkSettings
         InterfaceIndex(interfaceIndex),
         InterfaceType(mediaType)
     {
+        // Only insert routes that have a valid next hop. A default-constructed or empty
+        // EndpointRoute indicates no gateway was found for that address family.
         if (!gateway.NextHopString.empty())
         {
             Routes.emplace(std::move(gateway));
@@ -329,12 +331,13 @@ struct NetworkSettings
 
     auto operator<=>(const NetworkSettings&) const = default;
 
-    std::wstring GetBestGatewayAddressString() const
+    // Returns the next-hop string of the first default route matching the given address family.
+    std::wstring GetBestGatewayAddressString(ADDRESS_FAMILY family = AF_INET) const
     {
-        // Best is currently defined as simply the first IPv4 gateway.
+        const auto& unspecified = (family == AF_INET) ? LX_INIT_UNSPECIFIED_ADDRESS : LX_INIT_UNSPECIFIED_V6_ADDRESS;
         for (const auto& route : Routes)
         {
-            if (route.Family == AF_INET && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == LX_INIT_UNSPECIFIED_ADDRESS)
+            if (route.Family == family && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == unspecified)
             {
                 return route.NextHopString;
             }
@@ -343,12 +346,13 @@ struct NetworkSettings
         return {};
     }
 
-    SOCKADDR_INET GetBestGatewayAddress() const
+    // Returns the next-hop address of the first default route matching the given address family.
+    SOCKADDR_INET GetBestGatewayAddress(ADDRESS_FAMILY family = AF_INET) const
     {
-        // Best is currently defined as simply the first IPv4 gateway.
+        const auto& unspecified = (family == AF_INET) ? LX_INIT_UNSPECIFIED_ADDRESS : LX_INIT_UNSPECIFIED_V6_ADDRESS;
         for (const auto& route : Routes)
         {
-            if (route.Family == AF_INET && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == LX_INIT_UNSPECIFIED_ADDRESS)
+            if (route.Family == family && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == unspecified)
             {
                 return route.NextHop;
             }
@@ -357,33 +361,7 @@ struct NetworkSettings
         return {};
     }
 
-    std::wstring GetBestGatewayMacAddress() const;
-
-    std::wstring GetBestGatewayV6AddressString() const
-    {
-        for (const auto& route : Routes)
-        {
-            if (route.Family == AF_INET6 && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == LX_INIT_UNSPECIFIED_V6_ADDRESS)
-            {
-                return route.NextHopString;
-            }
-        }
-
-        return {};
-    }
-
-    SOCKADDR_INET GetBestGatewayV6Address() const
-    {
-        for (const auto& route : Routes)
-        {
-            if (route.Family == AF_INET6 && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == LX_INIT_UNSPECIFIED_V6_ADDRESS)
-            {
-                return route.NextHop;
-            }
-        }
-
-        return {};
-    }
+    std::wstring GetBestGatewayMacAddress(ADDRESS_FAMILY addressFamily) const;
 
     std::wstring IpAddressesString() const
     {
@@ -436,7 +414,7 @@ std::shared_ptr<NetworkSettings> GetHostEndpointSettings();
         TraceLoggingValue((settings)->PreferredIpAddress.PrefixLength, "preferredIpAddressPrefixLength"), \
         TraceLoggingValue((settings)->PreferredIpv6Address.AddressString.c_str(), "preferredIpv6Address"), \
         TraceLoggingValue((settings)->PreferredIpv6Address.PrefixLength, "preferredIpv6AddressPrefixLength"), \
-        TraceLoggingValue((settings)->GetBestGatewayV6AddressString().c_str(), "bestGatewayV6Address"), \
+        TraceLoggingValue((settings)->GetBestGatewayAddressString(AF_INET6).c_str(), "bestGatewayV6Address"), \
         TraceLoggingValue((settings)->IpAddressesString().c_str(), "ipAddresses"), \
         TraceLoggingValue((settings)->RoutesString().c_str(), "routes"), \
         TraceLoggingValue((settings)->MacAddress.c_str(), "macAddress"), \

--- a/src/windows/common/WslCoreNetworkEndpointSettings.h
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.h
@@ -172,6 +172,27 @@ struct EndpointRoute
     EndpointRoute(const EndpointRoute&) = default;
     EndpointRoute& operator=(const EndpointRoute&) = default;
 
+    // Build a default route (0.0.0.0/0 or ::/0) with the given next hop.
+    static EndpointRoute DefaultRoute(ADDRESS_FAMILY family, const SOCKADDR_INET& nextHop)
+    {
+        EndpointRoute route{};
+        route.Family = family;
+        route.DestinationPrefix.PrefixLength = 0;
+        if (family == AF_INET)
+        {
+            IN4ADDR_SETANY(&route.DestinationPrefix.Prefix.Ipv4);
+            route.DestinationPrefixString = LX_INIT_UNSPECIFIED_ADDRESS;
+        }
+        else
+        {
+            IN6ADDR_SETANY(&route.DestinationPrefix.Prefix.Ipv6);
+            route.DestinationPrefixString = LX_INIT_UNSPECIFIED_V6_ADDRESS;
+        }
+        route.NextHop = nextHop;
+        route.NextHopString = windows::common::string::SockAddrInetToWstring(nextHop);
+        return route;
+    }
+
     EndpointRoute(const MIB_IPFORWARD_ROW2& RouteRow) :
         Family(RouteRow.NextHop.si_family),
         DestinationPrefix(RouteRow.DestinationPrefix),
@@ -258,19 +279,37 @@ struct NetworkSettings
 {
     NetworkSettings() = default;
 
-    NetworkSettings(const GUID& interfaceGuid, EndpointIpAddress preferredIpAddress, EndpointRoute gateway, std::wstring macAddress, uint32_t interfaceIndex, uint32_t mediaType) :
+    NetworkSettings(
+        const GUID& interfaceGuid,
+        EndpointIpAddress preferredIpAddress,
+        EndpointIpAddress preferredIpv6Address,
+        EndpointRoute gateway,
+        EndpointRoute v6Gateway,
+        std::wstring macAddress,
+        uint32_t interfaceIndex,
+        uint32_t mediaType) :
         InterfaceGuid(interfaceGuid),
         PreferredIpAddress(std::move(preferredIpAddress)),
+        PreferredIpv6Address(std::move(preferredIpv6Address)),
         MacAddress(std::move(macAddress)),
         InterfaceIndex(interfaceIndex),
         InterfaceType(mediaType)
     {
-        Routes.emplace(std::move(gateway));
+        if (!gateway.NextHopString.empty())
+        {
+            Routes.emplace(std::move(gateway));
+        }
+
+        if (!v6Gateway.NextHopString.empty())
+        {
+            Routes.emplace(std::move(v6Gateway));
+        }
     }
 
     GUID InterfaceGuid{};
     EndpointIpAddress PreferredIpAddress{};
-    std::set<EndpointIpAddress> IpAddresses{}; // Does not include PreferredIpAddress.
+    EndpointIpAddress PreferredIpv6Address{};
+    std::set<EndpointIpAddress> IpAddresses{}; // Does not include PreferredIpAddress or PreferredIpv6Address.
     std::set<EndpointRoute> Routes{};
     std::wstring MacAddress;
     IF_INDEX InterfaceIndex = 0;
@@ -319,6 +358,32 @@ struct NetworkSettings
     }
 
     std::wstring GetBestGatewayMacAddress() const;
+
+    std::wstring GetBestGatewayV6AddressString() const
+    {
+        for (const auto& route : Routes)
+        {
+            if (route.Family == AF_INET6 && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == LX_INIT_UNSPECIFIED_V6_ADDRESS)
+            {
+                return route.NextHopString;
+            }
+        }
+
+        return {};
+    }
+
+    SOCKADDR_INET GetBestGatewayV6Address() const
+    {
+        for (const auto& route : Routes)
+        {
+            if (route.Family == AF_INET6 && route.DestinationPrefix.PrefixLength == 0 && route.DestinationPrefixString == LX_INIT_UNSPECIFIED_V6_ADDRESS)
+            {
+                return route.NextHop;
+            }
+        }
+
+        return {};
+    }
 
     std::wstring IpAddressesString() const
     {
@@ -369,6 +434,9 @@ std::shared_ptr<NetworkSettings> GetHostEndpointSettings();
         TraceLoggingValue((settings)->GetBestGatewayAddressString().c_str(), "bestGatewayAddress"), \
         TraceLoggingValue((settings)->PreferredIpAddress.AddressString.c_str(), "preferredIpAddress"), \
         TraceLoggingValue((settings)->PreferredIpAddress.PrefixLength, "preferredIpAddressPrefixLength"), \
+        TraceLoggingValue((settings)->PreferredIpv6Address.AddressString.c_str(), "preferredIpv6Address"), \
+        TraceLoggingValue((settings)->PreferredIpv6Address.PrefixLength, "preferredIpv6AddressPrefixLength"), \
+        TraceLoggingValue((settings)->GetBestGatewayV6AddressString().c_str(), "bestGatewayV6Address"), \
         TraceLoggingValue((settings)->IpAddressesString().c_str(), "ipAddresses"), \
         TraceLoggingValue((settings)->RoutesString().c_str(), "routes"), \
         TraceLoggingValue((settings)->MacAddress.c_str(), "macAddress"), \

--- a/src/windows/common/WslCoreNetworkingSupport.h
+++ b/src/windows/common/WslCoreNetworkingSupport.h
@@ -544,7 +544,7 @@ private:
             m_buffer.resize(BufferSize);
             Result = GetAdaptersAddresses(
                 AF_UNSPEC,
-                (GAA_FLAG_SKIP_FRIENDLY_NAME | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST),
+                (GAA_FLAG_SKIP_FRIENDLY_NAME | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_INCLUDE_GATEWAYS),
                 nullptr,
                 (PIP_ADAPTER_ADDRESSES)m_buffer.data(),
                 &BufferSize);

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -576,7 +576,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)
             {
-                wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::None;
+                wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::Ipv6;
                 WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::LocalhostRelay, m_vmConfig.EnableLocalhostRelay);
                 m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
                     std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2249,10 +2249,8 @@ class NetworkTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Verify we have connectivity from the networking namespace when using ephemeral port selection.
@@ -2740,8 +2738,8 @@ class NetworkTests
             }
             else if (std::regex_search(line, match, routePattern) && match.size() >= 4)
             {
-                state.Routes.emplace_back(
-                    Route{match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
+                state.Routes.emplace_back(Route{
+                    match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
             }
         }
 
@@ -4036,15 +4034,12 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Add rule for port forwarding traffic with destination port 8080 to port 80 in the new namespace
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat PREROUTING tcp dport 8080 dnat to 192.168.15.2:80"), 0);
 
         // Start listeners in root namespace on port 8080 and new namespace on port 80
@@ -4118,10 +4113,8 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Create a listener on the Windows host on port 1234

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -3276,7 +3276,8 @@ class NetworkTests
             NET_LUID interfaceLuid{};
             CONTINUE_IF_FAILED_WIN32(ConvertInterfaceGuidToLuid(&interfaceGuid, &interfaceLuid));
 
-            for (const IP_ADAPTER_ADDRESSES* adapter = adapterAddresses.get(); adapter != nullptr; adapter = adapter->Next)
+            for (auto* adapter = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(adapterAddresses.data()); adapter != nullptr;
+                 adapter = adapter->Next)
             {
                 if (interfaceLuid.Value == adapter->Luid.Value && adapter->FirstUnicastAddress != nullptr && adapter->FirstGatewayAddress != nullptr)
                 {
@@ -3292,12 +3293,13 @@ class NetworkTests
     {
         ULONG bufferSize = 0;
         constexpr ULONG flags = GAA_FLAG_SKIP_FRIENDLY_NAME | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_INCLUDE_GATEWAYS;
-        std::unique_ptr<IP_ADAPTER_ADDRESSES> buffer;
+        std::vector<BYTE> buffer;
         ULONG result;
 
-        while ((result = GetAdaptersAddresses(AF_INET6, flags, nullptr, buffer.get(), &bufferSize)) == ERROR_BUFFER_OVERFLOW)
+        while ((result = GetAdaptersAddresses(AF_INET6, flags, nullptr, reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize)) ==
+               ERROR_BUFFER_OVERFLOW)
         {
-            buffer.reset(static_cast<IP_ADAPTER_ADDRESSES*>(malloc(bufferSize)));
+            buffer.resize(bufferSize);
         }
 
         if (result != NO_ERROR)
@@ -3315,7 +3317,8 @@ class NetworkTests
             return false;
         }
 
-        for (const IP_ADAPTER_ADDRESSES* adapter = buffer.get(); adapter != nullptr; adapter = adapter->Next)
+        for (auto* adapter = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(buffer.data()); adapter != nullptr;
+             adapter = adapter->Next)
         {
             if (adapter->IfIndex != bestIndex)
             {
@@ -3334,18 +3337,18 @@ class NetworkTests
         return false;
     }
 
-    static std::unique_ptr<IP_ADAPTER_ADDRESSES> GetAdapterAddresses(ADDRESS_FAMILY family)
+    static std::vector<BYTE> GetAdapterAddresses(ADDRESS_FAMILY family)
     {
         ULONG result;
         constexpr ULONG flags =
             (GAA_FLAG_SKIP_FRIENDLY_NAME | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER | GAA_FLAG_INCLUDE_GATEWAYS);
         ULONG bufferSize = 0;
-        std::unique_ptr<IP_ADAPTER_ADDRESSES> buffer;
+        std::vector<BYTE> buffer;
 
-        while ((result = GetAdaptersAddresses(family, flags, nullptr, buffer.get(), &bufferSize)) == ERROR_BUFFER_OVERFLOW)
+        while ((result = GetAdaptersAddresses(family, flags, nullptr, reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize)) ==
+               ERROR_BUFFER_OVERFLOW)
         {
-            buffer.reset(static_cast<IP_ADAPTER_ADDRESSES*>(malloc(bufferSize)));
-            VERIFY_IS_NOT_NULL(buffer.get());
+            buffer.resize(bufferSize);
         }
 
         VERIFY_WIN32_SUCCEEDED(result);
@@ -4793,7 +4796,8 @@ class VirtioProxyTests
         InetPtonW(AF_INET6, L"2001:4860:4860::8888", &dest.sin6_addr);
         if (GetBestInterfaceEx(reinterpret_cast<SOCKADDR*>(&dest), &bestIndex) == NO_ERROR)
         {
-            for (const IP_ADAPTER_ADDRESSES* adapter = adapterAddresses.get(); adapter != nullptr; adapter = adapter->Next)
+            for (auto* adapter = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(adapterAddresses.data()); adapter != nullptr;
+                 adapter = adapter->Next)
             {
                 if (adapter->IfIndex != bestIndex)
                 {

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -3294,12 +3294,11 @@ class NetworkTests
         ULONG bufferSize = 0;
         constexpr ULONG flags = GAA_FLAG_SKIP_FRIENDLY_NAME | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_INCLUDE_GATEWAYS;
         std::vector<BYTE> buffer;
-        ULONG result;
-
-        while ((result = GetAdaptersAddresses(AF_INET6, flags, nullptr, reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize)) ==
-               ERROR_BUFFER_OVERFLOW)
+        ULONG result = GetAdaptersAddresses(AF_INET6, flags, nullptr, nullptr, &bufferSize);
+        while (result == ERROR_BUFFER_OVERFLOW)
         {
             buffer.resize(bufferSize);
+            result = GetAdaptersAddresses(AF_INET6, flags, nullptr, reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize);
         }
 
         if (result != NO_ERROR)
@@ -3338,16 +3337,15 @@ class NetworkTests
 
     static std::vector<BYTE> GetAdapterAddresses(ADDRESS_FAMILY family)
     {
-        ULONG result;
         constexpr ULONG flags =
             (GAA_FLAG_SKIP_FRIENDLY_NAME | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER | GAA_FLAG_INCLUDE_GATEWAYS);
         ULONG bufferSize = 0;
         std::vector<BYTE> buffer;
-
-        while ((result = GetAdaptersAddresses(family, flags, nullptr, reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize)) ==
-               ERROR_BUFFER_OVERFLOW)
+        ULONG result = GetAdaptersAddresses(family, flags, nullptr, nullptr, &bufferSize);
+        while (result == ERROR_BUFFER_OVERFLOW)
         {
             buffer.resize(bufferSize);
+            result = GetAdaptersAddresses(family, flags, nullptr, reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize);
         }
 
         VERIFY_WIN32_SUCCEEDED(result);

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -3317,8 +3317,7 @@ class NetworkTests
             return false;
         }
 
-        for (auto* adapter = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(buffer.data()); adapter != nullptr;
-             adapter = adapter->Next)
+        for (auto* adapter = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(buffer.data()); adapter != nullptr; adapter = adapter->Next)
         {
             if (adapter->IfIndex != bestIndex)
             {

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4657,9 +4657,9 @@ class VirtioProxyTests
 
         // Verify that /etc/resolv.conf contains a 'search' line if the host has DNS suffixes
         auto [suffixOut, suffixErr] = LxsstuLaunchPowershellAndCaptureOutput(
-            L"@((Get-DnsClientGlobalSetting).SuffixSearchList) + @((Get-DnsClient).ConnectionSpecificSuffix) | Where-Object {$_} "
-            L"| Select-Object -First 1");
-        if (suffixOut.find_first_not_of(L" \t\r\n") != std::wstring::npos)
+            L"(@((Get-DnsClientGlobalSetting).SuffixSearchList) + @((Get-DnsClient).ConnectionSpecificSuffix) | Where-Object "
+            L"{$_}).Count");
+        if (_wtoi(suffixOut.c_str()) > 0)
         {
             VERIFY_IS_TRUE(out.find(L"search ") != std::wstring::npos);
         }
@@ -4793,49 +4793,48 @@ class VirtioProxyTests
         SOCKADDR_IN6 dest{};
         dest.sin6_family = AF_INET6;
         InetPtonW(AF_INET6, L"2001:4860:4860::8888", &dest.sin6_addr);
-        if (GetBestInterfaceEx(reinterpret_cast<SOCKADDR*>(&dest), &bestIndex) == NO_ERROR)
+        VERIFY_ARE_EQUAL(NO_ERROR, GetBestInterfaceEx(reinterpret_cast<SOCKADDR*>(&dest), &bestIndex));
+
+        for (auto* adapter = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(adapterAddresses.data()); adapter != nullptr;
+             adapter = adapter->Next)
         {
-            for (auto* adapter = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(adapterAddresses.data()); adapter != nullptr;
-                 adapter = adapter->Next)
+            if (adapter->IfIndex != bestIndex)
             {
-                if (adapter->IfIndex != bestIndex)
+                continue;
+            }
+
+            for (auto* unicast = adapter->FirstUnicastAddress; unicast != nullptr; unicast = unicast->Next)
+            {
+                if (unicast->Address.lpSockaddr->sa_family != AF_INET6)
                 {
                     continue;
                 }
 
-                for (auto* unicast = adapter->FirstUnicastAddress; unicast != nullptr; unicast = unicast->Next)
+                const auto& sin6 = *reinterpret_cast<SOCKADDR_IN6*>(unicast->Address.lpSockaddr);
+                if (IN6_IS_ADDR_LINKLOCAL(&sin6.sin6_addr) || IN6_IS_ADDR_LOOPBACK(&sin6.sin6_addr))
                 {
-                    if (unicast->Address.lpSockaddr->sa_family != AF_INET6)
-                    {
-                        continue;
-                    }
-
-                    const auto& sin6 = *reinterpret_cast<SOCKADDR_IN6*>(unicast->Address.lpSockaddr);
-                    if (IN6_IS_ADDR_LINKLOCAL(&sin6.sin6_addr) || IN6_IS_ADDR_LOOPBACK(&sin6.sin6_addr))
-                    {
-                        continue;
-                    }
-
-                    SOCKADDR_INET hostAddr{};
-                    hostAddr.Ipv6 = sin6;
-                    const auto hostAddrString = wsl::windows::common::string::SockAddrInetToWstring(hostAddr);
-
-                    // The host address may not be at index 0 due to SLAAC addresses from RA
-                    bool addressFound = false;
-                    for (const auto& v6Addr : state.V6Addresses)
-                    {
-                        if (v6Addr.Address == hostAddrString)
-                        {
-                            addressFound = true;
-                            break;
-                        }
-                    }
-                    VERIFY_IS_TRUE(addressFound);
-                    break;
+                    continue;
                 }
 
+                SOCKADDR_INET hostAddr{};
+                hostAddr.Ipv6 = sin6;
+                const auto hostAddrString = wsl::windows::common::string::SockAddrInetToWstring(hostAddr);
+
+                // The host address may not be at index 0 due to SLAAC addresses from RA
+                bool addressFound = false;
+                for (const auto& v6Addr : state.V6Addresses)
+                {
+                    if (v6Addr.Address == hostAddrString)
+                    {
+                        addressFound = true;
+                        break;
+                    }
+                }
+                VERIFY_IS_TRUE(addressFound);
                 break;
             }
+
+            break;
         }
     }
 

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4690,5 +4690,26 @@ class VirtioProxyTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .autoProxy = true}));
         NetworkTests::VerifyHttpProxySimple();
     }
+
+    TEST_METHOD(ConfigurationV6)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+
+        if (!NetworkTests::HostHasInternetConnectivity(AF_INET6))
+        {
+            LogSkipped("Host does not have IPv6 internet connectivity. Skipping...");
+            return;
+        }
+
+        const auto state = NetworkTests::GetInterfaceState(L"eth0");
+
+        // Verify that the guest has a global IPv6 address assigned
+        VERIFY_IS_FALSE(state.V6Addresses.empty());
+
+        // Verify that the guest has an IPv6 default gateway
+        VERIFY_IS_TRUE(state.V6Gateway.has_value());
+    }
 };
 } // namespace NetworkTests

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4602,23 +4602,18 @@ class VirtioProxyTests
             NetworkTests::BindHostPort(1234, SOCK_STREAM, IPPROTO_TCP, false);
         }
 
-        const wil::unique_socket listenSocket(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
-        VERIFY_IS_TRUE(!!listenSocket);
+        wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() {
+                const wil::unique_socket listenSocket(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                THROW_HR_IF(E_ABORT, !listenSocket);
 
-        SOCKADDR_IN Address{};
-        Address.sin_family = AF_INET;
-        Address.sin_port = htons(1234);
-
-        const auto timeout = std::chrono::steady_clock::now() + std::chrono::minutes(2);
-
-        bool bound = false;
-        while (!bound && std::chrono::steady_clock::now() < timeout)
-        {
-            bound = bind(listenSocket.get(), reinterpret_cast<SOCKADDR*>(&Address), sizeof(Address)) != SOCKET_ERROR;
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-
-        VERIFY_IS_TRUE(bound);
+                SOCKADDR_IN Address{};
+                Address.sin_family = AF_INET;
+                Address.sin_port = htons(1234);
+                THROW_HR_IF(E_FAIL, bind(listenSocket.get(), reinterpret_cast<SOCKADDR*>(&Address), sizeof(Address)) == SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::minutes(2));
     }
 
     TEST_METHOD(LoopbackGuestToHost)
@@ -4710,6 +4705,109 @@ class VirtioProxyTests
 
         // Verify that the guest has an IPv6 default gateway
         VERIFY_IS_TRUE(state.V6Gateway.has_value());
+
+        // Verify the guest IPv6 address matches the host global IPv6 address
+        const auto adapterAddresses = NetworkTests::GetAdapterAddresses(AF_INET6);
+        DWORD bestIndex = 0;
+        SOCKADDR_IN6 dest{};
+        dest.sin6_family = AF_INET6;
+        InetPtonW(AF_INET6, L"2001:4860:4860::8888", &dest.sin6_addr);
+        if (GetBestInterfaceEx(reinterpret_cast<SOCKADDR*>(&dest), &bestIndex) == NO_ERROR)
+        {
+            for (const IP_ADAPTER_ADDRESSES* adapter = adapterAddresses.get(); adapter != nullptr; adapter = adapter->Next)
+            {
+                if (adapter->IfIndex != bestIndex)
+                {
+                    continue;
+                }
+
+                for (auto* unicast = adapter->FirstUnicastAddress; unicast != nullptr; unicast = unicast->Next)
+                {
+                    if (unicast->Address.lpSockaddr->sa_family != AF_INET6)
+                    {
+                        continue;
+                    }
+
+                    const auto& sin6 = *reinterpret_cast<SOCKADDR_IN6*>(unicast->Address.lpSockaddr);
+                    if (IN6_IS_ADDR_LINKLOCAL(&sin6.sin6_addr) || IN6_IS_ADDR_LOOPBACK(&sin6.sin6_addr))
+                    {
+                        continue;
+                    }
+
+                    SOCKADDR_INET hostAddr{};
+                    hostAddr.Ipv6 = sin6;
+                    const auto hostAddrString = wsl::windows::common::string::SockAddrInetToWstring(hostAddr);
+                    VERIFY_ARE_EQUAL(hostAddrString, state.V6Addresses[0].Address);
+                    break;
+                }
+
+                break;
+            }
+        }
+    }
+
+    TEST_METHOD(DnsResolutionDigV6)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+
+        if (!NetworkTests::HostHasInternetConnectivity(AF_INET6))
+        {
+            LogSkipped("Host does not have IPv6 internet connectivity. Skipping...");
+            return;
+        }
+
+        // Test AAAA record resolution (IPv6) with both UDP and TCP
+        NetworkTests::VerifyDigDnsResolution(L"dig +short +time=5 AAAA bing.com");
+        NetworkTests::VerifyDigDnsResolution(L"dig +tcp +short +time=5 AAAA bing.com");
+    }
+
+    TEST_METHOD(GuestPortIsReleasedV6)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+
+        // Make sure the VM doesn't time out
+        WslKeepAlive keepAlive;
+
+        {
+            auto guestProcess = NetworkTests::BindGuestPort(L"TCP6-LISTEN:1234,bind=::", true);
+            NetworkTests::BindHostPort(1234, SOCK_STREAM, IPPROTO_TCP, false, true);
+        }
+
+        wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() {
+                const wil::unique_socket listenSocket(socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP));
+                THROW_HR_IF(E_ABORT, !listenSocket);
+
+                SOCKADDR_IN6 Address{};
+                Address.sin6_family = AF_INET6;
+                Address.sin6_port = htons(1234);
+                THROW_HR_IF(E_FAIL, bind(listenSocket.get(), reinterpret_cast<SOCKADDR*>(&Address), sizeof(Address)) == SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::minutes(2));
+    }
+
+    TEST_METHOD(ConfigurationV6DnsServers)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+
+        if (!NetworkTests::HostHasInternetConnectivity(AF_INET6))
+        {
+            LogSkipped("Host does not have IPv6 internet connectivity. Skipping...");
+            return;
+        }
+
+        auto [out, _] = LxsstuLaunchWslAndCaptureOutput(L"cat /etc/resolv.conf", 0);
+
+        // Verify that /etc/resolv.conf contains at least one IPv6 nameserver
+        const std::wregex v6Pattern(L"(.|\\n)*nameserver [0-9a-fA-F:]+\\n(.|\\n)*");
+        VERIFY_IS_TRUE(std::regex_match(out, v6Pattern));
     }
 };
 } // namespace NetworkTests

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2249,8 +2249,10 @@ class NetworkTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Verify we have connectivity from the networking namespace when using ephemeral port selection.
@@ -2729,14 +2731,17 @@ class NetworkTests
         {
             if (std::regex_search(line, match, defaultRoutePattern) && match.size() >= 3)
             {
-                VERIFY_IS_FALSE(state.DefaultRoute.has_value());
+                if (state.DefaultRoute.has_value())
+                {
+                    continue;
+                }
 
                 state.DefaultRoute = {{match.str(1), match.str(2), {}, match.size() > 4 && match[4].matched ? std::stoi(match.str(4)) : 0}};
             }
             else if (std::regex_search(line, match, routePattern) && match.size() >= 4)
             {
-                state.Routes.emplace_back(Route{
-                    match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
+                state.Routes.emplace_back(
+                    Route{match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
             }
         }
 
@@ -2752,6 +2757,24 @@ class NetworkTests
         std::wregex routePattern(L"([0-9,.,/]+) via ([0-9,.]+) dev ([a-zA-Z0-9]*) *(metric ([0-9]+))?");
 
         return GetRoutingTableState(out, defaultRoutePattern, routePattern);
+    }
+
+    static void WaitForIpv6DefaultRoute()
+    {
+        const auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (std::chrono::steady_clock::now() < timeout)
+        {
+            auto state = GetIpv6RoutingTableState();
+            if (state.DefaultRoute.has_value())
+            {
+                return;
+            }
+
+            LogInfo("Waiting for IPv6 default route...");
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+
+        VERIFY_FAIL(L"Timed out waiting for IPv6 default route");
     }
 
     static RoutingTableState GetIpv6RoutingTableState()
@@ -3258,6 +3281,52 @@ class NetworkTests
             for (const IP_ADAPTER_ADDRESSES* adapter = adapterAddresses.get(); adapter != nullptr; adapter = adapter->Next)
             {
                 if (interfaceLuid.Value == adapter->Luid.Value && adapter->FirstUnicastAddress != nullptr && adapter->FirstGatewayAddress != nullptr)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static bool HostHasIpv6DnsServers()
+    {
+        ULONG bufferSize = 0;
+        constexpr ULONG flags = GAA_FLAG_SKIP_FRIENDLY_NAME | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_INCLUDE_GATEWAYS;
+        std::unique_ptr<IP_ADAPTER_ADDRESSES> buffer;
+        ULONG result;
+
+        while ((result = GetAdaptersAddresses(AF_INET6, flags, nullptr, buffer.get(), &bufferSize)) == ERROR_BUFFER_OVERFLOW)
+        {
+            buffer.reset(static_cast<IP_ADAPTER_ADDRESSES*>(malloc(bufferSize)));
+        }
+
+        if (result != NO_ERROR)
+        {
+            return false;
+        }
+
+        DWORD bestIndex = 0;
+        SOCKADDR_IN6 dest{};
+        dest.sin6_family = AF_INET6;
+        InetPtonW(AF_INET6, L"2001:4860:4860::8888", &dest.sin6_addr);
+
+        if (GetBestInterfaceEx(reinterpret_cast<SOCKADDR*>(&dest), &bestIndex) != NO_ERROR)
+        {
+            return false;
+        }
+
+        for (const IP_ADAPTER_ADDRESSES* adapter = buffer.get(); adapter != nullptr; adapter = adapter->Next)
+        {
+            if (adapter->IfIndex != bestIndex)
+            {
+                continue;
+            }
+
+            for (auto* dns = adapter->FirstDnsServerAddress; dns != nullptr; dns = dns->Next)
+            {
+                if (dns->Address.lpSockaddr->sa_family == AF_INET6)
                 {
                     return true;
                 }
@@ -3967,12 +4036,15 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Add rule for port forwarding traffic with destination port 8080 to port 80 in the new namespace
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat PREROUTING tcp dport 8080 dnat to 192.168.15.2:80"), 0);
 
         // Start listeners in root namespace on port 8080 and new namespace on port 80
@@ -4046,8 +4118,10 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Create a listener on the Windows host on port 1234
@@ -4566,6 +4640,8 @@ class VirtioProxyTests
             return;
         }
 
+        NetworkTests::WaitForIpv6DefaultRoute();
+
         NetworkTests::GuestClient(L"tcp6-connect:bing.com:80");
     }
 
@@ -4584,8 +4660,14 @@ class VirtioProxyTests
 
         VERIFY_IS_TRUE(std::regex_match(out, pattern));
 
-        // Verify that /etc/resolv.conf contains a 'search' line with DNS suffixes
-        VERIFY_IS_TRUE(out.find(L"search ") != std::wstring::npos);
+        // Verify that /etc/resolv.conf contains a 'search' line if the host has DNS suffixes
+        auto [suffixOut, suffixErr] = LxsstuLaunchPowershellAndCaptureOutput(
+            L"@((Get-DnsClientGlobalSetting).SuffixSearchList) + @((Get-DnsClient).ConnectionSpecificSuffix) | Where-Object {$_} "
+            L"| Select-Object -First 1");
+        if (suffixOut.find_first_not_of(L" \t\r\n") != std::wstring::npos)
+        {
+            VERIFY_IS_TRUE(out.find(L"search ") != std::wstring::npos);
+        }
     }
 
     TEST_METHOD(GuestPortIsReleased)
@@ -4698,6 +4780,10 @@ class VirtioProxyTests
             return;
         }
 
+        // Wait for the device host to send an IPv6 Router Advertisement
+        // before querying the interface state.
+        NetworkTests::WaitForIpv6DefaultRoute();
+
         const auto state = NetworkTests::GetInterfaceState(L"eth0");
 
         // Verify that the guest has a global IPv6 address assigned
@@ -4737,7 +4823,18 @@ class VirtioProxyTests
                     SOCKADDR_INET hostAddr{};
                     hostAddr.Ipv6 = sin6;
                     const auto hostAddrString = wsl::windows::common::string::SockAddrInetToWstring(hostAddr);
-                    VERIFY_ARE_EQUAL(hostAddrString, state.V6Addresses[0].Address);
+
+                    // The host address may not be at index 0 due to SLAAC addresses from RA
+                    bool addressFound = false;
+                    for (const auto& v6Addr : state.V6Addresses)
+                    {
+                        if (v6Addr.Address == hostAddrString)
+                        {
+                            addressFound = true;
+                            break;
+                        }
+                    }
+                    VERIFY_IS_TRUE(addressFound);
                     break;
                 }
 
@@ -4800,6 +4897,12 @@ class VirtioProxyTests
         if (!NetworkTests::HostHasInternetConnectivity(AF_INET6))
         {
             LogSkipped("Host does not have IPv6 internet connectivity. Skipping...");
+            return;
+        }
+
+        if (!NetworkTests::HostHasIpv6DnsServers())
+        {
+            LogSkipped("Host does not have IPv6 DNS servers configured. Skipping...");
             return;
         }
 


### PR DESCRIPTION
This change adds support for ipv6 support to the virtioproxy networking mode. The changes here are primarily:
1. Update the WSL DeviceHost nuget package to a version that support specifying the 'client_ip_ipv6' address
2. Update VirtioProxy network engine to set the IPv6 address and gateway address.
3. Update wsl::core::networking::NetworkSettings class to keep track of IPv6 addresses and routes.