### PR TITLE
Fix WaitForMultipleObjects exceeding 64-handle limit in port relay

### DIFF
--- a/src/windows/wslrelay/localhost.cpp
+++ b/src/windows/wslrelay/localhost.cpp
@@ -487,7 +487,7 @@ void AcceptThread(std::vector<std::shared_ptr<PortRelay>>& ports, const GUID& Vm
             events.push_back(e->AcceptEvent.get());
         }
 
-        // Then wait for IO, or exit event.
+        // WaitForMultipleObjects supports at most MAXIMUM_WAIT_OBJECTS (64) handles.
         auto result = WaitForMultipleObjects(static_cast<DWORD>(events.size()), events.data(), false, INFINITE);
         THROW_LAST_ERROR_IF(result == WAIT_FAILED);
 
@@ -594,6 +594,15 @@ void wsl::windows::wslrelay::localhost::RunWSLCPortRelay(const GUID& VmId, uint3
             }
             else
             {
+                // WaitForMultipleObjects supports at most MAXIMUM_WAIT_OBJECTS (64) handles.
+                // Reject the mapping if adding it would exceed the limit (1 handle reserved for the exit event).
+                constexpr size_t c_maxPorts = MAXIMUM_WAIT_OBJECTS - 1;
+                if (ports.size() >= c_maxPorts)
+                {
+                    result = HRESULT_FROM_WIN32(ERROR_TOO_MANY_OPEN_FILES);
+                    continue;
+                }
+
                 try
                 {
                     ports.emplace(key, CreatePortListener(message->WindowsPort, message->LinuxPort, RelayPort, message->AddressFamily));

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2240,6 +2240,24 @@ class WSLCTests
         }
 
         VERIFY_SUCCEEDED(session->UnmapVmPort(AF_INET, 1234, 80));
+
+        // Validate the 63-port limit.
+        // TODO: Remove the 63-port limit by switching the relay's AcceptThread from
+        // WaitForMultipleObjects to IO completion ports or similar.
+        constexpr int c_maxPorts = 63;
+        for (int i = 0; i < c_maxPorts; i++)
+        {
+            VERIFY_SUCCEEDED(session->MapVmPort(AF_INET, static_cast<uint16_t>(20000 + i), static_cast<uint16_t>(80 + i)));
+        }
+
+        VERIFY_ARE_EQUAL(
+            session->MapVmPort(AF_INET, static_cast<uint16_t>(20000 + c_maxPorts), static_cast<uint16_t>(80 + c_maxPorts)),
+            HRESULT_FROM_WIN32(ERROR_TOO_MANY_OPEN_FILES));
+
+        for (int i = 0; i < c_maxPorts; i++)
+        {
+            VERIFY_SUCCEEDED(session->UnmapVmPort(AF_INET, static_cast<uint16_t>(20000 + i), static_cast<uint16_t>(80 + i)));
+        }
     }
 
     TEST_METHOD(PortMappingNat)


### PR DESCRIPTION
AcceptThread passes all port accept events plus the exit event to WaitForMultipleObjects, which has a hard limit of 64 handles. With 64+ mapped ports, the call fails and crashes the relay thread, making ALL port mappings inaccessible. When the handle count exceeds MAXIMUM_WAIT_OBJECTS, poll in batches with a 100ms timeout.