### PR TITLE
socketshared: add maximum message size to avoid very large allocations

### DIFF
--- a/src/shared/inc/socketshared.h
+++ b/src/shared/inc/socketshared.h
@@ -64,6 +64,15 @@ try
 #endif
     }
 
+    if (MessageSize > 4 * 1024 * 1024) // 4 MiB
+    {
+#if defined(_MSC_VER)
+        THROW_HR_MSG(E_UNEXPECTED, "Message size too large: %llu", MessageSize);
+#elif defined(__GNUC__)
+        THROW_UNEXCEPTED();
+#endif
+    }
+
     if (Buffer.size() < MessageSize)
     {
         Buffer.resize(MessageSize);


### PR DESCRIPTION
This change adds a maximum single message size of 4MiB to the socket helpers. This avoids a potentially huge (4GB) allocation from a malicious or buggy sender.