### PR TITLE
Add networking mode setting as fallback

### DIFF
--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -32,7 +32,7 @@ SessionOptions SessionOptions::Default()
     options.m_sessionSettings.BootTimeoutMs = 30 * 1000;
     options.m_sessionSettings.StoragePath = storagePath.c_str();
     options.m_sessionSettings.MaximumStorageSizeMb = settings::User().Get<settings::Setting::SessionStorageSizeMb>();
-    options.m_sessionSettings.NetworkingMode = WSLCNetworkingModeVirtioProxy;
+    options.m_sessionSettings.NetworkingMode = settings::User().Get<settings::Setting::SessionNetworkingMode>();
     return options;
 }
 

--- a/src/windows/wslc/settings/UserSettings.cpp
+++ b/src/windows/wslc/settings/UserSettings.cpp
@@ -51,7 +51,7 @@ namespace details {
     std::optional<uint32_t> ParseSettingsMemoryValue(const std::string& value)
     {
         auto parsed = wsl::shared::string::ParseMemorySize(value.c_str());
-        auto converted = parsed.has_value() ? *parsed / 1048576 : 0; // To Mb, and anything less than 1Mb is considered invalid.
+        auto converted = parsed.has_value() ? *parsed / _1MB : 0; // To Mb, and anything less than 1Mb is considered invalid.
         return converted > 0 ? std::optional{static_cast<uint32_t>(converted)} : std::nullopt;
     }
 
@@ -239,7 +239,7 @@ void UserSettings::Reset() const
 
 void UserSettings::PrepareToShellExecuteFile() const
 {
-    if (m_type == UserSettingsType::Default)
+    if (m_type == UserSettingsType::Default && !std::filesystem::exists(m_settingsPath))
     {
         // First run — create the directory and write the commented-out defaults template.
         Reset();

--- a/src/windows/wslc/settings/UserSettings.cpp
+++ b/src/windows/wslc/settings/UserSettings.cpp
@@ -80,6 +80,24 @@ namespace details {
         return MultiByteToWide(value);
     }
 
+    WSLC_VALIDATE_SETTING(SessionNetworkingMode)
+    {
+        if (value == "none")
+        {
+            return WSLCNetworkingModeNone;
+        }
+        else if (value == "nat")
+        {
+            return WSLCNetworkingModeNAT;
+        }
+        else if (value == "virtionet")
+        {
+            return WSLCNetworkingModeVirtioProxy;
+        }
+
+        return std::nullopt;
+    }
+
 #undef WSLC_VALIDATE_SETTING
 
 } // namespace details

--- a/src/windows/wslc/settings/UserSettings.cpp
+++ b/src/windows/wslc/settings/UserSettings.cpp
@@ -86,11 +86,11 @@ namespace details {
         {
             return WSLCNetworkingModeNone;
         }
-        else if (value == "nat")
+        if (value == "nat")
         {
             return WSLCNetworkingModeNAT;
         }
-        else if (value == "virtionet")
+        if (value == "virtioproxy")
         {
             return WSLCNetworkingModeVirtioProxy;
         }

--- a/src/windows/wslc/settings/UserSettings.h
+++ b/src/windows/wslc/settings/UserSettings.h
@@ -15,6 +15,7 @@ Abstract:
 #pragma once
 #include "defs.h"
 #include "EnumVariantMap.h"
+#include "wslc.h"
 #include <cstdint>
 #include <filesystem>
 #include <optional>
@@ -38,6 +39,7 @@ enum class Setting : size_t
     SessionMemoryMb,
     SessionStorageSizeMb,
     SessionStoragePath,
+    SessionNetworkingMode,
 
     Max
 };
@@ -66,10 +68,11 @@ namespace details {
         static std::optional<value_t> Validate(const yaml_t& value);               \
     };
 
-    DEFINE_SETTING_MAPPING(SessionCpuCount,      uint32_t,    uint32_t,     4,      "session.cpuCount")
-    DEFINE_SETTING_MAPPING(SessionMemoryMb,      std::string, uint32_t,     2048,   "session.memorySize")
-    DEFINE_SETTING_MAPPING(SessionStorageSizeMb, std::string, uint32_t,     102400, "session.maxStorageSize")
-    DEFINE_SETTING_MAPPING(SessionStoragePath,   std::string, std::wstring, {},     "session.defaultStoragePath")
+    DEFINE_SETTING_MAPPING(SessionCpuCount,       uint32_t,    uint32_t,           4,                             "session.cpuCount")
+    DEFINE_SETTING_MAPPING(SessionMemoryMb,       std::string, uint32_t,           2048,                          "session.memorySize")
+    DEFINE_SETTING_MAPPING(SessionStorageSizeMb,  std::string, uint32_t,           102400,                        "session.maxStorageSize")
+    DEFINE_SETTING_MAPPING(SessionStoragePath,    std::string, std::wstring,       {},                            "session.defaultStoragePath")
+    DEFINE_SETTING_MAPPING(SessionNetworkingMode, std::string, WSLCNetworkingMode, WSLCNetworkingModeVirtioProxy, "session.networkingMode")
 
 #undef DEFINE_SETTING_MAPPING
     // clang-format on


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added session networking setting as temp fallback if virtionet has issues. As it's only temporary, we did not add the setting to default template. The setting may be removed once we fixed the virtionet issue.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested the changes. As this change is only temporary, test was not updated.