### PR TITLE
Add DCAT registration remediation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,8 @@ add_compile_definitions(UNICODE
                         WSL_PACKAGE_VERSION_MAJOR=${PACKAGE_VERSION_MAJOR}
                         WSL_PACKAGE_VERSION_MINOR=${PACKAGE_VERSION_MINOR}
                         WSL_PACKAGE_VERSION_REVISION=${PACKAGE_VERSION_REVISION}
-                        WSL_BUILD_WSL_SETTINGS=${WSL_BUILD_WSL_SETTINGS})
+                        WSL_BUILD_WSL_SETTINGS=${WSL_BUILD_WSL_SETTINGS}
+                        DCAT_REGISTRATION_KEY=R"\(${DCAT_REGISTRATION_KEY}\)")
 
 if (${OFFICIAL_BUILD})
     add_compile_definitions(WSL_OFFICIAL_BUILD)

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -713,9 +713,6 @@ try
     }
 
     wil::unique_hkey dcatKey = wsl::windows::common::registry::CreateKey(HKEY_LOCAL_MACHINE, TEXT(DCAT_REGISTRATION_KEY), KEY_SET_VALUE);
-    if (dcatKey)
-    {
-        wsl::windows::common::registry::WriteString(dcatKey.get(), nullptr, L"Version", registeredVersion.c_str());
-    }
+    wsl::windows::common::registry::WriteString(dcatKey.get(), nullptr, L"Version", registeredVersion.c_str());
 }
 CATCH_LOG()

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -698,3 +698,24 @@ bool wsl::windows::common::helpers::TryAttachConsole()
 
     return ReopenStdHandles();
 }
+
+void wsl::windows::common::helpers::RegisterWithDcat(_In_ bool IncludeVersionNumber)
+try
+{
+    std::wstring registeredVersion;
+    if (IncludeVersionNumber)
+    {
+        registeredVersion.assign(TEXT(WSL_PACKAGE_VERSION));
+    }
+    else
+    {
+        registeredVersion.assign(L"0.0.0.0");
+    }
+
+    wil::unique_hkey dcatKey = wsl::windows::common::registry::CreateKey(HKEY_LOCAL_MACHINE, TEXT(DCAT_REGISTRATION_KEY), KEY_SET_VALUE);
+    if (dcatKey)
+    {
+        wsl::windows::common::registry::WriteString(dcatKey.get(), nullptr, L"Version", registeredVersion.c_str());
+    }
+}
+CATCH_LOG()

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -199,4 +199,6 @@ void SetHandleInheritable(_In_ HANDLE Handle, _In_ bool Inheritable = true);
 
 bool TryAttachConsole();
 
+void RegisterWithDcat(_In_ bool IncludeVersionNumber = true);
+
 } // namespace wsl::windows::common::helpers

--- a/src/windows/service/exe/ServiceMain.cpp
+++ b/src/windows/service/exe/ServiceMain.cpp
@@ -193,6 +193,9 @@ try
     });
 
     EvaluateWslPolicy();
+
+    wsl::windows::common::helpers::RegisterWithDcat();
+
     return S_OK;
 }
 CATCH_RETURN()

--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -759,7 +759,7 @@ class InstallerTests
         ValidatePackageInstalledProperly();
     }
 
-    TEST_METHOD(InstallremovesStaleServiceRegistration)
+    TEST_METHOD(InstallRemovesStaleServiceRegistration)
     {
         // Remove the MSI package.
         UninstallMsi();
@@ -936,6 +936,47 @@ class InstallerTests
 
         // Verify that key was unprotected.
         VERIFY_IS_FALSE(SfcIsKeyProtected(HKEY_LOCAL_MACHINE, keyPath, KEY_WOW64_64KEY));
+    }
+
+    void ValidateDcatRegistration()
+    {
+        const auto versionValue =
+            wsl::windows::common::registry::ReadString(HKEY_LOCAL_MACHINE, WIDEN(DCAT_REGISTRATION_KEY), L"Version");
+        VERIFY_ARE_EQUAL(versionValue, WIDEN(WSL_PACKAGE_VERSION));
+    }
+
+    TEST_METHOD(InstallerRegistersWithDcat)
+    {
+        // Uninstalling should remove the registration
+        UninstallMsi();
+        VERIFY_IS_FALSE(IsMsiPackageInstalled());
+        VERIFY_IS_FALSE(IsMsixInstalled());
+
+        VERIFY_ARE_EQUAL(
+            wsl::windows::common::registry::OpenKeyNoThrow(HKEY_LOCAL_MACHINE, WIDEN(DCAT_REGISTRATION_KEY), KEY_READ).second,
+            HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+
+        // Installing should add the registration
+        InstallMsi();
+        VERIFY_IS_TRUE(IsMsiPackageInstalled());
+        VERIFY_IS_TRUE(IsMsixInstalled());
+
+        ValidateDcatRegistration();
+    }
+
+    TEST_METHOD(ServiceRemediatesDcatRegistration)
+    {
+        // Starting the service should create the registration if it is missing
+        StopWslService();
+        wsl::windows::common::registry::DeleteKey(HKEY_LOCAL_MACHINE, WIDEN(DCAT_REGISTRATION_KEY));
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--list"), 0);
+        ValidateDcatRegistration();
+
+        // Starting the service should fix the registration if needed
+        StopWslService();
+        wsl::windows::common::registry::WriteString(HKEY_LOCAL_MACHINE, WIDEN(DCAT_REGISTRATION_KEY), L"Version", L"1.0.0");
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--list"), 0);
+        ValidateDcatRegistration();
     }
 
     void CallWslUpdateViaMsi()

--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -968,7 +968,7 @@ class InstallerTests
     {
         // Starting the service should create the registration if it is missing
         StopWslService();
-        wsl::windows::common::registry::DeleteKey(HKEY_LOCAL_MACHINE, WIDEN(DCAT_REGISTRATION_KEY));
+        VERIFY_ARE_EQUAL(wsl::windows::common::registry::DeleteKey(HKEY_LOCAL_MACHINE, WIDEN(DCAT_REGISTRATION_KEY)), true);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--list"), 0);
         ValidateDcatRegistration();
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

To remediate the case where the registration key gets deleted, we re-set the key on every launch.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

I added the remediation to `wslservice`, near the end of the `OnServiceStarting()`. The registration function writes to the registry without checking, as we would want to update the version if it is wrong for some reason.
I added an option to set the registration version to 0.0.0.0, which can be used for the initial installation.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
