### PR TITLE
WSLc: change virtiofs mount operations to happen on a fork

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.1.14-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.1.39-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.2.0" />

--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -707,11 +707,10 @@ try
     });
 
     // Create the guest mount
+    auto [_, __, channel] = Fork(WSLA_FORK::Process);
     auto shareName = shared::string::GuidToString<char>(shareGuid, shared::string::None);
     if (!FeatureEnabled(WslaFeatureFlagsVirtioFs))
     {
-        auto [_, __, channel] = Fork(WSLA_FORK::Process);
-
         WSLA_CONNECT message;
         message.HostPort = LX_INIT_UTILITY_VM_PLAN9_PORT;
 
@@ -731,7 +730,7 @@ try
     else
     {
         std::string options = WI_IsFlagSet(Flags, WSLAMountFlagsReadOnly) ? "ro" : "rw";
-        Mount(m_initChannel, shareName.c_str(), LinuxPath, "virtiofs", options.c_str(), Flags);
+        Mount(channel, shareName.c_str(), LinuxPath, "virtiofs", options.c_str(), Flags);
     }
 
     deleteOnFailure.release();


### PR DESCRIPTION
I am currently debugging a virtiofs-related hang and I'm hopeful this will give better diagnostics. Currently if the mount operation hangs this will tie up the init channel.