### PR TITLE
Implement SDK IO callbacks

### DIFF
--- a/src/windows/WslcSDK/CMakeLists.txt
+++ b/src/windows/WslcSDK/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SOURCES
+    IOCallback.cpp
     ProgressCallback.cpp
     TerminationCallback.cpp
     wslcsdk.cpp
     WslcsdkPrivate.cpp
 )
 set(HEADERS
+    IOCallback.h
     ProgressCallback.h
     TerminationCallback.h
     wslcsdk.h

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -14,7 +14,8 @@ Abstract:
 #include "precomp.h"
 #include "WslcsdkPrivate.h"
 
-IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallbackOptions& options)
+IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallbackOptions& options) :
+    m_process(process), m_callbackOptions(std::make_unique<WslcContainerProcessIOCallbackOptions>(options))
 {
     using namespace wsl::windows::common::relay;
 
@@ -22,8 +23,8 @@ IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallba
         std::function<void(const gsl::span<char>& Buffer)> function;
         if (callback)
         {
-            function = [callback, context](const gsl::span<char>& buffer) {
-                callback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), context);
+            function = [ioHandle, callback, context](const gsl::span<char>& buffer) {
+                callback(ioHandle, reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), context);
             };
         }
         else
@@ -34,15 +35,34 @@ IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallba
         m_io.AddHandle(std::make_unique<ReadHandle>(GetIOHandle(process, ioHandle), std::move(function)));
     };
 
-    addIOCallback(WSLC_PROCESS_IO_HANDLE_STDOUT, options.stdOutCallback, options.stdOutCallbackContext);
-    addIOCallback(WSLC_PROCESS_IO_HANDLE_STDERR, options.stdErrCallback, options.stdErrCallbackContext);
+    addIOCallback(WSLC_PROCESS_IO_HANDLE_STDOUT, options.onStdOut, options.callbackContext);
+    addIOCallback(WSLC_PROCESS_IO_HANDLE_STDERR, options.onStdErr, options.callbackContext);
 
-    m_io.AddHandle(std::make_unique<EventHandle>(m_cancelEvent.get()), MultiHandleWait::CancelOnCompleted);
+    if (options.onExit)
+    {
+        wil::unique_handle processExitEvent;
+        THROW_IF_FAILED(process->GetExitEvent(&processExitEvent));
+        m_io.AddHandle(std::make_unique<EventHandle>(std::move(processExitEvent)));
+    }
+
+    m_io.AddHandle(std::make_unique<EventHandle>(m_cancelEvent.get()), MultiHandleWait::CancelOnCompleted | MultiHandleWait::NeedNotComplete);
 
     m_thread = std::thread([this]() {
         try
         {
-            m_io.Run({});
+            // Will be false when cancelled.
+            bool runResult = m_io.Run({});
+
+            if (runResult && m_process && m_callbackOptions && m_callbackOptions->onExit)
+            {
+                WSLAProcessState state{};
+                int exitCode = -2;
+
+                // Prefer to make the callback even if we don't properly retrieve the exit code.
+                LOG_IF_FAILED(m_process->GetState(&state, &exitCode));
+
+                m_callbackOptions->onExit(exitCode, m_callbackOptions->callbackContext);
+            }
         }
         CATCH_LOG();
     });
@@ -69,7 +89,7 @@ bool IOCallback::HasIOCallback(const WslcContainerProcessOptionsInternal* option
 
 bool IOCallback::HasIOCallback(const WslcContainerProcessIOCallbackOptions& options)
 {
-    return options.stdOutCallback || options.stdErrCallback;
+    return options.onStdOut || options.onStdErr || options.onExit;
 }
 
 wil::unique_handle IOCallback::GetIOHandle(IWSLAProcess* process, WslcProcessIOHandle ioHandle)

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -56,11 +56,21 @@ IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallba
             if (runResult && m_process && m_callbackOptions && m_callbackOptions->onExit)
             {
                 WSLAProcessState state{};
-                int exitCode = -2;
+                int exitCode = -1;
 
                 // Prefer to make the callback even if we don't properly retrieve the exit code.
-                LOG_IF_FAILED(m_process->GetState(&state, &exitCode));
+                if (FAILED_LOG(m_process->GetState(&state, &exitCode)))
+                {
+                    // Reset to our known value in case GetState stomped it while failing.
+                    exitCode = -1;
+                }
+                else
+                {
+                    WI_ASSERT(state == WslaProcessStateExited);
+                }
 
+                // Regardless of our ability to get the proper exit code, inform the caller that the process
+                // has exited and they will not be getting any additional IO callbacks.
                 m_callbackOptions->onExit(exitCode, m_callbackOptions->callbackContext);
             }
         }

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -16,34 +16,36 @@ Abstract:
 
 IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallbackOptions& options)
 {
-    if (options.stdOutCallback)
-    {
-        auto localCallback = options.stdOutCallback;
-        auto localContext = options.stdOutCallbackContext;
-        m_io.AddHandle(std::make_unique<wsl::windows::common::relay::ReadHandle>(
-            GetIOHandle(process, WSLC_PROCESS_IO_HANDLE_STDOUT), [localCallback, localContext](const auto& buffer) {
-                localCallback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), localContext);
-            }));
-    }
+    using namespace wsl::windows::common::relay;
 
-    if (options.stdErrCallback)
+    auto addIOCallback = [&](WslcProcessIOHandle ioHandle, WslcStdIOCallback callback, PVOID context)
     {
-        auto localCallback = options.stdErrCallback;
-        auto localContext = options.stdErrCallbackContext;
-        m_io.AddHandle(std::make_unique<wsl::windows::common::relay::ReadHandle>(
-            GetIOHandle(process, WSLC_PROCESS_IO_HANDLE_STDERR), [localCallback, localContext](const auto& buffer) {
-                localCallback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), localContext);
-            }));
-    }
+        std::function<void(const gsl::span<char>& Buffer)> function;
+        if (callback)
+        {
+            function = [callback, context](const gsl::span<char>& buffer) {
+                callback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), context);
+                };
+        }
+        else
+        {
+            function = [](const gsl::span<char>&) {};
+        }
+
+        m_io.AddHandle(std::make_unique<ReadHandle>(GetIOHandle(process, ioHandle), std::move(function)));
+    };
+
+    addIOCallback(WSLC_PROCESS_IO_HANDLE_STDOUT, options.stdOutCallback, options.stdOutCallbackContext);
+    addIOCallback(WSLC_PROCESS_IO_HANDLE_STDERR, options.stdErrCallback, options.stdErrCallbackContext);
+
+    m_io.AddHandle(std::make_unique<EventHandle>(m_cancelEvent.get()), MultiHandleWait::CancelOnCompleted);
 
     m_thread = std::thread([this]() {
         try
         {
             m_io.Run({});
         }
-        catch (...)
-        {
-        }
+        CATCH_LOG();
     });
 }
 
@@ -58,7 +60,7 @@ IOCallback::~IOCallback()
 
 void IOCallback::Cancel()
 {
-    m_io.Cancel();
+    m_cancelEvent.SetEvent();
 }
 
 bool IOCallback::HasIOCallback(const WslcContainerProcessOptionsInternal* options)

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -1,0 +1,79 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    IOCallback.cpp
+
+Abstract:
+
+    Holds IO callback objects.
+
+--*/
+#include "precomp.h"
+#include "WslcsdkPrivate.h"
+
+IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallbackOptions& options)
+{
+    if (options.stdOutCallback)
+    {
+        auto localCallback = options.stdOutCallback;
+        auto localContext = options.stdOutCallbackContext;
+        m_io.AddHandle(std::make_unique<wsl::windows::common::relay::ReadHandle>(
+            GetIOHandle(process, WSLC_PROCESS_IO_HANDLE_STDOUT),
+            [localCallback, localContext](const auto& buffer) { localCallback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), localContext); }));
+    }
+
+    if (options.stdErrCallback)
+    {
+        auto localCallback = options.stdErrCallback;
+        auto localContext = options.stdErrCallbackContext;
+        m_io.AddHandle(std::make_unique<wsl::windows::common::relay::ReadHandle>(
+            GetIOHandle(process, WSLC_PROCESS_IO_HANDLE_STDERR), [localCallback, localContext](const auto& buffer) {
+                localCallback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), localContext);
+            }));
+    }
+
+    m_thread = std::thread([this]() {
+        try
+        {
+            m_io.Run({});
+        }
+        catch (...){}
+    });
+}
+
+IOCallback::~IOCallback()
+{
+    Cancel();
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
+}
+
+void IOCallback::Cancel()
+{
+    m_io.Cancel();
+}
+
+bool IOCallback::HasIOCallback(const WslcContainerProcessOptionsInternal* options)
+{
+    return options && HasIOCallback(options->ioCallbacks);
+}
+
+bool IOCallback::HasIOCallback(const WslcContainerProcessIOCallbackOptions& options)
+{
+    return options.stdOutCallback || options.stdErrCallback;
+}
+
+wil::unique_handle IOCallback::GetIOHandle(IWSLAProcess* process, WslcProcessIOHandle ioHandle)
+{
+    ULONG ulongHandle = 0;
+
+    THROW_IF_FAILED(process->GetStdHandle(
+        static_cast<ULONG>(static_cast<std::underlying_type_t<WslcProcessIOHandle>>(ioHandle)), &ulongHandle));
+
+    return wil::unique_handle{ULongToHandle(ulongHandle)};
+}

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -18,14 +18,13 @@ IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallba
 {
     using namespace wsl::windows::common::relay;
 
-    auto addIOCallback = [&](WslcProcessIOHandle ioHandle, WslcStdIOCallback callback, PVOID context)
-    {
+    auto addIOCallback = [&](WslcProcessIOHandle ioHandle, WslcStdIOCallback callback, PVOID context) {
         std::function<void(const gsl::span<char>& Buffer)> function;
         if (callback)
         {
             function = [callback, context](const gsl::span<char>& buffer) {
                 callback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), context);
-                };
+            };
         }
         else
         {

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -21,8 +21,9 @@ IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallba
         auto localCallback = options.stdOutCallback;
         auto localContext = options.stdOutCallbackContext;
         m_io.AddHandle(std::make_unique<wsl::windows::common::relay::ReadHandle>(
-            GetIOHandle(process, WSLC_PROCESS_IO_HANDLE_STDOUT),
-            [localCallback, localContext](const auto& buffer) { localCallback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), localContext); }));
+            GetIOHandle(process, WSLC_PROCESS_IO_HANDLE_STDOUT), [localCallback, localContext](const auto& buffer) {
+                localCallback(reinterpret_cast<const BYTE*>(buffer.data()), static_cast<uint32_t>(buffer.size()), localContext);
+            }));
     }
 
     if (options.stdErrCallback)
@@ -40,7 +41,9 @@ IOCallback::IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallba
         {
             m_io.Run({});
         }
-        catch (...){}
+        catch (...)
+        {
+        }
     });
 }
 
@@ -72,8 +75,7 @@ wil::unique_handle IOCallback::GetIOHandle(IWSLAProcess* process, WslcProcessIOH
 {
     ULONG ulongHandle = 0;
 
-    THROW_IF_FAILED(process->GetStdHandle(
-        static_cast<ULONG>(static_cast<std::underlying_type_t<WslcProcessIOHandle>>(ioHandle)), &ulongHandle));
+    THROW_IF_FAILED(process->GetStdHandle(static_cast<ULONG>(static_cast<std::underlying_type_t<WslcProcessIOHandle>>(ioHandle)), &ulongHandle));
 
     return wil::unique_handle{ULongToHandle(ulongHandle)};
 }

--- a/src/windows/WslcSDK/IOCallback.h
+++ b/src/windows/WslcSDK/IOCallback.h
@@ -32,6 +32,8 @@ struct IOCallback
     static wil::unique_handle GetIOHandle(IWSLAProcess* process, WslcProcessIOHandle ioHandle);
 
 private:
+    wil::com_ptr<IWSLAProcess> m_process;
+    std::unique_ptr<WslcContainerProcessIOCallbackOptions> m_callbackOptions;
     std::thread m_thread;
     wsl::windows::common::relay::MultiHandleWait m_io;
     wil::unique_event m_cancelEvent{wil::EventOptions::ManualReset};

--- a/src/windows/WslcSDK/IOCallback.h
+++ b/src/windows/WslcSDK/IOCallback.h
@@ -13,7 +13,7 @@ Abstract:
 --*/
 #pragma once
 #include "wslaservice.h"
-#include "wslrelay.h"
+#include "relay.hpp"
 #include <thread>
 
 struct WslcContainerProcessIOCallbackOptions;
@@ -34,4 +34,5 @@ struct IOCallback
 private:
     std::thread m_thread;
     wsl::windows::common::relay::MultiHandleWait m_io;
+    wil::unique_event m_cancelEvent{wil::EventOptions::ManualReset};
 };

--- a/src/windows/WslcSDK/IOCallback.h
+++ b/src/windows/WslcSDK/IOCallback.h
@@ -1,0 +1,37 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    IOCallback.h
+
+Abstract:
+
+    Holds IO callback objects.
+
+--*/
+#pragma once
+#include "wslaservice.h"
+#include "wslrelay.h"
+#include <thread>
+
+struct WslcContainerProcessIOCallbackOptions;
+struct WslcContainerProcessOptionsInternal;
+
+struct IOCallback
+{
+    IOCallback(IWSLAProcess* process, const WslcContainerProcessIOCallbackOptions& options);
+    ~IOCallback();
+
+    void Cancel();
+
+    static bool HasIOCallback(const WslcContainerProcessOptionsInternal* options);
+    static bool HasIOCallback(const WslcContainerProcessIOCallbackOptions& options);
+
+    static wil::unique_handle GetIOHandle(IWSLAProcess* process, WslcProcessIOHandle ioHandle);
+
+private:
+    std::thread m_thread;
+    wsl::windows::common::relay::MultiHandleWait m_io;
+};

--- a/src/windows/WslcSDK/WslcsdkPrivate.h
+++ b/src/windows/WslcSDK/WslcsdkPrivate.h
@@ -15,6 +15,7 @@ Abstract:
 #include <windows.h>
 #include "wslcsdk.h"
 #include "wslaservice.h"
+#include "IOCallback.h"
 #include <stdint.h>
 #include <wil/com.h> // COM helpers
 // #include <wil/resource.h> // handle wrappers
@@ -45,6 +46,14 @@ static_assert(std::is_trivial_v<WslcSessionOptionsInternal>, "WSLC_SESSION_OPTIO
 
 WslcSessionOptionsInternal* GetInternalType(WslcSessionSettings* settings);
 
+struct WslcContainerProcessIOCallbackOptions
+{
+    WslcStdIOCallback stdOutCallback;
+    PVOID stdOutCallbackContext;
+    WslcStdIOCallback stdErrCallback;
+    PVOID stdErrCallbackContext;
+};
+
 // PROCESS DEFINITIONS
 typedef struct WslcContainerProcessOptionsInternal
 {
@@ -53,10 +62,7 @@ typedef struct WslcContainerProcessOptionsInternal
     PCSTR const* environment;
     uint32_t environmentCount;
     PCSTR currentDirectory;
-    WslcStdIOCallback stdOutCallback;
-    PVOID stdOutCallbackContext;
-    WslcStdIOCallback stdErrCallback;
-    PVOID stdErrCallbackContext;
+    WslcContainerProcessIOCallbackOptions ioCallbacks;
 } WslcContainerProcessOptionsInternal;
 
 static_assert(
@@ -107,24 +113,11 @@ struct WslcSessionImpl
 
 WslcSessionImpl* GetInternalType(WslcSession handle);
 
-// Holds IO callback objects.
-struct IOCallbackLifetime
-{
-    IOCallbackLifetime();
-    ~IOCallbackLifetime();
-
-    void Cancel();
-
-    static bool HasIOCallback(const WslcContainerProcessOptionsInternal& options);
-
-private:
-    std::thread m_thread;
-};
-
 struct WslcContainerImpl
 {
     wil::com_ptr<IWSLAContainer> container;
-    std::shared_ptr<IOCallbackLifetime> ioCallbacks;
+    WslcContainerProcessIOCallbackOptions ioCallbackOptions{};
+    std::atomic<std::shared_ptr<IOCallback>> ioCallbacks;
 };
 
 WslcContainerImpl* GetInternalType(WslcContainer handle);
@@ -132,7 +125,7 @@ WslcContainerImpl* GetInternalType(WslcContainer handle);
 struct WslcProcessImpl
 {
     wil::com_ptr<IWSLAProcess> process;
-    std::shared_ptr<IOCallbackLifetime> ioCallbacks;
+    std::shared_ptr<IOCallback> ioCallbacks;
 };
 
 WslcProcessImpl* GetInternalType(WslcProcess handle);

--- a/src/windows/WslcSDK/WslcsdkPrivate.h
+++ b/src/windows/WslcSDK/WslcsdkPrivate.h
@@ -46,12 +46,9 @@ static_assert(std::is_trivial_v<WslcSessionOptionsInternal>, "WSLC_SESSION_OPTIO
 
 WslcSessionOptionsInternal* GetInternalType(WslcSessionSettings* settings);
 
-struct WslcContainerProcessIOCallbackOptions
+struct WslcContainerProcessIOCallbackOptions : public WslcProcessCallbacks
 {
-    WslcStdIOCallback stdOutCallback;
-    PVOID stdOutCallbackContext;
-    WslcStdIOCallback stdErrCallback;
-    PVOID stdErrCallbackContext;
+    PVOID callbackContext;
 };
 
 // PROCESS DEFINITIONS

--- a/src/windows/WslcSDK/WslcsdkPrivate.h
+++ b/src/windows/WslcSDK/WslcsdkPrivate.h
@@ -53,11 +53,15 @@ typedef struct WslcContainerProcessOptionsInternal
     PCSTR const* environment;
     uint32_t environmentCount;
     PCSTR currentDirectory;
+    WslcStdIOCallback stdOutCallback;
+    PVOID stdOutCallbackContext;
+    WslcStdIOCallback stdErrCallback;
+    PVOID stdErrCallbackContext;
 } WslcContainerProcessOptionsInternal;
 
 static_assert(
     sizeof(WslcContainerProcessOptionsInternal) == WSLC_CONTAINER_PROCESS_OPTIONS_SIZE,
-    "WSLC_CONTAINER_PROCESS_OPTIONS_INTERNAL must be 48 bytes");
+    "WSLC_CONTAINER_PROCESS_OPTIONS_INTERNAL must be 72 bytes");
 static_assert(
     __alignof(WslcContainerProcessOptionsInternal) == WSLC_CONTAINER_PROCESS_OPTIONS_ALIGNMENT,
     "WSLC_CONTAINER_PROCESS_OPTIONS_INTERNAL must be 8-byte aligned");
@@ -103,9 +107,24 @@ struct WslcSessionImpl
 
 WslcSessionImpl* GetInternalType(WslcSession handle);
 
+// Holds IO callback objects.
+struct IOCallbackLifetime
+{
+    IOCallbackLifetime();
+    ~IOCallbackLifetime();
+
+    void Cancel();
+
+    static bool HasIOCallback(const WslcContainerProcessOptionsInternal& options);
+
+private:
+    std::thread m_thread;
+};
+
 struct WslcContainerImpl
 {
     wil::com_ptr<IWSLAContainer> container;
+    std::shared_ptr<IOCallbackLifetime> ioCallbacks;
 };
 
 WslcContainerImpl* GetInternalType(WslcContainer handle);
@@ -113,6 +132,7 @@ WslcContainerImpl* GetInternalType(WslcContainer handle);
 struct WslcProcessImpl
 {
     wil::com_ptr<IWSLAProcess> process;
+    std::shared_ptr<IOCallbackLifetime> ioCallbacks;
 };
 
 WslcProcessImpl* GetInternalType(WslcProcess handle);

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -555,9 +555,14 @@ try
     auto internalType = CheckAndGetInternalType(container);
     RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), internalType->container);
 
+    bool hasIOCallback = IOCallback::HasIOCallback(internalType->ioCallbackOptions);
+    // If callbacks were provided, ATTACH must be used.
+    // TODO: Consider if we should just override flags when callbacks were provided instead.
+    RETURN_HR_IF(E_INVALIDARG, WI_IsFlagClear(flags, WSLC_CONTAINER_START_FLAG_ATTACH) && hasIOCallback);
+
     if (SUCCEEDED(errorInfoWrapper.CaptureResult(internalType->container->Start(ConvertFlags(flags), nullptr))))
     {
-        if (IOCallback::HasIOCallback(internalType->ioCallbackOptions))
+        if (hasIOCallback)
         {
             wil::com_ptr<IWSLAProcess> process;
             RETURN_IF_FAILED(internalType->container->GetInitProcess(&process));

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -536,9 +536,9 @@ try
     {
         wsl::windows::common::security::ConfigureForCOMImpersonation(result->container.get());
 
-        if (HasIOCallback(internalContainerSettings->initProcessOptions))
+        if (IOCallback::HasIOCallback(internalContainerSettings->initProcessOptions))
         {
-            result->container->GetInitProcess();
+            result->ioCallbackOptions = internalContainerSettings->initProcessOptions->ioCallbacks;
         }
 
         *container = reinterpret_cast<WslcContainer>(result.release());
@@ -555,7 +555,18 @@ try
     auto internalType = CheckAndGetInternalType(container);
     RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), internalType->container);
 
-    return errorInfoWrapper.CaptureResult(internalType->container->Start(ConvertFlags(flags), nullptr));
+    if (SUCCEEDED(errorInfoWrapper.CaptureResult(internalType->container->Start(ConvertFlags(flags), nullptr))))
+    {
+        if (IOCallback::HasIOCallback(internalType->ioCallbackOptions))
+        {
+            wil::com_ptr<IWSLAProcess> process;
+            RETURN_IF_FAILED(internalType->container->GetInitProcess(&process));
+            wsl::windows::common::security::ConfigureForCOMImpersonation(process.get());
+            internalType->ioCallbacks = std::make_shared<IOCallback>(process.get(), internalType->ioCallbackOptions);
+        }
+    }
+
+    return errorInfoWrapper;
 }
 CATCH_RETURN();
 
@@ -686,6 +697,12 @@ try
     if (SUCCEEDED(errorInfoWrapper.CaptureResult(internalContainer->container->Exec(&runtimeOptions, nullptr, &result->process))))
     {
         wsl::windows::common::security::ConfigureForCOMImpersonation(result->process.get());
+
+        if (IOCallback::HasIOCallback(internalProcessSettings))
+        {
+            result->ioCallbacks = std::make_shared<IOCallback>(result->process.get(), internalProcessSettings->ioCallbacks);
+        }
+
         *newProcess = reinterpret_cast<WslcProcess>(result.release());
     }
 
@@ -730,6 +747,9 @@ try
     RETURN_IF_FAILED(internalType->container->GetInitProcess(&result->process));
 
     wsl::windows::common::security::ConfigureForCOMImpersonation(result->process.get());
+
+    result->ioCallbacks = internalType->ioCallbacks.load();
+
     *initProcess = reinterpret_cast<WslcProcess>(result.release());
 
     return S_OK;
@@ -930,13 +950,13 @@ try
 
     if (ioHandle == WSLC_PROCESS_IO_HANDLE_STDOUT)
     {
-        internalType->stdOutCallback = stdIOCallback;
-        internalType->stdOutCallbackContext = context;
+        internalType->ioCallbacks.stdOutCallback = stdIOCallback;
+        internalType->ioCallbacks.stdOutCallbackContext = context;
     }
     else if (ioHandle == WSLC_PROCESS_IO_HANDLE_STDERR)
     {
-        internalType->stdErrCallback = stdIOCallback;
-        internalType->stdErrCallbackContext = context;
+        internalType->ioCallbacks.stdErrCallback = stdIOCallback;
+        internalType->ioCallbacks.stdErrCallbackContext = context;
     }
 
     return S_OK;
@@ -952,17 +972,10 @@ try
 
     *handle = nullptr;
 
-    ULONG ulongHandle = 0;
+    auto result = IOCallback::GetIOHandle(internalType->process.get(), ioHandle);
+    *handle = result.release();
 
-    HRESULT hr = internalType->process->GetStdHandle(
-        static_cast<ULONG>(static_cast<std::underlying_type_t<WslcProcessIOHandle>>(ioHandle)), &ulongHandle);
-
-    if (SUCCEEDED_LOG(hr))
-    {
-        *handle = ULongToHandle(ulongHandle);
-    }
-
-    return hr;
+    return S_OK;
 }
 CATCH_RETURN();
 

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -945,23 +945,24 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSetProcessSettingsIOCallback(
-    _In_ WslcProcessSettings* processSettings, _In_ WslcProcessIOHandle ioHandle, _In_opt_ WslcStdIOCallback stdIOCallback, _In_opt_ PVOID context)
+STDAPI WslcSetProcessSettingsCallbacks(_In_ WslcProcessSettings* processSettings, _In_ const WslcProcessCallbacks* callbacks, _In_opt_ PVOID context)
 try
 {
     auto internalType = CheckAndGetInternalType(processSettings);
-    RETURN_HR_IF(E_INVALIDARG, ioHandle != WSLC_PROCESS_IO_HANDLE_STDOUT && ioHandle != WSLC_PROCESS_IO_HANDLE_STDERR);
-    RETURN_HR_IF(E_INVALIDARG, stdIOCallback == nullptr && context != nullptr);
+    RETURN_HR_IF(E_INVALIDARG, callbacks == nullptr && context != nullptr);
 
-    if (ioHandle == WSLC_PROCESS_IO_HANDLE_STDOUT)
+    static_assert(std::is_trivial_v<WslcProcessCallbacks>, "WslcProcessCallbacks must be trivial.");
+
+    WslcProcessCallbacks* internalCallbacks = &internalType->ioCallbacks;
+
+    if (callbacks)
     {
-        internalType->ioCallbacks.stdOutCallback = stdIOCallback;
-        internalType->ioCallbacks.stdOutCallbackContext = context;
+        *internalCallbacks = *callbacks;
+        internalType->ioCallbacks.callbackContext = context;
     }
-    else if (ioHandle == WSLC_PROCESS_IO_HANDLE_STDERR)
+    else
     {
-        internalType->ioCallbacks.stdErrCallback = stdIOCallback;
-        internalType->ioCallbacks.stdErrCallbackContext = context;
+        *internalCallbacks = {};
     }
 
     return S_OK;

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -535,6 +535,12 @@ try
     if (SUCCEEDED(errorInfoWrapper.CaptureResult(internalSession->session->CreateContainer(&containerOptions, &result->container))))
     {
         wsl::windows::common::security::ConfigureForCOMImpersonation(result->container.get());
+
+        if (HasIOCallback(internalContainerSettings->initProcessOptions))
+        {
+            result->container->GetInitProcess();
+        }
+
         *container = reinterpret_cast<WslcContainer>(result.release());
     }
 
@@ -914,19 +920,30 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcSetProcessSettingsIoCallback(
-    _In_ WslcProcessSettings* processSettings, _In_ WslcProcessIoHandle ioHandle, _In_opt_ WslcStdIOCallback stdIOCallback, _In_opt_ PVOID context)
+STDAPI WslcSetProcessSettingsIOCallback(
+    _In_ WslcProcessSettings* processSettings, _In_ WslcProcessIOHandle ioHandle, _In_opt_ WslcStdIOCallback stdIOCallback, _In_opt_ PVOID context)
 try
 {
-    UNREFERENCED_PARAMETER(processSettings);
-    UNREFERENCED_PARAMETER(ioHandle);
-    UNREFERENCED_PARAMETER(stdIOCallback);
-    UNREFERENCED_PARAMETER(context);
-    return E_NOTIMPL;
+    auto internalType = CheckAndGetInternalType(processSettings);
+    RETURN_HR_IF(E_INVALIDARG, ioHandle != WSLC_PROCESS_IO_HANDLE_STDOUT && ioHandle != WSLC_PROCESS_IO_HANDLE_STDERR);
+    RETURN_HR_IF(E_INVALIDARG, stdIOCallback == nullptr && context != nullptr);
+
+    if (ioHandle == WSLC_PROCESS_IO_HANDLE_STDOUT)
+    {
+        internalType->stdOutCallback = stdIOCallback;
+        internalType->stdOutCallbackContext = context;
+    }
+    else if (ioHandle == WSLC_PROCESS_IO_HANDLE_STDERR)
+    {
+        internalType->stdErrCallback = stdIOCallback;
+        internalType->stdErrCallbackContext = context;
+    }
+
+    return S_OK;
 }
 CATCH_RETURN();
 
-STDAPI WslcGetProcessIOHandle(_In_ WslcProcess process, _In_ WslcProcessIoHandle ioHandle, _Out_ HANDLE* handle)
+STDAPI WslcGetProcessIOHandle(_In_ WslcProcess process, _In_ WslcProcessIOHandle ioHandle, _Out_ HANDLE* handle)
 try
 {
     auto internalType = CheckAndGetInternalType(process);
@@ -938,7 +955,7 @@ try
     ULONG ulongHandle = 0;
 
     HRESULT hr = internalType->process->GetStdHandle(
-        static_cast<ULONG>(static_cast<std::underlying_type_t<WslcProcessIoHandle>>(ioHandle)), &ulongHandle);
+        static_cast<ULONG>(static_cast<std::underlying_type_t<WslcProcessIOHandle>>(ioHandle)), &ulongHandle);
 
     if (SUCCEEDED_LOG(hr))
     {

--- a/src/windows/WslcSDK/wslcsdk.def
+++ b/src/windows/WslcSDK/wslcsdk.def
@@ -46,7 +46,7 @@ WslcDeleteContainer
 WslcGetContainerID
 WslcGetContainerInitProcess
 
-WslcSetProcessSettingsIOCallback
+WslcSetProcessSettingsCallbacks
 WslcSetProcessSettingsCurrentDirectory
 WslcSetProcessSettingsCmdLine
 WslcSetProcessSettingsEnvVariables

--- a/src/windows/WslcSDK/wslcsdk.def
+++ b/src/windows/WslcSDK/wslcsdk.def
@@ -46,7 +46,7 @@ WslcDeleteContainer
 WslcGetContainerID
 WslcGetContainerInitProcess
 
-WslcSetProcessSettingsIoCallback
+WslcSetProcessSettingsIOCallback
 WslcSetProcessSettingsCurrentDirectory
 WslcSetProcessSettingsCmdLine
 WslcSetProcessSettingsEnvVariables

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -294,7 +294,8 @@ typedef enum WslcProcessIOHandle
     WSLC_PROCESS_IO_HANDLE_STDERR = 2
 } WslcProcessIOHandle;
 
-// Pass in Null for WslcStdIOCallback to clear the callback for the given handle
+// Only WSLC_PROCESS_IO_HANDLE_STDOUT and WSLC_PROCESS_IO_HANDLE_STDERR are supported for callbacks.
+// Pass in Null for WslcStdIOCallback to clear the callback for the given handle.
 STDAPI WslcSetProcessSettingsIOCallback(
     _In_ WslcProcessSettings* processSettings, _In_ WslcProcessIOHandle ioHandle, _In_opt_ WslcStdIOCallback stdIOCallback, _In_opt_ PVOID context);
 

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -261,10 +261,21 @@ STDAPI WslcSetProcessSettingsCmdLine(_In_ WslcProcessSettings* processSettings, 
 
 STDAPI WslcSetProcessSettingsEnvVariables(_In_ WslcProcessSettings* processSettings, _In_reads_(argc) PCSTR const* key_value, size_t argc);
 
+typedef enum WslcProcessIOHandle
+{
+    WSLC_PROCESS_IO_HANDLE_STDIN = 0,
+    WSLC_PROCESS_IO_HANDLE_STDOUT = 1,
+    WSLC_PROCESS_IO_HANDLE_STDERR = 2
+} WslcProcessIOHandle;
+
 // Callback invoked when stdout or stderr data is available from a running
 // WSLC process.
 //
 // Parameters:
+//   ioHandle
+//       The WslcProcessIOHandle that the IO callback is for.
+//       Only STDOUT and STDERR will recieve callbacks.
+//
 //   data
 //       Pointer to a buffer containing the bytes read. The buffer is owned
 //       by WSLC and is valid only for the duration of the callback.
@@ -286,18 +297,34 @@ STDAPI WslcSetProcessSettingsEnvVariables(_In_ WslcProcessSettings* processSetti
 //     WSLC's internal I/O processing.
 //   - The buffer is not null-terminated; it is a raw byte sequence.
 //
-typedef __callback void(CALLBACK* WslcStdIOCallback)(_In_reads_bytes_(dataSize) const BYTE* data, _In_ uint32_t dataSize, _In_opt_ PVOID context);
-typedef enum WslcProcessIOHandle
-{
-    WSLC_PROCESS_IO_HANDLE_STDIN = 0,
-    WSLC_PROCESS_IO_HANDLE_STDOUT = 1,
-    WSLC_PROCESS_IO_HANDLE_STDERR = 2
-} WslcProcessIOHandle;
+typedef __callback void(CALLBACK* WslcStdIOCallback)(
+    WslcProcessIOHandle ioHandle, _In_reads_bytes_(dataSize) const BYTE* data, _In_ uint32_t dataSize, _In_opt_ PVOID context);
 
-// Only WSLC_PROCESS_IO_HANDLE_STDOUT and WSLC_PROCESS_IO_HANDLE_STDERR are supported for callbacks.
-// Pass in Null for WslcStdIOCallback to clear the callback for the given handle.
-STDAPI WslcSetProcessSettingsIOCallback(
-    _In_ WslcProcessSettings* processSettings, _In_ WslcProcessIOHandle ioHandle, _In_opt_ WslcStdIOCallback stdIOCallback, _In_opt_ PVOID context);
+// Callback invoked when a WSLC process has exited AND any remaining IO has been flushed.
+//
+// Parameters:
+//   exitCode
+//       The exit code of the process.
+//
+//   context
+//       Caller-supplied context pointer that was provided when the callback
+//       was registered.
+//
+// Notes:
+//   - Once this callback is invoked, any registered IO callbacks will no longer be called.
+//
+typedef __callback void(CALLBACK* WslcProcessExitCallback)(INT32 exitCode, _In_opt_ PVOID context);
+
+// Using any callbacks will consume the IO handles, preventing acquisition through WslcGetProcessIOHandle.
+// If using IO callbacks, also use the exit callback to prevent a race between process exit and IO buffer flushing.
+typedef struct WslcProcessCallbacks
+{
+    WslcStdIOCallback onStdOut;
+    WslcStdIOCallback onStdErr;
+    WslcProcessExitCallback onExit;
+} WslcProcessCallbacks;
+
+STDAPI WslcSetProcessSettingsCallbacks(_In_ WslcProcessSettings* processSettings, _In_ const WslcProcessCallbacks* callbacks, _In_opt_ PVOID context);
 
 // PROCESS MANAGEMENT
 

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -292,7 +292,7 @@ typedef enum WslcProcessIOHandle
     WSLC_PROCESS_IO_HANDLE_STDIN = 0,
     WSLC_PROCESS_IO_HANDLE_STDOUT = 1,
     WSLC_PROCESS_IO_HANDLE_STDERR = 2
-} WslcProcessIoHandle;
+} WslcProcessIOHandle;
 
 // Pass in Null for WslcStdIOCallback to clear the callback for the given handle
 STDAPI WslcSetProcessSettingsIOCallback(

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -43,7 +43,7 @@ typedef struct WslcContainerSettings
 DECLARE_HANDLE(WslcContainer);
 
 // Process values
-#define WSLC_CONTAINER_PROCESS_OPTIONS_SIZE 40
+#define WSLC_CONTAINER_PROCESS_OPTIONS_SIZE 72
 #define WSLC_CONTAINER_PROCESS_OPTIONS_ALIGNMENT 8
 typedef struct WslcProcessSettings
 {
@@ -287,7 +287,7 @@ STDAPI WslcSetProcessSettingsEnvVariables(_In_ WslcProcessSettings* processSetti
 //   - The buffer is not null-terminated; it is a raw byte sequence.
 //
 typedef __callback void(CALLBACK* WslcStdIOCallback)(_In_reads_bytes_(dataSize) const BYTE* data, _In_ uint32_t dataSize, _In_opt_ PVOID context);
-typedef enum WslcProcessIoHandle
+typedef enum WslcProcessIOHandle
 {
     WSLC_PROCESS_IO_HANDLE_STDIN = 0,
     WSLC_PROCESS_IO_HANDLE_STDOUT = 1,
@@ -295,8 +295,8 @@ typedef enum WslcProcessIoHandle
 } WslcProcessIoHandle;
 
 // Pass in Null for WslcStdIOCallback to clear the callback for the given handle
-STDAPI WslcSetProcessSettingsIoCallback(
-    _In_ WslcProcessSettings* processSettings, _In_ WslcProcessIoHandle ioHandle, _In_opt_ WslcStdIOCallback stdIOCallback, _In_opt_ PVOID context);
+STDAPI WslcSetProcessSettingsIOCallback(
+    _In_ WslcProcessSettings* processSettings, _In_ WslcProcessIOHandle ioHandle, _In_opt_ WslcStdIOCallback stdIOCallback, _In_opt_ PVOID context);
 
 // PROCESS MANAGEMENT
 
@@ -318,7 +318,7 @@ STDAPI WslcGetProcessExitCode(_In_ WslcProcess process, _Out_ PINT32 exitCode);
 
 STDAPI WslcSignalProcess(_In_ WslcProcess process, _In_ WslcSignal signal);
 
-STDAPI WslcGetProcessIOHandle(_In_ WslcProcess process, _In_ WslcProcessIoHandle ioHandle, _Out_ HANDLE* handle);
+STDAPI WslcGetProcessIOHandle(_In_ WslcProcess process, _In_ WslcProcessIOHandle ioHandle, _Out_ HANDLE* handle);
 
 STDAPI WslcReleaseProcess(_In_ WslcProcess process);
 

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -961,18 +961,6 @@ try
 }
 CATCH_LOG()
 
-MultiHandleWait::MultiHandleWait(MultiHandleWait&& other) noexcept
-{
-    this->operator=(std::move(other));
-}
-
-MultiHandleWait& MultiHandleWait::operator=(MultiHandleWait&& other) noexcept
-{
-    this->m_handles = std::move(other.m_handles);
-    this->m_cancel = other.m_cancel.load();
-    return *this;
-}
-
 void MultiHandleWait::AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags)
 {
     m_handles.emplace_back(flags, std::move(handle));

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -1010,6 +1010,7 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
         }
 
         // Remove completed handles from m_handles.
+        bool hasHandleToWaitFor = false;
         for (auto it = m_handles.begin(); it != m_handles.end();)
         {
             if (!it->second)
@@ -1027,11 +1028,16 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
             }
             else
             {
+                // If only NeedNotComplete handles are left, we want to exit Run.
+                if (WI_IsFlagClear(it->first, Flags::NeedNotComplete))
+                {
+                    hasHandleToWaitFor = true;
+                }
                 ++it;
             }
         }
 
-        if (m_handles.empty() || m_cancel)
+        if (!hasHandleToWaitFor || m_cancel)
         {
             break;
         }

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -961,6 +961,18 @@ try
 }
 CATCH_LOG()
 
+MultiHandleWait::MultiHandleWait(MultiHandleWait&& other) noexcept
+{
+    this->operator=(std::move(other));
+}
+
+MultiHandleWait& MultiHandleWait::operator=(MultiHandleWait&& other) noexcept
+{
+    this->m_handles = std::move(other.m_handles);
+    this->m_cancel = other.m_cancel.load();
+    return *this;
+}
+
 void MultiHandleWait::AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags)
 {
     m_handles.emplace_back(flags, std::move(handle));

--- a/src/windows/common/relay.hpp
+++ b/src/windows/common/relay.hpp
@@ -498,7 +498,6 @@ class MultiHandleWait
 {
 public:
     NON_COPYABLE(MultiHandleWait);
-    DEFAULT_MOVABLE(MultiHandleWait);
 
     enum Flags
     {
@@ -509,13 +508,16 @@ public:
 
     MultiHandleWait() = default;
 
+    MultiHandleWait(MultiHandleWait&&) noexcept;
+    MultiHandleWait& operator=(MultiHandleWait&&) noexcept;
+
     void AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags = Flags::None);
     bool Run(std::optional<std::chrono::milliseconds> Timeout);
     void Cancel();
 
 private:
     std::vector<std::pair<Flags, std::unique_ptr<OverlappedIOHandle>>> m_handles;
-    bool m_cancel = false;
+    std::atomic_bool m_cancel = false;
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(MultiHandleWait::Flags);

--- a/src/windows/common/relay.hpp
+++ b/src/windows/common/relay.hpp
@@ -498,6 +498,7 @@ class MultiHandleWait
 {
 public:
     NON_COPYABLE(MultiHandleWait);
+    DEFAULT_MOVABLE(MultiHandleWait);
 
     enum Flags
     {
@@ -508,16 +509,13 @@ public:
 
     MultiHandleWait() = default;
 
-    MultiHandleWait(MultiHandleWait&&) noexcept;
-    MultiHandleWait& operator=(MultiHandleWait&&) noexcept;
-
     void AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags = Flags::None);
     bool Run(std::optional<std::chrono::milliseconds> Timeout);
     void Cancel();
 
 private:
     std::vector<std::pair<Flags, std::unique_ptr<OverlappedIOHandle>>> m_handles;
-    std::atomic_bool m_cancel = false;
+    bool m_cancel = false;
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(MultiHandleWait::Flags);

--- a/src/windows/common/relay.hpp
+++ b/src/windows/common/relay.hpp
@@ -504,7 +504,8 @@ public:
     {
         None = 0,
         CancelOnCompleted = 1,
-        IgnoreErrors = 2
+        IgnoreErrors = 2,
+        NeedNotComplete = 4,
     };
 
     MultiHandleWait() = default;

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1387,6 +1387,269 @@ class WslcSdkTests
     }
 
     // -----------------------------------------------------------------------
+    // WslcSetProcessSettingsIOCallback tests
+    // -----------------------------------------------------------------------
+
+    TEST_METHOD(ProcessIoCallbackUnit)
+    {
+        WSL2_TEST_ONLY();
+
+        auto noopCb = [](const BYTE*, uint32_t, PVOID) {};
+
+        // Negative: null processSettings must fail.
+        VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(nullptr, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr), E_POINTER);
+
+        // Negative: STDIN is not a valid output handle.
+        {
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDIN, noopCb, nullptr), E_INVALIDARG);
+        }
+
+        // Negative: out-of-range handle value must fail.
+        {
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, static_cast<WslcProcessIOHandle>(99), noopCb, nullptr), E_INVALIDARG);
+        }
+
+        // Negative: null callback with non-null context must fail.
+        {
+            int ctx = 0;
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, nullptr, &ctx), E_INVALIDARG);
+        }
+
+        // Positive: clear STDOUT (null callback, null context) must succeed.
+        {
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, nullptr, nullptr));
+        }
+
+        // Positive: clear STDERR (null callback, null context) must succeed.
+        {
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDERR, nullptr, nullptr));
+        }
+
+        // Positive: set a valid STDOUT callback must succeed.
+        {
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr));
+        }
+
+        // Positive: set a valid STDERR callback must succeed.
+        {
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDERR, noopCb, nullptr));
+        }
+
+        // Negative: StartContainer without ATTACH fails when callbacks are registered.
+        // The ATTACH flag is required so the IOCallback can claim the init process pipe handles.
+        {
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            const char* argv[] = {"/bin/sleep", "1"};
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr));
+
+            WslcContainerSettings containerSettings;
+            VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+            VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &procSettings));
+
+            UniqueContainer container;
+            VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+            VERIFY_ARE_EQUAL(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_NONE, nullptr), E_INVALIDARG);
+        }
+    }
+
+    TEST_METHOD(ProcessIoCallbackInitProcess)
+    {
+        WSL2_TEST_ONLY();
+
+        std::string stdoutData;
+        std::string stderrData;
+
+        auto appendToContextString = [](const BYTE* data, uint32_t size, PVOID ctx) {
+            static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
+        };
+
+        WslcProcessSettings procSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+        const char* argv[] = {"/bin/sh", "-c", "echo STDOUT && echo STDERR >&2"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, appendToContextString, &stdoutData));
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDERR, appendToContextString, &stderrData));
+
+        WslcContainerSettings containerSettings;
+        VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+        VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &procSettings));
+
+        UniqueContainer container;
+        VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+        VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_ATTACH, nullptr));
+
+        UniqueProcess process;
+        VERIFY_SUCCEEDED(WslcGetContainerInitProcess(container.get(), &process));
+
+        HANDLE exitEvent = nullptr;
+        VERIFY_SUCCEEDED(WslcGetProcessExitEvent(process.get(), &exitEvent));
+        VERIFY_ARE_EQUAL(WaitForSingleObject(exitEvent, 30 * 1000), static_cast<DWORD>(WAIT_OBJECT_0));
+
+        // Release the process handle first, then the container handle.
+        // Releasing the container destroys the WslcContainerImpl which joins the IOCallback
+        // thread, guaranteeing all bytes have been delivered before the assertions below.
+        process.reset();
+        container.reset();
+
+        VERIFY_ARE_EQUAL(stdoutData, "STDOUT\n");
+        VERIFY_ARE_EQUAL(stderrData, "STDERR\n");
+    }
+
+    TEST_METHOD(ProcessIoCallbackExecProcess)
+    {
+        WSL2_TEST_ONLY();
+
+        // Start a long-running container so we can exec into it.
+        WslcProcessSettings initProcSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&initProcSettings));
+        const char* initArgv[] = {"/bin/sleep", "99"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&initProcSettings, initArgv, ARRAYSIZE(initArgv)));
+
+        WslcContainerSettings containerSettings;
+        VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+        VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &initProcSettings));
+
+        UniqueContainer container;
+        VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+        VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_NONE, nullptr));
+
+        std::string stdoutData;
+        std::string stderrData;
+
+        auto stdoutCb = [](const BYTE* data, uint32_t size, PVOID ctx) {
+            static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
+        };
+        auto stderrCb = [](const BYTE* data, uint32_t size, PVOID ctx) {
+            static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
+        };
+
+        WslcProcessSettings execProcSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&execProcSettings));
+        const char* execArgv[] = {"/bin/sh", "-c", "echo EXEC_OUT && echo EXEC_ERR >&2"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&execProcSettings, execArgv, ARRAYSIZE(execArgv)));
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&execProcSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, stdoutCb, &stdoutData));
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&execProcSettings, WSLC_PROCESS_IO_HANDLE_STDERR, stderrCb, &stderrData));
+
+        UniqueProcess execProcess;
+        VERIFY_SUCCEEDED(WslcCreateContainerProcess(container.get(), &execProcSettings, &execProcess, nullptr));
+
+        HANDLE exitEvent = nullptr;
+        VERIFY_SUCCEEDED(WslcGetProcessExitEvent(execProcess.get(), &exitEvent));
+        VERIFY_ARE_EQUAL(WaitForSingleObject(exitEvent, 30 * 1000), static_cast<DWORD>(WAIT_OBJECT_0));
+
+        // Releasing the exec process handle destroys WslcProcessImpl and joins its IOCallback
+        // thread, ensuring all bytes are delivered before assertions.
+        execProcess.reset();
+
+        VERIFY_ARE_EQUAL(stdoutData, "EXEC_OUT\n");
+        VERIFY_ARE_EQUAL(stderrData, "EXEC_ERR\n");
+    }
+
+    TEST_METHOD(ProcessIoCallbackHandleExclusion)
+    {
+        WSL2_TEST_ONLY();
+
+        // Register a stdout callback only — no stderr callback.
+        // The IOCallback object will claim stdout's pipe handle via GetStdHandle (ownership
+        // transfer); calling WslcGetProcessIOHandle for stdout afterwards must therefore fail
+        // with ERROR_INVALID_STATE.  The stderr handle (no callback) must remain obtainable.
+        auto noopCb = [](const BYTE*, uint32_t, PVOID) {};
+
+        WslcProcessSettings procSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+        const char* argv[] = {"/bin/sleep", "99"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr));
+
+        WslcContainerSettings containerSettings;
+        VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+        VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &procSettings));
+
+        UniqueContainer container;
+        VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+        VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_ATTACH, nullptr));
+
+        UniqueProcess process;
+        VERIFY_SUCCEEDED(WslcGetContainerInitProcess(container.get(), &process));
+
+        // stdout handle was consumed by the IOCallback — must not be obtainable.
+        {
+            HANDLE h = nullptr;
+            VERIFY_ARE_EQUAL(
+                WslcGetProcessIOHandle(process.get(), WSLC_PROCESS_IO_HANDLE_STDOUT, &h),
+                HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
+        }
+
+        // stderr handle was NOT consumed — must still be obtainable.
+        {
+            HANDLE h = nullptr;
+            VERIFY_SUCCEEDED(WslcGetProcessIOHandle(process.get(), WSLC_PROCESS_IO_HANDLE_STDERR, &h));
+            VERIFY_IS_NOT_NULL(h);
+            CloseHandle(h);
+        }
+    }
+
+    TEST_METHOD(ProcessIoCallbackLargeOutput)
+    {
+        WSL2_TEST_ONLY();
+
+        // Generate ~1 MiB of stdout via: dd if=/dev/zero bs=1024 count=1024 | base64
+        // 1,048,576 zero bytes → base64 output is 1,398,104 bytes (ceil(1048576/3)*4 + newlines).
+        // We verify the accumulated size is at least 1,398,000 bytes to allow minor variance.
+        static constexpr size_t c_expectedMinBytes = 1'398'000;
+
+        std::string stdoutData;
+        stdoutData.reserve(c_expectedMinBytes + 4096);
+
+        auto stdoutCb = [](const BYTE* data, uint32_t size, PVOID ctx) {
+            static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
+        };
+
+        WslcProcessSettings procSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+        const char* argv[] = {"/bin/sh", "-c", "dd if=/dev/zero bs=1024 count=1024 2>/dev/null | base64"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, stdoutCb, &stdoutData));
+
+        WslcContainerSettings containerSettings;
+        VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+        VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &procSettings));
+
+        UniqueContainer container;
+        VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+        VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_ATTACH, nullptr));
+
+        UniqueProcess process;
+        VERIFY_SUCCEEDED(WslcGetContainerInitProcess(container.get(), &process));
+
+        HANDLE exitEvent = nullptr;
+        VERIFY_SUCCEEDED(WslcGetProcessExitEvent(process.get(), &exitEvent));
+        VERIFY_ARE_EQUAL(WaitForSingleObject(exitEvent, 60 * 1000), static_cast<DWORD>(WAIT_OBJECT_0));
+
+        // Join the IOCallback thread before inspecting the accumulator.
+        process.reset();
+        container.reset();
+
+        VERIFY_IS_TRUE(stdoutData.size() >= c_expectedMinBytes);
+    }
+
+    // -----------------------------------------------------------------------
     // Stub tests for unimplemented (E_NOTIMPL) functions.
     // Each of these confirms the current state of the SDK; once the underlying
     // function is implemented the assertion below will catch it and the test
@@ -1424,15 +1687,6 @@ class WslcSdkTests
         VERIFY_ARE_EQUAL(WslcInspectContainer(container.get(), &inspectData), E_NOTIMPL);
 
         VERIFY_SUCCEEDED(WslcDeleteContainer(container.get(), WSLC_DELETE_CONTAINER_FLAG_NONE, nullptr));
-    }
-
-    TEST_METHOD(ProcessIoCallbackNotImplemented)
-    {
-        WSL2_TEST_ONLY();
-
-        WslcProcessSettings procSettings;
-        VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-        VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, nullptr, nullptr), E_NOTIMPL);
     }
 
     TEST_METHOD(SessionCreateVhdNotImplemented)

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1591,9 +1591,7 @@ class WslcSdkTests
         // stdout handle was consumed by the IOCallback — must not be obtainable.
         {
             HANDLE h = nullptr;
-            VERIFY_ARE_EQUAL(
-                WslcGetProcessIOHandle(process.get(), WSLC_PROCESS_IO_HANDLE_STDOUT, &h),
-                HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
+            VERIFY_ARE_EQUAL(WslcGetProcessIOHandle(process.get(), WSLC_PROCESS_IO_HANDLE_STDOUT, &h), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
         }
 
         // stderr handle was NOT consumed — must still be obtainable.

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1432,7 +1432,7 @@ class WslcSdkTests
 
         WslcProcessSettings procSettings;
         VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-        VERIFY_ARE_EQUAL(WslcSetProcessSettingsIoCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, nullptr, nullptr), E_NOTIMPL);
+        VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, nullptr, nullptr), E_NOTIMPL);
     }
 
     TEST_METHOD(SessionCreateVhdNotImplemented)

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1594,12 +1594,10 @@ class WslcSdkTests
             VERIFY_ARE_EQUAL(WslcGetProcessIOHandle(process.get(), WSLC_PROCESS_IO_HANDLE_STDOUT, &h), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
         }
 
-        // stderr handle was NOT consumed — must still be obtainable.
+        // stderr handle was also consumed in order to drain it despite not being given a callback.
         {
             HANDLE h = nullptr;
-            VERIFY_SUCCEEDED(WslcGetProcessIOHandle(process.get(), WSLC_PROCESS_IO_HANDLE_STDERR, &h));
-            VERIFY_IS_NOT_NULL(h);
-            CloseHandle(h);
+            VERIFY_ARE_EQUAL(WslcGetProcessIOHandle(process.get(), WSLC_PROCESS_IO_HANDLE_STDERR, &h), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
         }
     }
 

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -539,7 +539,8 @@ class WslcSdkTests
         VERIFY_IS_TRUE(checkForImage("hello-world:latest"));
 
         // Positive: delete an existing image.
-        VERIFY_SUCCEEDED(WslcDeleteSessionImage(m_defaultSession, "hello-world:latest", nullptr));
+        wil::unique_cotaskmem_string errorMsg;
+        VERIFY_SUCCEEDED(WslcDeleteSessionImage(m_defaultSession, "hello-world:latest", &errorMsg));
 
         // Verify the image is no longer present in the list.
         VERIFY_IS_FALSE(checkForImage("hello-world:latest"));
@@ -1387,66 +1388,75 @@ class WslcSdkTests
     }
 
     // -----------------------------------------------------------------------
-    // WslcSetProcessSettingsIOCallback tests
+    // WslcSetProcessSettingsCallbacks tests
     // -----------------------------------------------------------------------
 
     TEST_METHOD(ProcessIoCallbackUnit)
     {
         WSL2_TEST_ONLY();
 
-        auto noopCb = [](const BYTE*, uint32_t, PVOID) {};
+        auto noopIoCb = [](WslcProcessIOHandle, const BYTE*, uint32_t, PVOID) {};
+        auto noopExitCb = [](INT32, PVOID) {};
 
         // Negative: null processSettings must fail.
-        VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(nullptr, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr), E_POINTER);
-
-        // Negative: STDIN is not a valid output handle.
         {
-            WslcProcessSettings procSettings;
-            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDIN, noopCb, nullptr), E_INVALIDARG);
+            WslcProcessCallbacks callbacks{};
+            callbacks.onStdOut = noopIoCb;
+            VERIFY_ARE_EQUAL(WslcSetProcessSettingsCallbacks(nullptr, &callbacks, nullptr), E_POINTER);
         }
 
-        // Negative: out-of-range handle value must fail.
-        {
-            WslcProcessSettings procSettings;
-            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, static_cast<WslcProcessIOHandle>(99), noopCb, nullptr), E_INVALIDARG);
-        }
-
-        // Negative: null callback with non-null context must fail.
+        // Negative: null callbacks pointer with non-null context must fail.
         {
             int ctx = 0;
             WslcProcessSettings procSettings;
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            VERIFY_ARE_EQUAL(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, nullptr, &ctx), E_INVALIDARG);
+            VERIFY_ARE_EQUAL(WslcSetProcessSettingsCallbacks(&procSettings, nullptr, &ctx), E_INVALIDARG);
         }
 
-        // Positive: clear STDOUT (null callback, null context) must succeed.
+        // Positive: null callbacks pointer with null context clears all callbacks.
         {
             WslcProcessSettings procSettings;
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, nullptr, nullptr));
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, nullptr, nullptr));
         }
 
-        // Positive: clear STDERR (null callback, null context) must succeed.
+        // Positive: set onStdOut only.
         {
             WslcProcessSettings procSettings;
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDERR, nullptr, nullptr));
+            WslcProcessCallbacks callbacks{};
+            callbacks.onStdOut = noopIoCb;
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, nullptr));
         }
 
-        // Positive: set a valid STDOUT callback must succeed.
+        // Positive: set onStdErr only.
         {
             WslcProcessSettings procSettings;
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr));
+            WslcProcessCallbacks callbacks{};
+            callbacks.onStdErr = noopIoCb;
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, nullptr));
         }
 
-        // Positive: set a valid STDERR callback must succeed.
+        // Positive: set onExit only.
         {
             WslcProcessSettings procSettings;
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDERR, noopCb, nullptr));
+            WslcProcessCallbacks callbacks{};
+            callbacks.onExit = noopExitCb;
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, nullptr));
+        }
+
+        // Positive: set all three callbacks with a context.
+        {
+            int ctx = 0;
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            WslcProcessCallbacks callbacks{};
+            callbacks.onStdOut = noopIoCb;
+            callbacks.onStdErr = noopIoCb;
+            callbacks.onExit = noopExitCb;
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, &ctx));
         }
 
         // Negative: StartContainer without ATTACH fails when callbacks are registered.
@@ -1456,7 +1466,9 @@ class WslcSdkTests
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
             const char* argv[] = {"/bin/sleep", "1"};
             VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
-            VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr));
+            WslcProcessCallbacks callbacks{};
+            callbacks.onStdOut = noopIoCb;
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, nullptr));
 
             WslcContainerSettings containerSettings;
             VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
@@ -1472,19 +1484,28 @@ class WslcSdkTests
     {
         WSL2_TEST_ONLY();
 
-        std::string stdoutData;
-        std::string stderrData;
+        struct IOContext
+        {
+            std::string stdoutData;
+            std::string stderrData;
+        } ioContext;
 
-        auto appendToContextString = [](const BYTE* data, uint32_t size, PVOID ctx) {
-            static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
+        // Both streams share one callback; ioHandle distinguishes which accumulator to use.
+        auto ioCb = [](WslcProcessIOHandle ioHandle, const BYTE* data, uint32_t size, PVOID ctx) {
+            auto* c = static_cast<IOContext*>(ctx);
+            auto& target = (ioHandle == WSLC_PROCESS_IO_HANDLE_STDOUT) ? c->stdoutData : c->stderrData;
+            target.append(reinterpret_cast<const char*>(data), size);
         };
 
         WslcProcessSettings procSettings;
         VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
         const char* argv[] = {"/bin/sh", "-c", "echo STDOUT && echo STDERR >&2"};
         VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
-        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, appendToContextString, &stdoutData));
-        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDERR, appendToContextString, &stderrData));
+
+        WslcProcessCallbacks callbacks{};
+        callbacks.onStdOut = ioCb;
+        callbacks.onStdErr = ioCb;
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, &ioContext));
 
         WslcContainerSettings containerSettings;
         VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
@@ -1507,8 +1528,8 @@ class WslcSdkTests
         process.reset();
         container.reset();
 
-        VERIFY_ARE_EQUAL(stdoutData, "STDOUT\n");
-        VERIFY_ARE_EQUAL(stderrData, "STDERR\n");
+        VERIFY_ARE_EQUAL(ioContext.stdoutData, "STDOUT\n");
+        VERIFY_ARE_EQUAL(ioContext.stderrData, "STDERR\n");
     }
 
     TEST_METHOD(ProcessIoCallbackExecProcess)
@@ -1529,22 +1550,27 @@ class WslcSdkTests
         VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
         VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_NONE, nullptr));
 
-        std::string stdoutData;
-        std::string stderrData;
+        struct IOContext
+        {
+            std::string stdoutData;
+            std::string stderrData;
+        } ioContext;
 
-        auto stdoutCb = [](const BYTE* data, uint32_t size, PVOID ctx) {
-            static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
-        };
-        auto stderrCb = [](const BYTE* data, uint32_t size, PVOID ctx) {
-            static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
+        auto ioCb = [](WslcProcessIOHandle ioHandle, const BYTE* data, uint32_t size, PVOID ctx) {
+            auto* c = static_cast<IOContext*>(ctx);
+            auto& target = (ioHandle == WSLC_PROCESS_IO_HANDLE_STDOUT) ? c->stdoutData : c->stderrData;
+            target.append(reinterpret_cast<const char*>(data), size);
         };
 
         WslcProcessSettings execProcSettings;
         VERIFY_SUCCEEDED(WslcInitProcessSettings(&execProcSettings));
         const char* execArgv[] = {"/bin/sh", "-c", "echo EXEC_OUT && echo EXEC_ERR >&2"};
         VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&execProcSettings, execArgv, ARRAYSIZE(execArgv)));
-        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&execProcSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, stdoutCb, &stdoutData));
-        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&execProcSettings, WSLC_PROCESS_IO_HANDLE_STDERR, stderrCb, &stderrData));
+
+        WslcProcessCallbacks callbacks{};
+        callbacks.onStdOut = ioCb;
+        callbacks.onStdErr = ioCb;
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&execProcSettings, &callbacks, &ioContext));
 
         UniqueProcess execProcess;
         VERIFY_SUCCEEDED(WslcCreateContainerProcess(container.get(), &execProcSettings, &execProcess, nullptr));
@@ -1557,25 +1583,27 @@ class WslcSdkTests
         // thread, ensuring all bytes are delivered before assertions.
         execProcess.reset();
 
-        VERIFY_ARE_EQUAL(stdoutData, "EXEC_OUT\n");
-        VERIFY_ARE_EQUAL(stderrData, "EXEC_ERR\n");
+        VERIFY_ARE_EQUAL(ioContext.stdoutData, "EXEC_OUT\n");
+        VERIFY_ARE_EQUAL(ioContext.stderrData, "EXEC_ERR\n");
     }
 
     TEST_METHOD(ProcessIoCallbackHandleExclusion)
     {
         WSL2_TEST_ONLY();
 
-        // Register a stdout callback only — no stderr callback.
-        // The IOCallback object will claim stdout's pipe handle via GetStdHandle (ownership
-        // transfer); calling WslcGetProcessIOHandle for stdout afterwards must therefore fail
-        // with ERROR_INVALID_STATE.  The stderr handle (no callback) must remain obtainable.
-        auto noopCb = [](const BYTE*, uint32_t, PVOID) {};
+        // Register a stdout callback only. IOCallback always acquires ALL pipe handles
+        // (draining uncallbacked streams to prevent deadlock), so both stdout and stderr
+        // handles are consumed and neither can be obtained via WslcGetProcessIOHandle.
+        auto noopIoCb = [](WslcProcessIOHandle, const BYTE*, uint32_t, PVOID) {};
 
         WslcProcessSettings procSettings;
         VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
         const char* argv[] = {"/bin/sleep", "99"};
         VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
-        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, noopCb, nullptr));
+
+        WslcProcessCallbacks callbacks{};
+        callbacks.onStdOut = noopIoCb;
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, nullptr));
 
         WslcContainerSettings containerSettings;
         VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
@@ -1601,6 +1629,74 @@ class WslcSdkTests
         }
     }
 
+    TEST_METHOD(ProcessIoCallbackExitCallback)
+    {
+        WSL2_TEST_ONLY();
+
+        // Verify the onExit callback fires with the correct exit code after IO has been flushed.
+        // We test both exit 0 and a non-zero exit code.
+        auto RunAndCaptureExit = [&](int exitCodeArg) -> std::pair<INT32, std::string> {
+            std::string stdoutData;
+            std::atomic<INT32> capturedExitCode{-999};
+
+            struct Context
+            {
+                std::string* stdoutData;
+                std::atomic<INT32>* capturedExitCode;
+                wil::unique_event exitEvent{wil::EventOptions::ManualReset};
+            } ctx{&stdoutData, &capturedExitCode};
+
+            auto ioCb = [](WslcProcessIOHandle, const BYTE* data, uint32_t size, PVOID c) {
+                static_cast<Context*>(c)->stdoutData->append(reinterpret_cast<const char*>(data), size);
+            };
+            auto exitCb = [](INT32 code, PVOID c) {
+                static_cast<Context*>(c)->capturedExitCode->store(code);
+                static_cast<Context*>(c)->exitEvent.SetEvent();
+            };
+
+            std::string script = "echo HELLO && exit " + std::to_string(exitCodeArg);
+            const char* argv[] = {"/bin/sh", "-c", script.c_str()};
+
+            WslcProcessSettings procSettings;
+            THROW_IF_FAILED(WslcInitProcessSettings(&procSettings));
+            THROW_IF_FAILED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
+
+            WslcProcessCallbacks callbacks{};
+            callbacks.onStdOut = ioCb;
+            callbacks.onExit = exitCb;
+            THROW_IF_FAILED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, &ctx));
+
+            WslcContainerSettings containerSettings;
+            THROW_IF_FAILED(WslcInitContainerSettings("debian:latest", &containerSettings));
+            THROW_IF_FAILED(WslcSetContainerSettingsInitProcess(&containerSettings, &procSettings));
+
+            UniqueContainer container;
+            THROW_IF_FAILED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+            THROW_IF_FAILED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_ATTACH, nullptr));
+
+            UniqueProcess process;
+            THROW_IF_FAILED(WslcGetContainerInitProcess(container.get(), &process));
+
+            THROW_HR_IF(HRESULT_FROM_WIN32(WAIT_TIMEOUT), WaitForSingleObject(ctx.exitEvent.get(), 60 * 1000) != WAIT_OBJECT_0);
+
+            return {capturedExitCode.load(), stdoutData};
+        };
+
+        // Exit 0: onExit must fire with code 0; IO must have been delivered first.
+        {
+            auto [exitCode, output] = RunAndCaptureExit(0);
+            VERIFY_ARE_EQUAL(exitCode, 0);
+            VERIFY_ARE_EQUAL(output, "HELLO\n");
+        }
+
+        // Non-zero exit: onExit must report the correct code.
+        {
+            auto [exitCode, output] = RunAndCaptureExit(42);
+            VERIFY_ARE_EQUAL(exitCode, 42);
+            VERIFY_ARE_EQUAL(output, "HELLO\n");
+        }
+    }
+
     TEST_METHOD(ProcessIoCallbackLargeOutput)
     {
         WSL2_TEST_ONLY();
@@ -1613,7 +1709,7 @@ class WslcSdkTests
         std::string stdoutData;
         stdoutData.reserve(c_expectedMinBytes + 4096);
 
-        auto stdoutCb = [](const BYTE* data, uint32_t size, PVOID ctx) {
+        auto ioCb = [](WslcProcessIOHandle, const BYTE* data, uint32_t size, PVOID ctx) {
             static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
         };
 
@@ -1621,7 +1717,10 @@ class WslcSdkTests
         VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
         const char* argv[] = {"/bin/sh", "-c", "dd if=/dev/zero bs=1024 count=1024 2>/dev/null | base64"};
         VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
-        VERIFY_SUCCEEDED(WslcSetProcessSettingsIOCallback(&procSettings, WSLC_PROCESS_IO_HANDLE_STDOUT, stdoutCb, &stdoutData));
+
+        WslcProcessCallbacks callbacks{};
+        callbacks.onStdOut = ioCb;
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, &stdoutData));
 
         WslcContainerSettings containerSettings;
         VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1732,9 +1732,7 @@ class WslcSdkTests
         auto ioCb = [](WslcProcessIOHandle, const BYTE*, uint32_t, PVOID c) {
             static_cast<Context*>(c)->callbackCount.fetch_add(1);
         };
-        auto exitCb = [](INT32, PVOID c) {
-            static_cast<Context*>(c)->exitFired.store(true);
-        };
+        auto exitCb = [](INT32, PVOID c) { static_cast<Context*>(c)->exitFired.store(true); };
 
         // Continuous writer: emits one line every 50 ms indefinitely.
         WslcProcessSettings execProcSettings;

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1697,17 +1697,90 @@ class WslcSdkTests
         }
     }
 
+    TEST_METHOD(ProcessIoCallbackCancelOnRelease)
+    {
+        WSL2_TEST_ONLY();
+
+        // Verify that releasing the process handle while an exec'd process is still running
+        // and writing IO cancels the IOCallback pump:
+        //   - No IO callbacks arrive after the handle is released.
+        //   - onExit is never invoked (cancellation returns runResult=false, suppressing it).
+        //
+        // A secondary (exec'd) process is used so that the long-lived init process keeps the
+        // container alive, allowing UniqueContainer to clean up normally at scope exit.
+
+        // Start a long-running init process to keep the container alive.
+        WslcProcessSettings initProcSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&initProcSettings));
+        const char* initArgv[] = {"/bin/sleep", "999"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&initProcSettings, initArgv, ARRAYSIZE(initArgv)));
+
+        WslcContainerSettings containerSettings;
+        VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+        VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &initProcSettings));
+
+        UniqueContainer container;
+        VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+        VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_NONE, nullptr));
+
+        struct Context
+        {
+            std::atomic<int> callbackCount{0};
+            std::atomic<bool> exitFired{false};
+        } ctx;
+
+        auto ioCb = [](WslcProcessIOHandle, const BYTE*, uint32_t, PVOID c) {
+            static_cast<Context*>(c)->callbackCount.fetch_add(1);
+        };
+        auto exitCb = [](INT32, PVOID c) {
+            static_cast<Context*>(c)->exitFired.store(true);
+        };
+
+        // Continuous writer: emits one line every 50 ms indefinitely.
+        WslcProcessSettings execProcSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&execProcSettings));
+        const char* execArgv[] = {"/bin/sh", "-c", "while true; do echo LINE; sleep 0.05; done"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&execProcSettings, execArgv, ARRAYSIZE(execArgv)));
+
+        WslcProcessCallbacks callbacks{};
+        callbacks.onStdOut = ioCb;
+        callbacks.onExit = exitCb;
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&execProcSettings, &callbacks, &ctx));
+
+        UniqueProcess execProcess;
+        VERIFY_SUCCEEDED(WslcCreateContainerProcess(container.get(), &execProcSettings, &execProcess, nullptr));
+
+        // Wait long enough for at least several callbacks to arrive.
+        Sleep(500);
+        VERIFY_IS_TRUE(ctx.callbackCount.load() > 0);
+
+        // Release the exec process handle while the process is still running and writing.
+        // This destructs WslcProcessImpl → cancels the IOCallback → joins its thread.
+        // By the time execProcess.reset() returns, the pump thread has exited.
+        execProcess.reset();
+
+        // Snapshot the count now that the thread is confirmed stopped.
+        int countAtRelease = ctx.callbackCount.load();
+
+        // onExit must not have fired: cancellation sets runResult=false, suppressing the call.
+        VERIFY_IS_FALSE(ctx.exitFired.load());
+
+        // Wait another interval — no further callbacks can arrive after the thread has joined.
+        Sleep(200);
+        VERIFY_ARE_EQUAL(ctx.callbackCount.load(), countAtRelease);
+        VERIFY_IS_FALSE(ctx.exitFired.load());
+    }
+
     TEST_METHOD(ProcessIoCallbackLargeOutput)
     {
         WSL2_TEST_ONLY();
 
         // Generate ~1 MiB of stdout via: dd if=/dev/zero bs=1024 count=1024 | base64
-        // 1,048,576 zero bytes → base64 output is 1,398,104 bytes (ceil(1048576/3)*4 + newlines).
-        // We verify the accumulated size is at least 1,398,000 bytes to allow minor variance.
-        static constexpr size_t c_expectedMinBytes = 1'398'000;
+        // 1,048,576 zero bytes → base64 output is 1,398,104 bytes (ceil(1048576/3)*4).
+        static constexpr size_t c_expectedBytes = 1'398'104;
 
         std::string stdoutData;
-        stdoutData.reserve(c_expectedMinBytes + 4096);
+        stdoutData.reserve(c_expectedBytes + 4096);
 
         auto ioCb = [](WslcProcessIOHandle, const BYTE* data, uint32_t size, PVOID ctx) {
             static_cast<std::string*>(ctx)->append(reinterpret_cast<const char*>(data), size);
@@ -1715,7 +1788,7 @@ class WslcSdkTests
 
         WslcProcessSettings procSettings;
         VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-        const char* argv[] = {"/bin/sh", "-c", "dd if=/dev/zero bs=1024 count=1024 2>/dev/null | base64"};
+        const char* argv[] = {"/bin/sh", "-c", "dd if=/dev/zero bs=1024 count=1024 2>/dev/null | base64 -w 0"};
         VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
 
         WslcProcessCallbacks callbacks{};
@@ -1741,7 +1814,7 @@ class WslcSdkTests
         process.reset();
         container.reset();
 
-        VERIFY_IS_TRUE(stdoutData.size() >= c_expectedMinBytes);
+        VERIFY_ARE_EQUAL(stdoutData.size(), c_expectedBytes);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implements IO callbacks for processes created through the SDK.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Implements `WslcSetProcessSettingsIOCallback` and the use of those inputs for both initial and subsequent processes.  A new thread is started to run the `MultiHandleWait` and the container/process objects hold a `shared_ptr` reference to it.  The caller must keep one of the objects alive for the callback thread to keep working.

**Open question:** I made it an error to specify callbacks and not ATTACH on the container start. ***Should we just force ATTACH if callbacks are provided?***

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tests added and run.