### PR TITLE
wsla: fix use-after-free dangling pointer in m_trackedProcesses

### DIFF
--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -511,13 +511,14 @@ Microsoft::WRL::ComPtr<WSLAProcess> WSLAVirtualMachine::CreateLinuxProcessImpl(
 
     auto io = std::make_unique<VMProcessIO>(std::move(stdHandles));
     auto control = std::make_unique<VMProcessControl>(*this, pid, std::move(ttyControlHandle));
+    auto* controlPtr = control.get();
+
+    auto process = wil::MakeOrThrow<WSLAProcess>(std::move(control), std::move(io));
 
     {
         std::lock_guard lock{m_trackedProcessesLock};
-        m_trackedProcesses.emplace_back(control.get());
+        m_trackedProcesses.emplace_back(controlPtr);
     }
-
-    auto process = wil::MakeOrThrow<WSLAProcess>(std::move(control), std::move(io));
 
     setErrno(0);
 


### PR DESCRIPTION
Move emplace_back of raw VMProcessControl pointer to after MakeOrThrow succeeds. Previously, if MakeOrThrow threw (e.g., allocation failure), the unique_ptr<VMProcessControl> was destroyed while its raw pointer remained in m_trackedProcesses, leading to a use-after-free when WatchForExitedProcesses iterates the vector.
