### PR TITLE
Keep track of handle types in the service

### DIFF
--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1348,11 +1348,11 @@ WSLCHandle wsl::windows::common::wslutil::ToCOMOutputHandle(HANDLE Handle, DWORD
     switch (Type)
     {
     case WSLCHandleTypeFile:
-        return WSLCHandle{.Type = WSLCHandleTypeFile, .Handle = {.File =  duplicatedHandle.release()}};
+        return WSLCHandle{.Type = WSLCHandleTypeFile, .Handle = {.File = duplicatedHandle.release()}};
     case WSLCHandleTypePipe:
-        return WSLCHandle{.Type = WSLCHandleTypePipe, .Handle = {.Pipe =  duplicatedHandle.release()}};
+        return WSLCHandle{.Type = WSLCHandleTypePipe, .Handle = {.Pipe = duplicatedHandle.release()}};
     case WSLCHandleTypeSocket:
-        return WSLCHandle{.Type = WSLCHandleTypeSocket, .Handle = {.Socket =  duplicatedHandle.release()}};
+        return WSLCHandle{.Type = WSLCHandleTypeSocket, .Handle = {.Socket = duplicatedHandle.release()}};
     default:
         THROW_HR_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), "Unsupported handle type: %d", static_cast<int>(Type));
     }

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1345,17 +1345,16 @@ WSLCHandle wsl::windows::common::wslutil::ToCOMOutputHandle(HANDLE Handle, DWORD
 
     // N.B. COM closes the handle when returning an out parameter.
     // The return value of this method should always be passed to a COM out parameter.
-    HANDLE raw = duplicatedHandle.release();
     switch (Type)
     {
     case WSLCHandleTypeFile:
-        return WSLCHandle{.Type = WSLCHandleTypeFile, .Handle = {.File = raw}};
+        return WSLCHandle{.Type = WSLCHandleTypeFile, .Handle = {.File =  duplicatedHandle.release()}};
     case WSLCHandleTypePipe:
-        return WSLCHandle{.Type = WSLCHandleTypePipe, .Handle = {.Pipe = raw}};
+        return WSLCHandle{.Type = WSLCHandleTypePipe, .Handle = {.Pipe =  duplicatedHandle.release()}};
     case WSLCHandleTypeSocket:
-        return WSLCHandle{.Type = WSLCHandleTypeSocket, .Handle = {.Socket = raw}};
+        return WSLCHandle{.Type = WSLCHandleTypeSocket, .Handle = {.Socket =  duplicatedHandle.release()}};
     default:
-        THROW_HR_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), "Unsupported handle type: %d", Type);
+        THROW_HR_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), "Unsupported handle type: %d", static_cast<int>(Type));
     }
 }
 

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1339,6 +1339,26 @@ WSLCHandle wsl::windows::common::wslutil::ToCOMOutputHandle(HANDLE Handle, DWORD
     return comHandle;
 }
 
+WSLCHandle wsl::windows::common::wslutil::ToCOMOutputHandle(HANDLE Handle, DWORD Access, WSLCHandleType Type)
+{
+    wil::unique_handle duplicatedHandle{DuplicateHandle(Handle, Access)};
+
+    // N.B. COM closes the handle when returning an out parameter.
+    // The return value of this method should always be passed to a COM out parameter.
+    HANDLE raw = duplicatedHandle.release();
+    switch (Type)
+    {
+    case WSLCHandleTypeFile:
+        return WSLCHandle{.Type = WSLCHandleTypeFile, .Handle = {.File = raw}};
+    case WSLCHandleTypePipe:
+        return WSLCHandle{.Type = WSLCHandleTypePipe, .Handle = {.Pipe = raw}};
+    case WSLCHandleTypeSocket:
+        return WSLCHandle{.Type = WSLCHandleTypeSocket, .Handle = {.Socket = raw}};
+    default:
+        THROW_HR_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), "Unsupported handle type: %d", Type);
+    }
+}
+
 WSLCHandle wsl::windows::common::wslutil::ToCOMInputHandle(HANDLE Handle)
 {
     auto type = GetFileType(Handle);

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -319,6 +319,7 @@ wil::unique_hlocal_string SidToString(_In_ PSID Sid);
 
 WSLCHandle ToCOMInputHandle(HANDLE Handle);
 [[nodiscard]] WSLCHandle ToCOMOutputHandle(HANDLE Handle, DWORD Access);
+[[nodiscard]] WSLCHandle ToCOMOutputHandle(HANDLE Handle, DWORD Access, WSLCHandleType Type);
 
 winrt::Windows::Management::Deployment::PackageVolume GetSystemVolume();
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -32,6 +32,7 @@ using wsl::windows::common::relay::ReadHandle;
 using wsl::windows::common::relay::RelayHandle;
 using wsl::windows::service::wslc::ContainerPortMapping;
 using wsl::windows::service::wslc::RelayedProcessIO;
+using wsl::windows::service::wslc::TypedHandle;
 using wsl::windows::service::wslc::VMPortMapping;
 using wsl::windows::service::wslc::WSLCContainer;
 using wsl::windows::service::wslc::WSLCContainerImpl;
@@ -463,7 +464,8 @@ void WSLCContainerImpl::Attach(LPCSTR DetachKeys, WSLCHandle* Stdin, WSLCHandle*
     // If this is a TTY process, the PTY handle can be returned directly.
     if (WI_IsFlagSet(m_initProcessFlags, WSLCProcessFlagsTty))
     {
-        *Stdin = common::wslutil::ToCOMOutputHandle(reinterpret_cast<HANDLE>(ioHandle.get()), GENERIC_READ | GENERIC_WRITE | SYNCHRONIZE);
+        *Stdin = common::wslutil::ToCOMOutputHandle(
+            reinterpret_cast<HANDLE>(ioHandle.get()), GENERIC_READ | GENERIC_WRITE | SYNCHRONIZE, WSLCHandleTypeSocket);
 
         return;
     }
@@ -488,11 +490,11 @@ void WSLCContainerImpl::Attach(LPCSTR DetachKeys, WSLCHandle* Stdin, WSLCHandle*
 
     m_ioRelay.AddHandles(std::move(handles));
 
-    *Stdin = common::wslutil::ToCOMOutputHandle(reinterpret_cast<HANDLE>(stdinWrite.get()), GENERIC_WRITE | SYNCHRONIZE);
+    *Stdin = common::wslutil::ToCOMOutputHandle(reinterpret_cast<HANDLE>(stdinWrite.get()), GENERIC_WRITE | SYNCHRONIZE, WSLCHandleTypePipe);
 
-    *Stdout = common::wslutil::ToCOMOutputHandle(reinterpret_cast<HANDLE>(stdoutRead.get()), GENERIC_READ | SYNCHRONIZE);
+    *Stdout = common::wslutil::ToCOMOutputHandle(reinterpret_cast<HANDLE>(stdoutRead.get()), GENERIC_READ | SYNCHRONIZE, WSLCHandleTypePipe);
 
-    *Stderr = common::wslutil::ToCOMOutputHandle(reinterpret_cast<HANDLE>(stderrRead.get()), GENERIC_READ | SYNCHRONIZE);
+    *Stderr = common::wslutil::ToCOMOutputHandle(reinterpret_cast<HANDLE>(stderrRead.get()), GENERIC_READ | SYNCHRONIZE, WSLCHandleTypePipe);
 }
 
 void WSLCContainerImpl::Start(WSLCContainerStartFlags Flags, LPCSTR DetachKeys)
@@ -518,7 +520,8 @@ void WSLCContainerImpl::Start(WSLCContainerStartFlags Flags, LPCSTR DetachKeys)
 
             if (WI_IsFlagSet(m_initProcessFlags, WSLCProcessFlagsTty))
             {
-                io = std::make_unique<TTYProcessIO>(wil::unique_handle{(HANDLE)m_dockerClient.AttachContainer(m_id, detachKeys).release()});
+                io = std::make_unique<TTYProcessIO>(TypedHandle{
+                    wil::unique_handle{(HANDLE)m_dockerClient.AttachContainer(m_id, detachKeys).release()}, WSLCHandleTypeSocket});
             }
             else
             {
@@ -878,7 +881,7 @@ void WSLCContainerImpl::Exec(const WSLCProcessOptions* Options, LPCSTR DetachKey
         std::unique_ptr<WSLCProcessIO> io;
         if (request.Tty)
         {
-            io = std::make_unique<TTYProcessIO>(std::move(stream));
+            io = std::make_unique<TTYProcessIO>(TypedHandle{std::move(stream), WSLCHandleTypeSocket});
         }
         else
         {
@@ -1342,7 +1345,7 @@ void WSLCContainerImpl::Logs(WSLCLogsFlags Flags, WSLCHandle* Stdout, WSLCHandle
         auto handle = std::make_unique<RelayHandle<HTTPChunkBasedReadHandle>>(std::move(socket), std::move(ttyWrite));
         m_ioRelay.AddHandle(std::move(handle));
 
-        *Stdout = common::wslutil::ToCOMOutputHandle(ttyRead.get(), GENERIC_READ | SYNCHRONIZE);
+        *Stdout = common::wslutil::ToCOMOutputHandle(ttyRead.get(), GENERIC_READ | SYNCHRONIZE, WSLCHandleTypePipe);
     }
     else
     {
@@ -1355,11 +1358,8 @@ void WSLCContainerImpl::Logs(WSLCLogsFlags Flags, WSLCHandle* Stdout, WSLCHandle
 
         m_ioRelay.AddHandle(std::move(handle));
 
-        *Stdout = common::wslutil::ToCOMOutputHandle(stdoutRead.get(), GENERIC_READ | SYNCHRONIZE);
-        *Stderr = common::wslutil::ToCOMOutputHandle(stderrRead.get(), GENERIC_READ | SYNCHRONIZE);
-
-        WI_ASSERT(Stdout->Type == WSLCHandleTypePipe);
-        WI_ASSERT(Stderr->Type == WSLCHandleTypePipe);
+        *Stdout = common::wslutil::ToCOMOutputHandle(stdoutRead.get(), GENERIC_READ | SYNCHRONIZE, WSLCHandleTypePipe);
+        *Stderr = common::wslutil::ToCOMOutputHandle(stderrRead.get(), GENERIC_READ | SYNCHRONIZE, WSLCHandleTypePipe);
     }
 }
 
@@ -1367,7 +1367,7 @@ std::unique_ptr<RelayedProcessIO> WSLCContainerImpl::CreateRelayedProcessIO(wil:
 {
     // Create one pipe for each STD handle.
     std::vector<std::unique_ptr<OverlappedIOHandle>> ioHandles;
-    std::map<ULONG, wil::unique_handle> fds;
+    std::map<ULONG, TypedHandle> fds;
 
     // This is required for docker to know when stdin is closed.
     auto closeStdin = [socket = stream.get(), this]() {
@@ -1380,7 +1380,7 @@ std::unique_ptr<RelayedProcessIO> WSLCContainerImpl::CreateRelayedProcessIO(wil:
         ioHandles.emplace_back(
             std::make_unique<RelayHandle<ReadHandle>>(HandleWrapper{std::move(stdinRead), std::move(closeStdin)}, stream.get()));
 
-        fds.emplace(WSLCFDStdin, stdinWrite.release());
+        fds.emplace(WSLCFDStdin, TypedHandle{wil::unique_handle{stdinWrite.release()}, WSLCHandleTypePipe});
     }
     else
     {
@@ -1391,8 +1391,8 @@ std::unique_ptr<RelayedProcessIO> WSLCContainerImpl::CreateRelayedProcessIO(wil:
     auto [stdoutRead, stdoutWrite] = common::wslutil::OpenAnonymousPipe(LX_RELAY_BUFFER_SIZE, true, true);
     auto [stderrRead, stderrWrite] = common::wslutil::OpenAnonymousPipe(LX_RELAY_BUFFER_SIZE, true, true);
 
-    fds.emplace(WSLCFDStdout, stdoutRead.release());
-    fds.emplace(WSLCFDStderr, stderrRead.release());
+    fds.emplace(WSLCFDStdout, TypedHandle{wil::unique_handle{stdoutRead.release()}, WSLCHandleTypePipe});
+    fds.emplace(WSLCFDStderr, TypedHandle{wil::unique_handle{stderrRead.release()}, WSLCHandleTypePipe});
 
     ioHandles.emplace_back(std::make_unique<DockerIORelayHandle>(
         std::move(stream), std::move(stdoutWrite), std::move(stderrWrite), common::relay::DockerIORelayHandle::Format::Raw));

--- a/src/windows/wslcsession/WSLCProcess.cpp
+++ b/src/windows/wslcsession/WSLCProcess.cpp
@@ -44,21 +44,21 @@ try
 {
     RETURN_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), !m_io, "Process IO not attached");
 
-    auto handle = m_io->OpenFd(Fd);
+    auto typedHandle = m_io->OpenFd(Fd);
 
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !handle.is_valid());
+    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !typedHandle.is_valid());
 
     DWORD Access = SYNCHRONIZE;
 
     WI_SetFlagIf(Access, GENERIC_WRITE, Fd == WSLCFDTty || Fd == WSLCFDStdin);
     WI_SetFlagIf(Access, GENERIC_READ, Fd == WSLCFDStdout || Fd == WSLCFDStderr || Fd == WSLCFDTty);
 
-    *Handle = common::wslutil::ToCOMOutputHandle(handle.get(), Access);
+    *Handle = common::wslutil::ToCOMOutputHandle(typedHandle.get(), Access, typedHandle.Type);
 
     WSL_LOG(
         "GetStdHandle",
         TraceLoggingValue(static_cast<int>(Fd), "fd"),
-        TraceLoggingValue(handle.get(), "handle"),
+        TraceLoggingValue(typedHandle.get(), "handle"),
         TraceLoggingValue(static_cast<int>(Handle->Type), "type"));
 
     return S_OK;
@@ -77,7 +77,7 @@ wil::unique_handle WSLCProcess::GetStdHandle(int Index)
 {
     THROW_WIN32_IF(ERROR_INVALID_STATE, !m_io);
 
-    return m_io->OpenFd(Index);
+    return std::move(m_io->OpenFd(Index).Handle);
 }
 
 HANDLE WSLCProcess::GetExitEvent()

--- a/src/windows/wslcsession/WSLCProcessIO.cpp
+++ b/src/windows/wslcsession/WSLCProcessIO.cpp
@@ -18,14 +18,15 @@ Abstract:
 
 using wsl::windows::service::wslc::RelayedProcessIO;
 using wsl::windows::service::wslc::TTYProcessIO;
+using wsl::windows::service::wslc::TypedHandle;
 using wsl::windows::service::wslc::VMProcessIO;
 using namespace wsl::windows::common::relay;
 
-RelayedProcessIO::RelayedProcessIO(std::map<ULONG, wil::unique_handle>&& fds) : m_relayedHandles(std::move(fds))
+RelayedProcessIO::RelayedProcessIO(std::map<ULONG, TypedHandle>&& fds) : m_relayedHandles(std::move(fds))
 {
 }
 
-wil::unique_handle RelayedProcessIO::OpenFd(ULONG Fd)
+TypedHandle RelayedProcessIO::OpenFd(ULONG Fd)
 {
     auto it = m_relayedHandles.find(Fd);
 
@@ -35,22 +36,22 @@ wil::unique_handle RelayedProcessIO::OpenFd(ULONG Fd)
     return std::move(it->second);
 }
 
-TTYProcessIO::TTYProcessIO(wil::unique_handle&& IoStream) : m_ioStream(std::move(IoStream))
+TTYProcessIO::TTYProcessIO(TypedHandle&& IoStream) : m_ioStream(std::move(IoStream))
 {
 }
 
-wil::unique_handle TTYProcessIO::OpenFd(ULONG Fd)
+TypedHandle TTYProcessIO::OpenFd(ULONG Fd)
 {
     THROW_HR_IF_MSG(E_INVALIDARG, Fd != WSLCFDTty, "Invalid fd type for TTY process: %i", static_cast<int>(Fd));
 
     return std::move(m_ioStream);
 }
 
-VMProcessIO::VMProcessIO(std::map<ULONG, wil::unique_handle>&& handles) : m_handles(std::move(handles))
+VMProcessIO::VMProcessIO(std::map<ULONG, TypedHandle>&& handles) : m_handles(std::move(handles))
 {
 }
 
-wil::unique_handle VMProcessIO::OpenFd(ULONG Fd)
+TypedHandle VMProcessIO::OpenFd(ULONG Fd)
 {
     auto it = m_handles.find(Fd);
     THROW_HR_IF_MSG(E_INVALIDARG, it == m_handles.end(), "Invalid fd type for VM process: %i", static_cast<int>(Fd));

--- a/src/windows/wslcsession/WSLCProcessIO.h
+++ b/src/windows/wslcsession/WSLCProcessIO.h
@@ -17,43 +17,63 @@ Abstract:
 
 namespace wsl::windows::service::wslc {
 
+struct TypedHandle
+{
+    wil::unique_handle Handle;
+    WSLCHandleType Type = WSLCHandleTypeUnknown;
+
+    TypedHandle() = default;
+    TypedHandle(wil::unique_handle&& handle, WSLCHandleType type) : Handle(std::move(handle)), Type(type)
+    {
+    }
+
+    bool is_valid() const noexcept
+    {
+        return Handle.is_valid();
+    }
+    HANDLE get() const noexcept
+    {
+        return Handle.get();
+    }
+};
+
 class WSLCProcessIO
 {
 public:
     virtual ~WSLCProcessIO() = default;
-    virtual wil::unique_handle OpenFd(ULONG Fd) = 0;
+    virtual TypedHandle OpenFd(ULONG Fd) = 0;
 };
 
 class RelayedProcessIO : public WSLCProcessIO
 {
 public:
-    RelayedProcessIO(std::map<ULONG, wil::unique_handle>&& fds);
+    RelayedProcessIO(std::map<ULONG, TypedHandle>&& fds);
 
-    wil::unique_handle OpenFd(ULONG Fd) override;
+    TypedHandle OpenFd(ULONG Fd) override;
 
 private:
-    std::map<ULONG, wil::unique_handle> m_relayedHandles;
+    std::map<ULONG, TypedHandle> m_relayedHandles;
 };
 
 class TTYProcessIO : public WSLCProcessIO
 {
 public:
-    TTYProcessIO(wil::unique_handle&& IoStream);
+    TTYProcessIO(TypedHandle&& IoStream);
 
-    wil::unique_handle OpenFd(ULONG Fd) override;
+    TypedHandle OpenFd(ULONG Fd) override;
 
 private:
-    wil::unique_handle m_ioStream;
+    TypedHandle m_ioStream;
 };
 
 class VMProcessIO : public WSLCProcessIO
 {
 public:
-    VMProcessIO(std::map<ULONG, wil::unique_handle>&& handles);
-    wil::unique_handle OpenFd(ULONG Fd) override;
+    VMProcessIO(std::map<ULONG, TypedHandle>&& handles);
+    TypedHandle OpenFd(ULONG Fd) override;
 
 private:
-    std::map<ULONG, wil::unique_handle> m_handles;
+    std::map<ULONG, TypedHandle> m_handles;
 };
 
 } // namespace wsl::windows::service::wslc

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -23,6 +23,7 @@ Abstract:
 #include "lxinitshared.h"
 
 using namespace wsl::windows::common;
+using wsl::windows::service::wslc::TypedHandle;
 using wsl::windows::service::wslc::VmPortAllocation;
 using wsl::windows::service::wslc::VMPortMapping;
 using wsl::windows::service::wslc::WSLCProcess;
@@ -703,7 +704,7 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
 
     wil::unique_socket ttyControlHandle;
 
-    std::map<ULONG, wil::unique_handle> stdHandles;
+    std::map<ULONG, TypedHandle> stdHandles;
     for (auto& [fd, handle] : sockets)
     {
         if (ttyControl != nullptr && fd == ttyControl->Fd)
@@ -712,7 +713,7 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
             continue;
         }
 
-        stdHandles.emplace(fd, reinterpret_cast<HANDLE>(handle.release()));
+        stdHandles.emplace(fd, TypedHandle{wil::unique_handle{reinterpret_cast<HANDLE>(handle.release())}, WSLCHandleTypeSocket});
     }
 
     auto io = std::make_unique<VMProcessIO>(std::move(stdHandles));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

I've seen a couple test failures where we fail to correctly determine the type of an output handle. For now let's just keep track of handle types in the service, this should avoid the issue entirely

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
