### PR TITLE
virtio networking: pass gateway MAC address to virtio net device

### DIFF
--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -172,32 +172,20 @@ try
     // Query current networking information before acquiring the lock.
     auto networkSettings = GetHostEndpointSettings();
 
-    // TODO: Determine gateway MAC address
     std::wstring device_options;
-    auto client_ip = networkSettings->PreferredIpAddress.AddressString;
-    if (!client_ip.empty())
-    {
-        device_options += L"client_ip=" + client_ip;
-    }
-
-    if (!networkSettings->MacAddress.empty())
-    {
-        if (!device_options.empty())
+    auto appendOption = [&device_options](std::wstring_view key, std::wstring_view value) {
+        if (!value.empty())
         {
-            device_options += L';';
+            std::format_to(std::back_inserter(device_options), L"{}{}={}", device_options.empty() ? L"" : L";", key, value);
         }
-        device_options += L"client_mac=" + networkSettings->MacAddress;
-    }
+    };
+
+    appendOption(L"client_ip", networkSettings->PreferredIpAddress.AddressString);
+    appendOption(L"client_mac", networkSettings->MacAddress);
 
     std::wstring default_route = networkSettings->GetBestGatewayAddressString();
-    if (!default_route.empty())
-    {
-        if (!device_options.empty())
-        {
-            device_options += L';';
-        }
-        device_options += L"gateway_ip=" + default_route;
-    }
+    appendOption(L"gateway_ip", default_route);
+    appendOption(L"gateway_mac", networkSettings->GetBestGatewayMacAddress());
 
     networking::DnsInfo currentDns{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))

--- a/src/windows/common/WslCoreNetworkEndpointSettings.cpp
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.cpp
@@ -94,3 +94,38 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
     return std::make_shared<NetworkSettings>(
         bestInterface->NetworkGuid, address, route, macAddress, bestInterface->IfIndex, bestInterface->IfType);
 }
+
+std::wstring wsl::core::networking::NetworkSettings::GetBestGatewayMacAddress() const
+{
+    auto gatewayAddress = GetBestGatewayAddress();
+    if (gatewayAddress.si_family != AF_INET)
+    {
+        return {};
+    }
+
+    MIB_IPNET_ROW2 ipNetRow{};
+    ipNetRow.Address = gatewayAddress;
+    ipNetRow.InterfaceIndex = InterfaceIndex;
+
+    const auto result = ResolveIpNetEntry2(&ipNetRow, nullptr);
+    if (result != NO_ERROR)
+    {
+        LOG_HR_MSG(HRESULT_FROM_WIN32(result), "Failed to resolve gateway MAC address");
+        return {};
+    }
+
+    if (ipNetRow.PhysicalAddressLength != 6)
+    {
+        return {};
+    }
+
+    return wsl::shared::string::FormatMacAddress(
+        wsl::shared::string::MacAddress{
+            ipNetRow.PhysicalAddress[0],
+            ipNetRow.PhysicalAddress[1],
+            ipNetRow.PhysicalAddress[2],
+            ipNetRow.PhysicalAddress[3],
+            ipNetRow.PhysicalAddress[4],
+            ipNetRow.PhysicalAddress[5]},
+        L'-');
+}

--- a/src/windows/common/WslCoreNetworkEndpointSettings.h
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.h
@@ -318,6 +318,8 @@ struct NetworkSettings
         return {};
     }
 
+    std::wstring GetBestGatewayMacAddress() const;
+
     std::wstring IpAddressesString() const
     {
         return std::accumulate(std::begin(IpAddresses), std::end(IpAddresses), std::wstring{}, [](const std::wstring& prev, const auto& addr) {


### PR DESCRIPTION
Use ResolveIpNetEntry2 to look up the host gateway's MAC address and pass it as the gateway_mac device option to the virtio net adapter. This allows the guest to see the real gateway MAC instead of the default hard-codedaddress.