### PR TITLE
test: enable virtiofs tests and enable WSLG during testing

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1450,8 +1450,6 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         return value;
     };
 
-    // TODO: Reset guiApplications to true by default once the virtio hang is solved.
-
     std::wstring newConfig =
         L"[wsl2]\n"
         L"crashDumpFolder=" +
@@ -1464,7 +1462,7 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         EscapePath(kernelLogs) +
         L"\n"
         L"telemetry=false\n" +
-        boolOptionToString(L"safeMode", Default.safeMode, false) + boolOptionToString(L"guiApplications", Default.guiApplications, false) +
+        boolOptionToString(L"safeMode", Default.safeMode, false) + boolOptionToString(L"guiApplications", Default.guiApplications, true) +
         L"earlyBootLogging=false\n" + networkingModeToString(Default.networkingMode) + drvFsModeToString(Default.drvFsMode);
 
     if (Default.kernel.has_value())

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -1341,12 +1341,10 @@ class WSL1 : public DrvFsTests
 
 WSL2_DRVFS_TEST_CLASS(Plan9);
 
+WSL2_DRVFS_TEST_CLASS(VirtioFs);
+
 // Disabled while an issue with the 6.1 Linux kernel causing disk corruption is investigated.
 // TODO: Enable again once the issue is resolved
 // WSL2_DRVFS_TEST_CLASS(Virtio9p);
-
-// Disabled because it causes too much noise.
-// TODO: Enable again once virtiofs is stable
-// WSL2_DRVFS_TEST_CLASS(VirtioFs);
 
 } // namespace DrvFsTests

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -271,6 +271,7 @@ class UnitTests
         };
 
         // Validate user sessions state with gui apps disabled.
+        WslConfigChange config(LxssGenerateTestConfig({.guiApplications = false}));
         {
             validateUserSession();
 
@@ -284,7 +285,7 @@ class UnitTests
 
         // Validate user sessions state with gui apps enabled.
         {
-            WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true}));
+            config.Update(LxssGenerateTestConfig({.guiApplications = true}));
 
             validateUserSession();
             auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"--user {} echo $DISPLAY", LXSST_TEST_USERNAME));


### PR DESCRIPTION
This change enables more virtio related testcases. This should help validate if the virtio queue corruption has been resolved by either a kernel or devicehost update.