### PR TITLE
Use THROW_HR_WITH_USER_ERROR for TTY console check

### DIFF
--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -68,8 +68,7 @@ static void SetContainerTTYOptions(WSLCProcessOptions& options)
         }
     }
 
-    PrintMessage(L"error: --tty requires stdin or stdout to be a console", stderr);
-    THROW_HR(E_FAIL);
+    THROW_HR_WITH_USER_ERROR(E_FAIL, L"--tty requires stdin or stdout to be a console");
 }
 
 static void SetContainerArguments(WSLCProcessOptions& options, std::vector<const char*>& argsStorage)


### PR DESCRIPTION
Replace manual PrintMessage + THROW_HR(E_FAIL) with the standard THROW_HR_WITH_USER_ERROR pattern used throughout the codebase.

This ensures the error message is properly captured by the ExecutionContext error collection system rather than being printed directly to stderr with inconsistent formatting.
