### PR TITLE
Validate empty host path in VolumeMount::Parse

### DIFF
--- a/src/windows/wslc/services/ContainerModel.cpp
+++ b/src/windows/wslc/services/ContainerModel.cpp
@@ -187,6 +187,14 @@ VolumeMount VolumeMount::Parse(const std::wstring& value)
     }
 
     vm.m_hostPath = value.substr(0, splitColon);
+
+    if (vm.m_hostPath.empty())
+    {
+        THROW_HR_WITH_USER_ERROR(
+            E_INVALIDARG,
+            std::format(L"Invalid volume specifications: '{}'. Host path cannot be empty. Expected format: <host path>:<container path>[:mode]", value));
+    }
+
     return vm;
 }
 

--- a/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
+++ b/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
@@ -33,9 +33,7 @@ class WSLCVolumeMountUnitTests
             {LR"(C:\hostPath:/containerPath:rw)", LR"(C:\hostPath)", R"(/containerPath)", false},
             {LR"(C:\host Path:/container Path:ro)", LR"(C:\host Path)", R"(/container Path)", true},
             {LR"(C:\host Path:/container Path:rw)", LR"(C:\host Path)", R"(/container Path)", false},
-            {LR"(:/containerPath)", LR"()", R"(/containerPath)", false},
             {LR"(C:\hostPath::ro)", LR"(C:\hostPath)", R"()", true},
-            {LR"(:/containerPath:ro)", LR"()", R"(/containerPath)", true},
             {LR"(C:\hostPath:)", LR"(C:\hostPath)", R"()", false},
             {LR"(C:\hostPath:ro)", LR"(C)", R"(\hostPath)", true},
             {LR"(C:\hostPath::rw)", LR"(C:\hostPath)", R"()", false},
@@ -44,7 +42,6 @@ class WSLCVolumeMountUnitTests
             {LR"(C:\hostPath:/containerPath:)", LR"(C:\hostPath:/containerPath)", R"()", false},
             {LR"(C:\hostPath)", LR"(C)", R"(\hostPath)", false},
             {LR"(C:/hostPath)", LR"(C)", R"(/hostPath)", false},
-            {LR"(:)", LR"()", R"()", false},
             {LR"(::)", LR"(:)", R"()", false},
         };
 
@@ -55,6 +52,21 @@ class WSLCVolumeMountUnitTests
             VERIFY_ARE_EQUAL(std::get<1>(arg), result.HostPath());
             VERIFY_ARE_EQUAL(std::get<2>(arg), result.ContainerPath());
             VERIFY_ARE_EQUAL(std::get<3>(arg), result.IsReadOnly());
+        }
+    }
+
+    TEST_METHOD(VolumeMount_Parse_InvalidArgs)
+    {
+        std::vector<std::wstring> emptyHostPathCases = {
+            LR"(:/containerPath)",
+            LR"(:/containerPath:ro)",
+            LR"(:)",
+        };
+
+        for (const auto& value : emptyHostPathCases)
+        {
+            WEX::Logging::Log::Comment(std::format(L"Testing invalid volume argument: '{}'", value).c_str());
+            VERIFY_THROWS(VolumeMount::Parse(value), wil::ResultException);
         }
     }
 };

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -255,7 +255,7 @@ class WSLCE2EContainerCreateTests
         {
             auto result =
                 RunWslc(std::format(L"container run --name {} --volume :/containerPath {}", WslcContainerName, AlpineImage.NameAndTag()));
-            result.Verify({.Stderr = L"The parameter is incorrect. \r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
+            result.Verify({.Stderr = L"Invalid volume specifications: ':/containerPath'. Host path cannot be empty. Expected format: <host path>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
@@ -269,7 +269,7 @@ class WSLCE2EContainerCreateTests
         {
             auto result = RunWslc(
                 std::format(L"container run --name {} --volume :/containerPath:ro {}", WslcContainerName, AlpineImage.NameAndTag()));
-            result.Verify({.Stderr = L"The parameter is incorrect. \r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
+            result.Verify({.Stderr = L"Invalid volume specifications: ':/containerPath:ro'. Host path cannot be empty. Expected format: <host path>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
@@ -351,7 +351,7 @@ class WSLCE2EContainerCreateTests
 
         {
             auto result = RunWslc(std::format(L"container run --name {} --volume \":\" {}", WslcContainerName, AlpineImage.NameAndTag()));
-            result.Verify({.Stderr = L"Unspecified error \r\nError code: E_FAIL\r\n", .ExitCode = 1});
+            result.Verify({.Stderr = L"Invalid volume specifications: ':'. Host path cannot be empty. Expected format: <host path>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 


### PR DESCRIPTION
When parsing volume mount specs without a mode suffix (e.g. ':container'), the host path validation was skipped, producing a VolumeMount with an empty host path. This would propagate to MountWindowsFolder('') and produce a confusing error. Add validation after computing m_hostPath to reject empty host paths with a clear error message.