### PR TITLE
 Track container creation time and display created timestamp in CLI

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -358,8 +358,9 @@ struct ContainerInfo
     std::map<std::string, std::string> Labels;
     std::vector<Port> Ports;
     ContainerState State{ContainerState::Unknown};
+    int64_t Created{};
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerInfo, Id, Names, Image, Labels, Ports, State);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerInfo, Id, Names, Image, Labels, Ports, State, Created);
 };
 
 struct BuildKitVertex

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -283,8 +283,6 @@ typedef struct _WSLAContainerEntry
     ULONGLONG StateChangedAt;
     ULONGLONG CreatedAt;
     WSLAContainerState State;
-
-    // TODO: Add creation timestamp and other fields that the command line tool might want to display.
 } WSLAContainerEntry;
 
 typedef enum _WSLAProcessState

--- a/src/windows/wslaservice/inc/wslaservice.idl
+++ b/src/windows/wslaservice/inc/wslaservice.idl
@@ -281,8 +281,8 @@ typedef struct _WSLAContainerEntry
     char Image[WSLA_MAX_IMAGE_NAME_LENGTH + 1];
     WSLAContainerId Id;
     ULONGLONG StateChangedAt;
+    ULONGLONG CreatedAt;
     WSLAContainerState State;
-
 
     // TODO: Add creation timestamp and other fields that the command line tool might want to display.
 } WSLAContainerEntry;

--- a/src/windows/wslasession/WSLAContainer.cpp
+++ b/src/windows/wslasession/WSLAContainer.cpp
@@ -397,6 +397,12 @@ void WSLAContainerImpl::GetStateChangedAt(ULONGLONG* Result)
     *Result = m_stateChangedAt;
 }
 
+void WSLAContainerImpl::GetCreatedAt(ULONGLONG* Result)
+{
+    auto lock = m_lock.lock_shared();
+    *Result = m_createdAt;
+}
+
 void WSLAContainerImpl::CopyTo(IWSLAContainer** Container) const
 {
     auto lock = m_lock.lock_shared();
@@ -1155,6 +1161,9 @@ std::unique_ptr<WSLAContainerImpl> WSLAContainerImpl::Open(
         DockerStateToWSLAState(dockerContainer.State),
         metadata.InitProcessFlags,
         metadata.Flags);
+
+    // Restore the creation timestamp from Docker list API data.
+    container->m_createdAt = static_cast<std::uint64_t>(dockerContainer.Created);
 
     // Restore the state change timestamp from Docker inspect data.
     try

--- a/src/windows/wslasession/WSLAContainer.h
+++ b/src/windows/wslasession/WSLAContainer.h
@@ -60,6 +60,7 @@ public:
     void Delete(WSLADeleteFlags Flags);
     void Export(ULONG TarHandle) const;
     void GetStateChangedAt(_Out_ ULONGLONG* StateChangedAt);
+    void GetCreatedAt(_Out_ ULONGLONG* CreatedAt);
     void GetState(_Out_ WSLAContainerState* State);
     void GetInitProcess(_Out_ IWSLAProcess** process) const;
     void Exec(_In_ const WSLAProcessOptions* Options, LPCSTR DetachKeys, _Out_ IWSLAProcess** Process);
@@ -133,6 +134,7 @@ private:
     wil::unique_event m_stoppedNotifiedEvent{wil::EventOptions::ManualReset};
     DockerHTTPClient& m_dockerClient;
     std::uint64_t m_stateChangedAt{static_cast<std::uint64_t>(std::time(nullptr))};
+    std::uint64_t m_createdAt{static_cast<std::uint64_t>(std::time(nullptr))};
     WSLAContainerState m_state = WslaContainerStateInvalid;
     WSLASession& m_wslaSession;
     WSLAVirtualMachine& m_virtualMachine;

--- a/src/windows/wslasession/WSLASession.cpp
+++ b/src/windows/wslasession/WSLASession.cpp
@@ -1118,6 +1118,7 @@ try
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Id, e->ID().c_str()) != 0);
         e->GetState(&output[index].State);
         e->GetStateChangedAt(&output[index].StateChangedAt);
+        e->GetCreatedAt(&output[index].CreatedAt);
         index++;
     }
 

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -62,7 +62,8 @@ struct ContainerInformation
     std::string Image;
     WSLAContainerState State;
     ULONGLONG StateChangedAt{};
+    ULONGLONG CreatedAt{};
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(ContainerInformation, Id, Name, Image, State, StateChangedAt);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(ContainerInformation, Id, Name, Image, State, StateChangedAt, CreatedAt);
 };
 } // namespace wsl::windows::wslc::models

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -101,7 +101,7 @@ static void StopInternal(IWSLAContainer& container, WSLASignal signal = WSLASign
     THROW_IF_FAILED(container.Stop(signal, timeout)); // TODO: Error message
 }
 
-static std::wstring FormatRelativeTime(ULONGLONG timestamp)
+std::wstring ContainerService::FormatRelativeTime(ULONGLONG timestamp)
 {
     constexpr LONGLONG SecondsPerMinute = std::chrono::duration_cast<std::chrono::seconds>(1min).count();
     constexpr LONGLONG SecondsPerHour = std::chrono::duration_cast<std::chrono::seconds>(1h).count();
@@ -198,11 +198,6 @@ std::wstring ContainerService::ContainerStateToString(WSLAContainerState state, 
     }
 
     return std::format(L"{} {}", stateString, FormatRelativeTime(stateChangedAt));
-}
-
-std::wstring ContainerService::ContainerCreatedAtToString(ULONGLONG createdAt)
-{
-    return FormatRelativeTime(createdAt);
 }
 
 int ContainerService::Run(Session& session, const std::string& image, ContainerOptions runOptions, IProgressCallback* callback)

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -101,6 +101,34 @@ static void StopInternal(IWSLAContainer& container, WSLASignal signal = WSLASign
     THROW_IF_FAILED(container.Stop(signal, timeout)); // TODO: Error message
 }
 
+static std::wstring FormatRelativeTime(ULONGLONG timestamp)
+{
+    constexpr LONGLONG SecondsPerMinute = std::chrono::duration_cast<std::chrono::seconds>(1min).count();
+    constexpr LONGLONG SecondsPerHour = std::chrono::duration_cast<std::chrono::seconds>(1h).count();
+    constexpr LONGLONG SecondsPerDay = std::chrono::duration_cast<std::chrono::seconds>(24h).count();
+
+    auto elapsed = static_cast<LONGLONG>(std::time(nullptr)) - static_cast<LONGLONG>(timestamp);
+    if (elapsed < 0)
+    {
+        elapsed = 0;
+    }
+
+    if (elapsed < SecondsPerMinute)
+    {
+        return std::format(L"{} seconds ago", elapsed);
+    }
+    else if (elapsed < SecondsPerHour)
+    {
+        return std::format(L"{} minutes ago", elapsed / SecondsPerMinute);
+    }
+    else if (elapsed < SecondsPerDay)
+    {
+        return std::format(L"{} hours ago", elapsed / SecondsPerHour);
+    }
+
+    return std::format(L"{} days ago", elapsed / SecondsPerDay);
+}
+
 int ContainerService::Attach(Session& session, const std::string& id)
 {
     wil::com_ptr<IWSLAContainer> container;
@@ -143,10 +171,6 @@ int ContainerService::Attach(Session& session, const std::string& id)
 
 std::wstring ContainerService::ContainerStateToString(WSLAContainerState state, ULONGLONG stateChangedAt)
 {
-    constexpr LONGLONG SecondsPerMinute = std::chrono::duration_cast<std::chrono::seconds>(1min).count();
-    constexpr LONGLONG SecondsPerHour = std::chrono::duration_cast<std::chrono::seconds>(1h).count();
-    constexpr LONGLONG SecondsPerDay = std::chrono::duration_cast<std::chrono::seconds>(24h).count();
-
     std::wstring stateString;
     switch (state)
     {
@@ -173,26 +197,12 @@ std::wstring ContainerService::ContainerStateToString(WSLAContainerState state, 
         return stateString;
     }
 
-    auto elapsed = static_cast<LONGLONG>(std::time(nullptr)) - static_cast<LONGLONG>(stateChangedAt);
-    if (elapsed < 0)
-    {
-        elapsed = 0;
-    }
+    return std::format(L"{} {}", stateString, FormatRelativeTime(stateChangedAt));
+}
 
-    if (elapsed < SecondsPerMinute)
-    {
-        return std::format(L"{} {} seconds ago", stateString, elapsed);
-    }
-    else if (elapsed < SecondsPerHour)
-    {
-        return std::format(L"{} {} minutes ago", stateString, elapsed / SecondsPerMinute);
-    }
-    else if (elapsed < SecondsPerDay)
-    {
-        return std::format(L"{} {} hours ago", stateString, elapsed / SecondsPerHour);
-    }
-
-    return std::format(L"{} {} days ago", stateString, elapsed / SecondsPerDay);
+std::wstring ContainerService::ContainerCreatedAtToString(ULONGLONG createdAt)
+{
+    return FormatRelativeTime(createdAt);
 }
 
 int ContainerService::Run(Session& session, const std::string& image, ContainerOptions runOptions, IProgressCallback* callback)
@@ -271,6 +281,7 @@ std::vector<ContainerInformation> ContainerService::List(Session& session)
         entry.State = current.State;
         entry.Id = current.Id;
         entry.StateChangedAt = current.StateChangedAt;
+        entry.CreatedAt = current.CreatedAt;
         result.emplace_back(std::move(entry));
     }
 

--- a/src/windows/wslc/services/ContainerService.h
+++ b/src/windows/wslc/services/ContainerService.h
@@ -19,7 +19,7 @@ namespace wsl::windows::wslc::services {
 struct ContainerService
 {
     static std::wstring ContainerStateToString(WSLAContainerState state, ULONGLONG stateChangedAt = 0);
-    static std::wstring ContainerCreatedAtToString(ULONGLONG createdAt);
+    static std::wstring FormatRelativeTime(ULONGLONG timestamp);
     static int Attach(models::Session& session, const std::string& id);
     static int Run(models::Session& session, const std::string& image, models::ContainerOptions options, IProgressCallback* callback);
     static models::CreateContainerResult Create(models::Session& session, const std::string& image, models::ContainerOptions options, IProgressCallback* callback);

--- a/src/windows/wslc/services/ContainerService.h
+++ b/src/windows/wslc/services/ContainerService.h
@@ -19,6 +19,7 @@ namespace wsl::windows::wslc::services {
 struct ContainerService
 {
     static std::wstring ContainerStateToString(WSLAContainerState state, ULONGLONG stateChangedAt = 0);
+    static std::wstring ContainerCreatedAtToString(ULONGLONG createdAt);
     static int Attach(models::Session& session, const std::string& id);
     static int Run(models::Session& session, const std::string& image, models::ContainerOptions options, IProgressCallback* callback);
     static models::CreateContainerResult Create(models::Session& session, const std::string& image, models::ContainerOptions options, IProgressCallback* callback);

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -145,7 +145,7 @@ void ListContainers(CLIExecutionContext& context)
                 MultiByteToWide(container.Id),
                 MultiByteToWide(container.Name),
                 MultiByteToWide(container.Image),
-                ContainerService::ContainerCreatedAtToString(container.CreatedAt),
+                ContainerService::FormatRelativeTime(container.CreatedAt),
                 ContainerService::ContainerStateToString(container.State, container.StateChangedAt),
             });
         }

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -138,13 +138,14 @@ void ListContainers(CLIExecutionContext& context)
     }
     case FormatType::Table:
     {
-        utils::TablePrinter tablePrinter({L"ID", L"NAME", L"IMAGE", L"STATUS"});
+        utils::TablePrinter tablePrinter({L"ID", L"NAME", L"IMAGE", L"CREATED", L"STATUS"});
         for (const auto& container : containers)
         {
             tablePrinter.AddRow({
                 MultiByteToWide(container.Id),
                 MultiByteToWide(container.Name),
                 MultiByteToWide(container.Image),
+                ContainerService::ContainerCreatedAtToString(container.CreatedAt),
                 ContainerService::ContainerStateToString(container.State, container.StateChangedAt),
             });
         }

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2884,6 +2884,7 @@ class WSLATests
                 VERIFY_ARE_EQUAL(expectedState, containers[i].State);
                 VERIFY_ARE_EQUAL(strlen(containers[i].Id), WSLA_CONTAINER_ID_LENGTH);
                 VERIFY_IS_TRUE(containers[i].StateChangedAt > 0);
+                VERIFY_IS_TRUE(containers[i].CreatedAt > 0);
             }
         };
 
@@ -2910,14 +2911,17 @@ class WSLATests
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateRunning);
             expectContainerList({{"test-container-1", "debian:latest", WslaContainerStateRunning}});
 
-            // Capture StateChangedAt while the container is running.
+            // Capture StateChangedAt and CreatedAt while the container is running.
             ULONGLONG runningStateChangedAt{};
+            ULONGLONG runningCreatedAt{};
             {
                 wil::unique_cotaskmem_array_ptr<WSLAContainerEntry> containers;
                 VERIFY_SUCCEEDED(m_defaultSession->ListContainers(&containers, containers.size_address<ULONG>()));
                 VERIFY_ARE_EQUAL(containers.size(), 1);
                 runningStateChangedAt = containers[0].StateChangedAt;
+                runningCreatedAt = containers[0].CreatedAt;
                 VERIFY_IS_TRUE(runningStateChangedAt > 0);
+                VERIFY_IS_TRUE(runningCreatedAt > 0);
             }
 
             // Kill the container init process and expect it to be in exited state.
@@ -2945,6 +2949,9 @@ class WSLATests
                 auto now = static_cast<ULONGLONG>(time(nullptr));
                 VERIFY_IS_TRUE(containers[0].StateChangedAt <= now);
                 VERIFY_IS_TRUE(containers[0].StateChangedAt >= runningStateChangedAt);
+
+                // CreatedAt must not change after state transitions.
+                VERIFY_ARE_EQUAL(containers[0].CreatedAt, runningCreatedAt);
             }
 
             // Open a new reference to the same container.
@@ -3144,6 +3151,7 @@ class WSLATests
                 VERIFY_ARE_EQUAL(expectedState, containers[i].State);
                 VERIFY_ARE_EQUAL(strlen(containers[i].Id), WSLA_CONTAINER_ID_LENGTH);
                 VERIFY_IS_TRUE(containers[i].StateChangedAt > 0);
+                VERIFY_IS_TRUE(containers[i].CreatedAt > 0);
             }
         };
 
@@ -4117,6 +4125,7 @@ class WSLATests
 
         std::string containerName = "test-container";
         ULONGLONG originalStateChangedAt{};
+        ULONGLONG originalCreatedAt{};
 
         // Phase 1: Create session and container, then stop the container
         {
@@ -4134,12 +4143,14 @@ class WSLATests
             VERIFY_SUCCEEDED(container.Get().Stop(WSLASignalSIGKILL, 0));
             VERIFY_ARE_EQUAL(container.State(), WslaContainerStateExited);
 
-            // Capture StateChangedAt before the session is destroyed.
+            // Capture StateChangedAt and CreatedAt before the session is destroyed.
             wil::unique_cotaskmem_array_ptr<WSLAContainerEntry> containers;
             VERIFY_SUCCEEDED(session->ListContainers(&containers, containers.size_address<ULONG>()));
             VERIFY_ARE_EQUAL(containers.size(), 1);
             originalStateChangedAt = containers[0].StateChangedAt;
+            originalCreatedAt = containers[0].CreatedAt;
             VERIFY_IS_TRUE(originalStateChangedAt > 0);
+            VERIFY_IS_TRUE(originalCreatedAt > 0);
         }
 
         // Phase 2: Create new session from same storage, recover and delete container
@@ -4154,6 +4165,7 @@ class WSLATests
             VERIFY_SUCCEEDED(session->ListContainers(&containers, containers.size_address<ULONG>()));
             VERIFY_ARE_EQUAL(containers.size(), 1);
             VERIFY_ARE_EQUAL(containers[0].StateChangedAt, originalStateChangedAt);
+            VERIFY_ARE_EQUAL(containers[0].CreatedAt, originalCreatedAt);
 
             VERIFY_SUCCEEDED(container.Get().Delete(WSLADeleteFlagsNone));
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add CreatedAt timestamp support to container listing. Containers now display a CREATED column in wslc container list showing how long ago container was created.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

-  Added int64_t Created{} to ContainerInfo in docker_schema.h to deserialize the Created Unix timestamp already returned by Docker's list API (/containers/json)
- Added ULONGLONG CreatedAt to WSLAContainerEntry in wslaservice.idl
- Added m_createdAt member to WSLAContainerImpl with a default initializer of std::time(nullptr) for new containers created via Create()
- In Open(), m_createdAt is restored directly from dockerContainer
- Added CREATED column to wslc container list table output

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
WSLATests::ContainerState  verifies CreatedAt > 0 and immutability after state transitions
WSLATests::ContainerNetwork verifies CreatedAt > 0 for all listed containers
WSLATests::ContainerRecoveryFromStorage  verifies CreatedAt is correctly restored after a session restart

