### PR TITLE
win10: remove IsWslSupportInterfacePresent check from wslservice

### DIFF
--- a/src/windows/service/exe/ServiceMain.cpp
+++ b/src/windows/service/exe/ServiceMain.cpp
@@ -174,9 +174,6 @@ try
 
     wsl::windows::common::security::ApplyProcessMitigationPolicies();
 
-    // Ensure that the OS has support for running lifted WSL.
-    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_SERVICE_DISABLED), !wsl::windows::common::helpers::IsWslSupportInterfacePresent());
-
     // Initialize Winsock.
     WSADATA Data;
     THROW_IF_WIN32_ERROR(WSAStartup(MAKEWORD(2, 2), &Data));


### PR DESCRIPTION
This check is currently the only thing requiring the that makes WSLC require the `Windows Subsystem for Linux` optional Windows feature. This check is belt-and-suspenders anyway, the WSL entry point already checks this and returns an appropriate error.

Assuming somebody installed the WSL package on a very old version of Windows without this interface, the service would run, but nothing would talk to it.
