### PR TITLE
CLI: Fix and improve interactive tests

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -696,10 +696,12 @@ class WSLCE2EContainerCreateTests
         WSL2_TEST_ONLY();
         VerifyContainerIsNotListed(WslcContainerName);
 
-        auto session = RunWslcInteractive(std::format(L"container run -it --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+        const auto& prompt = ">";
+        auto session = RunWslcInteractive(
+            std::format(L"container run -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
 
-        const auto& expectedPrompt = VT::InspectAndBuildContainerPrompt(WslcContainerName);
+        const auto& expectedPrompt = VT::BuildContainerPrompt(prompt);
         session.ExpectStdout(expectedPrompt);
 
         session.WriteLine("echo hello");
@@ -724,13 +726,10 @@ class WSLCE2EContainerCreateTests
         auto session = RunWslcInteractive(std::format(L"container run -i --name {} {} cat", WslcContainerName, DebianImage.NameAndTag()));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
 
-        // Write test data to stdin
         session.WriteLine("test line 1");
+        session.ExpectStdout("test line 1\n");
         session.WriteLine("test line 2");
-
-        // Stdin relay is confirmed working. Stdout verification is skipped due to a known
-        // limitation where we are not getting stdout data correctly from non-TTY process.
-        // BUG: Stdin does not support overlapped IO. Can verify output once this is fixed.
+        session.ExpectStdout("test line 2\n");
 
         // Close stdin to signal EOF to cat
         session.CloseStdin();
@@ -745,12 +744,15 @@ class WSLCE2EContainerCreateTests
     {
         WSL2_TEST_ONLY();
         VerifyContainerIsNotListed(WslcContainerName);
-        auto result = RunWslc(std::format(L"container run -itd --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+
+        const auto& prompt = ">";
+        auto result = RunWslc(std::format(
+            L"container run -itd -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
         auto containerId = result.GetStdoutOneLine();
 
-        const auto& expectedAttachPrompt = VT::InspectAndBuildContainerAttachPrompt(WslcContainerName);
-        const auto& expectedPrompt = VT::InspectAndBuildContainerPrompt(WslcContainerName);
+        const auto& expectedAttachPrompt = VT::BuildContainerAttachPrompt(prompt);
+        const auto& expectedPrompt = VT::BuildContainerPrompt(prompt);
 
         auto session = RunWslcInteractive(std::format(L"container attach {}", containerId));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
@@ -785,13 +787,10 @@ class WSLCE2EContainerCreateTests
         auto session = RunWslcInteractive(std::format(L"container attach {}", containerId));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
 
-        // Write test data to stdin
         session.WriteLine("test line 1");
+        session.ExpectStdout("test line 1\n");
         session.WriteLine("test line 2");
-
-        // Stdin relay is confirmed working. Stdout verification is skipped due to a known
-        // limitation where we are not getting stdout data correctly from non-TTY process.
-        // BUG: Stdin does not support overlapped IO. Can verify output once this is fixed.
+        session.ExpectStdout("test line 2\n");
 
         // Close stdin to signal EOF to cat
         session.CloseStdin();
@@ -806,13 +805,16 @@ class WSLCE2EContainerCreateTests
     {
         WSL2_TEST_ONLY();
         VerifyContainerIsNotListed(WslcContainerName);
-        auto result = RunWslc(std::format(L"container run -itd --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+
+        const auto& prompt = ">";
+        auto result =
+            RunWslc(std::format(L"container run -itd -e PS1={} --name {} {}", prompt, WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
         auto containerId = result.GetStdoutOneLine();
 
-        const auto& expectedPrompt = VT::InspectAndBuildContainerPrompt(WslcContainerName);
+        const auto& expectedPrompt = VT::BuildContainerPrompt(prompt);
 
-        auto session = RunWslcInteractive(std::format(L"container exec -it {} /bin/bash", containerId));
+        auto session = RunWslcInteractive(std::format(L"container exec -it {} /bin/bash --norc", containerId));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
 
         session.ExpectStdout(expectedPrompt);
@@ -843,13 +845,10 @@ class WSLCE2EContainerCreateTests
         auto session = RunWslcInteractive(std::format(L"container exec -i {} cat", containerId));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
 
-        // Write test data to stdin
         session.WriteLine("test line 1");
+        session.ExpectStdout("test line 1\n");
         session.WriteLine("test line 2");
-
-        // Stdin relay is confirmed working. Stdout verification is skipped due to a known
-        // limitation where we are not getting stdout data correctly from non-TTY process.
-        // BUG: Stdin does not support overlapped IO. Can verify output once this is fixed.
+        session.ExpectStdout("test line 2\n");
 
         // Close stdin to signal EOF to cat
         session.CloseStdin();
@@ -864,11 +863,14 @@ class WSLCE2EContainerCreateTests
     {
         WSL2_TEST_ONLY();
         VerifyContainerIsNotListed(WslcContainerName);
-        auto result = RunWslc(std::format(L"container create -it --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+
+        const auto& prompt = ">";
+        auto result = RunWslc(std::format(
+            L"container create -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
         auto containerId = result.GetStdoutOneLine();
 
-        const auto& expectedPrompt = VT::InspectAndBuildContainerPrompt(WslcContainerName);
+        const auto& expectedPrompt = VT::BuildContainerPrompt(prompt);
 
         auto session = RunWslcInteractive(std::format(L"container start --attach {}", containerId));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
@@ -902,13 +904,10 @@ class WSLCE2EContainerCreateTests
         auto session = RunWslcInteractive(std::format(L"container start --attach {}", containerId));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
 
-        // Write test data to stdin
         session.WriteLine("test line 1");
+        session.ExpectStdout("test line 1\n");
         session.WriteLine("test line 2");
-
-        // Stdin relay is confirmed working. Stdout verification is skipped due to a known
-        // limitation where we are not getting stdout data correctly from non-TTY process.
-        // BUG: Stdin does not support overlapped IO. Can verify output once this is fixed.
+        session.ExpectStdout("test line 2\n");
 
         // Close stdin to signal EOF to cat
         session.CloseStdin();

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -217,22 +217,6 @@ wslc_schema::InspectImage InspectImage(const std::wstring& imageName)
     return inspectData[0];
 }
 
-namespace VT {
-    std::string InspectAndBuildContainerPrompt(const std::wstring& containerNameOrId, bool withBracketedPaste)
-    {
-        const auto containerId = InspectContainer(containerNameOrId).Id;
-        const auto shortId = GetHashId(containerId);
-        return BuildContainerPrompt(shortId, withBracketedPaste);
-    }
-
-    std::string InspectAndBuildContainerAttachPrompt(const std::wstring& containerNameOrId)
-    {
-        const auto containerId = InspectContainer(containerNameOrId).Id;
-        const auto shortId = GetHashId(containerId);
-        return BuildContainerAttachPrompt(shortId);
-    }
-} // namespace VT
-
 void EnsureContainerDoesNotExist(const std::wstring& containerName)
 {
     auto listResult = RunWslc(L"container list --no-trunc --all");

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -37,8 +37,6 @@ namespace VT {
 
     // Prompt patterns used in WSLC.
     constexpr auto SESSION_PROMPT = VT_B_START VT_RED "root@ [ " VT_RESET "/" VT_RED " ]# ";
-    constexpr auto CONTAINER_PROMPT = VT_B_START "root@:/# ";
-    constexpr auto CONTAINER_ATTACH_PROMPT = VT_CR VT_ERASE_LINE VT_CR "root@:/# ";
 
     // Constexpr representations of the control sequences for use in tests.
     constexpr auto B_START = VT_B_START;
@@ -56,29 +54,20 @@ namespace VT {
 #undef VT_ERASE_LINE
 #undef VT_CR
 
-    // Helper function to build container prompt with container ID (first 12 chars)
-    // Example: root@2a88a6f4b7c8:/#
-    inline std::string BuildContainerPrompt(const std::string& containerId, bool withBracketedPaste = true)
+    // Helper function to build container prompt
+    inline std::string BuildContainerPrompt(const std::string& prompt, bool withBracketedPaste = true)
     {
-        const std::string shortId = containerId.substr(0, 12);
         if (withBracketedPaste)
         {
-            return std::format("{}root@{}:/# ", B_START, shortId);
+            return std::format("{}{}", B_START, prompt);
         }
-        return std::format("root@{}:/# ", shortId);
+        return std::format("{}", prompt);
     }
 
-    // Helper function to build container prompt by inspecting the container
-    std::string InspectAndBuildContainerPrompt(const std::wstring& containerNameOrId, bool withBracketedPaste = true);
-
-    inline std::string BuildContainerAttachPrompt(const std::string& containerId)
+    inline std::string BuildContainerAttachPrompt(const std::string& prompt)
     {
-        const std::string shortId = containerId.substr(0, 12);
-        return std::format("{}{}{}root@{}:/# ", CR, ERASE_LINE, CR, shortId);
+        return std::format("{}{}{}{}", CR, ERASE_LINE, CR, prompt);
     }
-
-    // Helper function to build container attach prompt by inspecting the container
-    std::string InspectAndBuildContainerAttachPrompt(const std::wstring& containerNameOrId);
 } // namespace VT
 
 struct TestImage

--- a/test/windows/wslc/e2e/WSLCExecutor.cpp
+++ b/test/windows/wslc/e2e/WSLCExecutor.cpp
@@ -236,11 +236,13 @@ WSLCInteractiveSession::~WSLCInteractiveSession()
 
 void WSLCInteractiveSession::ExpectStdout(const std::string& expected)
 {
+    Log::Comment(std::format(L"Expecting stdout: \"{}\"", wsl::shared::string::MultiByteToWide(EscapeString(expected))).c_str());
     m_stdoutReader->ExpectConsume(expected);
 }
 
 void WSLCInteractiveSession::ExpectStderr(const std::string& expected)
 {
+    Log::Comment(std::format(L"Expecting stderr: \"{}\"", wsl::shared::string::MultiByteToWide(EscapeString(expected))).c_str());
     m_stderrReader->ExpectConsume(expected);
 }
 
@@ -252,6 +254,8 @@ void WSLCInteractiveSession::ExpectCommandEcho(const std::string& command)
 
 void WSLCInteractiveSession::Write(const std::string& data)
 {
+    Log::Comment(std::format(L"Writing to stdin: \"{}\"", wsl::shared::string::MultiByteToWide(EscapeString(data))).c_str());
+
     OVERLAPPED overlapped{};
     wil::unique_event event(wil::EventOptions::ManualReset);
     overlapped.hEvent = event.get();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Fixes race in RunInteractive_TTY by using fixed prompt in the output, removing the need to inspect.
* Extended the new fixed prompt behavior to all other Interactive TTY tests.
* Implements the stdout checks in the NoTTY tests now that the relay bug is fixed.
* Adds logging to the interactive session writing and expecting for improved diagnosability in future test failures.

Here's a sample of the output with the additional logging (its the "Writing to..." and "Expecting..." lines)

<img width="904" height="386" alt="image" src="https://github.com/user-attachments/assets/17119fbd-2e14-46a4-abba-439298b62eac" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran the tests locally many times, verified output is as expected.