### PR TITLE
Move standard filesystem mounts to WSLA init startup

### DIFF
--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -527,6 +527,9 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_MOUNT& Me
             target = readField(Message.DestinationIndex);
         }
 
+        // Chroot without OverlayFs is not supported — the chroot logic depends on the overlay target path.
+        THROW_ERRNO_IF(EINVAL, WI_IsFlagSet(Message.Flags, WSLA_MOUNT::Chroot) && !WI_IsFlagSet(Message.Flags, WSLA_MOUNT::OverlayFs));
+
         THROW_LAST_ERROR_IF(
             UtilMount(source, target, readField(Message.TypeIndex), options.MountFlags, options.StringOptions.c_str(), c_defaultRetryTimeout) < 0);
 
@@ -548,18 +551,28 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLA_MOUNT& Me
                 // We'll chroot into it later, so moving the mountpoint isn't needed.
                 target = overlayTarget->c_str();
 
-                THROW_LAST_ERROR_IF(MountInit((overlayTarget.value() + "/wsl-init").c_str()) < 0); // Required to call /gns later
+                // Move standard filesystem mounts into the chroot.
+                // MS_MOVE moves the entire subtree, so /dev/pts comes with /dev and /sys/fs/cgroup comes with /sys.
+                for (const auto* mountPoint : {"/dev", "/proc", "/sys"})
+                {
+                    auto chrootTarget = std::format("{}{}", target, mountPoint);
+                    std::filesystem::create_directories(chrootTarget);
+
+                    THROW_LAST_ERROR_IF(mount(mountPoint, chrootTarget.c_str(), "none", MS_MOVE, nullptr) < 0);
+                }
+
+                THROW_LAST_ERROR_IF(MountInit(std::format("{}/wsl-init", target).c_str()) < 0); // Required to call /gns later
 
                 // If it exists, mount /etc/resolv.conf
                 if (std::filesystem::exists("/etc/resolv.conf"))
                 {
-                    THROW_LAST_ERROR_IF(UtilMountFile("/etc/resolv.conf", (overlayTarget.value() + "/etc/resolv.conf").c_str()) < 0);
+                    THROW_LAST_ERROR_IF(UtilMountFile("/etc/resolv.conf", std::format("{}/etc/resolv.conf", target).c_str()) < 0);
                 }
 
                 // If the modules were previously mounted, move them to the chroot.
                 if (g_state.ModulesMountPoint.has_value())
                 {
-                    auto chrootTarget = std::format("{}/{}", overlayTarget.value(), g_state.ModulesMountPoint->native());
+                    auto chrootTarget = std::format("{}/{}", target, g_state.ModulesMountPoint->native());
                     std::filesystem::create_directories(chrootTarget);
 
                     THROW_LAST_ERROR_IF(mount(g_state.ModulesMountPoint->c_str(), chrootTarget.c_str(), "none", MS_MOVE, nullptr) < 0);

--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -822,13 +822,12 @@ int WSLAEntryPoint(int Argc, char* Argv[])
 {
 
     //
-    // Mount devtmpfs.
+    // Perform initial mounts.
     //
 
-    int Result = UtilMount(nullptr, "/dev", "devtmpfs", 0, nullptr);
-    if (Result < 0)
+    if (UtilMount(nullptr, "/dev", "devtmpfs", 0, nullptr) < 0)
     {
-        FATAL_ERROR("Failed to mount /dev");
+        return -1;
     }
 
     if (UtilMount(nullptr, "/proc", "proc", 0, nullptr) < 0)
@@ -837,6 +836,16 @@ int WSLAEntryPoint(int Argc, char* Argv[])
     }
 
     if (UtilMount(nullptr, "/sys", "sysfs", 0, nullptr) < 0)
+    {
+        return -1;
+    }
+
+    if (UtilMount(nullptr, "/dev/pts", "devpts", MS_NOATIME | MS_NOSUID | MS_NOEXEC, "gid=5,mode=620") < 0)
+    {
+        return -1;
+    }
+
+    if (UtilMount(nullptr, "/sys/fs/cgroup", "cgroup2", 0, nullptr) < 0)
     {
         return -1;
     }

--- a/src/linux/init/WSLAInit.cpp
+++ b/src/linux/init/WSLAInit.cpp
@@ -838,17 +838,17 @@ int WSLAEntryPoint(int Argc, char* Argv[])
     // Perform initial mounts.
     //
 
-    if (UtilMount(nullptr, "/dev", "devtmpfs", 0, nullptr) < 0)
+    if (UtilMount(nullptr, "/dev", "devtmpfs", MS_SHARED, nullptr) < 0)
     {
         return -1;
     }
 
-    if (UtilMount(nullptr, "/proc", "proc", 0, nullptr) < 0)
+    if (UtilMount(nullptr, "/proc", "proc", MS_SHARED, nullptr) < 0)
     {
         return -1;
     }
 
-    if (UtilMount(nullptr, "/sys", "sysfs", 0, nullptr) < 0)
+    if (UtilMount(nullptr, "/sys", "sysfs", MS_SHARED, nullptr) < 0)
     {
         return -1;
     }

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1528,14 +1528,8 @@ Return Value:
     // Create a tmpfs mount for the cross-distro shared mount.
     //
 
-    if (UtilMount(nullptr, CROSS_DISTRO_SHARE_PATH, "tmpfs", 0, nullptr) < 0)
+    if (UtilMount(nullptr, CROSS_DISTRO_SHARE_PATH, "tmpfs", MS_SHARED, nullptr) < 0)
     {
-        return -1;
-    }
-
-    if (mount(nullptr, CROSS_DISTRO_SHARE_PATH, nullptr, MS_SHARED, nullptr) < 0)
-    {
-        LOG_ERROR("mount({}, MS_SHARED) failed {}", CROSS_DISTRO_SHARE_PATH, errno);
         return -1;
     }
 
@@ -2524,9 +2518,7 @@ void ProcessLaunchInitMessage(
                 // Create a tmpfs mount for a shared folder between user and system distro.
                 //
 
-                THROW_LAST_ERROR_IF(UtilMount(nullptr, WSLG_PATH, "tmpfs", 0, nullptr) < 0);
-
-                THROW_LAST_ERROR_IF(mount(nullptr, WSLG_PATH, nullptr, MS_SHARED, nullptr) < 0);
+                THROW_LAST_ERROR_IF(UtilMount(nullptr, WSLG_PATH, "tmpfs", MS_SHARED, nullptr) < 0);
 
                 //
                 // Create a directory to store x11 sockets.

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -1756,13 +1756,18 @@ Return Value:
     //      - For Plan9 (9p): device is busy or not found
     //      - For VirtioFS: invalid tag (device not ready)
     //
+    // N.B. MS_SHARED must be applied in a separate mount() call, so it is
+    //      stripped from the initial mount flags and applied after the mount.
+    //
+
+    const unsigned long initialFlags = MountFlags & ~MS_SHARED;
 
     try
     {
         if (TimeoutSeconds.has_value())
         {
             wsl::shared::retry::RetryWithTimeout<void>(
-                [&]() { THROW_LAST_ERROR_IF(mount(Source, Target, Type, MountFlags, Options) < 0); },
+                [&]() { THROW_LAST_ERROR_IF(mount(Source, Target, Type, initialFlags, Options) < 0); },
                 c_defaultRetryPeriod,
                 TimeoutSeconds.value(),
                 [&]() {
@@ -1788,7 +1793,7 @@ Return Value:
         }
         else
         {
-            THROW_LAST_ERROR_IF(mount(Source, Target, Type, MountFlags, Options) < 0);
+            THROW_LAST_ERROR_IF(mount(Source, Target, Type, initialFlags, Options) < 0);
         }
     }
     catch (...)
@@ -1796,6 +1801,16 @@ Return Value:
         errno = wil::ResultFromCaughtException();
         LOG_ERROR("mount({}, {}, {}, {:#x}, {}) failed {}", Source, Target, Type, MountFlags, Options, errno);
         return -errno;
+    }
+
+    // N.B. The shared flag must be applied in a separate mount() call.
+    if (WI_IsFlagSet(MountFlags, MS_SHARED))
+    {
+        if (mount(nullptr, Target, nullptr, MS_SHARED, nullptr) < 0)
+        {
+            LOG_ERROR("Failed to make shared mount {} {}", Target, errno);
+            return -errno;
+        }
     }
 
     return 0;

--- a/src/windows/wslasession/WSLAVirtualMachine.cpp
+++ b/src/windows/wslasession/WSLAVirtualMachine.cpp
@@ -280,8 +280,12 @@ void WSLAVirtualMachine::Initialize()
     // Configure networking
     ConfigureNetworking();
 
-    // Configure initial mounts
-    ConfigureInitialMounts();
+    // Mount VHDs
+    const auto rootDevice = GetVhdDevicePath(0);
+    Mount(m_initChannel, rootDevice.c_str(), "/mnt", m_rootVhdType.c_str(), "ro", WSLA_MOUNT::Chroot | WSLA_MOUNT::OverlayFs);
+
+    const auto modulesDevice = GetVhdDevicePath(1);
+    Mount(m_initChannel, modulesDevice.c_str(), "", "ext4", "ro", WSLA_MOUNT::KernelModules);
 
     // Configure GPU mounts if enabled
     MountGpuLibraries("/usr/lib/wsl/lib", "/usr/lib/wsl/drivers");
@@ -326,28 +330,6 @@ WSLAVirtualMachine::~WSLAVirtualMachine()
     {
         e->OnVmTerminated();
     }
-}
-
-void WSLAVirtualMachine::ConfigureInitialMounts()
-{
-    // Determine device paths from guest
-    const auto rootDevice = GetVhdDevicePath(0);
-    const auto modulesDevice = GetVhdDevicePath(1);
-
-    // Mount root filesystem with overlay
-    Mount(m_initChannel, rootDevice.c_str(), "/mnt", m_rootVhdType.c_str(), "ro", WSLA_MOUNT::Chroot | WSLA_MOUNT::OverlayFs);
-
-    // Mount standard filesystems
-    Mount(m_initChannel, nullptr, "/dev", "devtmpfs", "", 0);
-    Mount(m_initChannel, nullptr, "/sys", "sysfs", "", 0);
-    Mount(m_initChannel, nullptr, "/proc", "proc", "", 0);
-    Mount(m_initChannel, nullptr, "/dev/pts", "devpts", "noatime,nosuid,noexec,gid=5,mode=620", 0);
-
-    // Mount kernel modules
-    Mount(m_initChannel, modulesDevice.c_str(), "", "ext4", "ro", WSLA_MOUNT::KernelModules);
-
-    // Mount cgroup
-    Mount(m_initChannel, nullptr, "/sys/fs/cgroup", "cgroup2", "", 0);
 }
 
 void WSLAVirtualMachine::ConfigureNetworking()

--- a/src/windows/wslasession/WSLAVirtualMachine.h
+++ b/src/windows/wslasession/WSLAVirtualMachine.h
@@ -164,7 +164,6 @@ private:
     void MapRelayPort(_In_ int Family, _In_ unsigned short WindowsPort, _In_ unsigned short LinuxPort, _In_ bool Remove);
 
     // Initial setup during Connect()
-    void ConfigureInitialMounts();
     void ConfigureNetworking();
 
     static void Mount(wsl::shared::SocketChannel& Channel, LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags);


### PR DESCRIPTION
Move devtmpfs, proc, sysfs, devpts, and cgroup2 mounts from the Windows-side ConfigureInitialMounts() to WSLAEntryPoint() in the Linux init daemon. These mounts don't depend on host communication and can be performed earlier during init startup.

Inline the remaining VHD-dependent mounts (root overlay and kernel modules) directly into Initialize() and remove the now-unnecessary ConfigureInitialMounts method.