### PR TITLE
Add Git worktree management scripts and documentation

### DIFF
--- a/.github/skills/worktree-manager/SKILL.md
+++ b/.github/skills/worktree-manager/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: worktree-manager
+description: Create and manage Git worktrees for parallel development workflows. Use when multiple self-contained issues should NOT be fixed in a single branch, when human-Copilot iteration requires isolated environments with separate chat history and commits, or when parallel work items need independent build/test results. Triggers on requests involving branch isolation, work item separation, parallel development, or avoiding messy branch switching.
+---
+
+# Git Worktree Manager
+
+This skill provides helper scripts and workflows for creating and managing Git worktrees, enabling parallel development across multiple branches without cloning the repository multiple times.
+
+## When to Use This Skill
+
+**Primary triggers** — Create a new worktree when:
+
+1. **Multiple self-contained issues exist** — Different problems should NOT be fixed together in a single branch. Each issue deserves its own branch with isolated commits, separate PR, and independent review.
+
+2. **Human-Copilot iteration is needed** — Step-by-step collaboration requires an isolated environment where:
+   - Each worktree has its own Copilot chat history and context
+   - Plan and TODO progress stays scoped to that specific issue
+   - Commits are atomic and traceable to one problem
+
+3. **Parallel work avoids branch-switching chaos** — Instead of constantly switching branches (which mixes up build artifacts, test results, and Copilot context), worktrees let you:
+   - Keep each VS Code window focused on one task
+   - Run builds/tests independently without cross-contamination
+   - Resume work instantly without stashing or context loss
+
+**Anti-patterns** — Do NOT use worktrees when:
+- A quick one-liner fix can be committed directly
+- Changes are tightly coupled and belong in the same PR
+- You're just reading code (no commits planned)
+
+## Prerequisites
+
+- Git installed and configured
+- PowerShell 5.1+ (Windows) or PowerShell Core (cross-platform)
+- VS Code installed (for automatic workspace opening)
+- Repository must be a Git repository (not inside a worktree already)
+
+## Available Scripts
+
+This skill provides focused scripts for each worktree operation.
+
+### New-WorktreeFromBranch.ps1
+
+Create or reuse a worktree for an existing local or remote branch.
+
+**Location**: `./scripts/New-WorktreeFromBranch.ps1`
+
+```powershell
+./scripts/New-WorktreeFromBranch.ps1 -Branch <branch-name> [-NoFetch]
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `-Branch` | Yes | - | Branch name (local or `origin/<name>` form) |
+| `-NoFetch` | No | `$false` | Skip remote fetch if branch missing locally |
+
+**Examples**:
+```powershell
+# From a local or remote branch
+./scripts/New-WorktreeFromBranch.ps1 -Branch feature/login
+
+# From origin remote (normalizes automatically)
+./scripts/New-WorktreeFromBranch.ps1 -Branch origin/bugfix/nullref
+```
+
+---
+
+### New-WorktreeFromIssue.ps1
+
+Start a new work item branch with consistent naming and create a worktree for it.
+
+**Location**: `./scripts/New-WorktreeFromIssue.ps1`
+
+```powershell
+./scripts/New-WorktreeFromIssue.ps1 -Number <workitem-number> [-Title <description>] [-Base <ref>]
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `-Number` | Yes | - | Azure DevOps work item number for branch naming |
+| `-Title` | No | - | Descriptive title (slugified into branch name) |
+| `-Base` | No | `origin/main` | Base ref to branch from |
+
+**Examples**:
+```powershell
+# Work item branch with title
+./scripts/New-WorktreeFromIssue.ps1 -Number 1234 -Title "Crash on launch"
+# Creates: workitem/1234-crash-on-launch
+
+# Work item branch from different base
+./scripts/New-WorktreeFromIssue.ps1 -Number 42 -Base origin/develop
+
+# Simple work item branch (no title slug)
+./scripts/New-WorktreeFromIssue.ps1 -Number 999
+# Creates: workitem/999
+```
+
+---
+
+### Delete-Worktree.ps1
+
+Remove a worktree and optionally its associated branch.
+
+**Location**: `./scripts/Delete-Worktree.ps1`
+
+```powershell
+./scripts/Delete-Worktree.ps1 -Pattern <pattern> [-Force] [-KeepBranch]
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `-Pattern` | Yes | - | Partial branch name or path to match |
+| `-Force` | No | `$false` | Force removal even with uncommitted changes |
+| `-KeepBranch` | No | `$false` | Don't delete the local branch |
+
+**Examples**:
+```powershell
+# Delete worktree by branch pattern
+./scripts/Delete-Worktree.ps1 -Pattern feature/perf-tweak
+
+# Force delete with uncommitted changes
+./scripts/Delete-Worktree.ps1 -Pattern workitem/1234 -Force
+
+# Delete worktree but keep the branch
+./scripts/Delete-Worktree.ps1 -Pattern feature/ui -KeepBranch
+```
+
+---
+
+### List Worktrees
+
+Use Git directly to list worktrees:
+
+```powershell
+git worktree list --porcelain
+```
+
+## Step-by-Step Workflows
+
+### Workflow 1: Work on an Azure DevOps Work Item
+
+1. Note the work item number and title
+2. Create work item branch and worktree:
+   ```powershell
+   ./scripts/New-WorktreeFromIssue.ps1 -Number 1234 -Title "Fix null reference"
+   ```
+3. Build, test, and develop as normal
+4. Commit, push, and open PR
+5. Delete worktree when PR is merged:
+   ```powershell
+   ./scripts/Delete-Worktree.ps1 -Pattern workitem/1234
+   ```
+
+### Workflow 2: Parallel Feature Development
+
+1. Create worktrees for each feature:
+   ```powershell
+   ./scripts/New-WorktreeFromBranch.ps1 -Branch feature/login
+   ./scripts/New-WorktreeFromBranch.ps1 -Branch feature/dashboard
+   ```
+2. Work on each independently (different VS Code windows)
+3. Keep ≤ 3 active worktrees to manage cognitive load
+
+## Worktree Naming & Locations
+
+| Source | Local Branch Name | Worktree Folder |
+|--------|-------------------|-----------------|
+| Local/remote branch | Same as branch | `<RepoName>-<hash>/` |
+| Work item | `workitem/<number>-<slug>` | `<RepoName>-<hash>/` |
+
+Worktrees are created as **sibling folders** to the repository root (e.g., `MyRepo/` and `MyRepo-ab12/`).
+
+## Best Practices
+
+- **Keep ≤ 3 active worktrees** per developer to reduce cognitive load
+- **Delete stale worktrees early** — each adds file watchers and build churn
+- **Avoid editing the same file** across multiple worktrees simultaneously
+- **Run `git fetch --all --prune`** periodically in the primary repo, not every worktree
+- **Use targeted builds** inside worktrees instead of full builds
+
+## Troubleshooting
+
+| Symptom | Solution |
+|---------|----------|
+| Cannot lock ref (*.lock error) | Run `git worktree prune` or delete stale `.lock` file manually |
+| Worktree already exists | Use `git worktree list` to find existing path; reuse that folder |
+| Local branch missing for remote | Run `git branch --track <name> origin/<name>` then retry |
+| Submodules not initialized | Run `git submodule update --init --recursive` in the worktree |
+
+## Common Commands Reference
+
+```powershell
+# List all worktrees
+git worktree list --porcelain
+
+# List local branches with tracking info
+git branch -vv
+
+# List remotes
+git remote -v
+
+# Prune stale worktree references
+git worktree prune
+
+# Force remove a worktree with uncommitted changes
+git worktree remove --force <path>
+```
+
+## Security Notes
+
+- Scripts do **not** store credentials — they rely on your existing Git credential helper
+- No destructive operations without explicit `-Force` flag
+
+## Script Locations
+
+All implementation is self-contained within this skill folder:
+
+**Scripts** (master source):
+- [New-WorktreeFromBranch.ps1](./scripts/New-WorktreeFromBranch.ps1) — create worktree from branch
+- [New-WorktreeFromIssue.ps1](./scripts/New-WorktreeFromIssue.ps1) — create worktree for work item
+- [Delete-Worktree.ps1](./scripts/Delete-Worktree.ps1) — remove worktree and branch
+- [WorktreeLib.ps1](./scripts/WorktreeLib.ps1) — shared helper functions
+
+**Human-friendly wrappers** (in `tools/git/`):
+- `tools/git/New-WorktreeFromBranch.cmd` — delegates to skill's master script
+- `tools/git/New-WorktreeFromIssue.cmd` — delegates to skill's master script  
+- `tools/git/Delete-Worktree.cmd` — delegates to skill's master script
+- `tools/git/Worktree-Guidelines.md` — quick reference for developers

--- a/.github/skills/worktree-manager/SKILL.md
+++ b/.github/skills/worktree-manager/SKILL.md
@@ -31,7 +31,7 @@ This skill provides helper scripts and workflows for creating and managing Git w
 ## Prerequisites
 
 - Git installed and configured
-- PowerShell 5.1+ (Windows) or PowerShell Core (cross-platform)
+- PowerShell 5.1+ on Windows (PowerShell 7+ recommended) or PowerShell Core cross-platform
 - VS Code installed (for automatic workspace opening)
 - Repository must be a Git repository (not inside a worktree already)
 
@@ -79,7 +79,7 @@ Start a new work item branch with consistent naming and create a worktree for it
 |-----------|----------|---------|-------------|
 | `-Number` | Yes | - | Azure DevOps work item number for branch naming |
 | `-Title` | No | - | Descriptive title (slugified into branch name) |
-| `-Base` | No | `origin/main` | Base ref to branch from |
+| `-Base` | No | Auto-detected (`upstream/master` > `upstream/main` > `origin/master` > `origin/main`, then `origin/HEAD` when available) | Base ref to branch from |
 
 **Examples**:
 ```powershell

--- a/.github/skills/worktree-manager/scripts/Delete-Worktree.ps1
+++ b/.github/skills/worktree-manager/scripts/Delete-Worktree.ps1
@@ -1,0 +1,146 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#!
+.SYNOPSIS
+    Remove a Git worktree and optionally its associated branch.
+
+.DESCRIPTION
+    Finds a worktree by pattern match (branch name or path), removes the worktree directory,
+    and optionally cleans up the local branch.
+
+.PARAMETER Pattern
+    Partial branch name or path pattern to match the worktree.
+
+.PARAMETER Force
+    Force removal even if there are uncommitted changes.
+
+.PARAMETER KeepBranch
+    Do not delete the local branch after removing the worktree.
+
+.PARAMETER Help
+    Show this help message.
+
+.EXAMPLE
+    ./Delete-Worktree.ps1 -Pattern feature/perf-tweak
+
+.EXAMPLE
+    ./Delete-Worktree.ps1 -Pattern workitem/1234 -Force
+
+.NOTES
+    Manual equivalent:
+        git worktree list
+        git worktree remove <path>
+        git branch -d <branch>
+        git worktree prune
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Pattern,
+    [switch] $Force,
+    [switch] $KeepBranch,
+    [switch] $Help
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/WorktreeLib.ps1"
+
+if ($Help -or -not $Pattern) { Show-FileEmbeddedHelp -ScriptPath $MyInvocation.MyCommand.Path; return }
+
+try {
+    $repoRoot = Get-RepoRoot
+    $entries = @(Get-WorktreeEntries)
+    
+    if ($entries.Count -eq 0) {
+        Info "No worktrees found."
+        return
+    }
+    
+    # Find matching worktrees (by branch or path)
+    $matchedEntries = @($entries | Where-Object { 
+        $_.Branch -like "*$Pattern*" -or $_.Path -like "*$Pattern*" 
+    })
+    
+    if ($matchedEntries.Count -eq 0) {
+        Err "No worktree found matching pattern: $Pattern"
+        Info "Available worktrees:"
+        $entries | ForEach-Object { Info "  $($_.Branch) -> $($_.Path)" }
+        exit 1
+    }
+    
+    if ($matchedEntries.Count -gt 1) {
+        Warn "Multiple worktrees match pattern '$Pattern'. Please be more specific:"
+        $matchedEntries | ForEach-Object { Info "  $($_.Branch) -> $($_.Path)" }
+        exit 1
+    }
+    
+    $target = $matchedEntries[0]
+    $worktreePath = $target.Path
+    $branchName = $target.Branch
+    
+    # Check if this is the main worktree (repo root)
+    $mainWorktree = git rev-parse --git-dir 2>$null
+    if ($mainWorktree -and (Resolve-Path $worktreePath -ErrorAction SilentlyContinue) -eq (Resolve-Path $repoRoot -ErrorAction SilentlyContinue)) {
+        Err "Cannot remove the main worktree (repository root)."
+        exit 1
+    }
+    
+    Info "Removing worktree: $branchName -> $worktreePath"
+    
+    # Remove the worktree
+    if ($Force) {
+        git worktree remove --force $worktreePath 2>&1 | Out-Null
+    } else {
+        $result = git worktree remove $worktreePath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Err "Failed to remove worktree. Use -Force to discard uncommitted changes."
+            Err $result
+            exit 1
+        }
+    }
+    
+    if ($LASTEXITCODE -eq 0) {
+        Info "Worktree removed: $worktreePath"
+    }
+    
+    # Clean up branch if requested
+    if (-not $KeepBranch) {
+        # Check if branch still exists
+        git show-ref --verify --quiet "refs/heads/$branchName"
+        if ($LASTEXITCODE -eq 0) {
+            Info "Deleting local branch: $branchName"
+            if ($Force) {
+                git branch -D $branchName 2>&1 | Out-Null
+            } else {
+                git branch -d $branchName 2>&1 | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    Warn "Could not delete branch (may have unmerged changes). Use -Force or delete manually:"
+                    Warn "  git branch -D $branchName"
+                }
+            }
+            if ($LASTEXITCODE -eq 0) {
+                Info "Branch deleted: $branchName"
+            }
+        }
+    } else {
+        Info "Keeping branch: $branchName"
+    }
+    
+    # Prune any stale worktree references
+    git worktree prune 2>&1 | Out-Null
+    
+    Show-WorktreeExecutionSummary -CurrentBranch $null -WorktreePath $null
+    Info "Done."
+    exit 0
+} catch {
+    Err "Error: $($_.Exception.Message)"
+    Warn 'Manual steps:'
+    Info '  git worktree list'
+    Info '  git worktree remove <path>'
+    Info '  git branch -d <branch>'
+    Info '  git worktree prune'
+    exit 1
+}

--- a/.github/skills/worktree-manager/scripts/Delete-Worktree.ps1
+++ b/.github/skills/worktree-manager/scripts/Delete-Worktree.ps1
@@ -82,8 +82,7 @@ try {
     $branchName = $target.Branch
     
     # Check if this is the main worktree (repo root)
-    $mainWorktree = git rev-parse --git-dir 2>$null
-    if ($mainWorktree -and (Resolve-Path $worktreePath -ErrorAction SilentlyContinue) -eq (Resolve-Path $repoRoot -ErrorAction SilentlyContinue)) {
+    if ((Resolve-Path $worktreePath -ErrorAction SilentlyContinue) -eq (Resolve-Path $repoRoot -ErrorAction SilentlyContinue)) {
         Err "Cannot remove the main worktree (repository root)."
         exit 1
     }
@@ -92,7 +91,12 @@ try {
     
     # Remove the worktree
     if ($Force) {
-        git worktree remove --force $worktreePath 2>&1 | Out-Null
+        $result = git worktree remove --force $worktreePath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Err "Failed to force-remove worktree."
+            Err $result
+            exit 1
+        }
     } else {
         $result = git worktree remove $worktreePath 2>&1
         if ($LASTEXITCODE -ne 0) {

--- a/.github/skills/worktree-manager/scripts/New-WorktreeFromBranch.ps1
+++ b/.github/skills/worktree-manager/scripts/New-WorktreeFromBranch.ps1
@@ -53,7 +53,8 @@ if ($Help -or -not $Branch) { Show-FileEmbeddedHelp -ScriptPath $MyInvocation.My
 # Normalize <remote>/<name> to <name> for any configured remote
 $remotes = Get-OrderedRemotes
 foreach ($r in $remotes) {
-    if ($Branch -match "^$r/(.+)$") { $Branch = $Matches[1]; break }
+    $escapedRemote = [regex]::Escape($r)
+    if ($Branch -match "^$escapedRemote/(.+)$") { $Branch = $Matches[1]; break }
 }
 
 try {

--- a/.github/skills/worktree-manager/scripts/New-WorktreeFromBranch.ps1
+++ b/.github/skills/worktree-manager/scripts/New-WorktreeFromBranch.ps1
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#!
+.SYNOPSIS
+    Create (or reuse) a worktree for an existing local or remote (origin) branch.
+
+.DESCRIPTION
+    Normalizes origin/<name> to <name>. If the branch does not exist locally (and -NoFetch is not
+    provided) it will fetch and create a tracking branch from origin. Reuses any existing worktree
+    bound to the branch; otherwise creates a new one adjacent to the repository root.
+
+.PARAMETER Branch
+    Branch name (local or origin/<name> form) to materialize as a worktree.
+
+.PARAMETER VSCodeProfile
+    VS Code profile to open (Default).
+
+.PARAMETER NoFetch
+    Skip fetch if branch missing locally; script will error instead of creating it.
+
+.EXAMPLE
+    ./New-WorktreeFromBranch.ps1 -Branch feature/login
+
+.EXAMPLE
+    ./New-WorktreeFromBranch.ps1 -Branch origin/bugfix/nullref
+
+.EXAMPLE
+    ./New-WorktreeFromBranch.ps1 -Branch release/v1 -NoFetch
+
+.NOTES
+    Manual recovery:
+        git fetch origin && git checkout <branch>
+        git worktree add ../RepoName-XX <branch>
+        code ../RepoName-XX --profile Default
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Branch,
+    [Alias('Profile')][string] $VSCodeProfile = 'Default',
+    [switch] $NoFetch,
+    [switch] $Help
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/WorktreeLib.ps1"
+
+if ($Help -or -not $Branch) { Show-FileEmbeddedHelp -ScriptPath $MyInvocation.MyCommand.Path; return }
+
+# Normalize <remote>/<name> to <name> for any configured remote
+$remotes = Get-OrderedRemotes
+foreach ($r in $remotes) {
+    if ($Branch -match "^$r/(.+)$") { $Branch = $Matches[1]; break }
+}
+
+try {
+    git show-ref --verify --quiet "refs/heads/$Branch"
+    if ($LASTEXITCODE -ne 0) {
+        if (-not $NoFetch) {
+            Warn "Local branch '$Branch' not found; attempting remote fetch..."
+            git fetch --all --prune 2>$null | Out-Null
+            $remoteRef = Find-BranchOnRemotes -BranchName $Branch
+            if ($remoteRef) {
+                git branch --track $Branch $remoteRef 2>$null | Out-Null
+                if ($LASTEXITCODE -ne 0) { throw "Failed to create tracking branch '$Branch' from $remoteRef" }
+                Info "Created local tracking branch '$Branch' from $remoteRef."
+            } else { throw "Branch '$Branch' not found locally or on any remote. Use git fetch or specify a valid branch." }
+        } else { throw "Branch '$Branch' does not exist locally (remote fetch disabled with -NoFetch)." }
+    }
+
+    New-WorktreeForExistingBranch -Branch $Branch -VSCodeProfile $VSCodeProfile
+    $after = Get-WorktreeEntries | Where-Object { $_.Branch -eq $Branch }
+    $path = ($after | Select-Object -First 1).Path
+    Show-WorktreeExecutionSummary -CurrentBranch $Branch -WorktreePath $path
+    exit 0
+} catch {
+    Err "Error: $($_.Exception.Message)"
+    Warn 'Manual steps:'
+    Info '  git fetch origin'
+    Info "  git checkout $Branch  (or: git branch --track $Branch origin/$Branch)"
+    Info '  git worktree add ../<Repo>-XX <branch>'
+    Info '  code ../<Repo>-XX'
+    exit 1
+}

--- a/.github/skills/worktree-manager/scripts/New-WorktreeFromIssue.ps1
+++ b/.github/skills/worktree-manager/scripts/New-WorktreeFromIssue.ps1
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#!
+.SYNOPSIS
+    Create (or reuse) a worktree for a new work item branch derived from a base ref.
+
+.DESCRIPTION
+    Composes a branch name as workitem/<number> or workitem/<number>-<slug> (slug from optional -Title).
+    If the branch does not already exist, it is created from -Base (default origin/main). Then a
+    worktree is created or reused.
+
+.PARAMETER Number
+    Azure DevOps work item number used to construct the branch name.
+
+.PARAMETER Title
+    Optional descriptive title; slug into the branch name.
+
+.PARAMETER Base
+    Base ref to branch from. Auto-detected if omitted: prefers upstream/master
+    (fork setup) then origin/master (direct clone), then origin/main.
+
+.PARAMETER VSCodeProfile
+    VS Code profile to open (Default).
+
+.EXAMPLE
+    ./New-WorktreeFromIssue.ps1 -Number 1234 -Title "Crash on launch"
+
+.EXAMPLE
+    ./New-WorktreeFromIssue.ps1 -Number 42 -Base origin/develop
+
+.NOTES
+    Manual recovery:
+        git fetch origin
+        git checkout -b workitem/<num>-<slug> <base>
+        git worktree add ../Repo-XX workitem/<num>-<slug>
+        code ../Repo-XX
+#>
+
+[CmdletBinding()]
+param(
+    [int] $Number,
+    [string] $Title,
+    [string] $Base,
+    [Alias('Profile')][string] $VSCodeProfile = 'Default',
+    [switch] $Help
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/WorktreeLib.ps1"
+$scriptPath = $MyInvocation.MyCommand.Path
+if ($Help -or -not $Number) { Show-FileEmbeddedHelp -ScriptPath $scriptPath; return }
+
+# Auto-detect base if not provided: upstream/master > origin/master > origin/main
+if (-not $Base) { $Base = Get-DefaultBaseRef; Info "Auto-detected base: $Base" }
+
+# Compose branch name
+if ($Title) {
+    $slug = ($Title -replace '[^\w\- ]','').ToLower() -replace ' +','-'
+    $branch = "workitem/$Number-$slug"
+} else {
+    $branch = "workitem/$Number"
+}
+
+try {
+    # Create branch if missing
+    git show-ref --verify --quiet "refs/heads/$branch"
+    if ($LASTEXITCODE -ne 0) {
+        Info "Creating branch $branch from $Base"
+        git branch $branch $Base 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "Failed to create branch $branch from $Base" }
+    } else {
+        Info "Branch $branch already exists locally." 
+    }
+
+    New-WorktreeForExistingBranch -Branch $branch -VSCodeProfile $VSCodeProfile
+    $after = Get-WorktreeEntries | Where-Object { $_.Branch -eq $branch }
+    $entry = $after | Select-Object -First 1
+    $path = if ($entry) { $entry.Path } else { $null }
+    Show-WorktreeExecutionSummary -CurrentBranch $branch -WorktreePath $path
+    exit 0
+} catch {
+    Err "Error: $($_.Exception.Message)"
+    Warn 'Manual steps:'
+    Info "  git fetch origin"
+    Info "  git checkout -b $branch $Base  (if branch missing)"
+    Info "  git worktree add ../<Repo>-XX $branch"
+    Info '  code ../<Repo>-XX'
+    exit 1
+}

--- a/.github/skills/worktree-manager/scripts/New-WorktreeFromIssue.ps1
+++ b/.github/skills/worktree-manager/scripts/New-WorktreeFromIssue.ps1
@@ -7,8 +7,8 @@
 
 .DESCRIPTION
     Composes a branch name as workitem/<number> or workitem/<number>-<slug> (slug from optional -Title).
-    If the branch does not already exist, it is created from -Base (default origin/main). Then a
-    worktree is created or reused.
+    If the branch does not already exist, it is created from -Base (auto-detected via Get-DefaultBaseRef
+    when omitted). Then a worktree is created or reused.
 
 .PARAMETER Number
     Azure DevOps work item number used to construct the branch name.
@@ -17,8 +17,8 @@
     Optional descriptive title; slug into the branch name.
 
 .PARAMETER Base
-    Base ref to branch from. Auto-detected if omitted: prefers upstream/master
-    (fork setup) then origin/master (direct clone), then origin/main.
+    Base ref to branch from. Auto-detected if omitted by checking, in order:
+    upstream/master, upstream/main, origin/master, origin/main, then origin/HEAD when available.
 
 .PARAMETER VSCodeProfile
     VS Code profile to open (Default).
@@ -53,7 +53,7 @@ $ErrorActionPreference = 'Stop'
 $scriptPath = $MyInvocation.MyCommand.Path
 if ($Help -or -not $Number) { Show-FileEmbeddedHelp -ScriptPath $scriptPath; return }
 
-# Auto-detect base if not provided: upstream/master > origin/master > origin/main
+# Auto-detect base if not provided: upstream/master > upstream/main > origin/master > origin/main > origin/HEAD
 if (-not $Base) { $Base = Get-DefaultBaseRef; Info "Auto-detected base: $Base" }
 
 # Compose branch name

--- a/.github/skills/worktree-manager/scripts/WorktreeLib.ps1
+++ b/.github/skills/worktree-manager/scripts/WorktreeLib.ps1
@@ -1,0 +1,480 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# WorktreeLib.ps1 - Shared helpers for worktree management
+# This is the master source for the worktree-manager skill
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+function Info { param([string]$Message) Write-Host $Message -ForegroundColor Cyan }
+function Warn { param([string]$Message) Write-Host $Message -ForegroundColor Yellow }
+function Err  { param([string]$Message) Write-Host $Message -ForegroundColor Red }
+
+<#
+.SYNOPSIS
+    Gets the root directory of the current Git repository.
+
+.DESCRIPTION
+    Uses git rev-parse to find the top-level directory of the current Git repository.
+    Throws an exception if not inside a Git repository.
+
+.OUTPUTS
+    System.String. The absolute path to the repository root.
+
+.EXAMPLE
+    $root = Get-RepoRoot
+
+.NOTES
+    Requires Git to be installed and available in PATH.
+#>
+function Get-RepoRoot {
+  $root = git rev-parse --show-toplevel 2>$null
+  if (-not $root) { throw 'Not inside a git repository.' }
+  return $root
+}
+
+<#
+.SYNOPSIS
+    Gets the parent directory where worktrees should be created.
+
+.DESCRIPTION
+    Returns the parent directory of the repository root, which is the default location
+    for creating worktree directories as siblings of the main repository folder.
+
+.PARAMETER RepoRoot
+    The absolute path to the repository root directory.
+
+.OUTPUTS
+    System.String. The resolved path to the parent directory.
+
+.EXAMPLE
+    $basePath = Get-WorktreeBasePath -RepoRoot 'C:\repos\MyProject'
+
+.NOTES
+    Worktrees are created as siblings to the main repo folder (e.g., MyProject-ab12).
+#>
+function Get-WorktreeBasePath {
+  param([string]$RepoRoot)
+  # Always use parent of repo root (folder that contains the main repo directory)
+  $parent = Split-Path -Parent $RepoRoot
+  if (-not (Test-Path $parent)) { throw "Parent path for repo root not found: $parent" }
+  return (Resolve-Path $parent).ProviderPath
+}
+
+<#
+.SYNOPSIS
+    Generates a short hash from a string for unique folder naming.
+
+.DESCRIPTION
+    Computes an MD5 hash of the input text and returns the first 4 hex characters.
+    Used to create unique but short suffixes for worktree folder names.
+
+.PARAMETER Text
+    The input text to hash.
+
+.OUTPUTS
+    System.String. A 4-character hexadecimal string.
+
+.EXAMPLE
+    $hash = Get-ShortHashFromString -Text 'feature/login'
+    # Returns something like 'ab12'
+
+.NOTES
+    MD5 is used for speed and collision avoidance, not for security.
+#>
+function Get-ShortHashFromString {
+  param([Parameter(Mandatory)][string]$Text)
+  $md5 = [System.Security.Cryptography.MD5]::Create()
+  try {
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Text)
+    $digest = $md5.ComputeHash($bytes)
+    return -join ($digest[0..1] | ForEach-Object { $_.ToString('x2') })
+  } finally { $md5.Dispose() }
+}
+
+<#
+.SYNOPSIS
+    Initializes Git submodules in a worktree if any exist.
+
+.DESCRIPTION
+    Checks if the repository has a .gitmodules file and, if so, syncs and updates
+    all submodules recursively in the specified worktree path.
+
+.PARAMETER RepoRoot
+    The path to the main repository root to check for .gitmodules.
+
+.PARAMETER WorktreePath
+    The path to the worktree where submodules should be initialized.
+
+.OUTPUTS
+    System.Boolean. Returns $true if submodules were initialized, $false otherwise.
+
+.EXAMPLE
+    $initialized = Initialize-SubmodulesIfAny -RepoRoot 'C:\repos\MyProject' -WorktreePath 'C:\repos\MyProject-ab12'
+
+.NOTES
+    Submodule initialization can take time for large repositories.
+#>
+function Initialize-SubmodulesIfAny {
+  param([string]$RepoRoot,[string]$WorktreePath)
+  $hasGitmodules = Test-Path (Join-Path $RepoRoot '.gitmodules')
+  if ($hasGitmodules) {
+    git -C $WorktreePath submodule sync --recursive | Out-Null
+    git -C $WorktreePath submodule update --init --recursive | Out-Null
+    return $true
+  }
+  return $false
+}
+
+<#
+.SYNOPSIS
+    Creates or reuses a worktree for an existing local branch.
+
+.DESCRIPTION
+    Checks if a worktree already exists for the specified branch. If so, opens it in VS Code.
+    Otherwise, creates a new worktree in a sibling folder and opens it in VS Code.
+
+.PARAMETER Branch
+    The name of the local branch to create a worktree for.
+
+.PARAMETER VSCodeProfile
+    The VS Code profile to use when opening the worktree folder.
+
+.EXAMPLE
+    New-WorktreeForExistingBranch -Branch 'feature/login' -VSCodeProfile 'Default'
+
+.NOTES
+    The branch must exist locally. Use New-WorktreeFromBranch.ps1 for remote branches.
+#>
+function New-WorktreeForExistingBranch {
+  param(
+    [Parameter(Mandatory)][string] $Branch,
+    [Parameter(Mandatory)][string] $VSCodeProfile
+  )
+  $repoRoot = Get-RepoRoot
+  git show-ref --verify --quiet "refs/heads/$Branch"; if ($LASTEXITCODE -ne 0) { throw "Branch '$Branch' does not exist locally." }
+
+  # Detect existing worktree for this branch
+  $entries = Get-WorktreeEntries
+  $match = $entries | Where-Object { $_.Branch -eq $Branch } | Select-Object -First 1
+  if ($match) {
+    # If the branch is checked out in the main repo (not a secondary worktree),
+    # detach main repo and create a proper worktree instead of reusing.
+    $mainWorktreePath = (Resolve-Path $repoRoot).ProviderPath
+    $matchPath = ($match.Path -replace '/', '\')
+    $mainNormalized = ($mainWorktreePath -replace '/', '\')
+    if ($matchPath -eq $mainNormalized) {
+      Info "Branch '$Branch' is checked out in the main repo. Switching main repo to free the branch..."
+      # Switch main repo to master/main so it's on a useful branch, not detached
+      $defaultBase = Get-DefaultBaseRef
+      $localDefault = ($defaultBase -replace '^[^/]+/', '')
+      git show-ref --verify --quiet "refs/heads/$localDefault" 2>$null
+      if ($LASTEXITCODE -eq 0 -and $localDefault -ne $Branch) {
+        git checkout $localDefault 2>$null | Out-Null
+        Info "Switched main repo to '$localDefault'."
+      } else {
+        git checkout --detach 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "Cannot free branch '$Branch' from main repo. Checkout a different branch first." }
+        Warn "Main repo is now in detached HEAD. Run 'git checkout master' when done."
+      }
+      # Now fall through to create the worktree below
+    } else {
+      Info "Reusing existing worktree for '$Branch': $($match.Path)"
+      code --new-window "$($match.Path)" --profile "$VSCodeProfile" | Out-Null
+      return
+    }
+  }
+
+  $safeBranch = ($Branch -replace '[\\/:*?"<>|]','-')
+  $hash = Get-ShortHashFromString -Text $safeBranch
+  $folderName = "$(Split-Path -Leaf $repoRoot)-$hash"
+  $base = Get-WorktreeBasePath -RepoRoot $repoRoot
+  $folder = Join-Path $base $folderName
+  $worktreeOutput = git worktree add $folder $Branch 2>&1
+  if ($LASTEXITCODE -ne 0) { throw "Failed to create worktree at '$folder' for branch '$Branch': $worktreeOutput" }
+  $inited = Initialize-SubmodulesIfAny -RepoRoot $repoRoot -WorktreePath $folder
+  code --new-window "$folder" --profile "$VSCodeProfile" | Out-Null
+  Info "Created worktree for branch '$Branch' at $folder."; if ($inited) { Info 'Submodules initialized.' }
+}
+
+<#
+.SYNOPSIS
+    Gets all Git worktree entries in the repository.
+
+.DESCRIPTION
+    Parses the output of 'git worktree list --porcelain' and returns structured objects
+    containing the path and branch name for each worktree.
+
+.OUTPUTS
+    System.Object[]. Array of objects with Path and Branch properties.
+
+.EXAMPLE
+    $worktrees = Get-WorktreeEntries
+    $worktrees | ForEach-Object { Write-Host "$($_.Branch) -> $($_.Path)" }
+
+.NOTES
+    Returns an empty array if no worktrees exist or if not in a Git repository.
+#>
+function Get-WorktreeEntries {
+  # Returns objects with Path and Branch (branch without refs/heads/ prefix)
+  $lines = git worktree list --porcelain 2>$null
+  if (-not $lines) { return @() }
+  $entries = @(); $current=@{ path=$null; branch=$null }
+  foreach($l in $lines){
+    if ($l -eq '') { if ($current.path -and $current.branch){ $entries += ,([pscustomobject]@{ Path=$current.path; Branch=($current.branch -replace '^refs/heads/','') }) }; $current=@{ path=$null; branch=$null }; continue }
+    if ($l -like 'worktree *'){ $current.path = ($l -split ' ',2)[1] }
+    elseif ($l -like 'branch *'){ $current.branch = ($l -split ' ',2)[1].Trim() }
+  }
+  if ($current.path -and $current.branch){ $entries += ,([pscustomobject]@{ Path=$current.path; Branch=($current.branch -replace '^refs/heads/','') }) }
+  return ($entries | Sort-Object Path,Branch -Unique)
+}
+
+<#
+.SYNOPSIS
+    Gets the upstream remote name for a branch.
+
+.DESCRIPTION
+    Returns the remote name (e.g., 'origin') if the branch has an upstream configured,
+    or $null if no upstream is set.
+
+.PARAMETER Branch
+    The local branch name to check.
+
+.OUTPUTS
+    System.String or $null. The remote name if configured, otherwise $null.
+
+.EXAMPLE
+    $remote = Get-BranchUpstreamRemote -Branch 'main'
+    # Returns 'origin' if main tracks origin/main
+
+.NOTES
+    Requires the branch to exist locally.
+#>
+function Get-BranchUpstreamRemote {
+  param([Parameter(Mandatory)][string]$Branch)
+  # Returns remote name if branch has an upstream, else $null
+  $ref = git rev-parse --abbrev-ref --symbolic-full-name "$Branch@{upstream}" 2>$null
+  if ($LASTEXITCODE -ne 0 -or -not $ref) { return $null }
+  if ($ref -match '^(?<remote>[^/]+)/.+$') { return $Matches.remote }
+  return $null
+}
+
+<#
+.SYNOPSIS
+    Displays common manual Git commands for worktree troubleshooting.
+
+.DESCRIPTION
+    Prints a formatted list of helpful Git commands that users can run manually
+    when automated worktree operations fail or need verification.
+
+.EXAMPLE
+    Show-CommonManualStepsFooter
+
+.NOTES
+    Called at the end of help displays and error recovery messages.
+#>
+function Show-CommonManualStepsFooter {
+  Info '--- Common Manual Steps ---'
+  Info 'List worktree:      git worktree list --porcelain'
+  Info 'List branches:       git branch -vv'
+  Info 'List remotes:        git remote -v'
+  Info 'Prune worktree:     git worktree prune'
+  Info 'Remove worktree dir: Remove-Item -Recurse -Force <path>'
+  Info 'Reset branch:        git reset --hard HEAD'
+}
+
+<#
+.SYNOPSIS
+    Displays a summary of worktree operations and current state.
+
+.DESCRIPTION
+    Prints information about the current branch, worktree path, all existing worktrees,
+    and configured remotes. Used after worktree operations to confirm success.
+
+.PARAMETER CurrentBranch
+    The branch name associated with the current operation (optional).
+
+.PARAMETER WorktreePath
+    The path to the worktree that was created or modified (optional).
+
+.EXAMPLE
+    Show-WorktreeExecutionSummary -CurrentBranch 'feature/login' -WorktreePath 'C:\repos\MyProject-ab12'
+
+.NOTES
+    Shows all existing worktrees regardless of which one was just created.
+#>
+function Show-WorktreeExecutionSummary {
+  param(
+    [string]$CurrentBranch,
+    [string]$WorktreePath
+  )
+  Info '--- Summary ---'
+  if ($CurrentBranch) { Info "Branch:        $CurrentBranch" }
+  if ($WorktreePath) { Info "Worktree path: $WorktreePath" }
+  $entries = Get-WorktreeEntries
+  if ($entries.Count -gt 0) {
+    Info 'Existing worktrees:'
+    $entries | ForEach-Object { Info ("  {0} -> {1}" -f $_.Branch,$_.Path) }
+  }
+  Info 'Remotes:'
+  git remote -v 2>$null | Sort-Object | Get-Unique | ForEach-Object { Info "  $_" }
+}
+
+<#
+.SYNOPSIS
+    Displays embedded help from a script file's comment block.
+
+.DESCRIPTION
+    Reads a PowerShell script file and extracts the help text from a special
+    embedded help block (delimited by angle-bracket-hash-exclamation markers),
+    then displays it along with common manual steps.
+
+.PARAMETER ScriptPath
+    The full path to the script file containing embedded help.
+
+.EXAMPLE
+    Show-FileEmbeddedHelp -ScriptPath 'C:\scripts\New-WorktreeFromBranch.ps1'
+
+.NOTES
+    The script must contain an embedded help block with the special marker syntax.
+#>
+function Show-FileEmbeddedHelp {
+  param([string]$ScriptPath)
+  if (-not (Test-Path $ScriptPath)) { throw "Cannot load help; file missing: $ScriptPath" }
+  $content = Get-Content -LiteralPath $ScriptPath -ErrorAction Stop
+  $inBlock=$false
+  foreach($line in $content){
+    if ($line -match '^<#!') { $inBlock=$true; continue }
+    if ($line -match '#>$') { break }
+    if ($inBlock) { Write-Host $line }
+  }
+  Show-CommonManualStepsFooter
+}
+
+<#
+.SYNOPSIS
+    Sets or updates the upstream tracking branch for a local branch.
+
+.DESCRIPTION
+    Configures the upstream remote and branch for a local branch. If already set to
+    the specified upstream, takes no action. If set to a different upstream, updates it.
+
+.PARAMETER LocalBranch
+    The local branch name to configure.
+
+.PARAMETER RemoteName
+    The name of the remote (e.g., 'origin').
+
+.PARAMETER RemoteBranchPath
+    The branch path on the remote (e.g., 'main' for origin/main).
+
+.EXAMPLE
+    Set-BranchUpstream -LocalBranch 'feature/login' -RemoteName 'origin' -RemoteBranchPath 'feature/login'
+
+.NOTES
+    Displays a warning if the upstream cannot be set automatically.
+#>
+function Set-BranchUpstream {
+  param(
+    [Parameter(Mandatory)][string]$LocalBranch,
+    [Parameter(Mandatory)][string]$RemoteName,
+    [Parameter(Mandatory)][string]$RemoteBranchPath
+  )
+  $current = git rev-parse --abbrev-ref --symbolic-full-name "$LocalBranch@{upstream}" 2>$null
+  if (-not $current) {
+    Info "Setting upstream: $LocalBranch -> $RemoteName/$RemoteBranchPath"
+    git branch --set-upstream-to "$RemoteName/$RemoteBranchPath" $LocalBranch 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { Warn "Failed to set upstream automatically. Run: git branch --set-upstream-to $RemoteName/$RemoteBranchPath $LocalBranch" }
+    return
+  }
+  if ($current -ne "$RemoteName/$RemoteBranchPath") {
+    Warn "Upstream mismatch ($current != $RemoteName/$RemoteBranchPath); updating..."
+    git branch --set-upstream-to "$RemoteName/$RemoteBranchPath" $LocalBranch 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { Warn "Could not update upstream; manual fix: git branch --set-upstream-to $RemoteName/$RemoteBranchPath $LocalBranch" } else { Info 'Upstream corrected.' }
+  } else { Info "Upstream already: $current" }
+}
+
+<#
+.SYNOPSIS
+    Returns an ordered list of remote names, preferring 'upstream' then 'origin'.
+
+.DESCRIPTION
+    Queries 'git remote' and returns all configured remotes sorted so that
+    'upstream' (if present) comes first, then 'origin', then any others.
+    Works for both fork setups (origin=fork, upstream=source) and direct
+    clones (origin=source, no upstream).
+
+.OUTPUTS
+    System.String[]. Ordered list of remote names.
+
+.EXAMPLE
+    $remotes = Get-OrderedRemotes
+    # Fork:   @('upstream', 'origin')
+    # Direct: @('origin')
+#>
+function Get-OrderedRemotes {
+  $all = @(git remote 2>$null)
+  if (-not $all) { return @() }
+  $ordered = @()
+  if ($all -contains 'upstream') { $ordered += 'upstream' }
+  if ($all -contains 'origin')   { $ordered += 'origin' }
+  $ordered += ($all | Where-Object { $_ -ne 'upstream' -and $_ -ne 'origin' })
+  return $ordered
+}
+
+<#
+.SYNOPSIS
+    Finds the best default base ref for new branches (upstream master/main).
+
+.DESCRIPTION
+    Looks for the default branch on the canonical upstream remote.
+    In a fork setup (upstream=microsoft/WSL), returns upstream/master.
+    In a direct clone (origin=microsoft/WSL), returns origin/master.
+    Falls back to checking 'main' if 'master' doesn't exist.
+
+.OUTPUTS
+    System.String. A remote ref like 'upstream/master' or 'origin/master'.
+
+.EXAMPLE
+    $base = Get-DefaultBaseRef
+    # Fork:   'upstream/master'
+    # Direct: 'origin/master'
+#>
+function Get-DefaultBaseRef {
+  $remotes = Get-OrderedRemotes
+  foreach ($remote in $remotes) {
+    foreach ($branch in @('master', 'main')) {
+      git show-ref --verify --quiet "refs/remotes/$remote/$branch" 2>$null
+      if ($LASTEXITCODE -eq 0) { return "$remote/$branch" }
+    }
+  }
+  return 'origin/master'
+}
+
+<#
+.SYNOPSIS
+    Finds a branch across all remotes and returns the first matching remote ref.
+
+.DESCRIPTION
+    Searches all configured remotes (upstream first, then origin, then others)
+    for a branch name. Returns the first matching remote/branch ref, or $null.
+
+.PARAMETER BranchName
+    The branch name to search for (without remote prefix).
+
+.OUTPUTS
+    System.String or $null. E.g., 'upstream/feature/foo' or 'origin/feature/foo'.
+
+.EXAMPLE
+    $ref = Find-BranchOnRemotes -BranchName 'feature/login'
+#>
+function Find-BranchOnRemotes {
+  param([Parameter(Mandatory)][string]$BranchName)
+  $remotes = Get-OrderedRemotes
+  foreach ($remote in $remotes) {
+    git show-ref --verify --quiet "refs/remotes/$remote/$BranchName" 2>$null
+    if ($LASTEXITCODE -eq 0) { return "$remote/$BranchName" }
+  }
+  return $null
+}

--- a/.github/skills/worktree-manager/scripts/WorktreeLib.ps1
+++ b/.github/skills/worktree-manager/scripts/WorktreeLib.ps1
@@ -176,7 +176,7 @@ function New-WorktreeForExistingBranch {
       } else {
         git checkout --detach 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) { throw "Cannot free branch '$Branch' from main repo. Checkout a different branch first." }
-        Warn "Main repo is now in detached HEAD. Run 'git checkout master' when done."
+        Warn "Main repo is now in detached HEAD. Run 'git checkout $localDefault' when done."
       }
       # Now fall through to create the worktree below
     } else {
@@ -225,6 +225,7 @@ function Get-WorktreeEntries {
     if ($l -eq '') { if ($current.path -and $current.branch){ $entries += ,([pscustomobject]@{ Path=$current.path; Branch=($current.branch -replace '^refs/heads/','') }) }; $current=@{ path=$null; branch=$null }; continue }
     if ($l -like 'worktree *'){ $current.path = ($l -split ' ',2)[1] }
     elseif ($l -like 'branch *'){ $current.branch = ($l -split ' ',2)[1].Trim() }
+    elseif ($l -eq 'detached'){ $current.branch = '(detached)' }
   }
   if ($current.path -and $current.branch){ $entries += ,([pscustomobject]@{ Path=$current.path; Branch=($current.branch -replace '^refs/heads/','') }) }
   return ($entries | Sort-Object Path,Branch -Unique)
@@ -425,31 +426,31 @@ function Get-OrderedRemotes {
 
 <#
 .SYNOPSIS
-    Finds the best default base ref for new branches (upstream master/main).
+    Finds the best default base ref for new branches.
 
 .DESCRIPTION
-    Looks for the default branch on the canonical upstream remote.
-    In a fork setup (upstream=microsoft/WSL), returns upstream/master.
-    In a direct clone (origin=microsoft/WSL), returns origin/master.
-    Falls back to checking 'main' if 'master' doesn't exist.
+    Checks remote-tracking refs in this order: upstream/master, upstream/main,
+    origin/master, origin/main. If none of those refs exist locally, it tries to
+    resolve origin/HEAD and falls back to origin/main.
 
 .OUTPUTS
-    System.String. A remote ref like 'upstream/master' or 'origin/master'.
+    System.String. A remote ref such as 'upstream/master' or 'origin/main'.
 
 .EXAMPLE
     $base = Get-DefaultBaseRef
     # Fork:   'upstream/master'
-    # Direct: 'origin/master'
+    # Direct: 'origin/main' or 'origin/master'
 #>
 function Get-DefaultBaseRef {
-  $remotes = Get-OrderedRemotes
-  foreach ($remote in $remotes) {
-    foreach ($branch in @('master', 'main')) {
-      git show-ref --verify --quiet "refs/remotes/$remote/$branch" 2>$null
-      if ($LASTEXITCODE -eq 0) { return "$remote/$branch" }
-    }
+  foreach ($ref in @('upstream/master', 'upstream/main', 'origin/master', 'origin/main')) {
+    git show-ref --verify --quiet "refs/remotes/$ref" 2>$null
+    if ($LASTEXITCODE -eq 0) { return $ref }
   }
-  return 'origin/master'
+
+  $originHead = git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>$null
+  if ($LASTEXITCODE -eq 0 -and $originHead) { return $originHead.Trim() }
+
+  return 'origin/main'
 }
 
 <#

--- a/tools/git/Delete-Worktree.cmd
+++ b/tools/git/Delete-Worktree.cmd
@@ -1,0 +1,11 @@
+@echo off
+REM Delete-Worktree.cmd - Convenience wrapper for human users
+REM Master source: .github/skills/worktree-manager/scripts/Delete-Worktree.ps1
+REM Usage: Delete-Worktree.cmd -Pattern <pattern> [-Force] [-KeepBranch]
+setlocal
+for /f "delims=" %%i in ('git rev-parse --show-toplevel 2^>nul') do set REPO_ROOT=%%i
+if "%REPO_ROOT%"=="" (
+    echo Error: Not inside a Git repository.
+    exit /b 1
+)
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\Delete-Worktree.ps1" %*

--- a/tools/git/Delete-Worktree.cmd
+++ b/tools/git/Delete-Worktree.cmd
@@ -8,4 +8,10 @@ if "%REPO_ROOT%"=="" (
     echo Error: Not inside a Git repository.
     exit /b 1
 )
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\Delete-Worktree.ps1" %*
+where pwsh >nul 2>nul
+if %ERRORLEVEL%==0 (
+    set "PS_EXE=pwsh"
+) else (
+    set "PS_EXE=powershell.exe"
+)
+"%PS_EXE%" -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\Delete-Worktree.ps1" %*

--- a/tools/git/New-WorktreeFromBranch.cmd
+++ b/tools/git/New-WorktreeFromBranch.cmd
@@ -1,0 +1,10 @@
+@echo off
+REM New-WorktreeFromBranch.cmd - Convenience wrapper for human users
+REM Master source: .github/skills/worktree-manager/scripts/New-WorktreeFromBranch.ps1
+setlocal
+for /f "delims=" %%i in ('git rev-parse --show-toplevel 2^>nul') do set REPO_ROOT=%%i
+if "%REPO_ROOT%"=="" (
+    echo Error: Not inside a Git repository.
+    exit /b 1
+)
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\New-WorktreeFromBranch.ps1" %*

--- a/tools/git/New-WorktreeFromBranch.cmd
+++ b/tools/git/New-WorktreeFromBranch.cmd
@@ -7,4 +7,10 @@ if "%REPO_ROOT%"=="" (
     echo Error: Not inside a Git repository.
     exit /b 1
 )
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\New-WorktreeFromBranch.ps1" %*
+where pwsh >nul 2>nul
+if %ERRORLEVEL%==0 (
+    set "PS_EXE=pwsh"
+) else (
+    set "PS_EXE=powershell.exe"
+)
+"%PS_EXE%" -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\New-WorktreeFromBranch.ps1" %*

--- a/tools/git/New-WorktreeFromIssue.cmd
+++ b/tools/git/New-WorktreeFromIssue.cmd
@@ -1,0 +1,10 @@
+@echo off
+REM New-WorktreeFromIssue.cmd - Convenience wrapper for human users
+REM Master source: .github/skills/worktree-manager/scripts/New-WorktreeFromIssue.ps1
+setlocal
+for /f "delims=" %%i in ('git rev-parse --show-toplevel 2^>nul') do set REPO_ROOT=%%i
+if "%REPO_ROOT%"=="" (
+    echo Error: Not inside a Git repository.
+    exit /b 1
+)
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\New-WorktreeFromIssue.ps1" %*

--- a/tools/git/New-WorktreeFromIssue.cmd
+++ b/tools/git/New-WorktreeFromIssue.cmd
@@ -7,4 +7,10 @@ if "%REPO_ROOT%"=="" (
     echo Error: Not inside a Git repository.
     exit /b 1
 )
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\New-WorktreeFromIssue.ps1" %*
+where pwsh >nul 2>nul
+if %ERRORLEVEL%==0 (
+    set "PS_EXE=pwsh"
+) else (
+    set "PS_EXE=powershell.exe"
+)
+"%PS_EXE%" -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%\.github\skills\worktree-manager\scripts\New-WorktreeFromIssue.ps1" %*

--- a/tools/git/Worktree-Guidelines.md
+++ b/tools/git/Worktree-Guidelines.md
@@ -1,0 +1,94 @@
+# Git Worktree Helper Scripts
+
+This folder contains convenience wrapper scripts for human users. The **master implementation** lives in the self-contained skill at `.github/skills/worktree-manager/`.
+
+## Architecture
+
+```
+.github/skills/worktree-manager/       # Master source (self-contained skill)
+├── SKILL.md                           # Skill documentation
+└── scripts/
+    ├── WorktreeLib.ps1                # Shared helpers (master)
+    ├── New-WorktreeFromBranch.ps1     # Implementation
+    ├── New-WorktreeFromIssue.ps1      # Implementation
+    └── Delete-Worktree.ps1            # Implementation
+
+tools/git/                             # Human-friendly wrappers
+├── New-WorktreeFromBranch.cmd         # Wrapper -> skill
+├── New-WorktreeFromIssue.cmd          # Wrapper -> skill
+├── Delete-Worktree.cmd                # Wrapper -> skill
+└── Worktree-Guidelines.md             # This file
+```
+
+## Why This Structure?
+
+- **Self-contained skill**: The `.github/skills/worktree-manager/` folder is portable and works with GitHub Copilot agent skills
+- **Human convenience**: The `tools/git/` wrappers provide familiar paths for developers
+- **Single source of truth**: All logic lives in the skill folder; wrappers just delegate
+
+## Why Worktrees?
+
+Git worktrees let you have several checked-out branches sharing a single `.git` object store. Benefits:
+- Fast context switching: no re-clone, no duplicate large binary/object downloads
+- Lower disk usage versus multiple full clones
+- Keeps each change isolated in its own folder so you can run builds/tests independently
+- Enables working in parallel with branches created using GitHub Copilot assistance or by Copilot agents while the main clone stays clean
+
+Recommended: keep active parallel worktrees to **≤ 3** per developer to reduce cognitive load and avoid excessive incremental build invalidations.
+
+## Scripts Overview
+
+| Script | Purpose |
+|--------|---------|
+| `New-WorktreeFromBranch.cmd` | Create/reuse a worktree for an existing local or remote (origin) branch |
+| `New-WorktreeFromIssue.cmd` | Start a new work item branch from a base (default `origin/main`) using naming `workitem/<number>-<slug>` |
+| `Delete-Worktree.cmd` | Remove a worktree and optionally its local branch |
+
+## Typical Flows
+
+### 1. Create from an existing or remote branch
+```cmd
+New-WorktreeFromBranch.cmd -Branch origin/feature/new-ui
+```
+Fetches if needed and creates a tracking branch if missing, then creates/reuses the worktree.
+
+### 2. Start a new work item branch (Azure DevOps)
+```cmd
+New-WorktreeFromIssue.cmd -Number 1234 -Title "Crash on launch"
+```
+Creates branch `workitem/1234-crash-on-launch` off the auto-detected base (or explicit `-Base`), then worktree.
+The base is auto-detected: `upstream/master` in a fork setup, `origin/master` in a direct clone.
+
+### 3. Delete a worktree when done
+```cmd
+Delete-Worktree.cmd -Pattern feature/perf-tweak
+```
+If only one match, removes the worktree directory. Add `-Force` to discard local changes. Use `-KeepBranch` if you still need the branch.
+
+## Naming & Locations
+
+- Worktrees are created as sibling folders of the repo root (e.g., `WindowsAppSDK` + `WindowsAppSDK-ab12`), using a hash/short pattern to avoid collisions
+- Work item branches: `workitem/<number>` or `workitem/<number>-<slug>`
+
+## Best Practices
+
+- Keep ≤ 3 active parallel worktrees (e.g., main dev, a long-lived feature, a quick fix / experiment) plus the root clone
+- Delete stale worktrees early; each adds file watchers & potential incremental build churn
+- Avoid editing the same file across multiple worktrees simultaneously to reduce merge friction
+- Run `git fetch --all --prune` periodically in the primary repo, not in every worktree
+
+## Troubleshooting
+
+| Symptom | Hint |
+|---------|------|
+| Cannot lock ref *.lock | Stale lock: run `git worktree prune` or manually delete the `.lock` file then retry |
+| Worktree already exists error | Use `git worktree list` to locate existing path; open that folder instead of creating a duplicate |
+| Local branch missing for remote | Use `git branch --track <name> origin/<name>` then re-run the branch script |
+
+## Security & Safety Notes
+
+- Scripts avoid force-deleting unless you pass `-Force` (Delete script)
+- No network credentials are stored; they rely on your existing Git credential helper
+
+---
+**Note**: For the full skill documentation, see [.github/skills/worktree-manager/SKILL.md](../../.github/skills/worktree-manager/SKILL.md).

--- a/tools/git/Worktree-Guidelines.md
+++ b/tools/git/Worktree-Guidelines.md
@@ -41,7 +41,7 @@ Recommended: keep active parallel worktrees to **≤ 3** per developer to reduce
 | Script | Purpose |
 |--------|---------|
 | `New-WorktreeFromBranch.cmd` | Create/reuse a worktree for an existing local or remote (origin) branch |
-| `New-WorktreeFromIssue.cmd` | Start a new work item branch from a base (default `origin/main`) using naming `workitem/<number>-<slug>` |
+| `New-WorktreeFromIssue.cmd` | Start a new work item branch from an auto-detected base (`upstream/master` > `upstream/main` > `origin/master` > `origin/main`, then `origin/HEAD` when available) using naming `workitem/<number>-<slug>` |
 | `Delete-Worktree.cmd` | Remove a worktree and optionally its local branch |
 
 ## Typical Flows
@@ -57,7 +57,7 @@ Fetches if needed and creates a tracking branch if missing, then creates/reuses 
 New-WorktreeFromIssue.cmd -Number 1234 -Title "Crash on launch"
 ```
 Creates branch `workitem/1234-crash-on-launch` off the auto-detected base (or explicit `-Base`), then worktree.
-The base is auto-detected: `upstream/master` in a fork setup, `origin/master` in a direct clone.
+The base is auto-detected in this order: `upstream/master`, `upstream/main`, `origin/master`, `origin/main`, then `origin/HEAD` when available.
 
 ### 3. Delete a worktree when done
 ```cmd
@@ -67,7 +67,7 @@ If only one match, removes the worktree directory. Add `-Force` to discard local
 
 ## Naming & Locations
 
-- Worktrees are created as sibling folders of the repo root (e.g., `WindowsAppSDK` + `WindowsAppSDK-ab12`), using a hash/short pattern to avoid collisions
+- Worktrees are created as sibling folders of the repo root (e.g., `WSL` + `WSL-ab12`), using a hash/short pattern to avoid collisions
 - Work item branches: `workitem/<number>` or `workitem/<number>-<slug>`
 
 ## Best Practices


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request introduces a new "worktree-manager" skill for managing Git worktrees, supporting parallel development workflows. It adds comprehensive documentation, robust PowerShell scripts for creating and deleting worktrees, and human-friendly Windows command wrappers. The changes make it easier for developers to create isolated environments for different tasks, automate common worktree operations, and follow best practices for branch and worktree management.

**Worktree management scripts and documentation:**

* Added detailed documentation in `SKILL.md` describing when and how to use worktrees, script usage, workflows, troubleshooting, and best practices.
* Implemented `New-WorktreeFromBranch.ps1`: creates or reuses a worktree for an existing branch, including remote tracking and VS Code integration.
* Implemented `New-WorktreeFromIssue.ps1`: creates a new branch and worktree for a specified work item, with auto-naming and base branch detection.
* Implemented `Delete-Worktree.ps1`: safely removes a worktree and optionally its branch, with pattern matching, force options, and user guidance.

**Developer convenience wrappers:**

* Added `.cmd` wrappers in `tools/git/` for all main scripts, allowing easy execution from the command line in Windows environments. [[1]](diffhunk://#diff-24ca25b8552045257d1b16e8552e55f975939c20e227b68ba9616e90cbd7c1c5R1-R10) [[2]](diffhunk://#diff-bf0dfe5437d0cd713b4114e9764f951d0317813c8265a93d902118224563b700R1-R10) [[3]](diffhunk://#diff-7b396985e23896efa1f4bab2c90c5ebda15304b0ad0acfd849627722487a8a61R1-R11)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Dev docs:** Added/updated if needed