### PR TITLE
wslc: resolve ContainerRecoveryFromStorage test issue by storing timestamp from docker, not the host

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -339,6 +339,7 @@ WSLCContainerImpl::WSLCContainerImpl(
     DockerHTTPClient& DockerClient,
     IORelay& Relay,
     WSLCContainerState InitialState,
+    std::uint64_t CreatedAt,
     WSLCProcessFlags InitProcessFlags,
     WSLCContainerFlags ContainerFlags) :
     m_wslcSession(wslcSession),
@@ -357,6 +358,7 @@ WSLCContainerImpl::WSLCContainerImpl(
     m_containerEvents(EventTracker.RegisterContainerStateUpdates(
         m_id, std::bind(&WSLCContainerImpl::OnEvent, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3))),
     m_state(InitialState),
+    m_createdAt(CreatedAt),
     m_initProcessFlags(InitProcessFlags),
     m_containerFlags(ContainerFlags)
 {
@@ -1163,12 +1165,8 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
     auto result =
         DockerClient.CreateContainer(request, containerOptions.Name != nullptr ? containerOptions.Name : std::optional<std::string>{});
 
-    // If no name was passed, inspect the container to fetch its generated name.
-    common::docker_schema::InspectContainer inspectData;
-    if (containerOptions.Name == nullptr)
-    {
-        inspectData = DockerClient.InspectContainer(result.Id);
-    }
+    // Inspect the container to fetch its generated name (if needed) and Docker's authoritative Created timestamp.
+    auto inspectData = DockerClient.InspectContainer(result.Id);
 
     auto container = std::make_unique<WSLCContainerImpl>(
         wslcSession,
@@ -1185,6 +1183,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         DockerClient,
         IoRelay,
         WslcContainerStateCreated,
+        ParseDockerTimestamp(inspectData.Created),
         containerOptions.InitProcessOptions.Flags,
         containerOptions.Flags);
 
@@ -1257,11 +1256,9 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
         DockerClient,
         ioRelay,
         DockerStateToWSLCState(dockerContainer.State),
+        static_cast<std::uint64_t>(dockerContainer.Created),
         metadata.InitProcessFlags,
         metadata.Flags);
-
-    // Restore the creation timestamp from Docker list API data.
-    container->m_createdAt = static_cast<std::uint64_t>(dockerContainer.Created);
 
     // Restore the state change timestamp from Docker inspect data.
     try

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -68,6 +68,7 @@ public:
         DockerHTTPClient& DockerClient,
         IORelay& Relay,
         WSLCContainerState InitialState,
+        std::uint64_t CreatedAt,
         WSLCProcessFlags InitProcessFlags,
         WSLCContainerFlags ContainerFlags);
 
@@ -159,7 +160,7 @@ private:
     std::optional<std::promise<std::uint64_t>> m_stopState;
     DockerHTTPClient& m_dockerClient;
     std::uint64_t m_stateChangedAt{static_cast<std::uint64_t>(std::time(nullptr))};
-    std::uint64_t m_createdAt{static_cast<std::uint64_t>(std::time(nullptr))};
+    std::uint64_t m_createdAt{};
     WSLCContainerState m_state = WslcContainerStateInvalid;
     WSLCSession& m_wslcSession;
     WSLCVirtualMachine& m_virtualMachine;


### PR DESCRIPTION
This change uses the timestamp from the inspect data, instead of using the time from the host. This resolves a test issue where the two clock sources do not line up.