### PR TITLE
Validate container path is absolute in VolumeMount::Parse

### DIFF
--- a/src/windows/wslc/services/ContainerModel.cpp
+++ b/src/windows/wslc/services/ContainerModel.cpp
@@ -195,6 +195,13 @@ VolumeMount VolumeMount::Parse(const std::wstring& value)
             std::format(L"Invalid volume specifications: '{}'. Host path cannot be empty. Expected format: <host path>:<container path>[:mode]", value));
     }
 
+    if (!vm.m_containerPath.empty() && vm.m_containerPath[0] != '/')
+    {
+        THROW_HR_WITH_USER_ERROR(
+            E_INVALIDARG,
+            std::format(L"Invalid volume specifications: '{}'. Container path must be an absolute path (starting with '/').", value));
+    }
+
     return vm;
 }
 

--- a/src/windows/wslc/services/ContainerModel.cpp
+++ b/src/windows/wslc/services/ContainerModel.cpp
@@ -195,11 +195,18 @@ VolumeMount VolumeMount::Parse(const std::wstring& value)
             std::format(L"Invalid volume specifications: '{}'. Host path cannot be empty. Expected format: <host path>:<container path>[:mode]", value));
     }
 
+    if (!std::filesystem::path(vm.m_hostPath).is_absolute())
+    {
+        THROW_HR_WITH_USER_ERROR(
+            E_INVALIDARG,
+            std::format(L"Invalid volume specifications: '{}'. Host path must be an absolute path. Expected format: <host path>:<container path>[:mode]", value));
+    }
+
     if (!vm.m_containerPath.empty() && vm.m_containerPath[0] != '/')
     {
         THROW_HR_WITH_USER_ERROR(
             E_INVALIDARG,
-            std::format(L"Invalid volume specifications: '{}'. Container path must be an absolute path (starting with '/').", value));
+            std::format(L"Invalid volume specifications: '{}'. Container path must be an absolute path (starting with '/'). Expected format: <host path>:<container path>[:mode]", value));
     }
 
     return vm;

--- a/src/windows/wslc/services/ContainerModel.cpp
+++ b/src/windows/wslc/services/ContainerModel.cpp
@@ -195,13 +195,6 @@ VolumeMount VolumeMount::Parse(const std::wstring& value)
             std::format(L"Invalid volume specifications: '{}'. Host path cannot be empty. Expected format: <host path>:<container path>[:mode]", value));
     }
 
-    if (!std::filesystem::path(vm.m_hostPath).is_absolute())
-    {
-        THROW_HR_WITH_USER_ERROR(
-            E_INVALIDARG,
-            std::format(L"Invalid volume specifications: '{}'. Host path must be an absolute path. Expected format: <host path>:<container path>[:mode]", value));
-    }
-
     if (!vm.m_containerPath.empty() && vm.m_containerPath[0] != '/')
     {
         THROW_HR_WITH_USER_ERROR(

--- a/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
+++ b/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
@@ -35,13 +35,10 @@ class WSLCVolumeMountUnitTests
             {LR"(C:\host Path:/container Path:rw)", LR"(C:\host Path)", R"(/container Path)", false},
             {LR"(C:\hostPath::ro)", LR"(C:\hostPath)", R"()", true},
             {LR"(C:\hostPath:)", LR"(C:\hostPath)", R"()", false},
-            {LR"(C:\hostPath:ro)", LR"(C)", R"(\hostPath)", true},
             {LR"(C:\hostPath::rw)", LR"(C:\hostPath)", R"()", false},
             {LR"(C:\hostPath:/containerPath:invalid_mode)", LR"(C:\hostPath:/containerPath)", R"(invalid_mode)", false},
             {LR"(C:\hostPath:/containerPath:ro:extra)", LR"(C:\hostPath:/containerPath:ro)", R"(extra)", false},
             {LR"(C:\hostPath:/containerPath:)", LR"(C:\hostPath:/containerPath)", R"()", false},
-            {LR"(C:\hostPath)", LR"(C)", R"(\hostPath)", false},
-            {LR"(C:/hostPath)", LR"(C)", R"(/hostPath)", false},
             {LR"(::)", LR"(:)", R"()", false},
         };
 
@@ -66,6 +63,21 @@ class WSLCVolumeMountUnitTests
         for (const auto& value : emptyHostPathCases)
         {
             WEX::Logging::Log::Comment(std::format(L"Testing invalid volume argument: '{}'", value).c_str());
+            VERIFY_THROWS(VolumeMount::Parse(value), wil::ResultException);
+        }
+    }
+
+    TEST_METHOD(VolumeMount_Parse_InvalidContainerPath)
+    {
+        // Container paths must be absolute Linux paths (starting with '/')
+        std::vector<std::wstring> invalidContainerPathCases = {
+            LR"(C:\hostPath:ro)", // drive colon misinterpreted as separator, container = \hostPath
+            LR"(C:\hostPath)",    // drive colon misinterpreted as separator, container = \hostPath
+        };
+
+        for (const auto& value : invalidContainerPathCases)
+        {
+            WEX::Logging::Log::Comment(std::format(L"Testing invalid container path: '{}'", value).c_str());
             VERIFY_THROWS(VolumeMount::Parse(value), wil::ResultException);
         }
     }

--- a/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
+++ b/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
@@ -36,9 +36,10 @@ class WSLCVolumeMountUnitTests
             {LR"(C:\hostPath::ro)", LR"(C:\hostPath)", R"()", true},
             {LR"(C:\hostPath:)", LR"(C:\hostPath)", R"()", false},
             {LR"(C:\hostPath::rw)", LR"(C:\hostPath)", R"()", false},
-            {LR"(C:\hostPath:/containerPath:invalid_mode)", LR"(C:\hostPath:/containerPath)", R"(invalid_mode)", false},
-            {LR"(C:\hostPath:/containerPath:ro:extra)", LR"(C:\hostPath:/containerPath:ro)", R"(extra)", false},
             {LR"(C:\hostPath:/containerPath:)", LR"(C:\hostPath:/containerPath)", R"()", false},
+            {LR"(C:/hostPath:ro)", LR"(C)", R"(/hostPath)", true},
+            {LR"(C:/hostPath)", LR"(C)", R"(/hostPath)", false},
+            {LR"(::)", LR"(:)", R"()", false},
         };
 
         for (const auto& arg : validVolumeArgs)
@@ -66,16 +67,15 @@ class WSLCVolumeMountUnitTests
         }
     }
 
-    TEST_METHOD(VolumeMount_Parse_InvalidPaths)
+    TEST_METHOD(VolumeMount_Parse_InvalidContainerPath)
     {
         // Drive colon gets misinterpreted as the host:container separator,
-        // producing a non-absolute host path. Now caught by host path validation.
+        // producing a non-absolute container path. Caught by container path validation.
         std::vector<std::wstring> invalidPathCases = {
-            LR"(C:\hostPath:ro)", // host='C' (not absolute), container=\hostPath
-            LR"(C:\hostPath)",    // host='C' (not absolute), container=\hostPath
-            LR"(C:/hostPath:ro)", // host='C' (not absolute), container=/hostPath
-            LR"(C:/hostPath)",    // host='C' (not absolute), container=/hostPath
-            LR"(::)",             // host=':' (not absolute)
+            LR"(C:\hostPath:ro)",                          // host='C', container=\hostPath (not absolute)
+            LR"(C:\hostPath)",                             // host='C', container=\hostPath (not absolute)
+            LR"(C:\hostPath:/containerPath:invalid_mode)", // container=invalid_mode (not absolute)
+            LR"(C:\hostPath:/containerPath:ro:extra)",     // container=extra (not absolute)
         };
 
         for (const auto& value : invalidPathCases)

--- a/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
+++ b/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
@@ -39,7 +39,6 @@ class WSLCVolumeMountUnitTests
             {LR"(C:\hostPath:/containerPath:invalid_mode)", LR"(C:\hostPath:/containerPath)", R"(invalid_mode)", false},
             {LR"(C:\hostPath:/containerPath:ro:extra)", LR"(C:\hostPath:/containerPath:ro)", R"(extra)", false},
             {LR"(C:\hostPath:/containerPath:)", LR"(C:\hostPath:/containerPath)", R"()", false},
-            {LR"(::)", LR"(:)", R"()", false},
         };
 
         for (const auto& arg : validVolumeArgs)
@@ -67,17 +66,21 @@ class WSLCVolumeMountUnitTests
         }
     }
 
-    TEST_METHOD(VolumeMount_Parse_InvalidContainerPath)
+    TEST_METHOD(VolumeMount_Parse_InvalidPaths)
     {
-        // Container paths must be absolute Linux paths (starting with '/')
-        std::vector<std::wstring> invalidContainerPathCases = {
-            LR"(C:\hostPath:ro)", // drive colon misinterpreted as separator, container = \hostPath
-            LR"(C:\hostPath)",    // drive colon misinterpreted as separator, container = \hostPath
+        // Drive colon gets misinterpreted as the host:container separator,
+        // producing a non-absolute host path. Now caught by host path validation.
+        std::vector<std::wstring> invalidPathCases = {
+            LR"(C:\hostPath:ro)", // host='C' (not absolute), container=\hostPath
+            LR"(C:\hostPath)",    // host='C' (not absolute), container=\hostPath
+            LR"(C:/hostPath:ro)", // host='C' (not absolute), container=/hostPath
+            LR"(C:/hostPath)",    // host='C' (not absolute), container=/hostPath
+            LR"(::)",             // host=':' (not absolute)
         };
 
-        for (const auto& value : invalidContainerPathCases)
+        for (const auto& value : invalidPathCases)
         {
-            WEX::Logging::Log::Comment(std::format(L"Testing invalid container path: '{}'", value).c_str());
+            WEX::Logging::Log::Comment(std::format(L"Testing invalid path: '{}'", value).c_str());
             VERIFY_THROWS(VolumeMount::Parse(value), wil::ResultException);
         }
     }

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -289,7 +289,7 @@ class WSLCE2EContainerCreateTests
         {
             auto result =
                 RunWslc(std::format(L"container run --name {} --volume C:\\hostPath:ro {}", WslcContainerName, AlpineImage.NameAndTag()));
-            result.Verify({.Stderr = L"The parameter is incorrect. \r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
+            result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:ro'. Container path must be an absolute path (starting with '/'). Expected format: <host path>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
@@ -309,14 +309,14 @@ class WSLCE2EContainerCreateTests
         {
             auto result = RunWslc(std::format(
                 L"container run --name {} --volume C:\\hostPath:/containerPath:invalid_mode {}", WslcContainerName, AlpineImage.NameAndTag()));
-            result.Verify({.Stderr = L"Unspecified error \r\nError code: E_FAIL\r\n", .ExitCode = 1});
+            result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:invalid_mode'. Container path must be an absolute path (starting with '/'). Expected format: <host path>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
         {
             auto result = RunWslc(std::format(
                 L"container run --name {} --volume C:\\hostPath:/containerPath:ro:extra {}", WslcContainerName, AlpineImage.NameAndTag()));
-            result.Verify({.Stderr = L"Unspecified error \r\nError code: E_FAIL\r\n", .ExitCode = 1});
+            result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:ro:extra'. Container path must be an absolute path (starting with '/'). Expected format: <host path>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
@@ -338,7 +338,7 @@ class WSLCE2EContainerCreateTests
         {
             auto result = RunWslc(
                 std::format(L"container run --name {} --volume \"C:\\hostPath\" {}", WslcContainerName, AlpineImage.NameAndTag()));
-            result.Verify({.Stderr = L"The parameter is incorrect. \r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
+            result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath'. Container path must be an absolute path (starting with '/'). Expected format: <host path>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 


### PR DESCRIPTION
Add validation that non-empty container paths must start with '/' since they are Linux paths inside the container. This catches cases where Windows drive letter colons (e.g. C:\path) get misinterpreted as the host:container separator, producing invalid container paths like '\hostPath' instead of '/containerPath'.

Previously, 'C:\hostPath:ro' would silently parse as host='C', container='\hostPath', mode=ro - now it throws a clear error.

Updated tests to reflect the new validation and moved previously 'valid' but semantically incorrect cases to a new VolumeMount_Parse_InvalidContainerPath test.
