### PR TITLE
Update Microsoft.WSL.DeviceHost to version 1.1.48-0

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.1.47-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.1.48-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1450,8 +1450,6 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         return value;
     };
 
-    // TODO: Reset guiApplications to true by default once the virtio hang is solved.
-
     std::wstring newConfig =
         L"[wsl2]\n"
         L"crashDumpFolder=" +
@@ -1464,7 +1462,7 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         EscapePath(kernelLogs) +
         L"\n"
         L"telemetry=false\n" +
-        boolOptionToString(L"safeMode", Default.safeMode, false) + boolOptionToString(L"guiApplications", Default.guiApplications, false) +
+        boolOptionToString(L"safeMode", Default.safeMode, false) + boolOptionToString(L"guiApplications", Default.guiApplications, true) +
         L"earlyBootLogging=false\n" + networkingModeToString(Default.networkingMode) + drvFsModeToString(Default.drvFsMode);
 
     if (Default.kernel.has_value())

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -339,6 +339,9 @@ class UnitTests
     {
         WSL2_TEST_ONLY();
 
+        // The X11 socket is only created when gui applications are enabled.
+        WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true}));
+
         // ensures that we don't leave state on exit
         auto cleanup = EnableSystemd("initTimeout=0");
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -339,9 +339,6 @@ class UnitTests
     {
         WSL2_TEST_ONLY();
 
-        // The X11 socket is only created when gui applications are enabled.
-        WslConfigChange config(LxssGenerateTestConfig({.guiApplications = true}));
-
         // ensures that we don't leave state on exit
         auto cleanup = EnableSystemd("initTimeout=0");
 


### PR DESCRIPTION
Recently we found a host bug that could explain the virtio-related hangs that we have seen rarely on older host OS versions. This change updates the devicehost package to a version that works around that issue, and re-enables the WSLg tests that were previously (rarely) hitting this issue.