### PR TITLE
Add bounds check for WaitForMultipleObjects result in port relay

### DIFF
--- a/src/windows/wslrelay/localhost.cpp
+++ b/src/windows/wslrelay/localhost.cpp
@@ -488,11 +488,15 @@ void AcceptThread(std::vector<std::shared_ptr<PortRelay>>& ports, const GUID& Vm
             break;
         }
 
+        // Validate result is within expected range (accounts for exit event at index 0)
+        const DWORD portIndex = result - 1;
+        THROW_HR_IF(E_UNEXPECTED, portIndex >= static_cast<DWORD>(ports.size()));
+
         // Otherwise complete the accept and start a relay
         try
         {
-            ports[result - 1]->CompleteAccept();
-            ports[result - 1]->LaunchRelay(VmId);
+            ports[portIndex]->CompleteAccept();
+            ports[portIndex]->LaunchRelay(VmId);
         }
         CATCH_LOG();
     }


### PR DESCRIPTION
WaitForMultipleObjects can return WAIT_ABANDONED_0+n or other unexpected values. Validate the index is within the ports vector before access.
