### PR TITLE
Fix Content-Length truncation for Docker responses >4GB

### DIFF
--- a/src/windows/wslcsession/DockerHTTPClient.cpp
+++ b/src/windows/wslcsession/DockerHTTPClient.cpp
@@ -563,7 +563,7 @@ void DockerHTTPClient::DockerHttpResponseHandle::OnRead(const gsl::span<char>& C
             {
                 try
                 {
-                    RemainingContentLength = std::stoul(contentLength->value());
+                    RemainingContentLength = std::stoull(contentLength->value());
                 }
                 catch (const std::exception&)
                 {


### PR DESCRIPTION
std::stoul returns unsigned long (32-bit on Windows), truncating Content-Length values >4GB. This corrupts the socket stream for large image save/export operations. Replace with std::stoull to parse as 64-bit unsigned.