### PR TITLE
Fix CVE-2026-26127: bump .NET runtime from 10.0.0 to 10.0.4

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="10.0.0" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.0" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.0" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.4" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.4" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6676" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.251108.1" targetFramework="native" />


### PR DESCRIPTION
Addresses Dependabot alerts https://github.com/microsoft/WSL/security/dependabot/10 and https://github.com/microsoft/WSL/security/dependabot/11. The Microsoft.NETCore.App.Runtime packages (win-x64 and win-arm64) at version 10.0.0 are vulnerable to a denial of service via out-of-bounds read when decoding malformed Base64Url input (CVSS 7.5 High). Bumped to 10.0.4 which includes the fix.
