### PR TITLE
Fix partial write data loss in TTY stdin relay

### DIFF
--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -315,8 +315,8 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_TTY_RELAY
                 if (bytesWritten < 0)
                 {
                     //
-                    // If writing on stdin's pipe would block, mark the write as pending an continue.
-                    // This is required blocking on the write() could lead to a deadlock if the child process
+                    // If writing on stdin's pipe would block, mark the write as pending and continue.
+                    // This is required because blocking on the write() could lead to a deadlock if the child process
                     // is blocking trying to write on stderr / stdout while the relay tries to write stdin.
                     //
 
@@ -330,6 +330,11 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_TTY_RELAY
                         LOG_ERROR("write failed {}", errno);
                         break;
                     }
+                }
+                else if (bytesWritten < bytesRead)
+                {
+                    // Partial write — buffer the remaining bytes for the next iteration.
+                    pendingStdin.assign(buffer.begin() + bytesWritten, buffer.begin() + bytesRead);
                 }
             }
         }


### PR DESCRIPTION
When the TtyMaster fd is non-blocking, write() can return fewer bytes than requested (partial write). The existing code only handled the EAGAIN/EWOULDBLOCK case by buffering into pendingStdin, but silently dropped data on successful partial writes. Add handling for 0 < bytesWritten < bytesRead to buffer the unwritten bytes into pendingStdin.