### PR TITLE
test: disable LoopbackExplicit due to OS build 29555 regression

### DIFF
--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -3878,6 +3878,9 @@ class MirroredTests
 
     TEST_METHOD(LoopbackExplicit)
     {
+        // TODO: re-enable once OS build 29555 loopback regression is resolved.
+        SKIP_TEST_UNSTABLE();
+
         MIRRORED_NETWORKING_TEST_ONLY();
 
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));


### PR DESCRIPTION
This test started failing as soon as our CloudTest images were updated to the 3/17 re_prerelease build.