### PR TITLE
SDK verb-noun and error string update

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -253,7 +253,7 @@ try
         *session = reinterpret_cast<WslcSession>(result.release());
     }
 
-    return S_OK;
+    return hr;
 }
 CATCH_RETURN();
 

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -144,7 +144,7 @@ void EnsureAbsolutePath(const std::filesystem::path& path, bool containerPath)
 } // namespace
 
 // SESSION DEFINITIONS
-STDAPI WslcSessionInitSettings(_In_ PCWSTR name, _In_ PCWSTR storagePath, _Out_ WslcSessionSettings* sessionSettings)
+STDAPI WslcInitSessionSettings(_In_ PCWSTR name, _In_ PCWSTR storagePath, _Out_ WslcSessionSettings* sessionSettings)
 try
 {
     RETURN_HR_IF_NULL(E_POINTER, name);
@@ -165,7 +165,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionSettingsSetCpuCount(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t cpuCount)
+STDAPI WslcSetSessionSettingsCpuCount(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t cpuCount)
 try
 {
     auto internalType = CheckAndGetInternalType(sessionSettings);
@@ -183,7 +183,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionSettingsSetMemory(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t memoryMb)
+STDAPI WslcSetSessionSettingsMemory(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t memoryMb)
 try
 {
     auto internalType = CheckAndGetInternalType(sessionSettings);
@@ -201,7 +201,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionCreate(_In_ WslcSessionSettings* sessionSettings, _Out_ WslcSession* session)
+STDAPI WslcCreateSession(_In_ WslcSessionSettings* sessionSettings, _Out_ WslcSession* session, _Outptr_opt_result_z_ PWSTR* errorMessage)
 try
 {
     RETURN_HR_IF_NULL(E_POINTER, session);
@@ -241,15 +241,23 @@ try
     //       Not clear how to map dynamic and fixed to values like `ext4` and `tmpfs`.
     // runtimeSettings.RootVhdTypeOverride = ConvertType(internalType->vhdRequirements.type);
 
-    RETURN_IF_FAILED(sessionManager->CreateSession(&runtimeSettings, WSLASessionFlagsNone, &result->session));
-    wsl::windows::common::security::ConfigureForCOMImpersonation(result->session.get());
+    HRESULT hr = sessionManager->CreateSession(&runtimeSettings, WSLASessionFlagsNone, &result->session);
 
-    *session = reinterpret_cast<WslcSession>(result.release());
+    if (FAILED_LOG(hr))
+    {
+        GetErrorInfoFromCOM(errorMessage);
+    }
+    else
+    {
+        wsl::windows::common::security::ConfigureForCOMImpersonation(result->session.get());
+        *session = reinterpret_cast<WslcSession>(result.release());
+    }
+
     return S_OK;
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionTerminate(_In_ WslcSession session)
+STDAPI WslcTerminateSession(_In_ WslcSession session)
 try
 {
     auto internalType = CheckAndGetInternalType(session);
@@ -259,7 +267,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionSettingsSetTimeout(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t timeoutMS)
+STDAPI WslcSetSessionSettingsTimeout(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t timeoutMS)
 try
 {
     auto internalType = CheckAndGetInternalType(sessionSettings);
@@ -286,7 +294,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionSettingsSetVHD(_In_ WslcSessionSettings* sessionSettings, _In_ const WslcVhdRequirements* vhdRequirements)
+STDAPI WslcSetSessionSettingsVHD(_In_ WslcSessionSettings* sessionSettings, _In_ const WslcVhdRequirements* vhdRequirements)
 try
 {
     auto internalType = CheckAndGetInternalType(sessionSettings);
@@ -322,7 +330,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionSettingsSetFeatureFlags(_In_ WslcSessionSettings* sessionSettings, _In_ WslcSessionFeatureFlags flags)
+STDAPI WslcSetSessionSettingsFeatureFlags(_In_ WslcSessionSettings* sessionSettings, _In_ WslcSessionFeatureFlags flags)
 try
 {
     auto internalType = CheckAndGetInternalType(sessionSettings);
@@ -333,7 +341,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionSettingsSetTerminateCallback(
+STDAPI WslcSetSessionSettingsTerminationCallback(
     _In_ WslcSessionSettings* sessionSettings, _In_opt_ WslcSessionTerminationCallback terminationCallback, _In_opt_ PVOID terminationContext)
 try
 {
@@ -347,7 +355,7 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSessionRelease(_In_ WslcSession session)
+STDAPI WslcReleaseSession(_In_ WslcSession session)
 try
 {
     auto internalType = CheckAndGetInternalTypeUniquePointer(session);

--- a/src/windows/WslcSDK/wslcsdk.def
+++ b/src/windows/WslcSDK/wslcsdk.def
@@ -2,25 +2,25 @@ LIBRARY wslcsdk
 
 EXPORTS
 
-WslcSessionInitSettings
+WslcInitSessionSettings
 WslcContainerInitSettings
 WslcProcessInitSettings
 
-WslcSessionCreate
+WslcCreateSession
 WslcContainerCreate
 
-WslcSessionRelease
+WslcReleaseSession
 WslcContainerRelease
 WslcProcessRelease
 
-WslcSessionSettingsSetFeatureFlags
-WslcSessionSettingsSetTerminateCallback
-WslcSessionSettingsSetCpuCount
-WslcSessionSettingsSetMemory
-WslcSessionSettingsSetTimeout
-WslcSessionSettingsSetVHD
+WslcSetSessionSettingsFeatureFlags
+WslcSetSessionSettingsTerminationCallback
+WslcSetSessionSettingsCpuCount
+WslcSetSessionSettingsMemory
+WslcSetSessionSettingsTimeout
+WslcSetSessionSettingsVHD
  
-WslcSessionTerminate
+WslcTerminateSession
 WslcSessionImagePull
 WslcSessionImageImport
 WslcSessionImageLoad

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -87,25 +87,25 @@ typedef enum WslcSessionTerminationReason
 
 typedef __callback void(CALLBACK* WslcSessionTerminationCallback)(_In_ WslcSessionTerminationReason reason, _In_opt_ PVOID context);
 
-STDAPI WslcSessionInitSettings(_In_ PCWSTR name, _In_ PCWSTR storagePath, _Out_ WslcSessionSettings* sessionSettings);
+STDAPI WslcInitSessionSettings(_In_ PCWSTR name, _In_ PCWSTR storagePath, _Out_ WslcSessionSettings* sessionSettings);
 
-STDAPI WslcSessionCreate(_In_ WslcSessionSettings* sessionSettings, _Out_ WslcSession* session);
+STDAPI WslcCreateSession(_In_ WslcSessionSettings* sessionSettings, _Out_ WslcSession* session, _Outptr_opt_result_z_ PWSTR* errorMessage);
 
 // OPTIONAL SESSION SETTINGS
-STDAPI WslcSessionSettingsSetCpuCount(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t cpuCount);
-STDAPI WslcSessionSettingsSetMemory(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t memoryMb);
-STDAPI WslcSessionSettingsSetTimeout(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t timeoutMS);
+STDAPI WslcSetSessionSettingsCpuCount(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t cpuCount);
+STDAPI WslcSetSessionSettingsMemory(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t memoryMb);
+STDAPI WslcSetSessionSettingsTimeout(_In_ WslcSessionSettings* sessionSettings, _In_ uint32_t timeoutMS);
 
-STDAPI WslcSessionSettingsSetVHD(_In_ WslcSessionSettings* sessionSettings, _In_ const WslcVhdRequirements* vhdRequirements);
+STDAPI WslcSetSessionSettingsVHD(_In_ WslcSessionSettings* sessionSettings, _In_ const WslcVhdRequirements* vhdRequirements);
 
-STDAPI WslcSessionSettingsSetFeatureFlags(_In_ WslcSessionSettings* sessionSettings, _In_ WslcSessionFeatureFlags flags);
+STDAPI WslcSetSessionSettingsFeatureFlags(_In_ WslcSessionSettings* sessionSettings, _In_ WslcSessionFeatureFlags flags);
 
 // Pass in Null for callback to clear the termination callback
-STDAPI WslcSessionSettingsSetTerminateCallback(
+STDAPI WslcSetSessionSettingsTerminationCallback(
     _In_ WslcSessionSettings* sessionSettings, _In_opt_ WslcSessionTerminationCallback terminationCallback, _In_opt_ PVOID terminationContext);
 
-STDAPI WslcSessionTerminate(_In_ WslcSession session);
-STDAPI WslcSessionRelease(_In_ WslcSession session);
+STDAPI WslcTerminateSession(_In_ WslcSession session);
+STDAPI WslcReleaseSession(_In_ WslcSession session);
 
 // CONTAINER DEFINITIONS
 

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -32,8 +32,8 @@ void CloseSession(WslcSession session)
 {
     if (session)
     {
-        WslcSessionTerminate(session);
-        WslcSessionRelease(session);
+        WslcTerminateSession(session);
+        WslcReleaseSession(session);
     }
 }
 
@@ -187,17 +187,17 @@ class WslcSdkTests
 
         // Build session settings using the WSLC SDK.
         WslcSessionSettings sessionSettings;
-        VERIFY_SUCCEEDED(WslcSessionInitSettings(c_testSessionName, m_storagePath.c_str(), &sessionSettings));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetCpuCount(&sessionSettings, 4));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetMemory(&sessionSettings, 2048));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetTimeout(&sessionSettings, 30 * 1000));
+        VERIFY_SUCCEEDED(WslcInitSessionSettings(c_testSessionName, m_storagePath.c_str(), &sessionSettings));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsCpuCount(&sessionSettings, 4));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsMemory(&sessionSettings, 2048));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsTimeout(&sessionSettings, 30 * 1000));
 
         WslcVhdRequirements vhdReqs{};
         vhdReqs.sizeInBytes = 4096ull * 1024 * 1024; // 4 GB
         vhdReqs.type = WSLC_VHD_TYPE_DYNAMIC;
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetVHD(&sessionSettings, &vhdReqs));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsVHD(&sessionSettings, &vhdReqs));
 
-        VERIFY_SUCCEEDED(WslcSessionCreate(&sessionSettings, &m_defaultSession));
+        VERIFY_SUCCEEDED(WslcCreateSession(&sessionSettings, &m_defaultSession, nullptr));
 
         // Pull images required by the tests (no-op if already present).
         for (const char* image : {"debian:latest", "python:3.12-alpine"})
@@ -212,8 +212,8 @@ class WslcSdkTests
     {
         if (m_defaultSession)
         {
-            WslcSessionTerminate(m_defaultSession);
-            WslcSessionRelease(m_defaultSession);
+            WslcTerminateSession(m_defaultSession);
+            WslcReleaseSession(m_defaultSession);
             m_defaultSession = nullptr;
         }
 
@@ -242,26 +242,26 @@ class WslcSdkTests
         std::filesystem::path extraStorage = m_storagePath / "wslc-extra-session-storage";
 
         WslcSessionSettings sessionSettings;
-        VERIFY_SUCCEEDED(WslcSessionInitSettings(L"wslc-extra-session", extraStorage.c_str(), &sessionSettings));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetCpuCount(&sessionSettings, 2));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetMemory(&sessionSettings, 1024));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetTimeout(&sessionSettings, 30 * 1000));
+        VERIFY_SUCCEEDED(WslcInitSessionSettings(L"wslc-extra-session", extraStorage.c_str(), &sessionSettings));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsCpuCount(&sessionSettings, 2));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsMemory(&sessionSettings, 1024));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsTimeout(&sessionSettings, 30 * 1000));
 
         WslcVhdRequirements vhdReqs{};
         vhdReqs.sizeInBytes = 1024ull * 1024 * 1024; // 1 GB
         vhdReqs.type = WSLC_VHD_TYPE_DYNAMIC;
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetVHD(&sessionSettings, &vhdReqs));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsVHD(&sessionSettings, &vhdReqs));
 
         UniqueSession session;
-        VERIFY_SUCCEEDED(WslcSessionCreate(&sessionSettings, &session));
+        VERIFY_SUCCEEDED(WslcCreateSession(&sessionSettings, &session, nullptr));
         VERIFY_IS_NOT_NULL(session.get());
 
         // Null output pointer must fail.
-        VERIFY_ARE_EQUAL(WslcSessionCreate(&sessionSettings, nullptr), E_POINTER);
+        VERIFY_ARE_EQUAL(WslcCreateSession(&sessionSettings, nullptr, nullptr), E_POINTER);
 
         // Null settings pointer must fail.
         UniqueSession session2;
-        VERIFY_ARE_EQUAL(WslcSessionCreate(nullptr, &session2), E_POINTER);
+        VERIFY_ARE_EQUAL(WslcCreateSession(nullptr, &session2, nullptr), E_POINTER);
     }
 
     TEST_METHOD(TerminationCallbackViaTerminate)
@@ -278,15 +278,15 @@ class WslcSdkTests
         std::filesystem::path extraStorage = m_storagePath / "wslc-termcb-term-storage";
 
         WslcSessionSettings sessionSettings;
-        VERIFY_SUCCEEDED(WslcSessionInitSettings(L"wslc-termcb-term-test", extraStorage.c_str(), &sessionSettings));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetTimeout(&sessionSettings, 30 * 1000));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetTerminateCallback(&sessionSettings, callback, &promise));
+        VERIFY_SUCCEEDED(WslcInitSessionSettings(L"wslc-termcb-term-test", extraStorage.c_str(), &sessionSettings));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsTimeout(&sessionSettings, 30 * 1000));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsTerminationCallback(&sessionSettings, callback, &promise));
 
         UniqueSession session;
-        VERIFY_SUCCEEDED(WslcSessionCreate(&sessionSettings, &session));
+        VERIFY_SUCCEEDED(WslcCreateSession(&sessionSettings, &session, nullptr));
 
         // Terminating the session should trigger a graceful shutdown and fire the callback.
-        VERIFY_SUCCEEDED(WslcSessionTerminate(session.get()));
+        VERIFY_SUCCEEDED(WslcTerminateSession(session.get()));
 
         auto future = promise.get_future();
         VERIFY_ARE_EQUAL(future.wait_for(std::chrono::seconds(30)), std::future_status::ready);
@@ -307,15 +307,15 @@ class WslcSdkTests
         std::filesystem::path extraStorage = m_storagePath / "wslc-termcb-release-storage";
 
         WslcSessionSettings sessionSettings;
-        VERIFY_SUCCEEDED(WslcSessionInitSettings(L"wslc-termcb-release-test", extraStorage.c_str(), &sessionSettings));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetTimeout(&sessionSettings, 30 * 1000));
-        VERIFY_SUCCEEDED(WslcSessionSettingsSetTerminateCallback(&sessionSettings, callback, &promise));
+        VERIFY_SUCCEEDED(WslcInitSessionSettings(L"wslc-termcb-release-test", extraStorage.c_str(), &sessionSettings));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsTimeout(&sessionSettings, 30 * 1000));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsTerminationCallback(&sessionSettings, callback, &promise));
 
         UniqueSession session;
-        VERIFY_SUCCEEDED(WslcSessionCreate(&sessionSettings, &session));
+        VERIFY_SUCCEEDED(WslcCreateSession(&sessionSettings, &session, nullptr));
 
         // Releasing the session should trigger a graceful shutdown and fire the callback.
-        VERIFY_SUCCEEDED(WslcSessionRelease(session.get()));
+        VERIFY_SUCCEEDED(WslcReleaseSession(session.get()));
         // Calling WslcSessionRelease will destroy the session
         session.release();
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changes the SDK APIs to use verb-noun format and adds error strings.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Update the SDK APIs to use verb-noun arrangement based on API review feedback.  Add error string output to appropriate APIs. **Note that this change is only to the primary session management to start. With approval of the format I will broaden it to all APIs.**

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
