### PR TITLE
diagnostics: switch log archive from zip to tar.gz

### DIFF
--- a/.github/actions/triage/action.yml
+++ b/.github/actions/triage/action.yml
@@ -38,6 +38,6 @@ runs:
                 $maybe_previous_body = @("--previous-issue-body", "previous_body.txt")
             }
             
-            curl.exe -L https://github.com/OneBlue/wti/releases/download/v0.1.12/wti.exe -o triage/wti.exe
+            curl.exe -L https://github.com/OneBlue/wti/releases/download/v0.2/wti.exe -o triage/wti.exe
             
             cd triage && .\wti.exe --issue ${{ inputs.issue }} --config config.yml --github-token "${{ inputs.token }}" --ignore-tags @maybe_comment @maybe_previous_body

--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -338,5 +338,18 @@ if ($LASTEXITCODE -eq 0)
 else
 {
     Remove-Item $logArchive -ErrorAction Ignore
-    Write-Host -ForegroundColor Red "Failed to compress logs. They are available in: $(Resolve-Path $folder)"
+
+    # Fall back to zip if tar fails (e.g. on SKUs that lack tar.exe)
+    $logArchive = "$(Resolve-Path $folder).zip"
+    try
+    {
+        Compress-Archive -Path $folder -DestinationPath $logArchive -Force
+        Remove-Item $folder -Recurse
+        Write-Host -ForegroundColor Green "Logs saved in: $logArchive. Please attach that file to the GitHub issue."
+    }
+    catch
+    {
+        Remove-Item $logArchive -ErrorAction Ignore
+        Write-Host -ForegroundColor Red "Failed to compress logs. They are available in: $(Resolve-Path $folder)"
+    }
 }

--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -328,8 +328,15 @@ if ($Dump)
     }
 }
 
-$logArchive = "$(Resolve-Path $folder).zip"
-Compress-Archive -Path $folder -DestinationPath $logArchive
-Remove-Item $folder -Recurse
-
-Write-Host -ForegroundColor Green "Logs saved in: $logArchive. Please attach that file to the GitHub issue."
+$logArchive = "$(Resolve-Path $folder).tar.gz"
+tar.exe -czf $logArchive $folder
+if ($LASTEXITCODE -eq 0)
+{
+    Remove-Item $folder -Recurse
+    Write-Host -ForegroundColor Green "Logs saved in: $logArchive. Please attach that file to the GitHub issue."
+}
+else
+{
+    Remove-Item $logArchive -ErrorAction Ignore
+    Write-Host -ForegroundColor Red "Failed to compress logs. They are available in: $(Resolve-Path $folder)"
+}


### PR DESCRIPTION
This change moves from using Compress-Archive to the inbox tar.exe. Compress-Archive can fail for very large files, so this approach will be more reliable.

This change also requires an update to WTI which I've published here: https://github.com/OneBlue/wti/pull/5