### PR TITLE
wslc: enable virtiofs by default for wslc.exe and wslcsdk

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -353,6 +353,7 @@ try
         runtimeSettings.TerminationCallback = terminationCallback.get();
     }
     runtimeSettings.FeatureFlags = ConvertFlags(internalType->featureFlags);
+    WI_SetFlag(runtimeSettings.FeatureFlags, WslcFeatureFlagsVirtioFs);
 
     // TODO: Debug message output? No user control? Expects a handle value as a ULONG (to write debug info to?)
     // runtimeSettings.DmesgOutput;

--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -36,6 +36,7 @@ SessionOptions::SessionOptions()
     m_sessionSettings.BootTimeoutMs = s_defaultBootTimeoutMs;
     m_sessionSettings.MaximumStorageSizeMb = settings::User().Get<settings::Setting::SessionStorageSizeMb>();
     m_sessionSettings.NetworkingMode = settings::User().Get<settings::Setting::SessionNetworkingMode>();
+    m_sessionSettings.FeatureFlags = WslcFeatureFlagsVirtioFs;
 }
 
 } // namespace wsl::windows::wslc::models


### PR DESCRIPTION
This change enables using virtiofs for Windows share mounting for wslc.exe and the WSLC SDK. This is the expected shipping configuration so it would be good to test with this enabled.