### PR TITLE
Fix deadlock between WatchForExitedProcesses and VMProcessControl destructor

### DIFF
--- a/src/windows/wslcsession/WSLCProcess.cpp
+++ b/src/windows/wslcsession/WSLCProcess.cpp
@@ -18,7 +18,7 @@ Abstract:
 
 using wsl::windows::service::wslc::WSLCProcess;
 
-WSLCProcess::WSLCProcess(std::unique_ptr<WSLCProcessControl>&& Control, std::unique_ptr<WSLCProcessIO>&& Io) :
+WSLCProcess::WSLCProcess(std::shared_ptr<WSLCProcessControl> Control, std::unique_ptr<WSLCProcessIO>&& Io) :
     m_control(std::move(Control)), m_io(std::move(Io))
 {
 }

--- a/src/windows/wslcsession/WSLCProcess.h
+++ b/src/windows/wslcsession/WSLCProcess.h
@@ -25,7 +25,7 @@ class DECLSPEC_UUID("AFBEA6D6-D8A4-4F81-8FED-F947EB74B33B") WSLCProcess
     : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IWSLCProcess, IFastRundown>
 {
 public:
-    WSLCProcess(std::unique_ptr<WSLCProcessControl>&& Control, std::unique_ptr<WSLCProcessIO>&& Io);
+    WSLCProcess(std::shared_ptr<WSLCProcessControl> Control, std::unique_ptr<WSLCProcessIO>&& Io);
     WSLCProcess(const WSLCProcess&) = delete;
     WSLCProcess& operator=(const WSLCProcess&) = delete;
 
@@ -41,7 +41,7 @@ public:
     int GetPid() const;
 
 private:
-    std::unique_ptr<WSLCProcessControl> m_control;
+    std::shared_ptr<WSLCProcessControl> m_control;
     std::unique_ptr<WSLCProcessIO> m_io;
 };
 } // namespace wsl::windows::service::wslc

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -328,7 +328,10 @@ WSLCVirtualMachine::~WSLCVirtualMachine()
     // Clear the state of all remaining processes now that the VM has exited.
     for (auto& e : m_trackedProcesses)
     {
-        e->OnVmTerminated();
+        if (auto locked = e.lock())
+        {
+            locked->OnVmTerminated();
+        }
     }
 }
 
@@ -419,25 +422,30 @@ try
             TraceLoggingValue(message->Signaled, "Signaled"));
 
         // Signal the exited process, if it's been monitored.
+        // N.B. Lock weak_ptr under lock, then call OnExited outside it to avoid
+        // deadlock with the destructor's m_lock -> m_trackedProcessesLock ordering.
+        std::shared_ptr<VMProcessControl> exited;
         {
             std::lock_guard lock{m_trackedProcessesLock};
 
-            bool found = false;
             for (auto& e : m_trackedProcesses)
             {
-                if (e->GetPid() == message->Pid)
+                auto locked = e.lock();
+                if (locked && locked->GetPid() == message->Pid)
                 {
-                    WI_ASSERT(!found);
-
-                    try
-                    {
-                        e->OnExited(message->Signaled ? 128 + message->Code : message->Code);
-                    }
-                    CATCH_LOG();
-
-                    found = true;
+                    exited = std::move(locked);
+                    break;
                 }
             }
+        }
+
+        if (exited)
+        {
+            try
+            {
+                exited->OnExited(message->Signaled ? 128 + message->Code : message->Code);
+            }
+            CATCH_LOG();
         }
     }
 }
@@ -708,11 +716,11 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
     }
 
     auto io = std::make_unique<VMProcessIO>(std::move(stdHandles));
-    auto control = std::make_unique<VMProcessControl>(*this, pid, std::move(ttyControlHandle));
+    auto control = std::make_shared<VMProcessControl>(*this, pid, std::move(ttyControlHandle));
 
     {
         std::lock_guard lock{m_trackedProcessesLock};
-        m_trackedProcesses.emplace_back(control.get());
+        m_trackedProcesses.emplace_back(control);
     }
 
     auto process = wil::MakeOrThrow<WSLCProcess>(std::move(control), std::move(io));
@@ -1068,7 +1076,10 @@ void WSLCVirtualMachine::OnProcessReleased(int Pid)
 {
     std::lock_guard lock{m_trackedProcessesLock};
 
-    std::erase_if(m_trackedProcesses, [Pid](const auto* e) { return e->GetPid() == Pid; });
+    std::erase_if(m_trackedProcesses, [Pid](const auto& e) {
+        auto locked = e.lock();
+        return !locked || locked->GetPid() == Pid;
+    });
 }
 
 std::shared_ptr<VmPortAllocation> WSLCVirtualMachine::TryAllocatePort(uint16_t Port, int Family, int Protocol)

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -216,7 +216,7 @@ private:
     GUID m_vmId{};
 
     std::mutex m_trackedProcessesLock;
-    std::vector<VMProcessControl*> m_trackedProcesses;
+    std::vector<std::weak_ptr<VMProcessControl>> m_trackedProcesses;
 
     wil::unique_event m_vmTerminatingEvent{wil::EventOptions::ManualReset};
 


### PR DESCRIPTION
Use shared_ptr for VMProcessControl in m_trackedProcesses so that WatchForExitedProcesses can safely hold a reference while calling OnExited() outside m_trackedProcessesLock. This eliminates both the deadlock and any use-after-free risk from the raw pointer approach.