### PR TITLE
Fix wrong enum type in DeleteExclusiveLockHeld

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -700,7 +700,7 @@ __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::DeleteExclusiveLo
 
     try
     {
-        m_dockerClient.DeleteContainer(m_id, WI_IsFlagSet(Flags, WSLCDeleteImageFlagsForce));
+        m_dockerClient.DeleteContainer(m_id, WI_IsFlagSet(Flags, WSLCDeleteFlagsForce));
     }
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to delete container '%hs'", m_id.c_str());
 


### PR DESCRIPTION
WSLCDeleteImageFlagsForce (from WSLCDeleteImageFlags enum) was used instead of WSLCDeleteFlagsForce (from WSLCDeleteFlags enum). Both values are currently 1, so no functional issue today, but this is a type confusion that will break silently if either enum changes.