### PR TITLE
Add support for forced container deletion

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -62,6 +62,14 @@ struct FlagsTraits<WslcContainerStartFlags>
     WSLC_FLAG_VALUE_ASSERT(WSLC_CONTAINER_START_FLAG_ATTACH, WSLAContainerStartFlagsAttach);
 };
 
+template <>
+struct FlagsTraits<WslcDeleteContainerFlags>
+{
+    using WslaType = WSLADeleteFlags;
+    constexpr static WslcDeleteContainerFlags Mask = WSLC_DELETE_CONTAINER_FLAG_FORCE;
+    WSLC_FLAG_VALUE_ASSERT(WSLC_DELETE_CONTAINER_FLAG_FORCE, WSLADeleteFlagsForce);
+};
+
 template <typename Flags>
 typename FlagsTraits<Flags>::WslaType ConvertFlags(Flags flags)
 {
@@ -570,10 +578,7 @@ try
     auto internalType = CheckAndGetInternalType(container);
     RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), internalType->container);
 
-    // TODO: Flags?
-    UNREFERENCED_PARAMETER(flags);
-
-    RETURN_HR(internalType->container->Delete());
+    RETURN_HR(internalType->container->Delete(ConvertFlags(flags)));
 }
 CATCH_RETURN();
 

--- a/src/windows/common/WSLAContainerLauncher.cpp
+++ b/src/windows/common/WSLAContainerLauncher.cpp
@@ -37,8 +37,7 @@ void RunningWSLAContainer::Reset()
     if (m_container && m_deleteOnClose)
     {
         // Attempt to stop and delete the container.
-        LOG_IF_FAILED(m_container->Stop(WSLASignalSIGKILL, 0));
-        LOG_IF_FAILED(m_container->Delete());
+        LOG_IF_FAILED(m_container->Delete(WSLADeleteFlagsForce));
     }
 
     m_container.reset();

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -396,6 +396,14 @@ typedef enum _WSLALogsFlags
     WSLALogsFlagsTimestamps = 2,
 } WSLALogsFlags;
 
+typedef enum _WSLADeleteFlags
+{
+    WSLADeleteFlagsNone = 0,
+    WSLADeleteFlagsForce = 1,
+    WSLADeleteFlagsValid = WSLADeleteFlagsForce
+    // TODO: Flags to remove anonymous volumes, bridge links, etc.
+} WSLADeleteFlags;
+
 
 [
     uuid(7577FE8D-DE85-471E-B870-11669986F332),
@@ -407,7 +415,7 @@ interface IWSLAContainer : IUnknown
     HRESULT Attach([in, unique] LPCSTR DetachKeys, [out] ULONG* StdIn, [out] ULONG* StdOut, [out] ULONG* StdErr);
     HRESULT Stop([in] WSLASignal Signal, [in] LONG TimeoutSeconds);
     HRESULT Start([in] WSLAContainerStartFlags Flags, [in, unique] LPCSTR DetachKeys);
-    HRESULT Delete(); // TODO: Look into lifetime logic.
+    HRESULT Delete([in] WSLADeleteFlags Flags);
     HRESULT Export([in] ULONG TarHandle);
     HRESULT GetState([out] enum WSLA_CONTAINER_STATE* State);
     HRESULT GetInitProcess([out] IWSLAProcess** Process);

--- a/src/windows/wslasession/DockerHTTPClient.cpp
+++ b/src/windows/wslasession/DockerHTTPClient.cpp
@@ -287,9 +287,16 @@ void DockerHTTPClient::SignalContainer(const std::string& Id, int Signal)
     Transaction(verb::post, url);
 }
 
-void DockerHTTPClient::DeleteContainer(const std::string& Id)
+void DockerHTTPClient::DeleteContainer(const std::string& Id, bool Force)
 {
-    Transaction(verb::delete_, URL::Create("/containers/{}", Id));
+    auto url = URL::Create("/containers/{}", Id);
+
+    if (Force)
+    {
+        url.SetParameter("force", true);
+    }
+
+    Transaction(verb::delete_, url);
 }
 
 docker_schema::InspectContainer DockerHTTPClient::InspectContainer(const std::string& Id)

--- a/src/windows/wslasession/DockerHTTPClient.h
+++ b/src/windows/wslasession/DockerHTTPClient.h
@@ -126,7 +126,7 @@ public:
     common::docker_schema::CreatedContainer CreateContainer(const common::docker_schema::CreateContainer& Request, const std::optional<std::string>& Name);
     void StartContainer(const std::string& Id, const std::optional<std::string>& DetachKeys);
     void StopContainer(const std::string& Id, std::optional<WSLASignal> Signal, std::optional<ULONG> TimeoutSeconds);
-    void DeleteContainer(const std::string& Id);
+    void DeleteContainer(const std::string& Id, bool Force);
     void SignalContainer(const std::string& Id, int Signal);
     common::docker_schema::InspectContainer InspectContainer(const std::string& Id);
     common::docker_schema::InspectExec InspectExec(const std::string& Id);

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -625,9 +625,11 @@ __requires_exclusive_lock_held(m_lock) void WSLAContainerImpl::DeleteExclusiveLo
         m_name.c_str(),
         m_state);
 
+    WI_ASSERT(m_state != WslaContainerStateInvalid);
+
     try
     {
-        m_dockerClient.DeleteContainer(m_id, Flags);
+        m_dockerClient.DeleteContainer(m_id, WI_IsFlagSet(Flags, WSLADeleteImageFlagsForce));
     }
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to delete container '%hs'", m_id.c_str());
 

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -609,8 +609,6 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
 
 void WSLAContainerImpl::Delete(WSLADeleteFlags Flags)
 {
-    THROW_HR_IF_MSG(E_INVALIDARG, WI_IsAnyFlagSet(Flags, ~WSLADeleteFlagsValid), "Invalid flags: %i", Flags);
-
     // Acquire an exclusive lock since this method modifies m_state.
     auto lock = m_lock.lock_exclusive();
 
@@ -1356,6 +1354,8 @@ HRESULT WSLAContainer::Delete(WSLADeleteFlags Flags)
 try
 {
     COMServiceExecutionContext context;
+
+    THROW_HR_IF_MSG(E_INVALIDARG, WI_IsAnyFlagSet(Flags, ~WSLADeleteFlagsValid), "Invalid flags: %i", Flags);
 
     // Special case for Delete(): If deletion is successful, notify the WSLASession that the container has been deleted.
     auto [lock, impl] = LockImpl();

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -532,7 +532,7 @@ void WSLAContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
             Transition(WslaContainerStateExited);
             if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
             {
-                DeleteExclusiveLockHeld();
+                DeleteExclusiveLockHeld(WSLADeleteFlagsNone);
             }
         }
     }
@@ -592,7 +592,7 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
 
     if (WI_IsFlagSet(m_containerFlags, WSLAContainerFlagsRm))
     {
-        DeleteExclusiveLockHeld();
+        DeleteExclusiveLockHeld(WSLADeleteFlagsForce);
     }
     else
     {
@@ -607,27 +607,29 @@ void WSLAContainerImpl::Stop(WSLASignal Signal, LONG TimeoutSeconds)
     }
 }
 
-void WSLAContainerImpl::Delete()
+void WSLAContainerImpl::Delete(WSLADeleteFlags Flags)
 {
+    THROW_HR_IF_MSG(E_INVALIDARG, WI_IsAnyFlagSet(Flags, ~WSLADeleteFlagsValid), "Invalid flags: %i", Flags);
+
     // Acquire an exclusive lock since this method modifies m_state.
     auto lock = m_lock.lock_exclusive();
 
-    DeleteExclusiveLockHeld();
+    DeleteExclusiveLockHeld(Flags);
 }
 
-__requires_exclusive_lock_held(m_lock) void WSLAContainerImpl::DeleteExclusiveLockHeld()
+__requires_exclusive_lock_held(m_lock) void WSLAContainerImpl::DeleteExclusiveLockHeld(WSLADeleteFlags Flags)
 {
     // Validate that the container is not running or already deleted.
     THROW_HR_IF_MSG(
         HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
-        m_state != WslaContainerStateCreated && m_state != WslaContainerStateExited,
+        (m_state == WslaContainerStateRunning && WI_IsFlagClear(Flags, WSLADeleteFlagsForce)) || m_state == WslaContainerStateDeleted,
         "Cannot delete container '%hs', state: %i",
         m_name.c_str(),
         m_state);
 
     try
     {
-        m_dockerClient.DeleteContainer(m_id);
+        m_dockerClient.DeleteContainer(m_id, Flags);
     }
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to delete container '%hs'", m_id.c_str());
 
@@ -1350,7 +1352,7 @@ HRESULT WSLAContainer::Inspect(LPSTR* Output)
     return CallImpl(&WSLAContainerImpl::Inspect, Output);
 }
 
-HRESULT WSLAContainer::Delete()
+HRESULT WSLAContainer::Delete(WSLADeleteFlags Flags)
 try
 {
     COMServiceExecutionContext context;
@@ -1358,7 +1360,7 @@ try
     // Special case for Delete(): If deletion is successful, notify the WSLASession that the container has been deleted.
     auto [lock, impl] = LockImpl();
 
-    impl->Delete();
+    impl->Delete(Flags);
     m_onDeleted(impl);
 
     return S_OK;

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -57,7 +57,7 @@ public:
     void Start(WSLAContainerStartFlags Flags, LPCSTR DetachKeys);
     void Attach(LPCSTR DetachKeys, ULONG* Stdin, ULONG* Stdout, ULONG* Stderr) const;
     void Stop(_In_ WSLASignal Signal, _In_ LONG TimeoutSeconds);
-    void Delete();
+    void Delete(WSLADeleteFlags Flags);
     void Export(ULONG TarHandle) const;
     void GetState(_Out_ WSLA_CONTAINER_STATE* State);
     void GetInitProcess(_Out_ IWSLAProcess** process) const;
@@ -109,7 +109,7 @@ public:
         IORelay& Relay);
 
 private:
-    __requires_exclusive_lock_held(m_lock) void DeleteExclusiveLockHeld();
+    __requires_exclusive_lock_held(m_lock) void DeleteExclusiveLockHeld(WSLADeleteFlags Flags);
 
     void OnEvent(ContainerEvent event, std::optional<int> exitCode);
     void WaitForContainerEvent();
@@ -153,7 +153,7 @@ public:
 
     IFACEMETHOD(Attach)(_In_opt_ LPCSTR DetachKeys, _Out_ ULONG* Stdin, _Out_ ULONG* Stdout, _Out_ ULONG* Stderr) override;
     IFACEMETHOD(Stop)(_In_ WSLASignal Signal, _In_ LONG TimeoutSeconds) override;
-    IFACEMETHOD(Delete)() override;
+    IFACEMETHOD(Delete)(WSLADeleteFlags Flags) override;
     IFACEMETHOD(Export)(_In_ ULONG TarHandle) override;
     IFACEMETHOD(GetState)(_Out_ WSLA_CONTAINER_STATE* State) override;
     IFACEMETHOD(GetInitProcess)(_Out_ IWSLAProcess** process) override;

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -179,12 +179,7 @@ void ContainerService::Delete(Session& session, const std::string& id, bool forc
 {
     wil::com_ptr<IWSLAContainer> container;
     THROW_IF_FAILED(session.Get()->OpenContainer(id.c_str(), &container));
-    if (force)
-    {
-        StopInternal(*container, WSLASignalSIGKILL);
-    }
-
-    THROW_IF_FAILED(container->Delete());
+    THROW_IF_FAILED(container->Delete(force ? WSLADeleteFlagsForce : WSLADeleteFlagsNone));
 }
 
 std::vector<ContainerInformation> ContainerService::List(Session& session)

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -3163,7 +3163,11 @@ class WSLATests
             // Verify that a running container can be deleted with the force flag.
             VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsForce));
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsForce), HRESULT_FROM_WIN32(RPC_E_DISCONNECTED));
+
+            // Validate that invalid flags are rejected.
+            VERIFY_ARE_EQUAL(container.Get().Delete(static_cast<WSLADeleteFlags>(0x2)), E_INVALIDARG);
         }
+
     }
 
     TEST_METHOD(ContainerNetwork)

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -3167,7 +3167,6 @@ class WSLATests
             // Validate that invalid flags are rejected.
             VERIFY_ARE_EQUAL(container.Get().Delete(static_cast<WSLADeleteFlags>(0x2)), E_INVALIDARG);
         }
-
     }
 
     TEST_METHOD(ContainerNetwork)

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1617,7 +1617,7 @@ class WSLATests
                 ULONG outFile = HandleToULong(contTarFileHandle.get());
 
                 container.Get().Stop(WSLASignalSIGILL, 10);
-                container.Get().Delete();
+                container.Get().Delete(WSLADeleteFlagsNone);
                 VERIFY_ARE_EQUAL(container.Get().Export(outFile), RPC_E_DISCONNECTED);
 
                 VERIFY_IS_TRUE(GetFileSizeEx(contTarFileHandle.get(), &fileSize));
@@ -2636,7 +2636,7 @@ class WSLATests
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
                 wil::com_ptr<IWSLAContainer> openedContainer;
                 VERIFY_SUCCEEDED(m_defaultSession->OpenContainer(containerId.c_str(), &openedContainer));
-                VERIFY_SUCCEEDED(openedContainer->Delete());
+                VERIFY_SUCCEEDED(openedContainer->Delete(WSLADeleteFlagsNone));
             });
 
             auto process = container.GetInitProcess();
@@ -2763,7 +2763,7 @@ class WSLATests
 
             wil::com_ptr<IWSLAContainer> container;
             VERIFY_SUCCEEDED(m_defaultSession->CreateContainer(&options, &container));
-            VERIFY_SUCCEEDED(container->Delete());
+            VERIFY_SUCCEEDED(container->Delete(WSLADeleteFlagsNone));
         }
     }
 
@@ -2820,7 +2820,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             // Validate that deleted containers can't be started.
             VERIFY_ARE_EQUAL(container.Get().Start(WSLAContainerStartFlagsNone, nullptr), RPC_E_DISCONNECTED);
@@ -3000,7 +3000,7 @@ class WSLATests
             VERIFY_SUCCEEDED(sameContainer->GetState(&state));
             VERIFY_ARE_EQUAL(state, WslaContainerStateExited);
 
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
         }
 
         // Test StopContainer
@@ -3028,7 +3028,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
 
             // Verify that deleting a container stopped via Stop() works.
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
             expectContainerList({});
         }
 
@@ -3052,7 +3052,7 @@ class WSLATests
                 HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
 
             // Validate that running containers can't be deleted.
-            VERIFY_ARE_EQUAL(container.Get().Delete(), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
 
             // Kill the container.
             auto initProcess = container.GetInitProcess();
@@ -3073,13 +3073,13 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
 
             // Verify that stopped containers can be deleted.
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             // Verify that stopping a deleted container returns ERROR_INVALID_STATE.
             VERIFY_ARE_EQUAL(container.Get().Stop(WSLASignalSIGTERM, 0), HRESULT_FROM_WIN32(RPC_E_DISCONNECTED));
 
             // Verify that deleted containers can't be deleted again.
-            VERIFY_ARE_EQUAL(container.Get().Delete(), HRESULT_FROM_WIN32(RPC_E_DISCONNECTED));
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), HRESULT_FROM_WIN32(RPC_E_DISCONNECTED));
 
             // Verify that deleted containers don't show up in the container list.
             expectContainerList({});
@@ -3111,7 +3111,7 @@ class WSLATests
             VERIFY_SUCCEEDED(container->Get().Stop(WSLASignalSIGKILL, 0));
             VERIFY_ARE_EQUAL(container->State(), WslaContainerStateExited);
 
-            VERIFY_SUCCEEDED(container->Get().Delete());
+            VERIFY_SUCCEEDED(container->Get().Delete(WSLADeleteFlagsNone));
 
             WSLA_CONTAINER_STATE state{};
             VERIFY_ARE_EQUAL(container->Get().GetState(&state), RPC_E_DISCONNECTED);
@@ -3126,7 +3126,7 @@ class WSLATests
 
             // Delete the container to avoid leaving it dangling after test completion.
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             // Terminate the session
             ResetTestSession();
@@ -3135,6 +3135,34 @@ class WSLATests
             WSLA_CONTAINER_STATE state = WslaContainerStateRunning;
             VERIFY_ARE_EQUAL(container.Get().GetState(&state), HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE));
             VERIFY_ARE_EQUAL(state, WslaContainerStateInvalid);
+        }
+    }
+
+    TEST_METHOD(DeleteContainer)
+    {
+        WSL2_TEST_ONLY();
+        WSLAContainerLauncher launcher("debian:latest", "test-container-delete", {"sleep", "99999"});
+
+        {
+            // Verify that a created container can be deleted.
+            auto container = launcher.Create(*m_defaultSession);
+            VERIFY_ARE_EQUAL(container.State(), WslaContainerStateCreated);
+
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
+
+            // Verify that a deleted container can't be deleted again.
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), HRESULT_FROM_WIN32(RPC_E_DISCONNECTED));
+        }
+
+        {
+            // Verify that a running container can't be deleted by default.
+            auto container = launcher.Launch(*m_defaultSession);
+            VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
+
+            // Verify that a running container can be deleted with the force flag.
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsForce));
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsForce), HRESULT_FROM_WIN32(RPC_E_DISCONNECTED));
         }
     }
 
@@ -3179,7 +3207,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
 
             // Verify that deleting a container stopped via Stop() works.
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             expectContainerList({});
         }
@@ -3201,7 +3229,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
 
             // Verify that deleting a container stopped via Stop() works.
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             expectContainerList({});
         }
@@ -3235,7 +3263,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
 
             // Verify that deleting a container stopped via Stop() works.
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             expectContainerList({});
         }
@@ -3351,7 +3379,7 @@ class WSLATests
                 {{"/test-volume", "bind", true}, {"/test-volume-ro", "bind", false}, {"/mnt/wsla-tmpfs-inspect", "tmpfs", true}});
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
         }
 
         // Test an exited container still returns correct schema shape.
@@ -3381,7 +3409,7 @@ class WSLATests
             expectPorts(details.Ports, {});
             expectMounts(details.Mounts, {});
 
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
         }
     }
 
@@ -3547,7 +3575,7 @@ class WSLATests
 
         // Destroy the container (Stop + Delete + release COM reference).
         VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
-        VERIFY_SUCCEEDED(container.Get().Delete());
+        VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
         container.Reset();
 
         // The exec process exit event must be signaled within a reasonable timeout.
@@ -3647,7 +3675,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(hresult, HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             container.Reset(); // TODO: Re-think container lifetime management.
 
@@ -3669,7 +3697,7 @@ class WSLATests
                 ExpectHttpResponse(L"http://127.0.0.1:1234", 200);
 
                 VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
-                VERIFY_SUCCEEDED(container.Get().Delete());
+                VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
                 container.Reset(); // TODO: Re-think container lifetime management.
             }
         }
@@ -3846,7 +3874,7 @@ class WSLATests
             ValidateProcessOutput(process, {{1, "OK\n"}});
 
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
         }
 
         // Validate that the volumes are not mounted after container exits.
@@ -4154,7 +4182,7 @@ class WSLATests
 
             auto container = OpenContainer(session.get(), containerName);
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 
             // Verify container is no longer accessible
             wil::com_ptr<IWSLAContainer> notFound;
@@ -4227,7 +4255,7 @@ class WSLATests
             ExpectHttpResponse(L"http://127.0.0.1:1250/test.txt", 200);
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
-            VERIFY_SUCCEEDED(container.Get().Delete());
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
         }
 
         // Delete the host folder to simulate volume folder being missing on recovery
@@ -4674,7 +4702,7 @@ class WSLATests
                 HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
 
             // Validate that attaching to a deleted container fails.
-            VERIFY_SUCCEEDED(container->Get().Delete());
+            VERIFY_SUCCEEDED(container->Get().Delete(WSLADeleteFlagsNone));
             VERIFY_ARE_EQUAL(container->Get().Attach(nullptr, (ULONG*)&attachedStdin, (ULONG*)&attachedStdout, (ULONG*)&attachedStderr), RPC_E_DISCONNECTED);
 
             container->SetDeleteOnClose(false);
@@ -4838,7 +4866,7 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
 
-            VERIFY_ARE_EQUAL(container.Get().Delete(), RPC_E_DISCONNECTED);
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLAContainer> notFound;
             VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
@@ -4857,7 +4885,7 @@ class WSLATests
             VERIFY_SUCCEEDED(process.Get().Signal(WSLASignalSIGKILL));
             process.Wait();
 
-            VERIFY_ARE_EQUAL(container.Get().Delete(), RPC_E_DISCONNECTED);
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLAContainer> notFound;
             VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
@@ -4872,7 +4900,7 @@ class WSLATests
             auto process = container.GetInitProcess();
             process.Wait();
 
-            VERIFY_ARE_EQUAL(container.Get().Delete(), RPC_E_DISCONNECTED);
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLAContainer> notFound;
             VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
@@ -4897,7 +4925,7 @@ class WSLATests
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
 
             // verifyContainerDeleted("test-auto-remove");
-            VERIFY_ARE_EQUAL(container.Get().Delete(), RPC_E_DISCONNECTED);
+            VERIFY_ARE_EQUAL(container.Get().Delete(WSLADeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLAContainer> notFound;
             VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds support for forced deletion of running containers via a new flag in WSLAContainer::Delete() 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
