### PR TITLE
Fix placeholder CLI command descriptions

### DIFF
--- a/src/windows/wslc/commands/ContainerCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCommand.cpp
@@ -42,12 +42,12 @@ std::vector<Argument> ContainerCommand::GetArguments() const
 
 std::wstring ContainerCommand::ShortDescription() const
 {
-    return {L"Container command."};
+    return {L"Manage containers."};
 }
 
 std::wstring ContainerCommand::LongDescription() const
 {
-    return {L"Container command for demonstration purposes."};
+    return {L"Manage the lifecycle of WSL containers, including creating, starting, stopping, and removing them."};
 }
 
 void ContainerCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImageCommand.cpp
+++ b/src/windows/wslc/commands/ImageCommand.cpp
@@ -38,12 +38,12 @@ std::vector<Argument> ImageCommand::GetArguments() const
 
 std::wstring ImageCommand::ShortDescription() const
 {
-    return {L"Image command."};
+    return {L"Manage images."};
 }
 
 std::wstring ImageCommand::LongDescription() const
 {
-    return {L"Image command."};
+    return {L"Manage container images, including building, pulling, listing, and removing them."};
 }
 
 void ImageCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/SessionCommand.cpp
+++ b/src/windows/wslc/commands/SessionCommand.cpp
@@ -35,12 +35,12 @@ std::vector<Argument> SessionCommand::GetArguments() const
 
 std::wstring SessionCommand::ShortDescription() const
 {
-    return {L"Session command."};
+    return {L"Manage sessions."};
 }
 
 std::wstring SessionCommand::LongDescription() const
 {
-    return {L"Session command."};
+    return {L"Manage WSL container sessions, including listing active sessions and launching interactive shells."};
 }
 
 void SessionCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
@@ -58,7 +58,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Container command for demonstration purposes.\r\n\r\n";
+        return L"Manage the lifecycle of WSL containers, including creating, starting, stopping, and removing them.\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -413,9 +413,9 @@ private:
     {
         std::wstringstream commands;
         commands << L"The following commands are available:\r\n"
-                 << L"  container  Container command.\r\n"
-                 << L"  image      Image command.\r\n"
-                 << L"  session    Session command.\r\n"
+                 << L"  container  Manage containers.\r\n"
+                 << L"  image      Manage images.\r\n"
+                 << L"  session    Manage sessions.\r\n"
                  << L"  settings   Open the settings file in the default editor.\r\n"
                  << L"  attach     Attach to a container.\r\n"
                  << L"  build      Build an image from a Dockerfile.\r\n"

--- a/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
@@ -57,7 +57,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Image command.\r\n\r\n";
+        return L"Manage container images, including building, pulling, listing, and removing them.\r\n\r\n";
     }
 
     std::wstring GetUsage() const


### PR DESCRIPTION
Replace generic/demo placeholder descriptions with proper user-facing text:
- **ContainerCommand**: 'Container command for demonstration purposes.' → 'Manage the lifecycle of WSL containers...'
- **ImageCommand**: 'Image command.' → 'Manage container images, including building, pulling, listing, and removing them.'
- **SessionCommand**: 'Session command.' → 'Manage WSL container sessions, including listing active sessions and launching interactive shells.'