### PR TITLE
Remove VHD device path assert in ConfigureInitialMounts

### DIFF
--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -125,8 +125,6 @@ void WSLAVirtualMachine::ConfigureInitialMounts()
     const auto rootDevice = GetVhdDevicePath(0);
     const auto modulesDevice = GetVhdDevicePath(1);
 
-    WI_ASSERT(rootDevice == "/dev/sda" && modulesDevice == "/dev/sdb");
-
     // Mount root filesystem with overlay
     Mount(m_initChannel, rootDevice.c_str(), "/mnt", m_rootVhdType.c_str(), "ro", WSLA_MOUNT::Chroot | WSLA_MOUNT::OverlayFs);
 


### PR DESCRIPTION
The kernel SCSI device enumeration order can vary, and the code already uses the paths returned by init rather than hardcoded device names.
