### PR TITLE
Fix null pointer dereference in ProcessExited log

### DIFF
--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2324,10 +2324,9 @@ void WslCoreVm::RegisterCallbacks(_In_ const std::function<void(ULONG)>& DistroE
                     if (header->MessageType == LxMiniInitMessageChildExit)
                     {
                         const auto* exitMessage = gslhelpers::try_get_struct<LX_MINI_INIT_CHILD_EXIT_MESSAGE>(message);
-                        WSL_LOG("ProcessExited", TraceLoggingValue(exitMessage->ChildPid, "pid"));
-
                         if (exitMessage)
                         {
+                            WSL_LOG("ProcessExited", TraceLoggingValue(exitMessage->ChildPid, "pid"));
                             exitCallback(exitMessage->ChildPid);
                         }
                     }


### PR DESCRIPTION
exitMessage is dereferenced in WSL_LOG before the null check. Move the log call inside the null-checked block.