### PR TITLE
wslc: fix size_t underflow in TablePrinter::PrintRow

### DIFF
--- a/src/windows/wslc/core/TablePrinter.h
+++ b/src/windows/wslc/core/TablePrinter.h
@@ -88,7 +88,7 @@ private:
         ss << "|";
         for (size_t i = 0; i < row.size(); ++i)
         {
-            ss << " " << row[i] << std::wstring(m_widths[i] - row[i].size(), ' ') << " |";
+            ss << " " << row[i] << std::wstring((m_widths[i] > row[i].size()) ? (m_widths[i] - row[i].size()) : 0, ' ') << " |";
         }
         wsl::windows::common::wslutil::PrintMessage(ss.str(), stdout);
     }


### PR DESCRIPTION
If row[i].size() > m_widths[i], the unsigned subtraction wraps to a huge value, causing std::wstring to allocate enormous memory or crash. Clamp the padding to zero when the row value exceeds the column width.
