### PR TITLE
Fix: bind interrupted by seccomp signal race

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3615,7 +3615,8 @@ Return Value:
         .filter = Filter,
     };
 
-    wil::unique_fd Fd{syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_NEW_LISTENER, &Prog)};
+    wil::unique_fd Fd{syscall(
+        __NR_seccomp, SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_NEW_LISTENER | SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV, &Prog)};
     if (!Fd)
     {
         LOG_ERROR("Failed to register bpf syscall hook, {}", errno);

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3617,6 +3617,11 @@ Return Value:
 
     wil::unique_fd Fd{syscall(
         __NR_seccomp, SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_NEW_LISTENER | SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV, &Prog)};
+    if (!Fd && errno == EINVAL)
+    {
+        LOG_INFO("seccomp failed with EINVAL with SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV, retrying without it.");
+        Fd = syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_NEW_LISTENER, &Prog);
+    }
     if (!Fd)
     {
         LOG_ERROR("Failed to register bpf syscall hook, {}", errno);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The original seccomp syscall uses the default wait_for_completion_interruptible implementation. Which is prone to be interrupted by unrelated signals (in the linked issue, likely a SIGCHLD). Which could cause the waiting bind calls to fail with EINTR.
This PR adds the SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV flag so it uses wait_for_completion_killable instead. Avoid the bind call being interrupted unintentionally.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/14541
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

The original issue is time sensitive and hard to reproduce. So only existing unit tests were run.