### PR TITLE
Add warning to collect-wsl-logs.ps1 to be displayed when tool is missing

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -11,24 +11,45 @@ Set-StrictMode -Version Latest
 
 function Test-WslApplication {
     param (
-        $Name,
-        $Command
+        $Name
     )
 
     # Log warning when tool is not present in WSL
     try
     {
-        & wsl.exe -e sh -lc "command -v $Command >/dev/null 2>&1"
-        $available = ($LASTEXITCODE -eq 0)
+        # Capture any output/error from wsl.exe so we can distinguish
+        # between "command not found" and "WSL invocation failed".
+        $wslOutput = & wsl.exe -e sh -lc "command -v $Name >/dev/null 2>&1" 2>&1
+        $exitCode = $LASTEXITCODE
 
-        if (-not $available)
+        if ($exitCode -eq 0)
         {
-            Write-Warning "$Name not found in WSL. For a more complete log collection install $Name."
+            return $true
         }
 
-        return $available
+        # POSIX shells typically return 1 when command -v does not find the command, but we have seen sh returning 127.
+        if ($exitCode -eq 1 -or $exitCode -eq 127)
+        {
+            Write-Warning "$Name not found in WSL. For a more complete log collection install $Name."
+            return $false
+        }
+
+        # Any other exit code is assumed to indicate WSL itself failed
+        # (e.g., no distro installed, WSL disabled, or other startup error).
+        if (-not [string]::IsNullOrWhiteSpace($wslOutput))
+        {
+            Write-Warning "Unable to check for $Name in WSL. wsl.exe exited with code $exitCode. Output: $wslOutput"
+        }
+        else
+        {
+            Write-Warning "Unable to check for $Name in WSL. wsl.exe exited with code $exitCode."
+        }
+        return $false
     }
-    catch {}
+    catch
+    {
+        Write-Warning "Unexpected error while checking for $Name in WSL."
+    }
 
     return $false
 }
@@ -113,8 +134,8 @@ else
 # Networking-specific setup
 if ($LogProfile -eq "networking")
 {
-    Test-WslApplication -Name "tcpdump" -Command "tcpdump --version" | Out-Null
-    Test-WslApplication -Name "iptables" -Command "iptables --version" | Out-Null
+    Test-WslApplication -Name "tcpdump" | Out-Null
+    Test-WslApplication -Name "iptables" | Out-Null
 
     # Copy/download networking.sh script
     $networkingBashScript = "$folder/networking.sh"

--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -15,40 +15,33 @@ function Test-WslApplication {
     )
 
     # Log warning when tool is not present in WSL
-    try
+
+    # Capture any output/error from wsl.exe so we can distinguish
+    # between "command not found" and "WSL invocation failed".
+    $wslOutput = & wsl.exe -e sh -lc "command -v $Name >/dev/null 2>&1" 2>&1
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0)
     {
-        # Capture any output/error from wsl.exe so we can distinguish
-        # between "command not found" and "WSL invocation failed".
-        $wslOutput = & wsl.exe -e sh -lc "command -v $Name >/dev/null 2>&1" 2>&1
-        $exitCode = $LASTEXITCODE
+        return $true
+    }
 
-        if ($exitCode -eq 0)
-        {
-            return $true
-        }
-
-        # POSIX shells typically return 1 when command -v does not find the command, but we have seen sh returning 127.
-        if ($exitCode -eq 1 -or $exitCode -eq 127)
-        {
-            Write-Warning "$Name not found in WSL. For a more complete log collection install $Name."
-            return $false
-        }
-
-        # Any other exit code is assumed to indicate WSL itself failed
-        # (e.g., no distro installed, WSL disabled, or other startup error).
-        if (-not [string]::IsNullOrWhiteSpace($wslOutput))
-        {
-            Write-Warning "Unable to check for $Name in WSL. wsl.exe exited with code $exitCode. Output: $wslOutput"
-        }
-        else
-        {
-            Write-Warning "Unable to check for $Name in WSL. wsl.exe exited with code $exitCode."
-        }
+    # POSIX shells typically return 1 when command -v does not find the command, but we have seen sh returning 127.
+    if ($exitCode -eq 1 -or $exitCode -eq 127)
+    {
+        Write-Warning "$Name not found in WSL. For a more complete log collection install $Name."
         return $false
     }
-    catch
+
+    # Any other exit code is assumed to indicate WSL itself failed
+    # (e.g., no distro installed, WSL disabled, or other startup error).
+    if (-not [string]::IsNullOrWhiteSpace($wslOutput))
     {
-        Write-Warning "Unexpected error while checking for $Name in WSL."
+        Write-Warning "Unable to check for $Name in WSL. wsl.exe exited with code $exitCode. Output: $wslOutput"
+    }
+    else
+    {
+        Write-Warning "Unable to check for $Name in WSL. wsl.exe exited with code $exitCode."
     }
 
     return $false

--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -9,6 +9,30 @@ Param (
 
 Set-StrictMode -Version Latest
 
+function Test-WslApplication {
+    param (
+        $Name,
+        $Command
+    )
+
+    # Log warning when tool is not present in WSL
+    try
+    {
+        & wsl.exe -e sh -lc "command -v $Command >/dev/null 2>&1"
+        $available = ($LASTEXITCODE -eq 0)
+
+        if (-not $available)
+        {
+            Write-Warning "$Name not found in WSL. For a more complete log collection install $Name."
+        }
+
+        return $available
+    }
+    catch {}
+
+    return $false
+}
+
 function Collect-WindowsNetworkState {
     param (
         $Folder,
@@ -89,6 +113,9 @@ else
 # Networking-specific setup
 if ($LogProfile -eq "networking")
 {
+    Test-WslApplication -Name "tcpdump" -Command "tcpdump --version" | Out-Null
+    Test-WslApplication -Name "iptables" -Command "iptables --version" | Out-Null
+
     # Copy/download networking.sh script
     $networkingBashScript = "$folder/networking.sh"
     if (Test-Path "$PSScriptRoot/networking.sh")


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
On executing the log collection script, it will first confirm the required tools `tcpdump` and `iptables` are installed. For each tool
missing a warning is displayed, reminding the user that the tool should be installed prior to executing the script to get a more
complete log collection.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #14427 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** No automated test is deemed necessary to cover the scenarios
- [ ] **Localization:** Wrote warning in plain English, like the messages already present in the log collection script
- [ ] **Dev docs:** No doc update needed
- [ ] **Documentation updated:** No doc update needed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
<!-- ## Detailed Description of the Pull Request / Additional comments -->

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran the command below (from log collection instructions) manually in both scenarios where tools are installed and not installed.
Visually confirmed that both warning messages show up when the respective tool is not installed.
`.\collect-wsl-logs.ps1 -LogProfile networking`
