### PR TITLE
CLI: Add the cli session default name as the default session for shell command

### DIFF
--- a/src/windows/wslc/commands/SessionShellCommand.cpp
+++ b/src/windows/wslc/commands/SessionShellCommand.cpp
@@ -35,7 +35,7 @@ std::wstring SessionShellCommand::ShortDescription() const
 
 std::wstring SessionShellCommand::LongDescription() const
 {
-    return {L"Attaches to an active session. If no session ID is provided, the default session will be used."};
+    return {L"Attaches to an active session. If no session ID is provided, the wslc default session will be used."};
 }
 
 void SessionShellCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/SessionShellCommand.cpp
+++ b/src/windows/wslc/commands/SessionShellCommand.cpp
@@ -24,7 +24,7 @@ namespace wsl::windows::wslc {
 std::vector<Argument> SessionShellCommand::GetArguments() const
 {
     return {
-        Argument::Create(ArgType::SessionId, true),
+        Argument::Create(ArgType::SessionId),
     };
 }
 
@@ -35,7 +35,7 @@ std::wstring SessionShellCommand::ShortDescription() const
 
 std::wstring SessionShellCommand::LongDescription() const
 {
-    return {L"Attaches to an active session."};
+    return {L"Attaches to an active session. If no session ID is provided, the default session will be used."};
 }
 
 void SessionShellCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -23,7 +23,7 @@ SessionOptions SessionOptions::Default()
 
     // TODO: Have a configuration file for those.
     SessionOptions options{};
-    options.m_sessionSettings.DisplayName = s_DefaultSessionName.data();
+    options.m_sessionSettings.DisplayName = s_DefaultSessionName.c_str();
     options.m_sessionSettings.CpuCount = 4;
     options.m_sessionSettings.MemoryMb = 2048;
     options.m_sessionSettings.BootTimeoutMs = 30 * 1000;

--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -23,7 +23,7 @@ SessionOptions SessionOptions::Default()
 
     // TODO: Have a configuration file for those.
     SessionOptions options{};
-    options.m_sessionSettings.DisplayName = s_DefaultSessionName.c_str();
+    options.m_sessionSettings.DisplayName = s_DefaultSessionName;
     options.m_sessionSettings.CpuCount = 4;
     options.m_sessionSettings.MemoryMb = 2048;
     options.m_sessionSettings.BootTimeoutMs = 30 * 1000;

--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -23,7 +23,7 @@ SessionOptions SessionOptions::Default()
 
     // TODO: Have a configuration file for those.
     SessionOptions options{};
-    options.m_sessionSettings.DisplayName = L"wsla-cli";
+    options.m_sessionSettings.DisplayName = s_DefaultSessionName.data();
     options.m_sessionSettings.CpuCount = 4;
     options.m_sessionSettings.MemoryMb = 2048;
     options.m_sessionSettings.BootTimeoutMs = 30 * 1000;

--- a/src/windows/wslc/services/SessionModel.h
+++ b/src/windows/wslc/services/SessionModel.h
@@ -17,6 +17,9 @@ Abstract:
 #include <wslaservice.h>
 
 namespace wsl::windows::wslc::models {
+
+constexpr std::wstring_view s_DefaultSessionName = L"wsla-cli";
+
 struct Session
 {
     explicit Session(wil::com_ptr<IWSLASession> session) : m_session(std::move(session))

--- a/src/windows/wslc/services/SessionModel.h
+++ b/src/windows/wslc/services/SessionModel.h
@@ -18,7 +18,7 @@ Abstract:
 
 namespace wsl::windows::wslc::models {
 
-constexpr std::wstring_view s_DefaultSessionName = L"wsla-cli";
+const std::wstring s_DefaultSessionName = L"wsla-cli";
 
 struct Session
 {

--- a/src/windows/wslc/services/SessionModel.h
+++ b/src/windows/wslc/services/SessionModel.h
@@ -18,7 +18,7 @@ Abstract:
 
 namespace wsl::windows::wslc::models {
 
-const std::wstring s_DefaultSessionName = L"wsla-cli";
+inline constexpr wchar_t s_DefaultSessionName[] = L"wsla-cli";
 
 struct Session
 {

--- a/src/windows/wslc/tasks/SessionTasks.cpp
+++ b/src/windows/wslc/tasks/SessionTasks.cpp
@@ -29,8 +29,17 @@ namespace wsl::windows::wslc::task {
 
 void AttachToSession(CLIExecutionContext& context)
 {
-    WI_ASSERT(context.Args.Contains(ArgType::SessionId));
-    context.ExitCode = SessionService::Attach(context.Args.Get<ArgType::SessionId>());
+    std::wstring sessionId;
+    if (context.Args.Contains(ArgType::SessionId))
+    {
+        sessionId = context.Args.Get<ArgType::SessionId>();
+    }
+    else
+    {
+        sessionId = models::s_DefaultSessionName.data();
+    }
+
+    context.ExitCode = SessionService::Attach(sessionId);
 }
 
 void CreateSession(CLIExecutionContext& context)

--- a/src/windows/wslc/tasks/SessionTasks.cpp
+++ b/src/windows/wslc/tasks/SessionTasks.cpp
@@ -36,7 +36,7 @@ void AttachToSession(CLIExecutionContext& context)
     }
     else
     {
-        sessionId = models::s_DefaultSessionName.data();
+        sessionId = models::s_DefaultSessionName;
     }
 
     context.ExitCode = SessionService::Attach(sessionId);

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -32,6 +32,7 @@ COMMAND_LINE_TEST_CASE(L"session list --verbose --help", L"list", true)
 COMMAND_LINE_TEST_CASE(L"session list --notanarg", L"list", false)
 COMMAND_LINE_TEST_CASE(L"session list extraarg", L"list", false)
 COMMAND_LINE_TEST_CASE(L"session shell session1", L"shell", true)
+COMMAND_LINE_TEST_CASE(L"session shell", L"shell", true)
 
 // Container command tests
 COMMAND_LINE_TEST_CASE(L"container list", L"list", true)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds the CLI session name default as a constexpr stringview.
Makes the session id an optional argument for the session shell command
Uses the default if a session id is not provided for the session shell command.
Adds a test for this command line case.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Simple default for session shell command as discussed.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Adds test case.
Manually validated session creation works as expected and session shell works without an argument to connect to the CLI session.