### PR TITLE
WSLC: Enforce read-only VirtioFS shares at the device host level

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.1.14-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.1.39-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.2.0" />

--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -74,6 +74,10 @@ void DeviceHostProxy::RemoveDevice(const GUID& Type, const GUID& InstanceId)
         m_devices.erase(InstanceId);
     }
 
+    // TODO: Add this back after the the hotplug issue with the most recent wsldevicehost.dll is resolved.
+    //       See https://github.com/microsoft/openvmm/issues/3077 for more details.
+    return;
+
     // N.B. Removing the FlexIov device is best effort since not all versions of Windows support it.
     try
     {

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -527,7 +527,13 @@ try
     else
     {
         it->second = m_guestDeviceManager->AddGuestDevice(
-            VIRTIO_FS_DEVICE_ID, m_virtioFsClassId, shareName.c_str(), L"", WindowsPath, VIRTIO_FS_FLAGS_TYPE_FILES, m_userToken.get());
+            VIRTIO_FS_DEVICE_ID,
+            m_virtioFsClassId,
+            shareName.c_str(),
+            ReadOnly ? L"ro" : L"",
+            WindowsPath,
+            VIRTIO_FS_FLAGS_TYPE_FILES,
+            m_userToken.get());
     }
 
     cleanup.release();

--- a/test/windows/WSLATests.cpp
+++ b/test/windows/WSLATests.cpp
@@ -2217,6 +2217,45 @@ class WSLATests
             ExpectMount(session.get(), "/win-path", {});
         }
 
+        // Validate that a read-only share cannot be made writeable via mount -o remount,rw.
+        {
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", true));
+            ExpectMount(session.get(), "/win-path", expectedMountOptions(true));
+
+            // Attempt an in-place remount to read-write from the guest.
+            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "mount -o remount,rw /win-path"}, 0);
+
+            // Verify the folder is still not writeable.
+            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "echo -n content > /win-path/file.txt"}, 1);
+
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+            ExpectMount(session.get(), "/win-path", {});
+        }
+
+        // Validate that the device host enforces read-only even if the guest tries to bypass mount options.
+        if (enableVirtioFs)
+        {
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", true));
+            ExpectMount(session.get(), "/win-path", expectedMountOptions(true));
+
+            // Capture the mount source and type, unmount, then remount without read-only.
+            ExpectCommandResult(
+                session.get(),
+                {"/bin/sh",
+                 "-c",
+                 "src=$(findmnt -n -o SOURCE /win-path) && "
+                 "fstype=$(findmnt -n -o FSTYPE /win-path) && "
+                 "umount /win-path && "
+                 "mount -t $fstype $src /win-path"},
+                0);
+
+            // Verify the folder is still not writeable.
+            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "echo -n content > /win-path/file.txt"}, 1);
+
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+            ExpectMount(session.get(), "/win-path", {});
+        }
+
         // Validate various error paths
         {
             VERIFY_ARE_EQUAL(session->MountWindowsFolder(L"relative-path", "/win-path", true), E_INVALIDARG);


### PR DESCRIPTION
Pass the 'ro' option to AddGuestDevice when mounting a read-only VirtioFS share, ensuring the device host enforces write protection regardless of guest-side mount operations.

Updated DeviceHost package to 1.1.39-0. Added tests for read-only mount enforcement via remount and unmount+remount.
