### PR TITLE
Use pre-imported container images in the tests to avoid hitting the API limit

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1009,7 +1009,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "CMD [\"echo\", \"Hello from a WSL container!\"]\n";
         }
 
@@ -1037,7 +1037,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "COPY message.txt /message.txt\n";
             dockerfile << "CMD [\"cat\", \"/message.txt\"]\n";
         }
@@ -1082,7 +1082,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "COPY files/ /files/\n";
             // Verify every file is present and contains the expected content.
             // Only mismatches are printed; on success just the sentinel.
@@ -1127,7 +1127,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "COPY large.bin /large.bin\n";
             dockerfile << std::format(
                 "CMD [\"sh\", \"-c\", \"test $(stat -c %s /large.bin) -eq {} && echo size_ok\"]\n",
@@ -1178,13 +1178,13 @@ class WSLCTests
             std::ofstream dockerfile(contextDir / "Dockerfile");
             // Two independent stages that can build in parallel, each producing
             // part of the final output.  The last stage combines them.
-            dockerfile << "FROM alpine AS greeting\n";
+            dockerfile << "FROM debian:latest AS greeting\n";
             dockerfile << "RUN echo -n 'WSL containers' > /part.txt\n";
             dockerfile << "\n";
-            dockerfile << "FROM alpine AS description\n";
+            dockerfile << "FROM debian:latest AS description\n";
             dockerfile << "RUN echo -n 'support multi-stage builds' > /part.txt\n";
             dockerfile << "\n";
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "COPY --from=greeting /part.txt /greeting.txt\n";
             dockerfile << "COPY --from=description /part.txt /description.txt\n";
             dockerfile << "CMD [\"sh\", \"-c\", "
@@ -1228,7 +1228,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "COPY . /ctx/\n";
             dockerfile << "CMD [\"sh\", \"-c\", "
                        << "\"test -f /ctx/keep.txt "
@@ -1285,7 +1285,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "dockerfiles" / "Dockerfile.custom");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "CMD [\"echo\", \"custom-dockerfile-ok\"]\n";
         }
 
@@ -1311,7 +1311,7 @@ class WSLCTests
             std::filesystem::remove_all(contextDir, ec);
         });
 
-        auto dockerfileContent = "FROM alpine\nCMD [\"echo\", \"stdin-dockerfile-ok\"]\n";
+        auto dockerfileContent = "FROM debian:latest\nCMD [\"echo\", \"stdin-dockerfile-ok\"]\n";
 
         wil::unique_hfile readHandle;
         wil::unique_hfile writeHandle;
@@ -1357,7 +1357,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "ARG TEST_VALUE\n";
             dockerfile << "ENV TEST_VALUE=${TEST_VALUE}\n";
             dockerfile << "CMD echo \"build-arg-value=${TEST_VALUE}\"\n";
@@ -1396,7 +1396,7 @@ class WSLCTests
 
         {
             std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM alpine\n";
+            dockerfile << "FROM debian:latest\n";
             dockerfile << "CMD [\"echo\", \"multi-tag-ok\"]\n";
         }
         WSLCBuildImageOptions options{.Tags = {tags, 2}};

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -32,8 +32,8 @@ class WSLCE2EImageBuildTests
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsDeleted(DebianTestImage());
         DeleteAllBuiltImages();
+        EnsureImageIsDeleted(DebianTestImage());
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -26,12 +26,13 @@ class WSLCE2EImageBuildTests
     TEST_CLASS_SETUP(ClassSetup)
     {
         DeleteAllBuiltImages();
+        EnsureImageIsLoaded(DebianTestImage());
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsLoaded(DebianTestImage());
+        EnsureImageIsDeleted(DebianTestImage());
         DeleteAllBuiltImages();
         return true;
     }
@@ -45,7 +46,6 @@ class WSLCE2EImageBuildTests
     TEST_METHOD_CLEANUP(MethodCleanup)
     {
         DeleteAllBuiltImages();
-        EnsureImageIsDeleted(DebianTestImage());
         return true;
     }
 
@@ -62,7 +62,7 @@ class WSLCE2EImageBuildTests
         THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
 
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFile(dockerfilePath, "FROM debian:latest:latest\nCMD [\"echo\", \"wslc-e2e-build-ok\"]\n");
+        WriteTestFile(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"wslc-e2e-build-ok\"]\n");
 
         auto buildResult = RunWslc(
             std::format(L"build \"{}\" -f \"{}\" -t {}", contextDir.wstring(), dockerfilePath.wstring(), BuiltImage.NameAndTag()));

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -31,6 +31,7 @@ class WSLCE2EImageBuildTests
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
+        EnsureImageIsLoaded(DebianTestImage());
         DeleteAllBuiltImages();
         return true;
     }
@@ -44,6 +45,7 @@ class WSLCE2EImageBuildTests
     TEST_METHOD_CLEANUP(MethodCleanup)
     {
         DeleteAllBuiltImages();
+        EnsureImageIsDeleted(DebianTestImage());
         return true;
     }
 
@@ -60,7 +62,7 @@ class WSLCE2EImageBuildTests
         THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
 
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFile(dockerfilePath, "FROM alpine:latest\nCMD [\"echo\", \"wslc-e2e-build-ok\"]\n");
+        WriteTestFile(dockerfilePath, "FROM debian:latest:latest\nCMD [\"echo\", \"wslc-e2e-build-ok\"]\n");
 
         auto buildResult = RunWslc(
             std::format(L"build \"{}\" -f \"{}\" -t {}", contextDir.wstring(), dockerfilePath.wstring(), BuiltImage.NameAndTag()));
@@ -91,7 +93,7 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFile(
             dockerfilePath,
-            "FROM alpine:latest\n"
+            "FROM debian:latest\n"
             "ARG TEST_LABEL=default_value\n"
             "LABEL test_label=$TEST_LABEL\n"
             "COPY hello.txt /hello.txt\n"


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates our test to use the pre-installed test images instead of pulling from the docker registry

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
