### PR TITLE
Write a telemetry event on session creation

### DIFF
--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -104,6 +104,23 @@ struct PruneResult
     }
 };
 
+class StopWatch
+{
+    NON_COPYABLE(StopWatch);
+    NON_MOVABLE(StopWatch);
+
+public:
+    StopWatch() = default;
+
+    uint64_t ElapsedMilliseconds() const
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_startTime).count();
+    }
+
+private:
+    std::chrono::steady_clock::time_point m_startTime = std::chrono::steady_clock::now();
+};
+
 template <typename T>
 void AssertValidPrintfArg()
 {

--- a/src/windows/wslaservice/exe/WSLASessionManager.cpp
+++ b/src/windows/wslaservice/exe/WSLASessionManager.cpp
@@ -81,36 +81,53 @@ void WSLASessionManagerImpl::CreateSession(const WSLASessionSettings* Settings, 
         return; // Existing session was opened.
     }
 
-    // Get caller info.
-    const auto callerProcess = wslutil::OpenCallingProcess(PROCESS_QUERY_LIMITED_INFORMATION);
-    const ULONG sessionId = m_nextSessionId++;
-    const DWORD creatorPid = GetProcessId(callerProcess.get());
-    const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);
+    common::wslutil::StopWatch stopWatch;
 
-    // Create the VM in the SYSTEM service (privileged).
-    auto vm = Microsoft::WRL::Make<HcsVirtualMachine>(Settings);
+    HRESULT creationResult = wil::ResultFromException([&]() {
+        // Get caller info.
+        const auto callerProcess = wslutil::OpenCallingProcess(PROCESS_QUERY_LIMITED_INFORMATION);
+        const ULONG sessionId = m_nextSessionId++;
+        const DWORD creatorPid = GetProcessId(callerProcess.get());
+        const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);
 
-    // Launch per-user COM server factory and add it to our job object for crash cleanup.
-    auto factory = wslutil::CreateComServerAsUser<IWSLASessionFactory>(__uuidof(WSLASessionFactory), userToken.get());
-    AddSessionProcessToJobObject(factory.get());
+        // Create the VM in the SYSTEM service (privileged).
+        auto vm = Microsoft::WRL::Make<HcsVirtualMachine>(Settings);
 
-    // Create the session via the factory.
-    const auto sessionSettings = CreateSessionSettings(sessionId, creatorPid, Settings);
-    wil::com_ptr<IWSLASession> session;
-    wil::com_ptr<IWSLASessionReference> serviceRef;
-    THROW_IF_FAILED(factory->CreateSession(&sessionSettings, vm.Get(), &session, &serviceRef));
+        // Launch per-user COM server factory and add it to our job object for crash cleanup.
+        auto factory = wslutil::CreateComServerAsUser<IWSLASessionFactory>(__uuidof(WSLASessionFactory), userToken.get());
+        AddSessionProcessToJobObject(factory.get());
 
-    // Track the session via its service ref, along with metadata and security info.
-    m_sessions.push_back({std::move(serviceRef), sessionId, creatorPid, Settings->DisplayName, std::move(tokenInfo)});
+        // Create the session via the factory.
+        const auto sessionSettings = CreateSessionSettings(sessionId, creatorPid, Settings);
+        wil::com_ptr<IWSLASession> session;
+        wil::com_ptr<IWSLASessionReference> serviceRef;
+        THROW_IF_FAILED(factory->CreateSession(&sessionSettings, vm.Get(), &session, &serviceRef));
 
-    // For persistent sessions, also hold a strong reference to keep them alive.
-    const bool persistent = WI_IsFlagSet(Flags, WSLASessionFlagsPersistent);
-    if (persistent)
-    {
-        m_persistentSessions.emplace_back(sessionId, session);
-    }
+        // Track the session via its service ref, along with metadata and security info.
+        m_sessions.push_back({std::move(serviceRef), sessionId, creatorPid, Settings->DisplayName, std::move(tokenInfo)});
 
-    *WslaSession = session.detach();
+        // For persistent sessions, also hold a strong reference to keep them alive.
+        const bool persistent = WI_IsFlagSet(Flags, WSLASessionFlagsPersistent);
+        if (persistent)
+        {
+            m_persistentSessions.emplace_back(sessionId, session);
+        }
+
+        *WslaSession = session.detach();
+        result = S_OK;
+    });
+
+    // This telemetry event is used to keep track of session creation performance (via CreationTimeMs) and failure reasons (via Result).
+
+    WSL_LOG_TELEMETRY(
+        "WSLCCreateSession",
+        PDT_ProductAndServiceUsage,
+        TraceLoggingValue(Settings->DisplayName, "Name"),
+        TraceLoggingValue(stopWatch.ElapsedMilliseconds(), "CreationTimeMs"),
+        TraceLoggingValue(creationResult, "Result"),
+        TraceLoggingValue(static_cast<uint32_t>(Flags), "Flags"));
+
+    THROW_IF_FAILED_MSG(creationResult, "Failed to create session: %ls", Settings->DisplayName);
 }
 
 void WSLASessionManagerImpl::OpenSession(ULONG Id, IWSLASession** Session)

--- a/src/windows/wslaservice/exe/WSLASessionManager.cpp
+++ b/src/windows/wslaservice/exe/WSLASessionManager.cpp
@@ -81,7 +81,7 @@ void WSLASessionManagerImpl::CreateSession(const WSLASessionSettings* Settings, 
         return; // Existing session was opened.
     }
 
-    common::wslutil::StopWatch stopWatch;
+    wslutil::StopWatch stopWatch;
 
     HRESULT creationResult = wil::ResultFromException([&]() {
         // Get caller info.
@@ -114,7 +114,6 @@ void WSLASessionManagerImpl::CreateSession(const WSLASessionSettings* Settings, 
         }
 
         *WslaSession = session.detach();
-        result = S_OK;
     });
 
     // This telemetry event is used to keep track of session creation performance (via CreationTimeMs) and failure reasons (via Result).


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to create a telemetry event when a WSLASession is created. Sample event: 


```
Microsoft.Windows.Wsla	WSLCCreateSession
CreationTimeMs: 	2858
Flags: 	3
Name: 	wsla-cli
Result: 	0
wslVersion: 	2.7.0.539	
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
