### PR TITLE
Fix singular/plural grammar in FormatRelativeTime

### DIFF
--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -165,18 +165,22 @@ std::wstring ContainerService::FormatRelativeTime(ULONGLONG timestamp)
 
     if (elapsed < SecondsPerMinute)
     {
-        return std::format(L"{} seconds ago", elapsed);
+        const auto seconds = elapsed;
+        return std::format(L"{} {} ago", seconds, (seconds == 1 ? L"second" : L"seconds"));
     }
     else if (elapsed < SecondsPerHour)
     {
-        return std::format(L"{} minutes ago", elapsed / SecondsPerMinute);
+        const auto minutes = elapsed / SecondsPerMinute;
+        return std::format(L"{} {} ago", minutes, (minutes == 1 ? L"minute" : L"minutes"));
     }
     else if (elapsed < SecondsPerDay)
     {
-        return std::format(L"{} hours ago", elapsed / SecondsPerHour);
+        const auto hours = elapsed / SecondsPerHour;
+        return std::format(L"{} {} ago", hours, (hours == 1 ? L"hour" : L"hours"));
     }
 
-    return std::format(L"{} days ago", elapsed / SecondsPerDay);
+    const auto days = elapsed / SecondsPerDay;
+    return std::format(L"{} {} ago", days, (days == 1 ? L"day" : L"days"));
 }
 
 int ContainerService::Attach(Session& session, const std::string& id)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes grammatically incorrect output in FormatRelativeTime where singular time units were always displayed as plural (e.g., "1 seconds ago", "1 minutes ago"). Now correctly outputs "1 second ago", "1 minute ago", "1 hour ago", "1 day ago".
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
ContainerService::FormatRelativeTime was using hardcoded plural unit strings for all time values. This change introduces a ternary check for each time unit seconds, minutes, hours, and days to produce grammatically correct output.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
