### PR TITLE
Moves all Ubuntu distros to the tar-based format

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -270,36 +270,6 @@
             "PackageFamilyName": "KaliLinux.54290C8133FEE_ey8k8hqnwqnmg"
         },
         {
-            "Name": "Ubuntu-20.04",
-            "FriendlyName": "Ubuntu 20.04 LTS",
-            "StoreAppId": "9MTTCL66CPXJ",
-            "Amd64": true,
-            "Arm64": true,
-            "Amd64PackageUrl": "https://publicwsldistros.blob.core.windows.net/wsldistrostorage/Ubuntu2004-230608_x64.appx",
-            "Arm64PackageUrl": "https://publicwsldistros.blob.core.windows.net/wsldistrostorage/Ubuntu2004-230608_ARM64.appx",
-            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu20.04LTS_79rhkp1fndgsc"
-        },
-        {
-            "Name": "Ubuntu-22.04",
-            "FriendlyName": "Ubuntu 22.04 LTS",
-            "StoreAppId": "9PN20MSR04DW",
-            "Amd64": true,
-            "Arm64": true,
-            "Amd64PackageUrl": "https://publicwsldistros.blob.core.windows.net/wsldistrostorage/Ubuntu2204LTS-230518_x64.appx",
-            "Arm64PackageUrl": "https://publicwsldistros.blob.core.windows.net/wsldistrostorage/Ubuntu2204LTS-230518_ARM64.appx",
-            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu22.04LTS_79rhkp1fndgsc"
-        },
-        {
-            "Name": "Ubuntu-24.04",
-            "FriendlyName": "Ubuntu 24.04 LTS",
-            "StoreAppId": "9NZ3KLHXDJP5",
-            "Amd64": true,
-            "Arm64": true,
-            "Amd64PackageUrl": "https://publicwsldistros.blob.core.windows.net/wsldistrostorage/Ubuntu2404-240425.AppxBundle",
-            "Arm64PackageUrl": "https://publicwsldistros.blob.core.windows.net/wsldistrostorage/Ubuntu2404-240425.AppxBundle",
-            "PackageFamilyName": "CanonicalGroupLimited.Ubuntu24.04LTS_79rhkp1fndgsc"
-        },
-        {
             "Name": "OracleLinux_7_9",
             "FriendlyName": "Oracle Linux 7.9",
             "StoreAppId": "9P7L0QWBSLTK",

--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -26,6 +26,32 @@
                     "Url": "https://cdimages.ubuntu.com/releases/24.04.4/release/ubuntu-24.04.4-wsl-arm64.wsl",
                     "Sha256": "6b244d89f412a68f51e58f396fab65bed3b5896a25c045a99bef9c78a07df507"
                 }
+            },
+            {
+                "Name": "Ubuntu-22.04",
+                "FriendlyName": "Ubuntu 22.04 LTS",
+                "Default": false,
+                "Amd64Url": {
+                    "Url": "https://releases.ubuntu.com/jammy/ubuntu-22.04.5-wsl-amd64.wsl",
+                    "Sha256": "4499c4fe257f2fc83145b429ce211a0a43fd590e70d6261ede616210947d9f8f"
+                },
+                "Arm64Url": {
+                    "Url": "https://cdimage.ubuntu.com/ubuntu/releases/jammy/release/ubuntu-22.04.5-wsl-arm64.wsl",
+                    "Sha256": "3e2d77b92cf9dad1095eaebcad96feba2781007f5f52431cd4fe6fff63b201e5"
+                }
+            },
+            {
+                "Name": "Ubuntu-20.04",
+                "FriendlyName": "Ubuntu 20.04 LTS",
+                "Default": false,
+                "Amd64Url": {
+                    "Url": "https://releases.ubuntu.com/focal/ubuntu-20.04.6-wsl-amd64.wsl",
+                    "Sha256": "a9073f3726aab9661076506603706eadf284b80a791dec3adfde8e1989906fa4"
+                },
+                "Arm64Url": {
+                    "Url": "https://cdimage.ubuntu.com/ubuntu/releases/focal/release/ubuntu-20.04.6-wsl-arm64.wsl",
+                    "Sha256": "16174012f9a3f6fb10729e648fd8c7dfa205d039d76902e4c28de746f85bf3c8"
+                }
             }
         ],
         "openSUSE": [


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR aims to move all Ubuntu LTSes to the new tar-based format, removing support for the versioned appx based distros.
The existing instances will continue working as expected, but new installations shouldn't fetch appx's from Microsoft Store. Instead, new installations are going to leverage the new tar based format, bringing consistency to all Ubuntu LTSes on WSL.
The default unversioned Ubuntu appx is preserved as is, for backwards compatibility, ensuring that the "Default" field works on both modern and legacy WSL setups.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Used the resulting `DistributionInfo.json` as a replacement manifest by writing its path in the registry key `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss` `DIstributionListURL` value, then installed `Ubuntu-22.04` and `Ubuntu-20.04`.