### PR TITLE
devicehost: update to latest devicehost nuget with tracing improvements

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.1.39-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.1.47-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />


### PR DESCRIPTION
This change updates the devicehost nuget package which contains our virtiofs and virtio proxy networking mode implementation to the latest version which will have MUCH less verbose tracing. The previous tracing, especially for virtio proxy, was excessive and causing our .etl files to get really big (in case you were wondering the background of https://github.com/microsoft/WSL/pull/14530 which I think is still worth doing).