### PR TITLE
wsla: fix Content-Length parsing exception and TraceLogging truncation

### DIFF
--- a/src/windows/wslasession/ContainerEventTracker.cpp
+++ b/src/windows/wslasession/ContainerEventTracker.cpp
@@ -97,7 +97,8 @@ void ContainerEventTracker::OnEvent(const std::string_view& event)
 {
     WSL_LOG(
         "DockerEvent",
-        TraceLoggingCountedString(event.data(), static_cast<UINT16>(event.size()), "Data"),
+        TraceLoggingCountedString(
+            event.data(), static_cast<UINT16>(std::min(event.size(), static_cast<size_t>(USHRT_MAX))), "Data"),
         TraceLoggingValue(m_sessionId, "SessionId"));
 
     static std::map<std::string, ContainerEvent> events{

--- a/src/windows/wslasession/DockerHTTPClient.cpp
+++ b/src/windows/wslasession/DockerHTTPClient.cpp
@@ -543,7 +543,18 @@ void DockerHTTPClient::DockerHttpResponseHandle::OnRead(const gsl::span<char>& C
             auto contentLength = response.find(http::field::content_length);
             if (contentLength != response.end())
             {
-                RemainingContentLength = std::stoul(contentLength->value());
+                try
+                {
+                    RemainingContentLength = std::stoul(contentLength->value());
+                }
+                catch (const std::exception&)
+                {
+                    THROW_HR_MSG(
+                        E_UNEXPECTED,
+                        "Invalid Content-Length header: %.*hs",
+                        static_cast<int>(contentLength->value().size()),
+                        contentLength->value().data());
+                }
             }
         }
 


### PR DESCRIPTION
DockerHTTPClient.cpp: Wrap std::stoul() in try-catch to handle malformed Content-Length headers gracefully instead of crashing the session with an unhandled exception.

ContainerEventTracker.cpp: Clamp event.size() to USHRT_MAX before casting to UINT16 for TraceLoggingCountedString. Previously, events larger than 64KB would wrap the size, causing TraceLogging to read an incorrect number of bytes.
