### PR TITLE
Mask console-getty.service to prevent multi-distro failures (#13595)

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -34,6 +34,7 @@ DISCOURAGED_SYSTEM_UNITS = ['systemd-resolved.service',
                             'tmp.mount',
                             'NetworkManager.service',
                             'NetworkManager-wait-online.service',
+                            'console-getty.service',
                             'networking.service',
                             'hypervkvpd.service']
 

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -336,6 +336,10 @@ int GenerateSystemdUnits(int Argc, char** Argv)
         // Mask NetworkManager-wait-online.service for the same reason, as it causes timeouts on distros using NetworkManager.
         THROW_LAST_ERROR_IF(symlink("/dev/null", std::format("{}/NetworkManager-wait-online.service", installPath).c_str()) < 0);
 
+        // Mask console-getty.service since /dev/tty devices are shared at the VM level across all distros.
+        // When multiple distros are running, the second distro's getty fails because the tty is already held.
+        THROW_LAST_ERROR_IF(symlink("/dev/null", std::format("{}/console-getty.service", installPath).c_str()) < 0);
+
         // Only create the wslg unit if both enabled in wsl.conf, and if the wslg folder actually exists.
         if (enableGuiApps && access("/mnt/wslg/runtime-dir", F_OK) == 0)
         {

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -214,21 +214,18 @@ class UnitTests
         VERIFY_IS_TRUE(IsSystemdRunning(L"--system"));
 
         // Validate that systemd-networkd-wait-online.service is masked.
-        auto [out, _] =
-            LxsstuLaunchWslAndCaptureOutput(L"systemctl status systemd-networkd-wait-online.service  | grep -iF Loaded:");
-
-        VERIFY_ARE_EQUAL(out, L"     Loaded: masked (Reason: Unit systemd-networkd-wait-online.service is masked.)\n");
+        std::wstring out;
+        std::wstring err;
+        std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(L"systemctl show -p LoadState systemd-networkd-wait-online.service");
+        VERIFY_ARE_EQUAL(out, L"LoadState=masked\n");
 
         // Validate that NetworkManager-wait-online.service is masked.
-        auto [outNm, __] =
-            LxsstuLaunchWslAndCaptureOutput(L"systemctl status NetworkManager-wait-online.service  | grep -iF Loaded:");
-
-        VERIFY_ARE_EQUAL(outNm, L"     Loaded: masked (Reason: Unit NetworkManager-wait-online.service is masked.)\n");
+        std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(L"systemctl show -p LoadState NetworkManager-wait-online.service");
+        VERIFY_ARE_EQUAL(out, L"LoadState=masked\n");
 
         // Validate that console-getty.service is masked (tty devices are shared at VM level across distros).
-        auto [outGetty, ___] = LxsstuLaunchWslAndCaptureOutput(L"systemctl status console-getty.service  | grep -iF Loaded:");
-
-        VERIFY_ARE_EQUAL(outGetty, L"     Loaded: masked (Reason: Unit console-getty.service is masked.)\n");
+        std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(L"systemctl show -p LoadState console-getty.service");
+        VERIFY_ARE_EQUAL(out, L"LoadState=masked\n");
     }
 
     TEST_METHOD(SystemdUser)

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -226,8 +226,7 @@ class UnitTests
         VERIFY_ARE_EQUAL(outNm, L"     Loaded: masked (Reason: Unit NetworkManager-wait-online.service is masked.)\n");
 
         // Validate that console-getty.service is masked (tty devices are shared at VM level across distros).
-        auto [outGetty, ___] =
-            LxsstuLaunchWslAndCaptureOutput(L"systemctl status console-getty.service  | grep -iF Loaded:");
+        auto [outGetty, ___] = LxsstuLaunchWslAndCaptureOutput(L"systemctl status console-getty.service  | grep -iF Loaded:");
 
         VERIFY_ARE_EQUAL(outGetty, L"     Loaded: masked (Reason: Unit console-getty.service is masked.)\n");
     }

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -224,6 +224,12 @@ class UnitTests
             LxsstuLaunchWslAndCaptureOutput(L"systemctl status NetworkManager-wait-online.service  | grep -iF Loaded:");
 
         VERIFY_ARE_EQUAL(outNm, L"     Loaded: masked (Reason: Unit NetworkManager-wait-online.service is masked.)\n");
+
+        // Validate that console-getty.service is masked (tty devices are shared at VM level across distros).
+        auto [outGetty, ___] =
+            LxsstuLaunchWslAndCaptureOutput(L"systemctl status console-getty.service  | grep -iF Loaded:");
+
+        VERIFY_ARE_EQUAL(outGetty, L"     Loaded: masked (Reason: Unit console-getty.service is masked.)\n");
     }
 
     TEST_METHOD(SystemdUser)


### PR DESCRIPTION
When multiple WSL distros run concurrently, /dev/tty devices are shared at the VM level. The second distro's console-getty.service fails because the tty is already held by the first, causing systemd to report failed units and triggering user@UID.service failures.

Mask console-getty.service during WSL systemd unit generation, similar to the existing masking of networkd-wait-online. This service provides no value in WSL since users don't connect to the underlying tty.

Fixes #13595
