### PR TITLE
Fix localization and notice pipelines to use full branch name

### DIFF
--- a/.pipelines/wsl-build-nightly-localization.yml
+++ b/.pipelines/wsl-build-nightly-localization.yml
@@ -18,7 +18,7 @@ schedules:
   always: true
 
 variables:
-  targetBranch: ${{ variables['Build.SourceBranchName'] }}
+  targetBranch: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 pool:
   vmImage: 'windows-latest'

--- a/.pipelines/wsl-build-notice.yml
+++ b/.pipelines/wsl-build-notice.yml
@@ -4,7 +4,7 @@ trigger:
     - master
 
 variables:
-  targetBranch: ${{ variables['Build.SourceBranchName'] }}
+  targetBranch: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 pool:
     vmImage: 'windows-latest'


### PR DESCRIPTION
Build.SourceBranchName only returns the last segment after '/', breaking branches with slashes (e.g. feature/wsl-for-apps -> wsl-for-apps). Use Build.SourceBranch with refs/heads/ stripped instead.
