### PR TITLE
virtiofs: update logic so querying virtiofs mount source does not require a call to the service

### DIFF
--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -624,9 +624,16 @@ try
     //
 
     auto* Tag = wsl::shared::string::FromSpan(ResponseSpan, Response.TagOffset);
+    auto* ResponseSource = wsl::shared::string::FromSpan(ResponseSpan, Response.SourceOffset);
     THROW_LAST_ERROR_IF(MountWithRetry(Tag, Target, VIRTIO_FS_TYPE, MountOptions.c_str(), ExitCode) < 0);
 
-    SaveVirtiofsTagMapping(Tag, Source);
+    //
+    // Save the tag mapping.
+    //
+    // N.B. Use the source path from the response since the service canonicalizes it.
+    //
+
+    SaveVirtiofsTagMapping(Tag, ResponseSource);
 
     return 0;
 }
@@ -684,16 +691,10 @@ try
     }
 
     auto* NewTag = wsl::shared::string::FromSpan(ResponseSpan, Response.TagOffset);
+    auto* Source = wsl::shared::string::FromSpan(ResponseSpan, Response.SourceOffset);
     THROW_LAST_ERROR_IF(MountWithRetry(NewTag, Target, VIRTIO_FS_TYPE, Options) < 0);
 
-    auto Source = QueryVirtiofsMountSource(Tag);
-    if (Source.empty())
-    {
-        LOG_ERROR("Failed to query source for virtiofs tag {}", Tag);
-        return -1;
-    }
-
-    SaveVirtiofsTagMapping(NewTag, Source.c_str());
+    SaveVirtiofsTagMapping(NewTag, Source);
 
     return 0;
 }

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -21,6 +21,7 @@ Abstract:
 #include "config.h"
 #include "message.h"
 #include <cassert>
+#include <filesystem>
 #include <optional>
 
 using namespace std::chrono_literals;
@@ -739,22 +740,7 @@ try
     //
 
     auto LinkPath = std::format("{}/{}", VIRTIOFS_TAG_DIR, Tag);
-    std::string Result(PATH_MAX, '\0');
-    auto Length = readlink(LinkPath.c_str(), Result.data(), Result.size());
-    if (Length < 0)
-    {
-        LOG_WARNING("Failed to read virtiofs tag symlink {}: {}", LinkPath, errno);
-        return {};
-    }
-
-    if (static_cast<size_t>(Length) == Result.size())
-    {
-        LOG_WARNING("Virtiofs tag symlink {} target may be truncated", LinkPath);
-        return {};
-    }
-
-    Result.resize(Length);
-    return Result;
+    return std::filesystem::read_symlink(LinkPath).string();
 }
 catch (...)
 {

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -32,6 +32,8 @@ using namespace std::chrono_literals;
 #define PLAN9_SYMLINK_ROOT_OPTION "symlinkroot="
 #define PLAN9_UNC_PREFIX_LENGTH (2)
 
+#define VIRTIOFS_TAG_DIR "/run/wsl/virtiofs"
+
 #define LOG_STDERR(_errno) fprintf(stderr, "mount: %s\n", strerror(_errno))
 
 constexpr int c_exitCodeInvalidUsage = 1;
@@ -40,6 +42,62 @@ constexpr int c_exitCodeMountFail = 32;
 int MountFilesystem(const char* FsType, const char* Source, const char* Target, const char* Options, int* ExitCode = nullptr);
 
 int MountWithRetry(const char* Source, const char* Target, const char* FsType, const char* Options, int* ExitCode = nullptr);
+
+void SaveVirtiofsTagMapping(const char* Tag, const char* Source)
+
+/*++
+
+Routine Description:
+
+    This routine creates a symlink in VIRTIOFS_TAG_DIR that maps a virtiofs tag
+    to its Windows mount source path. This allows QueryVirtiofsMountSource to
+    resolve tags without talking to the service.
+
+Arguments:
+
+    Tag - Supplies the virtiofs tag.
+
+    Source - Supplies the Windows path the tag refers to.
+
+Return Value:
+
+    None.
+
+--*/
+
+{
+    //
+    // Validate the tag is a GUID to prevent path traversal.
+    //
+
+    const auto Guid = wsl::shared::string::ToGuid(Tag);
+    if (!Guid)
+    {
+        LOG_WARNING("Invalid virtiofs tag {}", Tag);
+        return;
+    }
+
+    //
+    // Canonicalize path separators to backslashes before persisting.
+    //
+
+    std::string CanonicalSource{Source};
+    UtilCanonicalisePathSeparator(CanonicalSource, PATH_SEP_NT);
+
+    UtilMkdirPath(VIRTIOFS_TAG_DIR, 0755);
+
+    auto LinkPath = std::format("{}/{}", VIRTIOFS_TAG_DIR, Tag);
+
+    //
+    // Remove any existing symlink for this tag before creating a new one.
+    //
+
+    unlink(LinkPath.c_str());
+    if (symlink(CanonicalSource.c_str(), LinkPath.c_str()) < 0)
+    {
+        LOG_WARNING("Failed to create virtiofs tag symlink {} -> {}: {}", LinkPath, CanonicalSource, errno);
+    }
+}
 
 std::pair<std::string, std::string> ConvertDrvfsMountOptionsToPlan9(std::string_view Options, const wsl::linux::WslDistributionConfig& Config)
 
@@ -565,7 +623,11 @@ try
     //
 
     auto* Tag = wsl::shared::string::FromSpan(ResponseSpan, Response.TagOffset);
-    return MountWithRetry(Tag, Target, VIRTIO_FS_TYPE, MountOptions.c_str(), ExitCode);
+    THROW_LAST_ERROR_IF(MountWithRetry(Tag, Target, VIRTIO_FS_TYPE, MountOptions.c_str(), ExitCode) < 0);
+
+    SaveVirtiofsTagMapping(Tag, Source);
+
+    return 0;
 }
 CATCH_RETURN_ERRNO()
 
@@ -620,8 +682,19 @@ try
         return -1;
     }
 
-    Tag = wsl::shared::string::FromSpan(ResponseSpan, Response.TagOffset);
-    return MountWithRetry(Tag, Target, VIRTIO_FS_TYPE, Options);
+    auto* NewTag = wsl::shared::string::FromSpan(ResponseSpan, Response.TagOffset);
+    THROW_LAST_ERROR_IF(MountWithRetry(NewTag, Target, VIRTIO_FS_TYPE, Options) < 0);
+
+    auto Source = QueryVirtiofsMountSource(Tag);
+    if (Source.empty())
+    {
+        LOG_ERROR("Failed to query source for virtiofs tag {}", Tag);
+        return -1;
+    }
+
+    SaveVirtiofsTagMapping(NewTag, Source.c_str());
+
+    return 0;
 }
 CATCH_RETURN_ERRNO()
 
@@ -631,7 +704,8 @@ std::string QueryVirtiofsMountSource(const char* Tag)
 
 Routine Description:
 
-    This routine takes a virtiofs tag and determines the Windows path it refers to.
+    This routine takes a virtiofs tag and determines the Windows path it refers to
+    by reading the symlink created during mount.
 
 Arguments:
 
@@ -660,28 +734,28 @@ try
         return {};
     }
 
-    wsl::shared::MessageWriter<LX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE> QueryShare(LxInitMessageQueryVirtioFsDevice);
-    QueryShare.WriteString(QueryShare->TagOffset, Tag);
-
     //
-    // Connect to the host and send the query request.
+    // Read the symlink that maps this tag to its Windows source path.
     //
 
-    wsl::shared::SocketChannel Channel{UtilConnectVsock(LX_INIT_UTILITY_VM_VIRTIOFS_PORT, true), "QueryVirtioFs"};
-    if (Channel.Socket() < 0)
+    auto LinkPath = std::format("{}/{}", VIRTIOFS_TAG_DIR, Tag);
+    struct stat st;
+    if (lstat(LinkPath.c_str(), &st) < 0)
     {
+        LOG_WARNING("Failed to stat virtiofs tag symlink {}: {}", LinkPath, errno);
         return {};
     }
 
-    gsl::span<gsl::byte> ResponseSpan;
-    const auto& Response = Channel.Transaction<LX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE>(QueryShare.Span(), &ResponseSpan);
-    if (Response.Result != 0)
+    std::string Result(st.st_size, '\0');
+    auto Length = readlink(LinkPath.c_str(), Result.data(), Result.size());
+    if (Length < 0)
     {
-        LOG_ERROR("Query virtiofs share for {} failed {}", Tag, Response.Result);
+        LOG_WARNING("Failed to read virtiofs tag symlink {}: {}", LinkPath, errno);
         return {};
     }
 
-    return wsl::shared::string::FromSpan(ResponseSpan, Response.TagOffset);
+    Result.resize(Length);
+    return Result;
 }
 catch (...)
 {

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -739,18 +739,17 @@ try
     //
 
     auto LinkPath = std::format("{}/{}", VIRTIOFS_TAG_DIR, Tag);
-    struct stat st;
-    if (lstat(LinkPath.c_str(), &st) < 0)
-    {
-        LOG_WARNING("Failed to stat virtiofs tag symlink {}: {}", LinkPath, errno);
-        return {};
-    }
-
-    std::string Result(st.st_size, '\0');
+    std::string Result(PATH_MAX, '\0');
     auto Length = readlink(LinkPath.c_str(), Result.data(), Result.size());
     if (Length < 0)
     {
         LOG_WARNING("Failed to read virtiofs tag symlink {}: {}", LinkPath, errno);
+        return {};
+    }
+
+    if (static_cast<size_t>(Length) == Result.size())
+    {
+        LOG_WARNING("Virtiofs tag symlink {} target may be truncated", LinkPath);
         return {};
     }
 

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -302,7 +302,6 @@ typedef enum _LX_MESSAGE_TYPE
     LxInitMessageAddVirtioFsDevice,
     LxInitMessageAddVirtioFsDeviceResponse,
     LxInitMessageRemountVirtioFsDevice,
-    LxInitMessageQueryVirtioFsDevice,
     LxInitMessageStartDistroInit,
     LxInitMessageCreateLoginSession,
     LxInitMessageStopPlan9Server,
@@ -1105,17 +1104,6 @@ typedef struct _LX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE
     PRETTY_PRINT(FIELD(Header), FIELD(Admin), STRING_FIELD(TagOffset));
 } LX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE, *PLX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE;
 
-typedef struct _LX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE
-{
-    static inline auto Type = LxInitMessageQueryVirtioFsDevice;
-    using TResponse = LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE;
-
-    MESSAGE_HEADER Header;
-    unsigned int TagOffset;
-    char Buffer[];
-
-    PRETTY_PRINT(FIELD(Header), STRING_FIELD(TagOffset));
-} LX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE, *PLX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE;
 //
 // The messages that can be sent to mini_init.
 //

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1072,9 +1072,10 @@ typedef struct _LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE
     MESSAGE_HEADER Header;
     int Result;
     unsigned int TagOffset;
+    unsigned int SourceOffset;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Result), STRING_FIELD(TagOffset));
+    PRETTY_PRINT(FIELD(Header), FIELD(Result), STRING_FIELD(TagOffset), STRING_FIELD(SourceOffset));
 } LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE, *PLX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE;
 
 typedef struct _LX_INIT_ADD_VIRTIOFS_SHARE_MESSAGE

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2128,7 +2128,7 @@ void WslCoreVm::WaitForPmemDeviceInVm(_In_ ULONG PmemId)
 }
 
 _Requires_lock_held_(m_guestDeviceLock)
-std::wstring WslCoreVm::AddVirtioFsShare(_In_ bool Admin, _In_ PCWSTR Path, _In_ PCWSTR Options, _In_opt_ HANDLE UserToken)
+std::pair<std::wstring, std::wstring> WslCoreVm::AddVirtioFsShare(_In_ bool Admin, _In_ PCWSTR Path, _In_ PCWSTR Options, _In_opt_ HANDLE UserToken)
 {
     WI_ASSERT(m_vmConfig.EnableVirtioFs);
 
@@ -2190,7 +2190,7 @@ std::wstring WslCoreVm::AddVirtioFsShare(_In_ bool Admin, _In_ PCWSTR Path, _In_
         TraceLoggingValue(created, "created"),
         TraceLoggingValue(m_virtioFsShares.size(), "shareCount"));
 
-    return tag;
+    return {tag, sharePath};
 }
 
 void WslCoreVm::OnCrash(_In_ LPCWSTR Details)
@@ -2607,8 +2607,7 @@ try
 
                         // Acquire the lock and attempt to add the device.
                         auto guestDeviceLock = m_guestDeviceLock.lock_exclusive();
-                        tag = AddVirtioFsShare(addShare->Admin, pathWide.c_str(), optionsWide.c_str());
-                        source = pathWide;
+                        std::tie(tag, source) = AddVirtioFsShare(addShare->Admin, pathWide.c_str(), optionsWide.c_str());
                     });
 
                     respondWithTag(tag, source, result);
@@ -2627,8 +2626,10 @@ try
                         const auto foundShare = FindVirtioFsShare(tagWide.c_str(), !remountShare->Admin);
                         THROW_HR_IF_MSG(E_UNEXPECTED, !foundShare.has_value(), "Unknown tag %ls", tagWide.c_str());
 
-                        source = foundShare->Path;
-                        newTag = AddVirtioFsShare(remountShare->Admin, foundShare->Path.c_str(), foundShare->OptionsString().c_str());
+                        std::tie(newTag, source) =
+                            AddVirtioFsShare(remountShare->Admin, foundShare->Path.c_str(), foundShare->OptionsString().c_str());
+
+                        WI_ASSERT(source == foundShare->Path);
                     });
 
                     respondWithTag(newTag, source, result);

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2628,24 +2628,6 @@ try
 
                     respondWithTag(newTag, result);
                 }
-                else if (message->MessageType == LxInitMessageQueryVirtioFsDevice)
-                {
-                    std::wstring newTag;
-                    const auto result = wil::ResultFromException([this, span, &newTag]() {
-                        const auto* query = gslhelpers::try_get_struct<LX_INIT_QUERY_VIRTIOFS_SHARE_MESSAGE>(span);
-                        THROW_HR_IF(E_UNEXPECTED, !query);
-
-                        const std::string tag = wsl::shared::string::FromSpan(span, query->TagOffset);
-                        const auto tagWide = wsl::shared::string::MultiByteToWide(tag);
-                        auto guestDeviceLock = m_guestDeviceLock.lock_exclusive();
-                        const auto foundShare = FindVirtioFsShare(tagWide.c_str());
-                        THROW_HR_IF_MSG(E_UNEXPECTED, !foundShare.has_value(), "Unknown tag %ls", tagWide.c_str());
-
-                        newTag = foundShare->Path;
-                    });
-
-                    respondWithTag(newTag, result);
-                }
                 else
                 {
                     THROW_HR_MSG(E_UNEXPECTED, "Unexpected MessageType %d", message->MessageType);

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2581,12 +2581,13 @@ try
                     return;
                 }
 
-                auto respondWithTag = [&](const std::wstring& tag, HRESULT result) {
+                auto respondWithTag = [&](const std::wstring& tag, const std::wstring& source, HRESULT result) {
                     // Respond to the guest with the tag that should be used to mount the device.
 
                     wsl::shared::MessageWriter<LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE> response(LxInitMessageAddVirtioFsDeviceResponse);
                     response->Result = SUCCEEDED(result) ? 0 : EINVAL; // TODO: Improved HRESULT -> errno mapping.
                     response.WriteString(response->TagOffset, tag);
+                    response.WriteString(response->SourceOffset, source);
 
                     channel.SendMessage<LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE>(response.Span());
                 };
@@ -2594,7 +2595,8 @@ try
                 if (message->MessageType == LxInitMessageAddVirtioFsDevice)
                 {
                     std::wstring tag;
-                    const auto result = wil::ResultFromException([this, span, &tag]() {
+                    std::wstring source;
+                    const auto result = wil::ResultFromException([this, span, &tag, &source]() {
                         const auto* addShare = gslhelpers::try_get_struct<LX_INIT_ADD_VIRTIOFS_SHARE_MESSAGE>(span);
                         THROW_HR_IF(E_UNEXPECTED, !addShare);
 
@@ -2606,14 +2608,16 @@ try
                         // Acquire the lock and attempt to add the device.
                         auto guestDeviceLock = m_guestDeviceLock.lock_exclusive();
                         tag = AddVirtioFsShare(addShare->Admin, pathWide.c_str(), optionsWide.c_str());
+                        source = pathWide;
                     });
 
-                    respondWithTag(tag, result);
+                    respondWithTag(tag, source, result);
                 }
                 else if (message->MessageType == LxInitMessageRemountVirtioFsDevice)
                 {
                     std::wstring newTag;
-                    const auto result = wil::ResultFromException([this, span, &newTag]() {
+                    std::wstring source;
+                    const auto result = wil::ResultFromException([this, span, &newTag, &source]() {
                         const auto* remountShare = gslhelpers::try_get_struct<LX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE>(span);
                         THROW_HR_IF(E_UNEXPECTED, !remountShare);
 
@@ -2623,10 +2627,11 @@ try
                         const auto foundShare = FindVirtioFsShare(tagWide.c_str(), !remountShare->Admin);
                         THROW_HR_IF_MSG(E_UNEXPECTED, !foundShare.has_value(), "Unknown tag %ls", tagWide.c_str());
 
+                        source = foundShare->Path;
                         newTag = AddVirtioFsShare(remountShare->Admin, foundShare->Path.c_str(), foundShare->OptionsString().c_str());
                     });
 
-                    respondWithTag(newTag, result);
+                    respondWithTag(newTag, source, result);
                 }
                 else
                 {

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -183,7 +183,7 @@ private:
     void AddPlan9Share(_In_ PCWSTR AccessName, _In_ PCWSTR Path, _In_ UINT32 Port, _In_ wsl::windows::common::hcs::Plan9ShareFlags Flags, _In_ HANDLE UserToken, _In_ PCWSTR VirtIoTag);
 
     _Requires_lock_held_(m_guestDeviceLock)
-    std::wstring AddVirtioFsShare(_In_ bool Admin, _In_ PCWSTR Path, _In_ PCWSTR Options, _In_opt_ HANDLE UserToken = nullptr);
+    std::pair<std::wstring, std::wstring> AddVirtioFsShare(_In_ bool Admin, _In_ PCWSTR Path, _In_ PCWSTR Options, _In_opt_ HANDLE UserToken = nullptr);
 
     _Requires_lock_held_(m_lock)
     ULONG AttachDiskLockHeld(_In_ PCWSTR Disk, _In_ DiskType Type, _In_ MountFlags Flags, _In_ std::optional<ULONG> Lun, _In_ bool IsUserDisk, _In_ HANDLE UserToken);


### PR DESCRIPTION
This avoids a call back to the service and will make it easier to do virtiofs to windows directory mapping. There is an upcoming change to the Linux plan9 server that will use this information to present drvfs / plan9 / virtiofs shares as symlinks so the Windows client can traverse them (current we return access denied in this case).