### PR TITLE
CLI: Add table support to always show header, default true

### DIFF
--- a/src/windows/wslc/core/TableOutput.h
+++ b/src/windows/wslc/core/TableOutput.h
@@ -85,6 +85,8 @@ struct ColumnDefinition
 template <size_t FieldCount>
 struct TableOutput
 {
+    static_assert(FieldCount > 0, "TableOutput requires at least one column");
+
     using header_t = std::array<std::wstring, FieldCount>;
     using line_t = std::array<std::wstring, FieldCount>;
     using column_config_t = std::array<ColumnWidthConfig, FieldCount>;

--- a/src/windows/wslc/core/TableOutput.h
+++ b/src/windows/wslc/core/TableOutput.h
@@ -134,6 +134,12 @@ struct TableOutput
         }
     }
 
+    // Set whether to always show header even when there are no rows
+    void SetAlwaysShowHeader(bool alwaysShow)
+    {
+        m_alwaysShowHeader = alwaysShow;
+    }
+
     void OutputLine(line_t&& line)
     {
         m_empty = false;
@@ -156,6 +162,10 @@ struct TableOutput
         if (!m_empty)
         {
             EvaluateAndFlushBuffer();
+        }
+        else if (m_alwaysShowHeader)
+        {
+            OutputHeaderOnly();
         }
     }
 
@@ -183,6 +193,7 @@ private:
     bool m_bufferEvaluated = false;
     bool m_empty = true;
     bool m_limitColumnWidths = false;
+    bool m_alwaysShowHeader = true;
     std::wstringstream m_stream;
 
     void InitializeColumns(header_t&& header)
@@ -219,6 +230,28 @@ private:
 
         // Default to 80 columns if console info is unavailable
         return 80;
+    }
+
+    void OutputHeaderOnly()
+    {
+        // Set MaxLength to MinLength for all columns (header width only)
+        for (size_t i = 0; i < FieldCount; ++i)
+        {
+            m_columns[i].MaxLength = m_columns[i].MinLength;
+        }
+
+        // Set spacing configuration
+        m_columns[FieldCount - 1].SpaceAfter = false;
+
+        // Output the header
+        line_t headerLine;
+        for (size_t i = 0; i < FieldCount; ++i)
+        {
+            headerLine[i] = m_columns[i].Name.c_str();
+        }
+
+        OutputLineToStream(headerLine);
+        m_bufferEvaluated = true;
     }
 
     void EvaluateAndFlushBuffer()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a configuration option to the table output to always show the header even when there are no rows, defaulted to true.
<img width="800" height="146" alt="image" src="https://github.com/user-attachments/assets/ab737cf7-05bb-4702-8bf7-20cce03df1c6" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Adds a table config option to always show the header, defaulted to true so no tables need to change to get this functionality.
* Implements showing only the header, using default spacing to fit the header columns. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Manual verification, will do more robust table unit testing in a forthcoming PR