### PR TITLE
cleanup: rename WSLA telemetry provider WSLC

### DIFF
--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -322,7 +322,7 @@
             <EventProviderId Value="vmwp"/>
             <EventProviderId Value="wsl_devicehost"/>
             <EventProviderId Value="wslapi"/>
-            <EventProviderId Value="wslaservice"/>
+            <EventProviderId Value="wslc"/>
             <EventProviderId Value="wslclient"/>
           </EventProviders>
         </EventCollectorId>

--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -260,7 +260,7 @@
     <EventProvider Id="wlidsvc_WPP" Name="3F8B9EF5-BBD2-4C81-B6C9-DA3CDB72D3C5" />
     <EventProvider Id="wsl_devicehost" Name="9d6c7b9e-2581-4d8a-b8c5-b90b4a17094a"/>
     <EventProvider Id="wslapi" Name="beb94edf-1a7b-5058-0696-ff9e6b1798d1"/>
-    <EventProvider Id="wslaservice" Name="0383CE62-8F86-4766-AFB2-9D66A7FB1E90"/>
+    <EventProvider Id="wslc" Name="0383CE62-8F86-4766-AFB2-9D66A7FB1E90"/>
     <EventProvider Id="wslclient" Name="8cbb7724-7223-5d6f-8137-564dac45104d"/>
 
     <!-- PROFILE: General WSL Tracing (Default, also serves as base for other profiles) -->

--- a/src/windows/common/WslTelemetry.cpp
+++ b/src/windows/common/WslTelemetry.cpp
@@ -33,8 +33,8 @@ TRACELOGGING_DEFINE_PROVIDER(
     TraceLoggingOptionMicrosoftTelemetry());
 
 TRACELOGGING_DEFINE_PROVIDER(
-    WslaTelemetryProvider,
-    "Microsoft.Windows.Wsla",
+    WslcTelemetryProvider,
+    "Microsoft.Windows.Wslc",
     // {0383CE62-8F86-4766-AFB2-9D66A7FB1E90}
     (0x383ce62, 0x8f86, 0x4766, 0xaf, 0xb2, 0x9d, 0x66, 0xa7, 0xfb, 0x1e, 0x90),
     TraceLoggingOptionMicrosoftTelemetry());

--- a/src/windows/common/WslTelemetry.h
+++ b/src/windows/common/WslTelemetry.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 TRACELOGGING_DECLARE_PROVIDER(LxssTelemetryProvider);
 TRACELOGGING_DECLARE_PROVIDER(WslServiceTelemetryProvider);
-TRACELOGGING_DECLARE_PROVIDER(WslaTelemetryProvider);
+TRACELOGGING_DECLARE_PROVIDER(WslcTelemetryProvider);
 #ifdef __cplusplus
 }
 #endif

--- a/src/windows/wslasession/main.cpp
+++ b/src/windows/wslasession/main.cpp
@@ -59,7 +59,7 @@ try
     wsl::windows::common::EnableContextualizedErrors(true);
 
     // Initialize telemetry
-    WslTraceLoggingInitialize(WslaTelemetryProvider, !wsl::shared::OfficialBuild);
+    WslTraceLoggingInitialize(WslcTelemetryProvider, !wsl::shared::OfficialBuild);
     auto cleanup = wil::scope_exit([] { WslTraceLoggingUninitialize(); });
 
     // Don't kill the process on unknown C++ exceptions

--- a/src/windows/wslc/core/Main.cpp
+++ b/src/windows/wslc/core/Main.cpp
@@ -36,7 +36,7 @@ try
     wslutil::ConfigureCrt();
     wslutil::InitializeWil();
 
-    WslTraceLoggingInitialize(WslaTelemetryProvider, !wsl::shared::OfficialBuild);
+    WslTraceLoggingInitialize(WslcTelemetryProvider, !wsl::shared::OfficialBuild);
     auto cleanupTelemetry = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { WslTraceLoggingUninitialize(); });
 
     wslutil::SetCrtEncoding(_O_U8TEXT);


### PR DESCRIPTION
This name changes the telemetry provider to reflect the new naming.