### PR TITLE
test: remove duplicated DNS test coverage

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -250,9 +250,9 @@ Return Value:
     {
         THROW_HR_MSG(
             E_UNEXPECTED,
-            "Command \"%ls\""
+            "Command \"%ls\" "
             "returned unexpected exit code (%lu != %i). "
-            "Stdout: '%ls'"
+            "Stdout: '%ls' "
             "Stderr: '%ls'",
             Cmd,
             ExitCode,

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -5068,6 +5068,5 @@ class VirtioProxyTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = false}));
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
-
 };
 } // namespace NetworkTests

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -809,19 +809,6 @@ class NetworkTests
         VerifyDigDnsResolution(L"dig +short +time=5 SOA bing.com");
     }
 
-    static void VerifyDnsResolutionDigV6()
-    {
-        if (!HostHasInternetConnectivity(AF_INET6))
-        {
-            LogSkipped("Host does not have IPv6 internet connectivity. Skipping...");
-            return;
-        }
-
-        // Test AAAA record resolution (IPv6) with both UDP and TCP
-        VerifyDigDnsResolution(L"dig +short +time=5 AAAA bing.com");
-        VerifyDigDnsResolution(L"dig +tcp +short +time=5 AAAA bing.com");
-    }
-
     static void VerifyDnsQueries()
     {
         // query for A/IPv4 records
@@ -5058,15 +5045,6 @@ class VirtioProxyTests
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
 
-    TEST_METHOD(DnsResolutionDigV6DnsTunneling)
-    {
-        VIRTIOPROXY_TEST_ONLY();
-        DNS_TUNNELING_TEST_ONLY();
-
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
-        NetworkTests::VerifyDnsResolutionDigV6();
-    }
-
     TEST_METHOD(DnsResolutionBasic)
     {
         VIRTIOPROXY_TEST_ONLY();
@@ -5091,12 +5069,5 @@ class VirtioProxyTests
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
 
-    TEST_METHOD(DnsResolutionDigV6)
-    {
-        VIRTIOPROXY_TEST_ONLY();
-
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = false}));
-        NetworkTests::VerifyDnsResolutionDigV6();
-    }
 };
 } // namespace NetworkTests


### PR DESCRIPTION
This coverage is duplicated by the VerifyDnsResolutionDig helper.