### PR TITLE
Allow small timestamp difference in ContainerRecoveryFromStorage test

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5182,7 +5182,8 @@ class WSLCTests
             wil::unique_cotaskmem_array_ptr<WSLCContainerPortMapping> ports;
             VERIFY_SUCCEEDED(session->ListContainers(&containers, containers.size_address<ULONG>(), &ports, ports.size_address<ULONG>()));
             VERIFY_ARE_EQUAL(containers.size(), 1);
-            VERIFY_ARE_EQUAL(containers[0].StateChangedAt, originalStateChangedAt);
+            VERIFY_IS_TRUE(containers[0].StateChangedAt <= originalStateChangedAt + 60);
+            VERIFY_IS_TRUE(containers[0].StateChangedAt + 60 >= originalStateChangedAt);
             VERIFY_ARE_EQUAL(containers[0].CreatedAt, originalCreatedAt);
 
             VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5182,8 +5182,12 @@ class WSLCTests
             wil::unique_cotaskmem_array_ptr<WSLCContainerPortMapping> ports;
             VERIFY_SUCCEEDED(session->ListContainers(&containers, containers.size_address<ULONG>(), &ports, ports.size_address<ULONG>()));
             VERIFY_ARE_EQUAL(containers.size(), 1);
-            VERIFY_IS_TRUE(containers[0].StateChangedAt <= originalStateChangedAt + 60);
-            VERIFY_IS_TRUE(containers[0].StateChangedAt + 60 >= originalStateChangedAt);
+
+            // StateChangedAt may differ by ~1s between live (event time) and recovery (FinishedAt).
+            auto stateChangedAtDiff = (containers[0].StateChangedAt > originalStateChangedAt)
+                                          ? (containers[0].StateChangedAt - originalStateChangedAt)
+                                          : (originalStateChangedAt - containers[0].StateChangedAt);
+            VERIFY_IS_TRUE(stateChangedAtDiff <= 60);
             VERIFY_ARE_EQUAL(containers[0].CreatedAt, originalCreatedAt);
 
             VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The ContainerRecoveryFromStorage test was failing because the live and recovery paths use different Docker timestamp sources (event.time vs InspectContainer().State.FinishedAt), which can differ by about a second. Updated the assertion to allow StateChangedAt to be within 60 seconds instead of requiring an exact match.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
