### PR TITLE
Clean up Docker container on Create() failure

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1165,6 +1165,15 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
     auto result =
         DockerClient.CreateContainer(request, containerOptions.Name != nullptr ? containerOptions.Name : std::optional<std::string>{});
 
+    // Clean up the Docker container if anything below fails.
+    auto deleteOnFailure = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+        try
+        {
+            DockerClient.DeleteContainer(result.Id, true);
+        }
+        CATCH_LOG();
+    });
+
     // Inspect the container to fetch its generated name (if needed) and Docker's authoritative Created timestamp.
     auto inspectData = DockerClient.InspectContainer(result.Id);
 
@@ -1187,6 +1196,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         containerOptions.InitProcessOptions.Flags,
         containerOptions.Flags);
 
+    deleteOnFailure.release();
     return container;
 }
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1166,13 +1166,9 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         DockerClient.CreateContainer(request, containerOptions.Name != nullptr ? containerOptions.Name : std::optional<std::string>{});
 
     // Clean up the Docker container if anything below fails.
-    auto deleteOnFailure = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-        try
-        {
-            DockerClient.DeleteContainer(result.Id, true);
-        }
-        CATCH_LOG();
-    });
+    // N.B. The container ID is captured by value since it is moved into the WSLCContainerImpl constructor below.
+    auto deleteOnFailure = wil::scope_exit_log(
+        WI_DIAGNOSTICS_INFO, [&DockerClient, containerId = result.Id]() { DockerClient.DeleteContainer(containerId, true); });
 
     // Inspect the container to fetch its generated name (if needed) and Docker's authoritative Created timestamp.
     auto inspectData = DockerClient.InspectContainer(result.Id);
@@ -1181,8 +1177,8 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         wslcSession,
         virtualMachine,
         std::move(result.Id),
-        std::move(containerOptions.Name == nullptr ? CleanContainerName(inspectData.Name) : std::string(containerOptions.Name)),
-        std::move(std::string(containerOptions.Image)),
+        CleanContainerName(inspectData.Name),
+        std::string(containerOptions.Image),
         containerOptions.ContainerNetwork.ContainerNetworkType,
         std::move(volumes),
         std::move(ports),


### PR DESCRIPTION
If InspectContainer or the WSLCContainerImpl constructor throws after CreateContainer succeeds, the Docker container is permanently orphaned with no way to manage it through WSLC APIs. Add a scope_exit to delete the Docker container on failure, released on success.