### PR TITLE
Don't fail to start a WSLCSession if anonymous volumes are present

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -65,7 +65,7 @@ struct Volume
     std::string Name;
     std::string Driver;
     std::string Mountpoint;
-    std::map<std::string, std::string> Options;
+    std::optional<std::map<std::string, std::string>> Options;
     std::map<std::string, std::string> Labels;
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Volume, Name, Driver, Mountpoint, Options, Labels);

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -265,7 +265,8 @@ void ProcessNamedVolumes(
 
 void ValidateNamedVolumes(
     const std::vector<wsl::windows::common::docker_schema::Mount>& mounts,
-    const std::unordered_map<std::string, std::unique_ptr<WSLCVhdVolumeImpl>>& sessionVolumes)
+    const std::unordered_map<std::string, std::unique_ptr<WSLCVhdVolumeImpl>>& sessionVolumes,
+    const std::unordered_set<std::string>& anonymousVolumes)
 {
     for (const auto& mount : mounts)
     {
@@ -274,7 +275,7 @@ void ValidateNamedVolumes(
             THROW_HR_WITH_USER_ERROR_IF(
                 WSLC_E_VOLUME_NOT_FOUND,
                 wsl::shared::Localization::MessageWslcVolumeNotFound(mount.Name),
-                !sessionVolumes.contains(mount.Name));
+                !sessionVolumes.contains(mount.Name) && !anonymousVolumes.contains(mount.Name));
         }
     }
 }
@@ -1237,6 +1238,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
     WSLCSession& wslcSession,
     WSLCVirtualMachine& virtualMachine,
     const std::unordered_map<std::string, std::unique_ptr<WSLCVhdVolumeImpl>>& sessionVolumes,
+    const std::unordered_set<std::string>& anonymousVolumes,
     std::function<void(const WSLCContainerImpl*)>&& OnDeleted,
     ContainerEventTracker& EventTracker,
     DockerHTTPClient& DockerClient,
@@ -1245,7 +1247,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
     // Extract container name from Docker's names list.
     std::string name = ExtractContainerName(dockerContainer.Names, dockerContainer.Id);
 
-    ValidateNamedVolumes(dockerContainer.Mounts, sessionVolumes);
+    ValidateNamedVolumes(dockerContainer.Mounts, sessionVolumes, anonymousVolumes);
 
     auto labels(dockerContainer.Labels);
     auto metadataIt = labels.find(WSLCContainerMetadataLabel);

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -123,6 +123,7 @@ public:
         WSLCSession& wslcSession,
         WSLCVirtualMachine& virtualMachine,
         const std::unordered_map<std::string, std::unique_ptr<WSLCVhdVolumeImpl>>& sessionVolumes,
+        const std::unordered_set<std::string>& anonymousVolumes,
         std::function<void(const WSLCContainerImpl*)>&& OnDeleted,
         ContainerEventTracker& EventTracker,
         DockerHTTPClient& DockerClient,

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2028,6 +2028,7 @@ void WSLCSession::RecoverExistingContainers()
                 *this,
                 m_virtualMachine.value(),
                 m_volumes,
+                m_anonymousVolumes,
                 std::bind(&WSLCSession::OnContainerDeleted, this, std::placeholders::_1),
                 m_eventTracker.value(),
                 m_dockerClient.value(),
@@ -2061,6 +2062,7 @@ void WSLCSession::RecoverExistingVolumes()
     {
         if (!volume.Labels.contains(WSLCVolumeMetadataLabel))
         {
+            m_anonymousVolumes.insert(volume.Name);
             continue;
         }
 

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -148,6 +148,7 @@ private:
     std::mutex m_volumesLock;
     std::vector<std::unique_ptr<WSLCContainerImpl>> m_containers;
     std::unordered_map<std::string, std::unique_ptr<WSLCVhdVolumeImpl>> m_volumes;
+    std::unordered_set<std::string> m_anonymousVolumes; // TODO: Implement proper anonymous volume support.
     wil::unique_event m_sessionTerminatingEvent{wil::EventOptions::ManualReset};
     wil::srwlock m_lock;
     IORelay m_ioRelay;

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -140,8 +140,10 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Open(
     THROW_HR_IF(E_INVALIDARG, vhdMetadata.HostPath.empty());
     THROW_HR_IF(E_INVALIDARG, vhdMetadata.SizeBytes == 0);
 
-    auto deviceIt = Volume.Options.find("device");
-    THROW_HR_IF(E_INVALIDARG, deviceIt == Volume.Options.end());
+    THROW_HR_IF_MSG(E_INVALIDARG, !Volume.Options.has_value(), "Volume.Options is empty");
+
+    auto deviceIt = Volume.Options->find("device");
+    THROW_HR_IF(E_INVALIDARG, deviceIt == Volume.Options->end());
     THROW_HR_IF(E_INVALIDARG, deviceIt->second.empty());
 
     std::string virtualMachinePath = deviceIt->second;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -6602,6 +6602,7 @@ class WSLCTests
         WSLCContainerLauncher launcher("debian:latest", "test-non-elevated-handles-2", {"echo", "OK"});
         auto container = launcher.Launch(*nonElevatedSession);
         auto initProcess = container.GetInitProcess();
+
         ValidateProcessOutput(initProcess, {{1, "OK\n"}});
     }
 };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -6594,12 +6594,14 @@ class WSLCTests
             LoadTestImage("debian:latest", nonElevatedSession.get());
 
             WSLCContainerLauncher launcher("debian:latest", "test-non-elevated-handles-1", {"echo", "OK"});
-            auto initProcess = launcher.Launch(*nonElevatedSession).GetInitProcess();
+            auto container = launcher.Launch(*nonElevatedSession);
+            auto initProcess = container.GetInitProcess();
             ValidateProcessOutput(initProcess, {{1, "OK\n"}});
         }
 
         WSLCContainerLauncher launcher("debian:latest", "test-non-elevated-handles-2", {"echo", "OK"});
-        auto initProcess = launcher.Launch(*nonElevatedSession).GetInitProcess();
+        auto container = launcher.Launch(*nonElevatedSession);
+        auto initProcess = container.GetInitProcess();
         ValidateProcessOutput(initProcess, {{1, "OK\n"}});
     }
 };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1516,6 +1516,62 @@ class WSLCTests
         VERIFY_ARE_EQUAL(E_ABORT, result.get_future().get());
     }
 
+    TEST_METHOD(AnonymousVolumes)
+    {
+        // TODO: Add more test coverage once anonymous volume are fully supported and switch to using -v instead of building an image.
+
+        WSL2_TEST_ONLY();
+
+        auto contextDir = std::filesystem::current_path() / "build-context";
+        std::filesystem::create_directories(contextDir);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            std::error_code ec;
+            std::filesystem::remove_all(contextDir, ec);
+
+            wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
+            WSLCDeleteImageOptions deleteOptions{.Image = "wslc-test-build:latest", .Flags = WSLCDeleteImageFlagsForce};
+            LOG_IF_FAILED(m_defaultSession->DeleteImage(&deleteOptions, &deletedImages, deletedImages.size_address<ULONG>()));
+        });
+
+        {
+            std::ofstream dockerfile(contextDir / "Dockerfile");
+            dockerfile << "FROM debian:latest\n";
+            dockerfile << "VOLUME /volume\n"; // Use VOLUME to force the creation of an anonymous volume.
+        }
+
+        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, "wslc-test-build:latest"));
+        ExpectImagePresent(*m_defaultSession, "wslc-test-build:latest");
+
+        WSLCContainerLauncher launcher("wslc-test-build:latest", "wslc-test-anonymous-volume", {"test", "-d", "/volume"});
+        auto container = launcher.Launch(*m_defaultSession);
+        auto result = container.GetInitProcess();
+
+        auto containerId = container.Id();
+
+        ValidateProcessOutput(result, {});
+
+        ResetTestSession();
+
+        container.SetDeleteOnClose(false);
+
+        // Manually cleanup the container since the session has been reset.
+        auto containerCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            wil::com_ptr<IWSLCContainer> container;
+            VERIFY_SUCCEEDED(m_defaultSession->OpenContainer(containerId.c_str(), &container));
+
+            VERIFY_SUCCEEDED(container->Delete(WSLCDeleteFlagsForce));
+        });
+
+        // Validate that the session is correctly restarted.
+        wil::unique_cotaskmem_array_ptr<WSLCContainerEntry> containers;
+        wil::unique_cotaskmem_array_ptr<WSLCContainerPortMapping> ports;
+
+        VERIFY_SUCCEEDED(m_defaultSession->ListContainers(&containers, containers.size_address<ULONG>(), &ports, ports.size_address<ULONG>()));
+
+        VERIFY_ARE_EQUAL(containers.size(), 1);
+        VERIFY_ARE_EQUAL(containers[0].Id, containerId);
+    }
+
     TEST_METHOD(TagImage)
     {
         WSL2_TEST_ONLY();
@@ -6538,15 +6594,12 @@ class WSLCTests
             LoadTestImage("debian:latest", nonElevatedSession.get());
 
             WSLCContainerLauncher launcher("debian:latest", "test-non-elevated-handles-1", {"echo", "OK"});
-            auto container = launcher.Launch(*nonElevatedSession);
-            auto initProcess = container.GetInitProcess();
+            auto initProcess = launcher.Launch(*nonElevatedSession).GetInitProcess();
             ValidateProcessOutput(initProcess, {{1, "OK\n"}});
         }
 
         WSLCContainerLauncher launcher("debian:latest", "test-non-elevated-handles-2", {"echo", "OK"});
-        auto container = launcher.Launch(*nonElevatedSession);
-        auto initProcess = container.GetInitProcess();
-
+        auto initProcess = launcher.Launch(*nonElevatedSession).GetInitProcess();
         ValidateProcessOutput(initProcess, {{1, "OK\n"}});
     }
 };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1518,7 +1518,7 @@ class WSLCTests
 
     TEST_METHOD(AnonymousVolumes)
     {
-        // TODO: Add more test coverage once anonymous volume are fully supported and switch to using -v instead of building an image.
+        // TODO: Add more test coverage once anonymous volumes are fully supported and switch to using -v instead of building an image.
 
         WSL2_TEST_ONLY();
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a session creation failure when anonymous volumes are returned by moby. 

This change is only designed as a fix, and is not meant to implement full anonymous volume support

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
