### PR TITLE
wsla: remove support for using pmem-backed VHDs during boot

### DIFF
--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1543,7 +1543,6 @@ int WslaShell(_In_ std::wstring_view commandLine)
     parser.AddArgument(rootVhdOverride, L"--vhd");
     parser.AddArgument(Utf8String(shell), L"--shell");
     parser.AddArgument(SetFlag<WslaFeatureFlagsDnsTunneling>(sessionSettings.FeatureFlags), L"--dns-tunneling");
-    parser.AddArgument(SetFlag<WslaFeatureFlagsPmemVhds>(sessionSettings.FeatureFlags), L"--pmem-vhds");
     parser.AddArgument(SetFlag<WslaFeatureFlagsVirtioFs>(sessionSettings.FeatureFlags), L"--virtiofs");
     parser.AddArgument(Integer(sessionSettings.MemoryMb), L"--memory");
     parser.AddArgument(Integer(sessionSettings.CpuCount), L"--cpu");

--- a/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
+++ b/src/windows/wslaservice/exe/HcsVirtualMachine.cpp
@@ -189,43 +189,22 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLASessionSettings* Settings)
 
     // Setup boot VHDs
     hcs::Scsi scsiController{};
-    if (!FeatureEnabled(WslaFeatureFlagsPmemVhds))
-    {
-        auto attachScsiDisk = [&](PCWSTR path) {
-            const ULONG lun = AllocateLun();
-            hcs::Attachment disk{};
-            disk.Type = hcs::AttachmentType::VirtualDisk;
-            disk.Path = path;
-            disk.ReadOnly = true;
-            disk.SupportCompressedVolumes = true;
-            disk.AlwaysAllowSparseFiles = true;
-            disk.SupportEncryptedFiles = true;
-            scsiController.Attachments[std::to_string(lun)] = std::move(disk);
-            DiskInfo diskInfo{path};
-            m_attachedDisks.emplace(lun, std::move(diskInfo));
-        };
+    auto attachScsiDisk = [&](PCWSTR path) {
+        const ULONG lun = AllocateLun();
+        hcs::Attachment disk{};
+        disk.Type = hcs::AttachmentType::VirtualDisk;
+        disk.Path = path;
+        disk.ReadOnly = true;
+        disk.SupportCompressedVolumes = true;
+        disk.AlwaysAllowSparseFiles = true;
+        disk.SupportEncryptedFiles = true;
+        scsiController.Attachments[std::to_string(lun)] = std::move(disk);
+        DiskInfo diskInfo{path};
+        m_attachedDisks.emplace(lun, std::move(diskInfo));
+    };
 
-        attachScsiDisk(rootVhdPath.c_str());
-        attachScsiDisk(kernelModulesPath.c_str());
-    }
-    else
-    {
-        hcs::VirtualPMemController pmemController{};
-        pmemController.Backing = hcs::VirtualPMemBackingType::Virtual;
-        ULONG nextDeviceId = 0;
-        auto attachPmemDisk = [&](PCWSTR path) {
-            auto deviceId = nextDeviceId++;
-            hcs::VirtualPMemDevice vhd{};
-            vhd.HostPath = path;
-            vhd.ReadOnly = true;
-            vhd.ImageFormat = hcs::VirtualPMemImageFormat::Vhd1;
-            pmemController.Devices[std::to_string(deviceId)] = std::move(vhd);
-        };
-
-        attachPmemDisk(rootVhdPath.c_str());
-        attachPmemDisk(kernelModulesPath.c_str());
-        vmSettings.Devices.VirtualPMem = std::move(pmemController);
-    }
+    attachScsiDisk(rootVhdPath.c_str());
+    attachScsiDisk(kernelModulesPath.c_str());
 
     vmSettings.Devices.Scsi["0"] = std::move(scsiController);
 

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -326,8 +326,7 @@ typedef enum _WSLAFeatureFlags
     WslaFeatureFlagsEarlyBootDmesg = 2,
     WslaFeatureFlagsGPU = 4,
     WslaFeatureFlagsVirtioFs = 8,
-    WslaFeatureFlagsPmemVhds = 16,
-    WslaFeatureFlagsDebug = 32,
+    WslaFeatureFlagsDebug = 16,
 } WSLAFeatureFlags;
 
 cpp_quote("DEFINE_ENUM_FLAG_OPERATORS(WSLAFeatureFlags);")

--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -121,31 +121,11 @@ WSLAVirtualMachine::~WSLAVirtualMachine()
 
 void WSLAVirtualMachine::ConfigureInitialMounts()
 {
-    // Get paths for root and modules VHDs
-    auto basePath = wslutil::GetBasePath();
+    // Determine device paths from guest
+    const auto rootDevice = GetVhdDevicePath(0);
+    const auto modulesDevice = GetVhdDevicePath(1);
 
-#ifdef WSL_KERNEL_MODULES_PATH
-    auto kernelModulesPath = std::filesystem::path(TEXT(WSL_KERNEL_MODULES_PATH));
-#else
-    auto kernelModulesPath = basePath / L"tools" / L"modules.vhd";
-#endif
-
-    // Determine device paths based on whether pmem VHDs are used
-    std::string rootDevice;
-    std::string modulesDevice;
-
-    if (!FeatureEnabled(WslaFeatureFlagsPmemVhds))
-    {
-        // SCSI attached disks - query device paths from guest
-        rootDevice = GetVhdDevicePath(0);
-        modulesDevice = GetVhdDevicePath(1);
-    }
-    else
-    {
-        // PMEM devices - use known device paths
-        rootDevice = "/dev/pmem0";
-        modulesDevice = "/dev/pmem1";
-    }
+    WI_ASSERT(rootDevice == "/dev/sda" && modulesDevice == "/dev/sdb");
 
     // Mount root filesystem with overlay
     Mount(m_initChannel, rootDevice.c_str(), "/mnt", m_rootVhdType.c_str(), "ro", WSLA_MOUNT::Chroot | WSLA_MOUNT::OverlayFs);

--- a/src/windows/wslasession/WSLAVirtualMachine.h
+++ b/src/windows/wslasession/WSLAVirtualMachine.h
@@ -125,7 +125,6 @@ private:
 
     ConnectedSocket ConnectSocket(wsl::shared::SocketChannel& Channel, int32_t Fd);
     std::string GetVhdDevicePath(ULONG Lun);
-    static void OpenLinuxFile(wsl::shared::SocketChannel& Channel, const char* Path, uint32_t Flags, int32_t Fd);
     void LaunchPortRelay();
 
     HRESULT MountWindowsFolderImpl(_In_ LPCWSTR WindowsPath, _In_ LPCSTR LinuxPath, _In_ WSLAMountFlags Flags = WSLAMountFlagsNone);

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2128,48 +2128,6 @@ class WSLATests
         ExpectCommandResult(m_defaultSession.get(), {"/bin/sh", "-c", "lsmod | grep ^xsk_diag"}, 0);
     }
 
-    TEST_METHOD(PmemVhds)
-    {
-        WSL2_TEST_ONLY();
-
-        // TODO: Remove once test failure is fixed.
-        SKIP_TEST_UNSTABLE();
-
-        // Test with SCSI boot VHDs.
-        {
-            auto settings = GetDefaultSessionSettings(L"pmem-vhd-test");
-            WI_ClearFlag(settings.FeatureFlags, WslaFeatureFlagsPmemVhds);
-
-            auto createNewSession = WI_IsFlagSet(m_defaultSessionSettings.FeatureFlags, WslaFeatureFlagsPmemVhds);
-            auto session = createNewSession ? CreateSession(settings) : m_defaultSession;
-
-            // Validate that SCSI devices are present and PMEM devices are not.
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "test -b /dev/sda"}, 0);
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "test -b /dev/sdb"}, 0);
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "test -b /dev/pmem0"}, 1);
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "test -b /dev/pmem1"}, 1);
-
-            // Verify that the SCSI device is readable.
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "dd if=/dev/sda of=/dev/null bs=512 count=1 2>&1"}, 0);
-        }
-
-        // Test with PMEM boot VHDs enabled.
-        {
-            auto settings = GetDefaultSessionSettings(L"pmem-vhd-test");
-            WI_SetFlag(settings.FeatureFlags, WslaFeatureFlagsPmemVhds);
-
-            auto createNewSession = !WI_IsFlagSet(m_defaultSessionSettings.FeatureFlags, WslaFeatureFlagsPmemVhds);
-            auto session = createNewSession ? CreateSession(settings) : m_defaultSession;
-
-            // Validate that PMEM devices are present.
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "test -b /dev/pmem0"}, 0);
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "test -b /dev/pmem1"}, 0);
-
-            // Verify that the PMEM devices can be read from.
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "dd if=/dev/pmem0 of=/dev/null bs=512 count=1 2>&1"}, 0);
-        }
-    }
-
     TEST_METHOD(CreateRootNamespaceProcess)
     {
         WSL2_TEST_ONLY();


### PR DESCRIPTION
This change removes the pmem-based VHD support from WSLA. This was initially added to experiment with potential runtime memory savings, and from testing I've determined it's not worth it right now. In the future we may add support for our virtio-pmem which supports DAX.