### PR TITLE
Update Microsoft.WSL.DeviceHost to version 1.1.48-0

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.1.47-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.1.48-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.3.0" />


### PR DESCRIPTION
This change updates the devicehost nuget package (which hosts virtio proxy networking and virtiofs) to the latest version. This version contains a workaround for a host bug that would most often manifest as network hanging.