### PR TITLE
Fix missing throw in GnsPortTracker::GetSocketProtocol

### DIFF
--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -424,7 +424,7 @@ int GnsPortTracker::GetSocketProtocol(int pid, int fd)
 
     if (result < 0)
     {
-        RuntimeErrorWithSourceLocation(std::format("Failed to read protocol for socket: {}, {}", path, errno));
+        throw RuntimeErrorWithSourceLocation(std::format("Failed to read protocol for socket: {}, {}", path, errno));
     }
 
     // In case the size of the attribute shrunk between the two getxattr calls


### PR DESCRIPTION
The throw keyword was accidentally dropped, causing the error to be silently discarded when getxattr fails to read the socket protocol. This corrupts port tracking state used by the mirrored-mode loopback relay.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
