### PR TITLE
DO NOT MERGE: test virtioproxy without setting gateway_ip

### DIFF
--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -174,30 +174,22 @@ try
 
     // TODO: Determine gateway MAC address
     std::wstring device_options;
-    auto client_ip = networkSettings->PreferredIpAddress.AddressString;
-    if (!client_ip.empty())
-    {
-        device_options += L"client_ip=" + client_ip;
-    }
-
-    if (!networkSettings->MacAddress.empty())
-    {
-        if (!device_options.empty())
+    auto appendOption = [&device_options](const std::wstring& key, const std::wstring& value) {
+        if (!value.empty())
         {
-            device_options += L';';
+            if (!device_options.empty())
+            {
+                device_options += L';';
+            }
+            device_options += key + L'=' + value;
         }
-        device_options += L"client_mac=" + networkSettings->MacAddress;
-    }
+    };
+
+    appendOption(L"client_ip", networkSettings->PreferredIpAddress.AddressString);
+    appendOption(L"client_mac", networkSettings->MacAddress);
 
     std::wstring default_route = networkSettings->GetBestGatewayAddressString();
-    if (!default_route.empty())
-    {
-        if (!device_options.empty())
-        {
-            device_options += L';';
-        }
-        device_options += L"gateway_ip=" + default_route;
-    }
+    //appendOption(L"gateway_ip", default_route); // TODO: determine if this is needed or not.
 
     networking::DnsInfo currentDns{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -189,7 +189,7 @@ try
     appendOption(L"client_mac", networkSettings->MacAddress);
 
     std::wstring default_route = networkSettings->GetBestGatewayAddressString();
-    //appendOption(L"gateway_ip", default_route); // TODO: determine if this is needed or not.
+    // appendOption(L"gateway_ip", default_route); // TODO: determine if this is needed or not.
 
     networking::DnsInfo currentDns{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))


### PR DESCRIPTION
I am debugging an issue with virtio proxy that I am not able to reproduce locally. As part of my ipv6 change I assumed that I did not need to pass the gateway_ip to the wsldevicehost via the options string. This works locally, but in CI I am getting dns resolution failures.

This will help me validate my theory.