### PR TITLE
Add session termination coverage for Export & Save

### DIFF
--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1561,12 +1561,22 @@ class WSLATests
         NON_COPYABLE(BlockingOperation);
         NON_MOVABLE(BlockingOperation);
 
-        BlockingOperation(std::function<HRESULT(HANDLE)>&& Operation, HRESULT ExpectedResult = S_OK) :
-            m_operation(std::move(Operation)), m_expectedResult(ExpectedResult)
+        BlockingOperation(std::function<HRESULT(HANDLE)>&& Operation, HRESULT ExpectedResult = S_OK, bool AllowEarlyCompletion = false, bool UseOverlappedWritePipe = false) :
+            m_operation(std::move(Operation)), m_expectedResult(ExpectedResult), m_allowEarlyCompletion(AllowEarlyCompletion)
         {
             wil::unique_handle pipeRead;
             wil::unique_handle pipeWrite;
-            VERIFY_WIN32_BOOL_SUCCEEDED(CreatePipe(&pipeRead, &pipeWrite, nullptr, 100000));
+
+            if (UseOverlappedWritePipe)
+            {
+                auto [read, write] = wsl::windows::common::wslutil::OpenAnonymousPipe(100000, false, true);
+                pipeRead.reset(read.release());
+                pipeWrite.reset(write.release());
+            }
+            else
+            {
+                VERIFY_WIN32_BOOL_SUCCEEDED(CreatePipe(&pipeRead, &pipeWrite, nullptr, 100000));
+            }
 
             m_operationThread = std::thread(&BlockingOperation::RunOperation, this, std::move(pipeWrite));
             m_ioThread = std::thread(&BlockingOperation::RunIO, this, std::move(pipeRead));
@@ -1592,9 +1602,10 @@ class WSLATests
         {
             m_result.set_value(m_operation(Handle.get()));
 
-            // Fail if the operation completed before the test signaled completion.
+            // Fail if the operation completed before the test signaled completion
+            // (unless early completion is expected, e.g. session termination).
             // Don't use VERIFY macros since this is running in a separate thread.
-            WI_ASSERT(m_testCompleteEvent.is_signaled());
+            WI_ASSERT(m_allowEarlyCompletion || m_testCompleteEvent.is_signaled());
         }
 
         void RunIO(wil::unique_handle Handle)
@@ -1646,6 +1657,7 @@ class WSLATests
         std::thread m_ioThread;
         std::promise<HRESULT> m_result;
         HRESULT m_expectedResult{};
+        bool m_allowEarlyCompletion{};
     };
 
     TEST_METHOD(SaveImage)
@@ -5356,6 +5368,46 @@ class WSLATests
             auto [result, _] = WSLAProcessLauncher({}, {"echo", "OK"}).LaunchNoThrow(container.Get());
             VERIFY_ARE_EQUAL(result, HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
         }
+    }
+
+    TEST_METHOD(SessionTerminationDuringSave)
+    {
+        WSL2_TEST_ONLY();
+
+        // Validate that SaveImage is aborted when the session terminates mid-operation.
+        // Use overlapped write pipe so the server-side WriteFile doesn't block synchronously.
+        BlockingOperation operation(
+            [&](HANDLE handle) { return m_defaultSession->SaveImage(HandleToULong(handle), "debian:latest", nullptr, nullptr); }, E_ABORT, true, true);
+
+        // Terminate the session while SaveImage is in-flight.
+        VERIFY_SUCCEEDED(m_defaultSession->Terminate());
+        operation.Complete();
+
+        // Re-create the session.
+        m_defaultSession.reset();
+        m_defaultSession = CreateSession(m_defaultSessionSettings);
+    }
+
+    TEST_METHOD(SessionTerminationDuringExport)
+    {
+        WSL2_TEST_ONLY();
+
+        // Validate that container Export is aborted when the session terminates mid-operation.
+        WSLAContainerLauncher launcher("debian:latest", "test-export-session-terminate", {"echo", "OK"});
+        auto container = launcher.Launch(*m_defaultSession);
+        container.GetInitProcess().Wait();
+
+        BlockingOperation operation([&](HANDLE handle) { return container.Get().Export(HandleToULong(handle)); }, E_ABORT, true);
+
+        // Terminate the session while Export is in-flight.
+        VERIFY_SUCCEEDED(m_defaultSession->Terminate());
+        operation.Complete();
+
+        // Re-create the session and clean up the leftover container.
+        m_defaultSession.reset();
+        m_defaultSession = CreateSession(m_defaultSessionSettings);
+        PruneResult result;
+        VERIFY_SUCCEEDED(m_defaultSession->PruneContainers(nullptr, 0, 0, &result.result));
     }
 
     TEST_METHOD(InteractiveDetach)

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1564,19 +1564,9 @@ class WSLATests
         BlockingOperation(std::function<HRESULT(HANDLE)>&& Operation, HRESULT ExpectedResult = S_OK, bool AllowEarlyCompletion = false, bool UseOverlappedWritePipe = false) :
             m_operation(std::move(Operation)), m_expectedResult(ExpectedResult), m_allowEarlyCompletion(AllowEarlyCompletion)
         {
-            wil::unique_handle pipeRead;
-            wil::unique_handle pipeWrite;
-
-            if (UseOverlappedWritePipe)
-            {
-                auto [read, write] = wsl::windows::common::wslutil::OpenAnonymousPipe(100000, false, true);
-                pipeRead.reset(read.release());
-                pipeWrite.reset(write.release());
-            }
-            else
-            {
-                VERIFY_WIN32_BOOL_SUCCEEDED(CreatePipe(&pipeRead, &pipeWrite, nullptr, 100000));
-            }
+            auto [read, write] = wsl::windows::common::wslutil::OpenAnonymousPipe(100000, false, UseOverlappedWritePipe);
+            wil::unique_handle pipeRead(read.release());
+            wil::unique_handle pipeWrite(write.release());
 
             m_operationThread = std::thread(&BlockingOperation::RunOperation, this, std::move(pipeWrite));
             m_ioThread = std::thread(&BlockingOperation::RunIO, this, std::move(pipeRead));

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -1564,9 +1564,7 @@ class WSLATests
         BlockingOperation(std::function<HRESULT(HANDLE)>&& Operation, HRESULT ExpectedResult = S_OK, bool AllowEarlyCompletion = false, bool UseOverlappedWritePipe = false) :
             m_operation(std::move(Operation)), m_expectedResult(ExpectedResult), m_allowEarlyCompletion(AllowEarlyCompletion)
         {
-            auto [read, write] = wsl::windows::common::wslutil::OpenAnonymousPipe(100000, false, UseOverlappedWritePipe);
-            wil::unique_handle pipeRead(read.release());
-            wil::unique_handle pipeWrite(write.release());
+            auto [pipeRead, pipeWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(100000, false, UseOverlappedWritePipe);
 
             m_operationThread = std::thread(&BlockingOperation::RunOperation, this, std::move(pipeWrite));
             m_ioThread = std::thread(&BlockingOperation::RunIO, this, std::move(pipeRead));
@@ -1588,7 +1586,7 @@ class WSLATests
             }
         }
 
-        void RunOperation(wil::unique_handle Handle)
+        void RunOperation(wil::unique_hfile Handle)
         {
             m_result.set_value(m_operation(Handle.get()));
 
@@ -1598,7 +1596,7 @@ class WSLATests
             WI_ASSERT(m_allowEarlyCompletion || m_testCompleteEvent.is_signaled());
         }
 
-        void RunIO(wil::unique_handle Handle)
+        void RunIO(wil::unique_hfile Handle)
         {
             std::vector<char> buffer(1024 * 1024);
             while (true)

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -5402,6 +5402,10 @@ class WSLATests
         // Use overlapped write pipe so the server-side WriteFile doesn't block synchronously.
         BlockingOperation operation([&](HANDLE handle) { return container.Get().Export(HandleToULong(handle)); }, E_ABORT, true, true);
 
+        // Avoid attempting container delete on scope exit after intentional session termination;
+        // rely on the prune scope-exit above to clean up instead.
+        container.SetDeleteOnClose(false);
+
         // Terminate the session.
         VERIFY_SUCCEEDED(m_defaultSession->Terminate());
         operation.Complete();

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -5374,40 +5374,38 @@ class WSLATests
     {
         WSL2_TEST_ONLY();
 
-        // Validate that SaveImage is aborted when the session terminates mid-operation.
+        // Validate that SaveImage is aborted when the session terminates.
         // Use overlapped write pipe so the server-side WriteFile doesn't block synchronously.
         BlockingOperation operation(
             [&](HANDLE handle) { return m_defaultSession->SaveImage(HandleToULong(handle), "debian:latest", nullptr, nullptr); }, E_ABORT, true, true);
 
-        // Terminate the session while SaveImage is in-flight.
+        // Terminate the session.
         VERIFY_SUCCEEDED(m_defaultSession->Terminate());
         operation.Complete();
-
-        // Re-create the session.
-        m_defaultSession.reset();
-        m_defaultSession = CreateSession(m_defaultSessionSettings);
+        auto restore = ResetTestSession();
     }
 
     TEST_METHOD(SessionTerminationDuringExport)
     {
         WSL2_TEST_ONLY();
 
-        // Validate that container Export is aborted when the session terminates mid-operation.
+        // Validate that container Export is aborted when the session terminates.
         WSLAContainerLauncher launcher("debian:latest", "test-export-session-terminate", {"echo", "OK"});
         auto container = launcher.Launch(*m_defaultSession);
-        container.GetInitProcess().Wait();
+        VERIFY_ARE_EQUAL(container.GetInitProcess().Wait(), 0);
 
-        BlockingOperation operation([&](HANDLE handle) { return container.Get().Export(HandleToULong(handle)); }, E_ABORT, true);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            PruneResult result;
+            LOG_IF_FAILED(m_defaultSession->PruneContainers(nullptr, 0, 0, &result.result));
+        });
 
-        // Terminate the session while Export is in-flight.
+        // Use overlapped write pipe so the server-side WriteFile doesn't block synchronously.
+        BlockingOperation operation([&](HANDLE handle) { return container.Get().Export(HandleToULong(handle)); }, E_ABORT, true, true);
+
+        // Terminate the session.
         VERIFY_SUCCEEDED(m_defaultSession->Terminate());
         operation.Complete();
-
-        // Re-create the session and clean up the leftover container.
-        m_defaultSession.reset();
-        m_defaultSession = CreateSession(m_defaultSessionSettings);
-        PruneResult result;
-        VERIFY_SUCCEEDED(m_defaultSession->PruneContainers(nullptr, 0, 0, &result.result));
+        auto restore = ResetTestSession();
     }
 
     TEST_METHOD(InteractiveDetach)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add test coverage for Export & Save session termination. Validates that `Export()` and `SaveImage()` return `E_ABORT` when the WSLA session terminates mid-operation.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Added two new test methods to WSLATests:
- SessionTerminationDuringSave: Validates that SaveImage() returns E_ABORT when the session terminates mid-operation.
- SessionTerminationDuringExport: Validates that container Export() returns E_ABORT when the session terminates mid-operation. Cleans up leftover containers after session re-creation.
Enhanced the BlockingOperation test helper with two new optional parameters:

- AllowEarlyCompletion: Allows the operation to finish early. In these tests, session termination can cause the operation to exit before Complete() is signaled.Allows the operation to finish early. In these tests, session termination can cause the operation to exit before Complete() is signaled.
- Uses OpenAnonymousPipe() instead of CreatePipe() so the write side supports overlapped I/O. This is needed for the SaveImage test — with CreatePipe(), once the pipe buffer fills up, WriteFile blocks synchronously and doesn’t respond to session termination. With overlapped writes, WriteFile returns ERROR_IO_PENDING, which allows the wait loop to pick up the termination event and return E_ABORT.

Both parameters default to `false`, so all existing callers of BlockingOperation are unaffected.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Ran SessionTerminationDuringSave : passes, returns E_ABORT
- Ran SessionTerminationDuringExport : passes, returns E_ABORT