### PR TITLE
Add logic to clean up images created during the tests

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -376,8 +376,7 @@ class WSLCTests
         }
     }
 
-    std::pair<HRESULT, wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation>> DeleteImageNoThrow(
-        const std::string& Image, DWORD Flags)
+    std::pair<HRESULT, wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation>> DeleteImageNoThrow(const std::string& Image, DWORD Flags)
     {
         WSLCDeleteImageOptions options{};
         options.Image = Image.c_str();
@@ -463,9 +462,8 @@ class WSLCTests
         auto validatePull = [&](const std::string& Image, const std::optional<std::string>& ExpectedTag = {}) {
             VERIFY_SUCCEEDED(m_defaultSession->PullImage(Image.c_str(), nullptr, nullptr));
 
-            auto cleanup = wil::scope_exit([&]() {
-                LOG_IF_FAILED(DeleteImageNoThrow(ExpectedTag.value_or(Image), WSLCDeleteImageFlagsForce).first);
-            });
+            auto cleanup = wil::scope_exit(
+                [&]() { LOG_IF_FAILED(DeleteImageNoThrow(ExpectedTag.value_or(Image), WSLCDeleteImageFlagsForce).first); });
 
             if (!ExpectedTag.has_value())
             {
@@ -882,9 +880,8 @@ class WSLCTests
     {
         WSL2_TEST_ONLY();
 
-        auto cleanup = wil::scope_exit([&]() {
-            LOG_IF_FAILED(DeleteImageNoThrow("my-hello-world:test", WSLCDeleteImageFlagsNone).first);
-        });
+        auto cleanup =
+            wil::scope_exit([&]() { LOG_IF_FAILED(DeleteImageNoThrow("my-hello-world:test", WSLCDeleteImageFlagsNone).first); });
 
         std::filesystem::path imageTar = std::filesystem::path{g_testDataPath} / L"HelloWorldExported.tar";
         wil::unique_handle imageTarFileHandle{
@@ -951,8 +948,7 @@ class WSLCTests
 
         // Test delete failed if image in use.
         VERIFY_ARE_EQUAL(
-            HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION),
-            DeleteImageNoThrow("alpine:latest", WSLCDeleteImageFlagsNone).first);
+            HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION), DeleteImageNoThrow("alpine:latest", WSLCDeleteImageFlagsNone).first);
 
         // Force should succeed.
         auto deletedImages = DeleteImage("alpine:latest", WSLCDeleteImageFlagsForce);
@@ -963,9 +959,7 @@ class WSLCTests
         ExpectImagePresent(*m_defaultSession, "alpine:latest", false);
 
         // Test delete failed if image does not exist.
-        VERIFY_ARE_EQUAL(
-            WSLC_E_IMAGE_NOT_FOUND,
-            DeleteImageNoThrow("alpine:latest", WSLCDeleteImageFlagsForce).first);
+        VERIFY_ARE_EQUAL(WSLC_E_IMAGE_NOT_FOUND, DeleteImageNoThrow("alpine:latest", WSLCDeleteImageFlagsForce).first);
     }
 
     void ValidateCOMErrorMessage(const std::optional<std::wstring>& Expected)
@@ -1150,7 +1144,6 @@ class WSLCTests
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
             LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-large:latest", WSLCDeleteImageFlagsForce).first);
-
 
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -376,6 +376,25 @@ class WSLCTests
         }
     }
 
+    std::pair<HRESULT, wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation>> DeleteImageNoThrow(
+        const std::string& Image, DWORD Flags)
+    {
+        WSLCDeleteImageOptions options{};
+        options.Image = Image.c_str();
+        options.Flags = Flags;
+        wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
+        auto hr = m_defaultSession->DeleteImage(&options, deletedImages.addressof(), deletedImages.size_address<ULONG>());
+        return {hr, std::move(deletedImages)};
+    }
+
+    wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> DeleteImage(const std::string& Image, DWORD Flags)
+    {
+        auto [hr, deletedImages] = DeleteImageNoThrow(Image, Flags);
+        VERIFY_SUCCEEDED(hr);
+
+        return std::move(deletedImages);
+    }
+
     TEST_METHOD(PullImage)
     {
         WSL2_TEST_ONLY();
@@ -445,10 +464,7 @@ class WSLCTests
             VERIFY_SUCCEEDED(m_defaultSession->PullImage(Image.c_str(), nullptr, nullptr));
 
             auto cleanup = wil::scope_exit([&]() {
-                WSLCDeleteImageOptions options{.Flags = WSLCDeleteImageFlagsForce};
-                options.Image = ExpectedTag.has_value() ? ExpectedTag->c_str() : Image.c_str();
-                wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-                LOG_IF_FAILED(m_defaultSession->DeleteImage(&options, &deletedImages, deletedImages.size_address<ULONG>()));
+                LOG_IF_FAILED(DeleteImageNoThrow(ExpectedTag.value_or(Image), WSLCDeleteImageFlagsForce).first);
             });
 
             if (!ExpectedTag.has_value())
@@ -527,12 +543,8 @@ class WSLCTests
         VERIFY_SUCCEEDED(m_defaultSession->TagImage(&tagOptions));
 
         auto cleanup = wil::scope_exit([&]() {
-            WSLCDeleteImageOptions options{.Image = "debian:test-tag1", .Flags = WSLCDeleteImageFlagsNone};
-            wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-            LOG_IF_FAILED(m_defaultSession->DeleteImage(&options, &deletedImages, deletedImages.size_address<ULONG>()));
-
-            options.Image = "debian:test-tag2";
-            LOG_IF_FAILED(m_defaultSession->DeleteImage(&options, &deletedImages, deletedImages.size_address<ULONG>()));
+            LOG_IF_FAILED(DeleteImageNoThrow("debian:test-tag1", WSLCDeleteImageFlagsNone).first);
+            LOG_IF_FAILED(DeleteImageNoThrow("debian:test-tag2", WSLCDeleteImageFlagsNone).first);
         });
 
         LogInfo("Test: Basic listing with nullptr options");
@@ -756,9 +768,7 @@ class WSLCTests
 
             auto alpineCleanup = wil::scope_exit([&]() {
                 RunCommand(m_defaultSession.get(), {"/usr/bin/docker", "image", "prune", "-f"});
-                WSLCDeleteImageOptions options{.Image = "alpine:latest", .Flags = WSLCDeleteImageFlagsNone};
-                wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-                LOG_IF_FAILED(m_defaultSession->DeleteImage(&options, &deletedImages, deletedImages.size_address<ULONG>()));
+                LOG_IF_FAILED(DeleteImageNoThrow("alpine:latest", WSLCDeleteImageFlagsNone).first);
             });
 
             // List only dangling images
@@ -872,6 +882,10 @@ class WSLCTests
     {
         WSL2_TEST_ONLY();
 
+        auto cleanup = wil::scope_exit([&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("my-hello-world:test", WSLCDeleteImageFlagsNone).first);
+        });
+
         std::filesystem::path imageTar = std::filesystem::path{g_testDataPath} / L"HelloWorldExported.tar";
         wil::unique_handle imageTarFileHandle{
             CreateFileW(imageTar.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
@@ -936,18 +950,12 @@ class WSLCTests
         VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
 
         // Test delete failed if image in use.
-        WSLCDeleteImageOptions options{};
-        options.Image = "alpine:latest";
-        options.Flags = WSLCDeleteImageFlagsNone;
-        wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-
         VERIFY_ARE_EQUAL(
             HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION),
-            m_defaultSession->DeleteImage(&options, deletedImages.addressof(), deletedImages.size_address<ULONG>()));
+            DeleteImageNoThrow("alpine:latest", WSLCDeleteImageFlagsNone).first);
 
         // Force should succeed.
-        options.Flags = WSLCDeleteImageFlagsForce;
-        VERIFY_SUCCEEDED(m_defaultSession->DeleteImage(&options, deletedImages.addressof(), deletedImages.size_address<ULONG>()));
+        auto deletedImages = DeleteImage("alpine:latest", WSLCDeleteImageFlagsForce);
         VERIFY_IS_TRUE(deletedImages.size() > 0);
         VERIFY_IS_TRUE(std::strlen(deletedImages[0].Image) > 0);
 
@@ -956,7 +964,8 @@ class WSLCTests
 
         // Test delete failed if image does not exist.
         VERIFY_ARE_EQUAL(
-            WSLC_E_IMAGE_NOT_FOUND, m_defaultSession->DeleteImage(&options, deletedImages.addressof(), deletedImages.size_address<ULONG>()));
+            WSLC_E_IMAGE_NOT_FOUND,
+            DeleteImageNoThrow("alpine:latest", WSLCDeleteImageFlagsForce).first);
     }
 
     void ValidateCOMErrorMessage(const std::optional<std::wstring>& Expected)
@@ -1018,6 +1027,8 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build:latest", WSLCDeleteImageFlagsForce).first);
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1046,6 +1057,8 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-file";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-context:latest", WSLCDeleteImageFlagsForce).first);
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1082,6 +1095,8 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-many";
         std::filesystem::create_directories(contextDir / "files");
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-many:latest", WSLCDeleteImageFlagsForce).first);
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1134,6 +1149,9 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-large";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-large:latest", WSLCDeleteImageFlagsForce).first);
+
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1185,6 +1203,8 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-multistage";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-multistage:latest", WSLCDeleteImageFlagsForce).first);
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1224,6 +1244,8 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-dockerignore";
         std::filesystem::create_directories(contextDir / "temp");
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-dockerignore:latest", WSLCDeleteImageFlagsForce).first);
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1294,6 +1316,8 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-failure-output";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-args:latest", WSLCDeleteImageFlagsForce).first);
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1347,6 +1371,8 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-stdin";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-stdin:latest", WSLCDeleteImageFlagsForce).first);
+
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
         });
@@ -1387,9 +1413,7 @@ class WSLCTests
         auto contextDir = std::filesystem::current_path() / "build-context-buildargs";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-            WSLCDeleteImageOptions deleteOptions{.Image = "wslc-test-build-args:latest", .Flags = WSLCDeleteImageFlagsForce};
-            wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-            LOG_IF_FAILED(m_defaultSession->DeleteImage(&deleteOptions, &deletedImages, deletedImages.size_address<ULONG>()));
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build-args:latest", WSLCDeleteImageFlagsForce).first);
 
             std::error_code ec;
             std::filesystem::remove_all(contextDir, ec);
@@ -1423,11 +1447,9 @@ class WSLCTests
         std::filesystem::create_directories(contextDir);
         LPCSTR tags[] = {"wslc-test-multitag:v1", "wslc-test-multitag:v2"};
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-            wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
             for (auto* tag : tags)
             {
-                WSLCDeleteImageOptions deleteOptions{.Image = tag, .Flags = WSLCDeleteImageFlagsForce};
-                LOG_IF_FAILED(m_defaultSession->DeleteImage(&deleteOptions, &deletedImages, deletedImages.size_address<ULONG>()));
+                LOG_IF_FAILED(DeleteImageNoThrow(tag, WSLCDeleteImageFlagsForce).first);
             }
 
             std::error_code ec;
@@ -1516,6 +1538,60 @@ class WSLCTests
         VERIFY_ARE_EQUAL(E_ABORT, result.get_future().get());
     }
 
+    TEST_METHOD(AnonymousVolumes)
+    {
+        // TODO: Add more test coverage once anonymous volumes are fully supported and switch to using -v instead of building an image.
+
+        WSL2_TEST_ONLY();
+
+        auto contextDir = std::filesystem::current_path() / "build-context";
+        std::filesystem::create_directories(contextDir);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            std::error_code ec;
+            std::filesystem::remove_all(contextDir, ec);
+
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-build:latest", WSLCDeleteImageFlagsForce).first);
+        });
+
+        {
+            std::ofstream dockerfile(contextDir / "Dockerfile");
+            dockerfile << "FROM debian:latest\n";
+            dockerfile << "VOLUME /volume\n"; // Use VOLUME to force the creation of an anonymous volume.
+        }
+
+        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, "wslc-test-build:latest"));
+        ExpectImagePresent(*m_defaultSession, "wslc-test-build:latest");
+
+        WSLCContainerLauncher launcher("wslc-test-build:latest", "wslc-test-anonymous-volume", {"test", "-d", "/volume"});
+        auto container = launcher.Launch(*m_defaultSession);
+        auto result = container.GetInitProcess();
+
+        auto containerId = container.Id();
+
+        ValidateProcessOutput(result, {});
+
+        ResetTestSession();
+
+        container.SetDeleteOnClose(false);
+
+        // Manually cleanup the container since the session has been reset.
+        auto containerCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            wil::com_ptr<IWSLCContainer> container;
+            VERIFY_SUCCEEDED(m_defaultSession->OpenContainer(containerId.c_str(), &container));
+
+            VERIFY_SUCCEEDED(container->Delete(WSLCDeleteFlagsForce));
+        });
+
+        // Validate that the session is correctly restarted.
+        wil::unique_cotaskmem_array_ptr<WSLCContainerEntry> containers;
+        wil::unique_cotaskmem_array_ptr<WSLCContainerPortMapping> ports;
+
+        VERIFY_SUCCEEDED(m_defaultSession->ListContainers(&containers, containers.size_address<ULONG>(), &ports, ports.size_address<ULONG>()));
+
+        VERIFY_ARE_EQUAL(containers.size(), 1);
+        VERIFY_ARE_EQUAL(containers[0].Id, containerId);
+    }
+
     TEST_METHOD(TagImage)
     {
         WSL2_TEST_ONLY();
@@ -1534,13 +1610,7 @@ class WSLCTests
             ExpectImagePresent(*m_defaultSession, "debian:latest");
 
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-                WSLCDeleteImageOptions deleteOptions{};
-                deleteOptions.Image = "debian:test-tag";
-                deleteOptions.Flags = WSLCDeleteImageFlagsNoPrune;
-
-                wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-                VERIFY_SUCCEEDED(
-                    m_defaultSession->DeleteImage(&deleteOptions, deletedImages.addressof(), deletedImages.size_address<ULONG>()));
+                DeleteImage("debian:test-tag", WSLCDeleteImageFlagsNoPrune);
 
                 ExpectImagePresent(*m_defaultSession, "debian:test-tag", false);
                 ExpectImagePresent(*m_defaultSession, "debian:latest");
@@ -1580,13 +1650,7 @@ class WSLCTests
             ExpectImagePresent(*m_defaultSession, "debian:latest");
 
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-                WSLCDeleteImageOptions deleteOptions{};
-                deleteOptions.Image = "myrepo/myimage:v1.0.0";
-                deleteOptions.Flags = WSLCDeleteImageFlagsNoPrune;
-
-                wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-                VERIFY_SUCCEEDED(
-                    m_defaultSession->DeleteImage(&deleteOptions, deletedImages.addressof(), deletedImages.size_address<ULONG>()));
+                DeleteImage("myrepo/myimage:v1.0.0", WSLCDeleteImageFlagsNoPrune);
 
                 ExpectImagePresent(*m_defaultSession, "myrepo/myimage:v1.0.0", false);
             });
@@ -1601,13 +1665,7 @@ class WSLCTests
             ExpectImagePresent(*m_defaultSession, "debian:latest");
 
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-                WSLCDeleteImageOptions deleteOptions{};
-                deleteOptions.Image = "debian:test-by-id";
-                deleteOptions.Flags = WSLCDeleteImageFlagsNoPrune;
-
-                wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-                VERIFY_SUCCEEDED(
-                    m_defaultSession->DeleteImage(&deleteOptions, deletedImages.addressof(), deletedImages.size_address<ULONG>()));
+                DeleteImage("debian:test-by-id", WSLCDeleteImageFlagsNoPrune);
 
                 ExpectImagePresent(*m_defaultSession, "debian:test-by-id", false);
             });
@@ -1634,13 +1692,7 @@ class WSLCTests
         // Positive test: Overwrite existing tag.
         {
             auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-                WSLCDeleteImageOptions deleteOptions{};
-                deleteOptions.Image = "test:duplicate-tag";
-                deleteOptions.Flags = WSLCDeleteImageFlagsNoPrune;
-
-                wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-                VERIFY_SUCCEEDED(
-                    m_defaultSession->DeleteImage(&deleteOptions, deletedImages.addressof(), deletedImages.size_address<ULONG>()));
+                DeleteImage("test:duplicate-tag", WSLCDeleteImageFlagsNoPrune);
 
                 ExpectImagePresent(*m_defaultSession, "test:duplicate-tag", false);
             });
@@ -2034,9 +2086,7 @@ class WSLCTests
                 VERIFY_IS_TRUE(GetFileSizeEx(containerTarFileHandle.get(), &fileSize));
 
                 auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-                    WSLCDeleteImageOptions options{.Image = "test-imported-container:latest", .Flags = WSLCDeleteImageFlagsNone};
-                    wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
-                    LOG_IF_FAILED(m_defaultSession->DeleteImage(&options, &deletedImages, deletedImages.size_address<ULONG>()));
+                    LOG_IF_FAILED(DeleteImageNoThrow("test-imported-container:latest", WSLCDeleteImageFlagsNone).first);
                 });
 
                 VERIFY_SUCCEEDED(m_defaultSession->ImportImage(

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -491,7 +491,7 @@ class WslcSdkTests
             WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr);
 
             auto cleanup =
-                wil::scope_exit([this]() { WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr); });
+                wil::scope_exit([this]() { LOG_IF_FAILED(WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr)); });
 
             wil::unique_handle imageTarFileHandle{CreateFileW(
                 exportedImageTar.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
@@ -512,7 +512,7 @@ class WslcSdkTests
 
             WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr);
 
-            auto cleanup = wil::scope_exit([this]() { WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr); });
+            auto cleanup = wil::scope_exit([this]() { LOG_IF_FAILED(WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr)); });
 
             VERIFY_SUCCEEDED(WslcImportSessionImageFromFile(m_defaultSession, c_pathImportedImageName, exportedImageTar.c_str(), nullptr, nullptr));
 

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -490,6 +490,9 @@ class WslcSdkTests
         {
             WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr);
 
+            auto cleanup =
+                wil::scope_exit([this]() { WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr); });
+
             wil::unique_handle imageTarFileHandle{CreateFileW(
                 exportedImageTar.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
             VERIFY_IS_FALSE(INVALID_HANDLE_VALUE == imageTarFileHandle.get());
@@ -506,7 +509,10 @@ class WslcSdkTests
 
         // Positive: import an exported image tar via path and verify the image can be run.
         {
+
             WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr);
+
+            auto cleanup = wil::scope_exit([this]() { WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr); });
 
             VERIFY_SUCCEEDED(WslcImportSessionImageFromFile(m_defaultSession, c_pathImportedImageName, exportedImageTar.c_str(), nullptr, nullptr));
 

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -490,8 +490,8 @@ class WslcSdkTests
         {
             WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr);
 
-            auto cleanup =
-                wil::scope_exit([this]() { LOG_IF_FAILED(WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr)); });
+            auto cleanup = wil::scope_exit(
+                [this]() { LOG_IF_FAILED(WslcDeleteSessionImage(m_defaultSession, c_handleImportedImageName, nullptr)); });
 
             wil::unique_handle imageTarFileHandle{CreateFileW(
                 exportedImageTar.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
@@ -512,7 +512,8 @@ class WslcSdkTests
 
             WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr);
 
-            auto cleanup = wil::scope_exit([this]() { LOG_IF_FAILED(WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr)); });
+            auto cleanup = wil::scope_exit(
+                [this]() { LOG_IF_FAILED(WslcDeleteSessionImage(m_defaultSession, c_pathImportedImageName, nullptr)); });
 
             VERIFY_SUCCEEDED(WslcImportSessionImageFromFile(m_defaultSession, c_pathImportedImageName, exportedImageTar.c_str(), nullptr, nullptr));
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a test failure that can happen when `-f` is used which is caused by test images being leaked during testpasses. 

Some untagged images are still leaked, but we can fix that once we have `image prune` support 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
