### PR TITLE
Update chunk reader to better handle split buffers

### DIFF
--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -1365,9 +1365,9 @@ void HTTPChunkBasedReadHandle::OnRead(const gsl::span<char>& Input)
     {
         if (PendingChunkSize == 0)
         {
-            if (buffer.front() == '\r' || buffer.front() == '\n')
+            // Consume CRLF's between chunks.
+            if (PendingBuffer.empty() && (buffer.front() == '\r' || buffer.front() == '\n'))
             {
-                // Consume CRLF's between chunks.
                 advance(1);
                 continue;
             }
@@ -1381,9 +1381,11 @@ void HTTPChunkBasedReadHandle::OnRead(const gsl::span<char>& Input)
                 // Incomplete size header, buffer until next read.
                 break;
             }
+            // Advance beyond the LF
+            advance(end - buffer.begin() + 1);
 
-            THROW_HR_IF_MSG(E_INVALIDARG, end - buffer.begin() < 2, "Malformed chunk header: %hs", PendingBuffer.c_str());
-            PendingBuffer.erase(PendingBuffer.end() - 1, PendingBuffer.end()); // Remove CRLF.
+            THROW_HR_IF_MSG(E_INVALIDARG, PendingBuffer.size() < 2, "Malformed chunk header: %hs", PendingBuffer.c_str());
+            PendingBuffer.erase(PendingBuffer.end() - 1, PendingBuffer.end()); // Remove CR.
 
 #ifdef WSLA_HTTP_DEBUG
 
@@ -1403,7 +1405,6 @@ void HTTPChunkBasedReadHandle::OnRead(const gsl::span<char>& Input)
             }
 
             ExpectHeader = false;
-            advance(PendingBuffer.size() + 2);
             PendingBuffer.clear();
         }
         else

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -1384,7 +1384,11 @@ void HTTPChunkBasedReadHandle::OnRead(const gsl::span<char>& Input)
             // Advance beyond the LF
             advance(end - buffer.begin() + 1);
 
-            THROW_HR_IF_MSG(E_INVALIDARG, PendingBuffer.size() < 2 || PendingBuffer.back() != '\r', "Malformed chunk header: %hs", PendingBuffer.c_str());
+            THROW_HR_IF_MSG(
+                E_INVALIDARG,
+                PendingBuffer.size() < 2 || PendingBuffer.back() != '\r',
+                "Malformed chunk header: %hs",
+                PendingBuffer.c_str());
             PendingBuffer.erase(PendingBuffer.end() - 1, PendingBuffer.end()); // Remove CR.
 
 #ifdef WSLA_HTTP_DEBUG

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -1384,7 +1384,7 @@ void HTTPChunkBasedReadHandle::OnRead(const gsl::span<char>& Input)
             // Advance beyond the LF
             advance(end - buffer.begin() + 1);
 
-            THROW_HR_IF_MSG(E_INVALIDARG, PendingBuffer.size() < 2, "Malformed chunk header: %hs", PendingBuffer.c_str());
+            THROW_HR_IF_MSG(E_INVALIDARG, PendingBuffer.size() < 2 || PendingBuffer.back() != '\r', "Malformed chunk header: %hs", PendingBuffer.c_str());
             PendingBuffer.erase(PendingBuffer.end() - 1, PendingBuffer.end()); // Remove CR.
 
 #ifdef WSLA_HTTP_DEBUG

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -4052,6 +4052,7 @@ class WSLATests
         };
 
         runTest("3\r\nfoo\r\n3\r\nbar", {"foo", "bar"});
+        runTest("3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n", {"foo", "bar"});
         runTest("1\r\na\r\n\r\n", {"a"});
 
         runTest("c\r\nlf\nin\r\nchunk\r\n3\r\nEOF", {"lf\nin\r\nchunk", "EOF"});
@@ -4065,6 +4066,73 @@ class WSLATests
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4invalid\nnocr", {}); }), E_INVALIDARG);
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4\rinvalid", {}); }), E_INVALIDARG);
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4\rinvalid\n", {}); }), E_INVALIDARG);
+    }
+
+    TEST_METHOD(HTTPChunkReaderSplitReads)
+    {
+        auto runTest = [](const std::vector<std::string>& Data, const std::vector<std::string>& ExpectedChunk) {
+            std::vector<std::string> chunks;
+            auto onData = [&](const gsl::span<char>& data) { chunks.emplace_back(data.data(), data.size()); };
+
+            auto reader = std::make_unique<wsl::windows::common::relay::HTTPChunkBasedReadHandle>(
+                wsl::windows::common::relay::HandleWrapper{nullptr}, std::move(onData));
+
+            std::string allData;
+            for (const auto& datum : Data)
+            {
+                size_t currentSize = allData.size();
+                allData.append(datum);
+                reader->OnRead(gsl::span<char>{&allData[currentSize], datum.size()});
+            }
+
+            // Final 0 byte read
+            reader->OnRead(gsl::span<char>{nullptr, static_cast<size_t>(0)});
+
+            for (size_t i = 0; i < ExpectedChunk.size(); i++)
+            {
+                if (i >= chunks.size())
+                {
+                    LogError(
+                        "Input: '%hs': Chunk %zu is missing. Expected: '%hs'",
+                        EscapeString(allData).c_str(),
+                        i,
+                        EscapeString(ExpectedChunk[i]).c_str());
+                    VERIFY_FAIL();
+                }
+                else if (ExpectedChunk[i] != chunks[i])
+                {
+                    LogError(
+
+                        "Input: '%hs': Chunk %zu does not match expected value. Expected: '%hs', Actual: '%hs'",
+                        EscapeString(allData).c_str(),
+                        i,
+                        EscapeString(ExpectedChunk[i]).c_str(),
+                        EscapeString(chunks[i]).c_str());
+                    VERIFY_FAIL();
+                }
+            }
+
+            if (ExpectedChunk.size() != chunks.size())
+            {
+                LogError(
+                    "Input: '%hs', Number of chunks do not match. Expected: %zu, Actual: %zu",
+                    EscapeString(allData).c_str(),
+                    ExpectedChunk.size(),
+                    chunks.size());
+                VERIFY_FAIL();
+            }
+
+            WEX::Logging::Log::Comment(EscapeString(allData).c_str(), "HTTPChunkReaderSplitReads success");
+        };
+
+        runTest({"3\r\nfo", "o\r\n3\r\nbar"}, {"foo", "bar"});
+        runTest({"1\r\n", "a\r\n\r\n"}, {"a"});
+
+        runTest({"c\r\nlf\n", "in\r\nchunk\r\n3\r\nEOF"}, {"lf\nin\r\nchunk", "EOF"});
+        runTest({"15\r\n\r\nchunkstartingwithlf\r\n", "3\r\nEOF"}, {"\r\nchunkstartingwithlf", "EOF"});
+
+        runTest({"3", "\r\nfoo\r\n3\r\nbar"}, {"foo", "bar"});
+        runTest({"3\r\nfoo\r\n3\r\nbar\r\n0", "\r\n\r\n"}, {"foo", "bar"});
     }
 
     TEST_METHOD(DockerIORelay)

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -4063,6 +4063,7 @@ class WSLATests
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("Invalid\r\nInvalid", {}); }), E_INVALIDARG);
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4nolf", {}); }), E_INVALIDARG);
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4\nnocr", {}); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("12\nyeseighteenletters", {}); }), E_INVALIDARG);
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4invalid\nnocr", {}); }), E_INVALIDARG);
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4\rinvalid", {}); }), E_INVALIDARG);
         VERIFY_ARE_EQUAL(wil::ResultFromException([&]() { runTest("4\rinvalid\n", {}); }), E_INVALIDARG);
@@ -4122,7 +4123,7 @@ class WSLATests
                 VERIFY_FAIL();
             }
 
-            WEX::Logging::Log::Comment(EscapeString(allData).c_str(), "HTTPChunkReaderSplitReads success");
+            LogInfo("HTTPChunkReaderSplitReads success. Input: %hs", EscapeString(allData).c_str());
         };
 
         runTest({"3\r\nfo", "o\r\n3\r\nbar"}, {"foo", "bar"});


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Improve chunk reader's handling of split buffers.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Due to intermittent failures in the WSLC SDK tests, I ran one of them in a loop until it failed consistently with the ADO pipelines (`E_INVALIDARG` on a container create call).

The debugger showed the error happening at https://github.com/microsoft/WSL/blob/bdc53f6d41d5fba9ac5aae2fa2f4f0ac3b9f41b3/src/windows/common/relay.cpp#L1354

due to `ExpectHeader` being `true`.  The incoming `Input` was "empty", but fortunately the buffer it came from was used consistently, showing the previous inputs.  The `PendingBuffer` was just `0` (at the end of the read buffer), while the first four bytes of the read buffer were `\r\n\r\n`.  When combined, these correctly signal the end of the chunked HTTP response.  Due to the read split though, the chunk buffer read was waiting to complete the 0 size header read, but threw out all of the final buffer containing only `\r\n\r\n`.

This change:
1. Only skips the initial `\r` or `\n` when `PendingBuffer` is empty ("between chunks")
2. Advances the buffer based on the amount read this time, not based on the total size of `PendingBuffer`
3. Checks for an empty header based on `PendingBuffer` size instead of the amount read this time

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Added tests for split buffer reading in the chunk reader.