### PR TITLE
Fix use-after-free: restore shared_from_this() in Dmesg thread

### DIFF
--- a/src/windows/common/Dmesg.cpp
+++ b/src/windows/common/Dmesg.cpp
@@ -72,13 +72,13 @@ std::pair<std::wstring, std::thread> DmesgCollector::StartDmesgThread(InputSourc
 
     THROW_LAST_ERROR_IF(!pipe);
 
-    auto workerThread = std::thread([this, Source, Pipe = std::move(pipe)]() {
+    auto workerThread = std::thread([Self = shared_from_this(), Source, Pipe = std::move(pipe)]() {
         try
         {
             wsl::windows::common::wslutil::SetThreadDescription(L"Dmesg");
 
             // When the pipe connects, start reading data.
-            wsl::windows::common::helpers::ConnectPipe(Pipe.get(), INFINITE, m_exitEvents);
+            wsl::windows::common::helpers::ConnectPipe(Pipe.get(), INFINITE, Self->m_exitEvents);
 
             std::vector<char> buffer(LX_RELAY_BUFFER_SIZE);
             const auto allBuffer = gsl::make_span(buffer);
@@ -89,7 +89,7 @@ std::pair<std::wstring, std::thread> DmesgCollector::StartDmesgThread(InputSourc
             {
                 overlappedEvent.ResetEvent();
                 const auto bytesRead = wsl::windows::common::relay::InterruptableRead(
-                    Pipe.get(), gslhelpers::convert_span<gsl::byte>(allBuffer), m_exitEvents, &overlapped);
+                    Pipe.get(), gslhelpers::convert_span<gsl::byte>(allBuffer), Self->m_exitEvents, &overlapped);
 
                 if (bytesRead == 0)
                 {
@@ -97,7 +97,7 @@ std::pair<std::wstring, std::thread> DmesgCollector::StartDmesgThread(InputSourc
                 }
 
                 auto validBuffer = allBuffer.subspan(0, bytesRead);
-                ProcessInput(Source, validBuffer);
+                Self->ProcessInput(Source, validBuffer);
             }
         }
         catch (...)


### PR DESCRIPTION
The worker thread captures raw 'this' but can outlive the DmesgCollector object. Restore shared_from_this() to extend the object lifetime.
