### PR TITLE
test: disable WSLG during testing (partial revert of #14387)

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1450,6 +1450,8 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         return value;
     };
 
+    // TODO: Reset guiApplications to true by default once the virtio hang is solved.
+
     std::wstring newConfig =
         L"[wsl2]\n"
         L"crashDumpFolder=" +
@@ -1462,7 +1464,7 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         EscapePath(kernelLogs) +
         L"\n"
         L"telemetry=false\n" +
-        boolOptionToString(L"safeMode", Default.safeMode, false) + boolOptionToString(L"guiApplications", Default.guiApplications, true) +
+        boolOptionToString(L"safeMode", Default.safeMode, false) + boolOptionToString(L"guiApplications", Default.guiApplications, false) +
         L"earlyBootLogging=false\n" + networkingModeToString(Default.networkingMode) + drvFsModeToString(Default.drvFsMode);
 
     if (Default.kernel.has_value())

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -339,6 +339,9 @@ class UnitTests
     {
         WSL2_TEST_ONLY();
 
+        // The X11 socket is only created when gui applications are enabled.
+        WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true}));
+
         // ensures that we don't leave state on exit
         auto cleanup = EnableSystemd("initTimeout=0");
 


### PR DESCRIPTION
Unfortunately we reproduced the virtio queue corruption issue in CI. Disable the tests for now because they are causing noise.