### PR TITLE
Rename image delete to remove and add aliases

### DIFF
--- a/src/windows/wslc/commands/ContainerCommand.h
+++ b/src/windows/wslc/commands/ContainerCommand.h
@@ -142,7 +142,7 @@ protected:
 struct ContainerRemoveCommand final : public Command
 {
     constexpr static std::wstring_view CommandName = L"remove";
-    ContainerRemoveCommand(const std::wstring& parent) : Command(CommandName, {L"rm"}, parent)
+    ContainerRemoveCommand(const std::wstring& parent) : Command(CommandName, {L"delete", L"rm"}, parent)
     {
     }
     std::vector<Argument> GetArguments() const override;

--- a/src/windows/wslc/commands/ImageCommand.cpp
+++ b/src/windows/wslc/commands/ImageCommand.cpp
@@ -22,7 +22,7 @@ std::vector<std::unique_ptr<Command>> ImageCommand::GetCommands() const
 {
     std::vector<std::unique_ptr<Command>> commands;
     commands.push_back(std::make_unique<ImageBuildCommand>(FullName()));
-    commands.push_back(std::make_unique<ImageDeleteCommand>(FullName()));
+    commands.push_back(std::make_unique<ImageRemoveCommand>(FullName()));
     commands.push_back(std::make_unique<ImageInspectCommand>(FullName()));
     commands.push_back(std::make_unique<ImageListCommand>(FullName()));
     commands.push_back(std::make_unique<ImageLoadCommand>(FullName()));

--- a/src/windows/wslc/commands/ImageCommand.h
+++ b/src/windows/wslc/commands/ImageCommand.h
@@ -91,11 +91,21 @@ protected:
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
 
-// Delete Command
-struct ImageDeleteCommand final : public Command
+// Remove Command
+struct ImageRemoveCommand final : public Command
 {
-    constexpr static std::wstring_view CommandName = L"delete";
-    ImageDeleteCommand(const std::wstring& parent) : Command(CommandName, parent)
+    constexpr static std::wstring_view CommandName = L"remove";
+
+    // When parented directly to the root, ImageRemoveCommand uses a different name
+    constexpr static std::wstring_view RootCommandName = L"rmi";
+
+    ImageRemoveCommand(const std::wstring& parent) : Command(CommandName, { L"delete", L"rm" }, parent)
+    {
+    }
+
+    // Image remove has an alias 'rmi' off the root
+    // The bool parameter is used as a tag to select the root-specific name.
+    ImageRemoveCommand(const std::wstring& parent, bool /*rootScoped*/) : Command(RootCommandName, {}, parent)
     {
     }
     std::vector<Argument> GetArguments() const override;

--- a/src/windows/wslc/commands/ImageCommand.h
+++ b/src/windows/wslc/commands/ImageCommand.h
@@ -99,7 +99,7 @@ struct ImageRemoveCommand final : public Command
     // When parented directly to the root, ImageRemoveCommand uses a different name
     constexpr static std::wstring_view RootCommandName = L"rmi";
 
-    ImageRemoveCommand(const std::wstring& parent) : Command(CommandName, { L"delete", L"rm" }, parent)
+    ImageRemoveCommand(const std::wstring& parent) : Command(CommandName, {L"delete", L"rm"}, parent)
     {
     }
 

--- a/src/windows/wslc/commands/ImageRemoveCommand.cpp
+++ b/src/windows/wslc/commands/ImageRemoveCommand.cpp
@@ -4,7 +4,7 @@ Copyright (c) Microsoft. All rights reserved.
 
 Module Name:
 
-    ImageDeleteCommand.cpp
+    ImageRemoveCommand.cpp
 
 Abstract:
 
@@ -23,8 +23,8 @@ using namespace wsl::windows::wslc::task;
 using namespace wsl::shared::string;
 
 namespace wsl::windows::wslc {
-// Image Delete Command
-std::vector<Argument> ImageDeleteCommand::GetArguments() const
+// Image Remove Command
+std::vector<Argument> ImageRemoveCommand::GetArguments() const
 {
     return {
         Argument::Create(ArgType::ImageId, true),
@@ -34,17 +34,17 @@ std::vector<Argument> ImageDeleteCommand::GetArguments() const
     };
 }
 
-std::wstring ImageDeleteCommand::ShortDescription() const
+std::wstring ImageRemoveCommand::ShortDescription() const
 {
-    return {L"Delete images."};
+    return {L"Remove images."};
 }
 
-std::wstring ImageDeleteCommand::LongDescription() const
+std::wstring ImageRemoveCommand::LongDescription() const
 {
-    return {L"Deletes images."};
+    return {L"Removes images."};
 }
 
-void ImageDeleteCommand::ExecuteInternal(CLIExecutionContext& context) const
+void ImageRemoveCommand::ExecuteInternal(CLIExecutionContext& context) const
 {
     context              //
         << CreateSession //

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -39,6 +39,7 @@ std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
     commands.push_back(std::make_unique<ContainerLogsCommand>(FullName()));
     commands.push_back(std::make_unique<ImagePullCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerRemoveCommand>(FullName()));
+    commands.push_back(std::make_unique<ImageRemoveCommand>(FullName(), true));
     commands.push_back(std::make_unique<ContainerRunCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerStartCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerStopCommand>(FullName()));

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -86,6 +86,7 @@ private:
                  << L"  logs       View container logs.\r\n"
                  << L"  pull       Pull images.\r\n"
                  << L"  remove     Remove containers.\r\n"
+                 << L"  rmi        Remove images.\r\n"
                  << L"  run        Run a container.\r\n"
                  << L"  start      Start a container.\r\n"
                  << L"  stop       Stop containers.\r\n"

--- a/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
@@ -134,6 +134,7 @@ private:
         output << GetWslcHeader()        //
                << GetDescription()       //
                << GetUsage()             //
+               << GetAvailableCommandAliases() //
                << GetAvailableCommands() //
                << GetAvailableOptions();
         return output.str();
@@ -141,12 +142,17 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Deletes images.\r\n\r\n";
+        return L"Removes images.\r\n\r\n";
     }
 
     std::wstring GetUsage() const
     {
-        return L"Usage: wslc image delete [<options>] <image>\r\n\r\n";
+        return L"Usage: wslc image remove [<options>] <image>\r\n\r\n";
+    }
+
+    std::wstring GetAvailableCommandAliases() const
+    {
+        return L"The following command aliases are available: delete rm\r\n\r\n";
     }
 
     std::wstring GetAvailableCommands() const

--- a/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
@@ -131,11 +131,11 @@ private:
     std::wstring GetHelpMessage() const
     {
         std::wstringstream output;
-        output << GetWslcHeader()        //
-               << GetDescription()       //
-               << GetUsage()             //
+        output << GetWslcHeader()              //
+               << GetDescription()             //
+               << GetUsage()                   //
                << GetAvailableCommandAliases() //
-               << GetAvailableCommands() //
+               << GetAvailableCommands()       //
                << GetAvailableOptions();
         return output.str();
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

```
wslc rmi <image>
wslc image rm <image>
wslc image remove <image>
wslc image delete <image>
```

I also updated wslc container to support `delete` in addition to the `remove` for consistency

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
