### PR TITLE
wsla: fix use-after-free in HandleMessageImpl detached thread

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -403,7 +403,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_FORK& Mes
     std::promise<pid_t> childPid;
 
     {
-        auto childLogic = [ListenSocketFd = ListenSocket.get(), &SocketAddress, &Channel, &Message, &childPid]() mutable {
+        auto childLogic = [ListenSocketFd = ListenSocket.get(), SocketAddress, &Channel, &Message, &childPid]() mutable {
             wil::unique_fd ListenSocket;
 
             // Close parent channel


### PR DESCRIPTION
Capture SocketAddress by value instead of by reference in the childLogic lambda. When ForkType == Thread, the detached thread calls childPid.set_value() before using SocketAddress on the next line. Once set_value unblocks the parent, HandleMessageImpl can return and destroy the stack-local SocketAddress before the thread reads it.
