### PR TITLE
Localize all user-facing wslc.exe CLI strings

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2168,7 +2168,7 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   </data>
   <data name="WSLCCLI_ContainerListLongDesc" xml:space="preserve">
     <value>Lists containers. By default, only running containers are shown; use --all to include all containers.</value>
-    <comment>{Locked="--all"}Command line arguments should not be translated</comment>
+    <comment>{Locked="--all "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_ContainerLogsDesc" xml:space="preserve">
     <value>View container logs.</value>
@@ -2187,7 +2187,7 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   </data>
   <data name="WSLCCLI_ContainerRunLongDesc" xml:space="preserve">
     <value>Runs a container. By default, the container is started in the background; use --detach to run in the foreground.</value>
-    <comment>{Locked="--detach"}Command line arguments should not be translated</comment>
+    <comment>{Locked="--detach "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_ContainerStartDesc" xml:space="preserve">
     <value>Start a container.</value>
@@ -2329,7 +2329,7 @@ On first run, creates the file with all settings commented out at their defaults
     <value>Follow log output</value>
   </data>
   <data name="WSLCCLI_FormatArgDescription" xml:space="preserve">
-    <value>Output formatting (json or table) (Default:table)</value>
+    <value>Output formatting (json or table) (Default: table)</value>
     <comment>{Locked="json"}{Locked="table"}Command line arguments should not be translated</comment>
   </data>
   <data name="WSLCCLI_ForwardArgsDescription" xml:space="preserve">
@@ -2373,7 +2373,7 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_SignalArgDescription" xml:space="preserve">
     <value>Signal to send (default: {})</value>
-    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_TagArgDescription" xml:space="preserve">
     <value>Tag for the built image</value>
@@ -2454,22 +2454,22 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_InvalidSignalError" xml:space="preserve">
     <value>Invalid {} value: {} is not a recognized signal name or number (Example: SIGKILL, kill, or 9).</value>
-    <comment>{FixedPlaceholder="{}"}{Locked="SIGKILL"}{Locked="kill"}Command line arguments should not be translated</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_SignalOutOfRangeError" xml:space="preserve">
     <value>Invalid {} value: {} is out of valid range ({}-{}).</value>
-    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_ImageNotFoundPulling" xml:space="preserve">
     <value>Image '{}' not found, pulling</value>
-    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_EnvKeyEmptyError" xml:space="preserve">
     <value>Environment variable key cannot be empty</value>
   </data>
   <data name="WSLCCLI_EnvKeyWhitespaceError" xml:space="preserve">
     <value>Environment variable key '{}' cannot contain whitespace</value>
-    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_ImageLoadNoInputError" xml:space="preserve">
     <value>Requested load but no input provided.</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2118,4 +2118,360 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>No Containerfile or Dockerfile found in '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="WSLCCLI_RootCommandDesc" xml:space="preserve">
+    <value>WSLC is the Windows Subsystem for Linux Container CLI tool.</value>
+    <comment>{Locked="WSLC"}Product names should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_RootCommandLongDesc" xml:space="preserve">
+    <value>WSLC is the Windows Subsystem for Linux Container CLI tool. It enables management and interaction with WSL containers from the command line.</value>
+    <comment>{Locked="WSLC"}{Locked="WSL"}Product names should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ContainerCommandDesc" xml:space="preserve">
+    <value>Manage containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerCommandLongDesc" xml:space="preserve">
+    <value>Manage the lifecycle of WSL containers, including creating, starting, stopping, and removing them.</value>
+    <comment>{Locked="WSL"}Product names should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ContainerAttachDesc" xml:space="preserve">
+    <value>Attach to a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerAttachLongDesc" xml:space="preserve">
+    <value>Attaches to a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerCreateDesc" xml:space="preserve">
+    <value>Create a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerCreateLongDesc" xml:space="preserve">
+    <value>Creates a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerExecDesc" xml:space="preserve">
+    <value>Execute a command in a running container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerExecLongDesc" xml:space="preserve">
+    <value>Executes a command in a running container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerInspectDesc" xml:space="preserve">
+    <value>Inspect a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerInspectLongDesc" xml:space="preserve">
+    <value>Display detailed information about a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerKillDesc" xml:space="preserve">
+    <value>Kill containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerKillLongDesc" xml:space="preserve">
+    <value>Kills containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerListDesc" xml:space="preserve">
+    <value>List containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerListLongDesc" xml:space="preserve">
+    <value>Lists containers. By default, only running containers are shown; use --all to include all containers.</value>
+    <comment>{Locked="--all"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ContainerLogsDesc" xml:space="preserve">
+    <value>View container logs.</value>
+  </data>
+  <data name="WSLCCLI_ContainerLogsLongDesc" xml:space="preserve">
+    <value>View logs for a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerRemoveDesc" xml:space="preserve">
+    <value>Remove containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerRemoveLongDesc" xml:space="preserve">
+    <value>Removes containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerRunDesc" xml:space="preserve">
+    <value>Run a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerRunLongDesc" xml:space="preserve">
+    <value>Runs a container. By default, the container is started in the background; use --detach to run in the foreground.</value>
+    <comment>{Locked="--detach"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ContainerStartDesc" xml:space="preserve">
+    <value>Start a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerStartLongDesc" xml:space="preserve">
+    <value>Starts a container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerStopDesc" xml:space="preserve">
+    <value>Stop containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerStopLongDesc" xml:space="preserve">
+    <value>Stops containers.</value>
+  </data>
+  <data name="WSLCCLI_ImageCommandDesc" xml:space="preserve">
+    <value>Manage images.</value>
+  </data>
+  <data name="WSLCCLI_ImageCommandLongDesc" xml:space="preserve">
+    <value>Manage container images, including building, pulling, listing, and removing them.</value>
+  </data>
+  <data name="WSLCCLI_ImageBuildDesc" xml:space="preserve">
+    <value>Build an image from a Dockerfile.</value>
+    <comment>{Locked="Dockerfile"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ImageBuildLongDesc" xml:space="preserve">
+    <value>Builds an image from a Dockerfile and a build context directory.</value>
+    <comment>{Locked="Dockerfile"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ImageInspectDesc" xml:space="preserve">
+    <value>Inspect images.</value>
+  </data>
+  <data name="WSLCCLI_ImageInspectLongDesc" xml:space="preserve">
+    <value>Inspect images.</value>
+  </data>
+  <data name="WSLCCLI_ImageListDesc" xml:space="preserve">
+    <value>List images.</value>
+  </data>
+  <data name="WSLCCLI_ImageListLongDesc" xml:space="preserve">
+    <value>Lists images.</value>
+  </data>
+  <data name="WSLCCLI_ImageLoadDesc" xml:space="preserve">
+    <value>Load images.</value>
+  </data>
+  <data name="WSLCCLI_ImageLoadLongDesc" xml:space="preserve">
+    <value>Loads images.</value>
+  </data>
+  <data name="WSLCCLI_ImagePullDesc" xml:space="preserve">
+    <value>Pull images.</value>
+  </data>
+  <data name="WSLCCLI_ImagePullLongDesc" xml:space="preserve">
+    <value>Pulls images.</value>
+  </data>
+  <data name="WSLCCLI_ImageRemoveDesc" xml:space="preserve">
+    <value>Remove images.</value>
+  </data>
+  <data name="WSLCCLI_ImageRemoveLongDesc" xml:space="preserve">
+    <value>Removes images.</value>
+  </data>
+  <data name="WSLCCLI_ImageSaveDesc" xml:space="preserve">
+    <value>Save images.</value>
+  </data>
+  <data name="WSLCCLI_ImageSaveLongDesc" xml:space="preserve">
+    <value>Saves images.</value>
+  </data>
+  <data name="WSLCCLI_SessionCommandDesc" xml:space="preserve">
+    <value>Manage sessions.</value>
+  </data>
+  <data name="WSLCCLI_SessionCommandLongDesc" xml:space="preserve">
+    <value>Manage WSL container sessions, including listing active sessions and launching interactive shells.</value>
+    <comment>{Locked="WSL"}Product names should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_SessionListDesc" xml:space="preserve">
+    <value>List sessions.</value>
+  </data>
+  <data name="WSLCCLI_SessionListLongDesc" xml:space="preserve">
+    <value>Lists active session(s).</value>
+  </data>
+  <data name="WSLCCLI_SessionShellDesc" xml:space="preserve">
+    <value>Attach to a session.</value>
+  </data>
+  <data name="WSLCCLI_SessionShellLongDesc" xml:space="preserve">
+    <value>Attaches to an active session. If no session ID is provided, the wslc default session will be used.</value>
+    <comment>{Locked="wslc"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_SessionTerminateDesc" xml:space="preserve">
+    <value>Terminate a session.</value>
+  </data>
+  <data name="WSLCCLI_SessionTerminateLongDesc" xml:space="preserve">
+    <value>Terminates an active session. If no session is specified, the default session will be terminated.</value>
+  </data>
+  <data name="WSLCCLI_SettingsCommandDesc" xml:space="preserve">
+    <value>Open the settings file in the default editor.</value>
+  </data>
+  <data name="WSLCCLI_SettingsCommandLongDesc" xml:space="preserve">
+    <value>Opens the wslc user settings file in the system default editor for .yaml files.
+On first run, creates the file with all settings commented out at their defaults.</value>
+    <comment>{Locked="wslc"}{Locked=".yaml"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_SettingsResetDesc" xml:space="preserve">
+    <value>Reset settings to built-in defaults.</value>
+  </data>
+  <data name="WSLCCLI_SettingsResetLongDesc" xml:space="preserve">
+    <value>Overwrites the settings file with a commented-out defaults template.</value>
+  </data>
+  <data name="WSLCCLI_SettingsResetConfirm" xml:space="preserve">
+    <value>Settings reset to defaults.</value>
+  </data>
+  <data name="WSLCCLI_AllArgDescription" xml:space="preserve">
+    <value>Show all regardless of state.</value>
+  </data>
+  <data name="WSLCCLI_BuildArgDescription" xml:space="preserve">
+    <value>Set build-time variables (KEY=VALUE)</value>
+    <comment>{Locked="KEY=VALUE"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_CommandArgDescription" xml:space="preserve">
+    <value>The command to run</value>
+  </data>
+  <data name="WSLCCLI_ForceArgDescription" xml:space="preserve">
+    <value>Delete containers even if they are running</value>
+  </data>
+  <data name="WSLCCLI_DetachArgDescription" xml:space="preserve">
+    <value>Run container in detached mode</value>
+  </data>
+  <data name="WSLCCLI_EntrypointArgDescription" xml:space="preserve">
+    <value>Specifies the container init process executable</value>
+  </data>
+  <data name="WSLCCLI_EnvArgDescription" xml:space="preserve">
+    <value>Key=Value pairs for environment variables</value>
+    <comment>{Locked="Key=Value"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_EnvFileArgDescription" xml:space="preserve">
+    <value>File containing key=value pairs of env variables</value>
+    <comment>{Locked="key=value"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_FileArgDescription" xml:space="preserve">
+    <value>Path to the Dockerfile (use "-" to read from stdin)</value>
+    <comment>{Locked="Dockerfile"}{Locked="stdin"}{Locked="-"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_FollowArgDescription" xml:space="preserve">
+    <value>Follow log output</value>
+  </data>
+  <data name="WSLCCLI_FormatArgDescription" xml:space="preserve">
+    <value>Output formatting (json or table) (Default:table)</value>
+    <comment>{Locked="json"}{Locked="table"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ForwardArgsDescription" xml:space="preserve">
+    <value>Arguments to pass to container's init process</value>
+  </data>
+  <data name="WSLCCLI_ImageForceArgDescription" xml:space="preserve">
+    <value>Delete images even if they are being used</value>
+  </data>
+  <data name="WSLCCLI_ImageIdArgDescription" xml:space="preserve">
+    <value>Image name</value>
+  </data>
+  <data name="WSLCCLI_InputArgDescription" xml:space="preserve">
+    <value>Provides path to the tar archive file containing the image</value>
+  </data>
+  <data name="WSLCCLI_NameArgDescription" xml:space="preserve">
+    <value>Name of the container</value>
+  </data>
+  <data name="WSLCCLI_NoPruneArgDescription" xml:space="preserve">
+    <value>Do not delete untagged parents</value>
+  </data>
+  <data name="WSLCCLI_NoTruncArgDescription" xml:space="preserve">
+    <value>Do not truncate output</value>
+  </data>
+  <data name="WSLCCLI_OutputArgDescription" xml:space="preserve">
+    <value>Path for the saved image</value>
+  </data>
+  <data name="WSLCCLI_PathArgDescription" xml:space="preserve">
+    <value>Path to the build context directory</value>
+  </data>
+  <data name="WSLCCLI_PublishArgDescription" xml:space="preserve">
+    <value>Publish a port from a container to host</value>
+  </data>
+  <data name="WSLCCLI_QuietArgDescription" xml:space="preserve">
+    <value>Outputs the container IDs only</value>
+  </data>
+  <data name="WSLCCLI_RemoveArgDescription" xml:space="preserve">
+    <value>Remove the container after it stops</value>
+  </data>
+  <data name="WSLCCLI_SessionIdPositionalArgDescription" xml:space="preserve">
+    <value>Session ID</value>
+  </data>
+  <data name="WSLCCLI_SignalArgDescription" xml:space="preserve">
+    <value>Signal to send (default: {})</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_TagArgDescription" xml:space="preserve">
+    <value>Tag for the built image</value>
+  </data>
+  <data name="WSLCCLI_TimeArgDescription" xml:space="preserve">
+    <value>Time in seconds to wait before executing (default 5)</value>
+  </data>
+  <data name="WSLCCLI_TTYArgDescription" xml:space="preserve">
+    <value>Open a TTY with the container process.</value>
+    <comment>{Locked="TTY"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_VerboseArgDescription" xml:space="preserve">
+    <value>Output verbose details</value>
+  </data>
+  <data name="WSLCCLI_VersionArgDescription" xml:space="preserve">
+    <value>Show version information for this tool</value>
+  </data>
+  <data name="WSLCCLI_VolumeArgDescription" xml:space="preserve">
+    <value>Bind mount a volume to the container</value>
+  </data>
+  <data name="WSLCCLI_CIDFileArgDescription" xml:space="preserve">
+    <value>Write the container ID to the provided path.</value>
+  </data>
+  <data name="WSLCCLI_DNSArgDescription" xml:space="preserve">
+    <value>IP address of the DNS nameserver in resolv.conf</value>
+    <comment>{Locked="resolv.conf"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_DNSDomainArgDescription" xml:space="preserve">
+    <value>Set the default DNS Domain</value>
+    <comment>{Locked="DNS"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_DNSOptionArgDescription" xml:space="preserve">
+    <value>Set DNS options</value>
+    <comment>{Locked="DNS"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_DNSSearchArgDescription" xml:space="preserve">
+    <value>Set DNS search domains</value>
+    <comment>{Locked="DNS"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_GroupIdArgDescription" xml:space="preserve">
+    <value>Group Id for the process</value>
+  </data>
+  <data name="WSLCCLI_NoDNSArgDescription" xml:space="preserve">
+    <value>No configuration of DNS in the container</value>
+    <comment>{Locked="DNS"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ProgressArgDescription" xml:space="preserve">
+    <value>Progress type (format: none|ansi) (default: ansi)</value>
+    <comment>{Locked="none"}{Locked="ansi"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_PullArgDescription" xml:space="preserve">
+    <value>Image pull policy (always|missing|never) (default:never)</value>
+    <comment>{Locked="always"}{Locked="missing"}{Locked="never"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_SchemeArgDescription" xml:space="preserve">
+    <value>Use this scheme for registry connection</value>
+  </data>
+  <data name="WSLCCLI_TMPFSArgDescription" xml:space="preserve">
+    <value>Mount tmpfs to the container at the given path</value>
+    <comment>{Locked="tmpfs"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_UserArgDescription" xml:space="preserve">
+    <value>User ID for the process (name|uid|uid:gid)</value>
+    <comment>{Locked="name|uid|uid:gid"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_VirtualArgDescription" xml:space="preserve">
+    <value>Expose virtualization capabilities to the container</value>
+  </data>
+  <data name="WSLCCLI_ContainerExecForwardArgsDescription" xml:space="preserve">
+    <value>Arguments to pass to the command being executed inside the container</value>
+  </data>
+  <data name="WSLCCLI_SessionListVerboseArgDescription" xml:space="preserve">
+    <value>Show detailed information about the listed sessions.</value>
+  </data>
+  <data name="WSLCCLI_InvalidFormatError" xml:space="preserve">
+    <value>Invalid format type specified. Supported format types are: json, table</value>
+    <comment>{Locked="json"}{Locked="table"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_InvalidSignalError" xml:space="preserve">
+    <value>Invalid {} value: {} is not a recognized signal name or number (Example: SIGKILL, kill, or 9).</value>
+    <comment>{FixedPlaceholder="{}"}{Locked="SIGKILL"}{Locked="kill"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_SignalOutOfRangeError" xml:space="preserve">
+    <value>Invalid {} value: {} is out of valid range ({}-{}).</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ImageNotFoundPulling" xml:space="preserve">
+    <value>Image '{}' not found, pulling</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_EnvKeyEmptyError" xml:space="preserve">
+    <value>Environment variable key cannot be empty</value>
+  </data>
+  <data name="WSLCCLI_EnvKeyWhitespaceError" xml:space="preserve">
+    <value>Environment variable key '{}' cannot contain whitespace</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_ImageLoadNoInputError" xml:space="preserve">
+    <value>Requested load but no input provided.</value>
+  </data>
 </root>

--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -33,53 +33,53 @@ Abstract:
 // Format: ARGUMENT(EnumName, Name, Alias, Kind, Desc)
 // clang-format off
 #define WSLC_ARGUMENTS(_) \
-_(All,            "all",                 L"a",              Kind::Flag,        L"Show all regardless of state.") \
+_(All,            "all",                 L"a",              Kind::Flag,        Localization::WSLCCLI_AllArgDescription()) \
 _(Attach,         "attach",              L"a",              Kind::Flag,        Localization::WSLCCLI_AttachArgDescription()) \
-_(BuildArg,       "build-arg",           NO_ALIAS,          Kind::Value,       L"Set build-time variables (KEY=VALUE)") \
-/*_(CIDFile,        "cidfile",             NO_ALIAS,          Kind::Value,       L"Write the container ID to the provided path.")*/ \
-_(Command,        "command",             NO_ALIAS,          Kind::Positional,  L"The command to run") \
+_(BuildArg,       "build-arg",           NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_BuildArgDescription()) \
+/*_(CIDFile,        "cidfile",             NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_CIDFileArgDescription())*/ \
+_(Command,        "command",             NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_CommandArgDescription()) \
 _(ContainerId,    "container-id",        NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_ContainerIdArgDescription()) \
-_(Force,          "force",               L"f",              Kind::Flag,        L"Delete containers even if they are running") \
-_(Detach,         "detach",              L"d",              Kind::Flag,        L"Run container in detached mode") \
-/*_(DNS,            "dns",                 NO_ALIAS,          Kind::Value,       L"IP address of the DNS nameserver in resolv.conf")*/ \
-/*_(DNSDomain,      "dns-domain",          NO_ALIAS,          Kind::Value,       L"Set the default DNS Domain")*/ \
-/*_(DNSOption,      "dns-option",          NO_ALIAS,          Kind::Value,       L"Set DNS options")*/ \
-/*_(DNSSearch,      "dns-search",          NO_ALIAS,          Kind::Value,       L"Set DNS search domains")*/ \
-_(Entrypoint,     "entrypoint",          NO_ALIAS,          Kind::Value,       L"Specifies the container init process executable") \
-_(Env,            "env",                 L"e",              Kind::Value,       L"Key=Value pairs for environment variables") \
-_(EnvFile,        "env-file",            NO_ALIAS,          Kind::Value,       L"File containing key=value pairs of env variables") \
-_(File,           "file",                L"f",              Kind::Value,       L"Path to the Dockerfile (use \"-\" to read from stdin)") \
-_(Follow,         "follow",              L"f",              Kind::Flag,        L"Follow log output") \
-_(Format,         "format",              NO_ALIAS,          Kind::Value,       L"Output formatting (json or table) (Default:table)") \
-_(ForwardArgs,    "arguments",           NO_ALIAS,          Kind::Forward,     L"Arguments to pass to container's init process") \
-/*_(GroupId,        "groupid",             NO_ALIAS,          Kind::Value,       L"Group Id for the process")*/ \
+_(Force,          "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_ForceArgDescription()) \
+_(Detach,         "detach",              L"d",              Kind::Flag,        Localization::WSLCCLI_DetachArgDescription()) \
+/*_(DNS,            "dns",                 NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_DNSArgDescription())*/ \
+/*_(DNSDomain,      "dns-domain",          NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_DNSDomainArgDescription())*/ \
+/*_(DNSOption,      "dns-option",          NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_DNSOptionArgDescription())*/ \
+/*_(DNSSearch,      "dns-search",          NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_DNSSearchArgDescription())*/ \
+_(Entrypoint,     "entrypoint",          NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_EntrypointArgDescription()) \
+_(Env,            "env",                 L"e",              Kind::Value,       Localization::WSLCCLI_EnvArgDescription()) \
+_(EnvFile,        "env-file",            NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_EnvFileArgDescription()) \
+_(File,           "file",                L"f",              Kind::Value,       Localization::WSLCCLI_FileArgDescription()) \
+_(Follow,         "follow",              L"f",              Kind::Flag,        Localization::WSLCCLI_FollowArgDescription()) \
+_(Format,         "format",              NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_FormatArgDescription()) \
+_(ForwardArgs,    "arguments",           NO_ALIAS,          Kind::Forward,     Localization::WSLCCLI_ForwardArgsDescription()) \
+/*_(GroupId,        "groupid",             NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_GroupIdArgDescription())*/ \
 _(Help,           "help",                WSLC_CLI_HELP_ARG, Kind::Flag,        Localization::WSLCCLI_HelpArgDescription()) \
-_(ImageForce,     "force",               L"f",              Kind::Flag,        L"Delete images even if they are being used") \
-_(ImageId,        "image",               NO_ALIAS,          Kind::Positional,  L"Image name") \
-_(Input,          "input",               L"i",              Kind::Value,       L"Provides path to the tar archive file containing the image") \
+_(ImageForce,     "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_ImageForceArgDescription()) \
+_(ImageId,        "image",               NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_ImageIdArgDescription()) \
+_(Input,          "input",               L"i",              Kind::Value,       Localization::WSLCCLI_InputArgDescription()) \
 _(Interactive,    "interactive",         L"i",              Kind::Flag,        Localization::WSLCCLI_InteractiveArgDescription()) \
-_(Name,           "name",                NO_ALIAS,          Kind::Value,       L"Name of the container") \
-/*_(NoDNS,          "no-dns",              NO_ALIAS,          Kind::Flag,        L"No configuration of DNS in the container")*/ \
-_(NoPrune,        "no-prune",            NO_ALIAS,          Kind::Flag,        L"Do not delete untagged parents") \
-_(NoTrunc,        "no-trunc",            NO_ALIAS,          Kind::Flag,        L"Do not truncate output") \
-_(Output,         "output",              L"o",              Kind::Value,       L"Path for the saved image") \
-_(Path,           "path",                NO_ALIAS,          Kind::Positional,  L"Path to the build context directory") \
-/*_(Progress,       "progress",            NO_ALIAS,          Kind::Value,       L"Progress type (format: none|ansi) (default: ansi)")*/ \
-_(Publish,        "publish",             L"p",              Kind::Value,       L"Publish a port from a container to host") \
-/*_(Pull,           "pull",                NO_ALIAS,          Kind::Value,       L"Image pull policy (always|missing|never) (default:never)")*/ \
-_(Quiet,          "quiet",               L"q",              Kind::Flag,        L"Outputs the container IDs only") \
-_(Remove,         "rm",                  NO_ALIAS,          Kind::Flag,        L"Remove the container after it stops") \
-/*_(Scheme,         "scheme",              NO_ALIAS,          Kind::Value,       L"Use this scheme for registry connection")*/ \
+_(Name,           "name",                NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NameArgDescription()) \
+/*_(NoDNS,          "no-dns",              NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NoDNSArgDescription())*/ \
+_(NoPrune,        "no-prune",            NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NoPruneArgDescription()) \
+_(NoTrunc,        "no-trunc",            NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NoTruncArgDescription()) \
+_(Output,         "output",              L"o",              Kind::Value,       Localization::WSLCCLI_OutputArgDescription()) \
+_(Path,           "path",                NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_PathArgDescription()) \
+/*_(Progress,       "progress",            NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_ProgressArgDescription())*/ \
+_(Publish,        "publish",             L"p",              Kind::Value,       Localization::WSLCCLI_PublishArgDescription()) \
+/*_(Pull,           "pull",                NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_PullArgDescription())*/ \
+_(Quiet,          "quiet",               L"q",              Kind::Flag,        Localization::WSLCCLI_QuietArgDescription()) \
+_(Remove,         "rm",                  NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_RemoveArgDescription()) \
+/*_(Scheme,         "scheme",              NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_SchemeArgDescription())*/ \
 _(Session,        "session",             NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_SessionIdArgDescription()) \
-_(SessionId,      "session-id",          NO_ALIAS,          Kind::Positional,  L"Session ID") \
-_(Signal,         "signal",              L"s",              Kind::Value,       L"Signal to send (default: SIGKILL)") \
-_(Tag,            "tag",                 L"t",              Kind::Value,       L"Tag for the built image") \
-_(Time,           "time",                L"t",              Kind::Value,       L"Time in seconds to wait before executing (default 5)") \
-/*_(TMPFS,          "tmpfs",               NO_ALIAS,          Kind::Value,       L"Mount tmpfs to the container at the given path")*/ \
-_(TTY,            "tty",                 L"t",              Kind::Flag,        L"Open a TTY with the container process.") \
-/*_(User,           "user",                L"u",              Kind::Value,       L"User ID for the process (name|uid|uid:gid)")*/ \
-_(Verbose,        "verbose",             L"v",              Kind::Flag,        L"Output verbose details") \
-_(Version,        "version",             L"v",              Kind::Flag,        L"Show version information for this tool") \
-/*_(Virtual,        "virtualization",      NO_ALIAS,          Kind::Value,       L"Expose virtualization capabilities to the container")*/ \
-_(Volume,         "volume",              L"v",              Kind::Value,       L"Bind mount a volume to the container") \
+_(SessionId,      "session-id",          NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_SessionIdPositionalArgDescription()) \
+_(Signal,         "signal",              L"s",              Kind::Value,       Localization::WSLCCLI_SignalArgDescription(L"SIGKILL")) \
+_(Tag,            "tag",                 L"t",              Kind::Value,       Localization::WSLCCLI_TagArgDescription()) \
+_(Time,           "time",                L"t",              Kind::Value,       Localization::WSLCCLI_TimeArgDescription()) \
+/*_(TMPFS,          "tmpfs",               NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_TMPFSArgDescription())*/ \
+_(TTY,            "tty",                 L"t",              Kind::Flag,        Localization::WSLCCLI_TTYArgDescription()) \
+/*_(User,           "user",                L"u",              Kind::Value,       Localization::WSLCCLI_UserArgDescription())*/ \
+_(Verbose,        "verbose",             L"v",              Kind::Flag,        Localization::WSLCCLI_VerboseArgDescription()) \
+_(Version,        "version",             L"v",              Kind::Flag,        Localization::WSLCCLI_VersionArgDescription()) \
+/*_(Virtual,        "virtualization",      NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_VirtualArgDescription())*/ \
+_(Volume,         "volume",              L"v",              Kind::Value,       Localization::WSLCCLI_VolumeArgDescription()) \
 // clang-format on

--- a/src/windows/wslc/arguments/ArgumentValidation.cpp
+++ b/src/windows/wslc/arguments/ArgumentValidation.cpp
@@ -153,8 +153,8 @@ FormatType GetFormatTypeFromString(const std::wstring& input, const std::wstring
     }
     else
     {
-        throw ArgumentException(
-            std::format(L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
+        throw ArgumentException(std::format(
+            L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
     }
 }
 

--- a/src/windows/wslc/arguments/ArgumentValidation.cpp
+++ b/src/windows/wslc/arguments/ArgumentValidation.cpp
@@ -22,6 +22,7 @@ Abstract:
 #include <wslc.h>
 
 using namespace wsl::windows::common;
+using namespace wsl::shared;
 using namespace wsl::shared::string;
 
 namespace wsl::windows::wslc {
@@ -121,13 +122,12 @@ WSLCSignal GetWSLCSignalFromString(const std::wstring& input, const std::wstring
     // failure since we also know it failed to be found in the map.
     catch (ArgumentException)
     {
-        throw ArgumentException(std::format(
-            L"Invalid {} value: {} is not a recognized signal name or number (Example: SIGKILL, kill, or 9).", argName, input));
+        throw ArgumentException(Localization::WSLCCLI_InvalidSignalError(argName, input));
     }
 
     if (signalValue < MIN_SIGNAL || signalValue > MAX_SIGNAL)
     {
-        throw ArgumentException(std::format(L"Invalid {} value: {} is out of valid range ({}-{}).", argName, input, MIN_SIGNAL, MAX_SIGNAL));
+        throw ArgumentException(Localization::WSLCCLI_SignalOutOfRangeError(argName, input, MIN_SIGNAL, MAX_SIGNAL));
     }
 
     return static_cast<WSLCSignal>(signalValue);
@@ -153,8 +153,8 @@ FormatType GetFormatTypeFromString(const std::wstring& input, const std::wstring
     }
     else
     {
-        throw ArgumentException(std::format(
-            L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
+        throw ArgumentException(
+            std::format(L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
     }
 }
 

--- a/src/windows/wslc/commands/ContainerAttachCommand.cpp
+++ b/src/windows/wslc/commands/ContainerAttachCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Attach Command
@@ -33,12 +34,12 @@ std::vector<Argument> ContainerAttachCommand::GetArguments() const
 
 std::wstring ContainerAttachCommand::ShortDescription() const
 {
-    return {L"Attach to a container."};
+    return Localization::WSLCCLI_ContainerAttachDesc();
 }
 
 std::wstring ContainerAttachCommand::LongDescription() const
 {
-    return {L"Attaches to a container."};
+    return Localization::WSLCCLI_ContainerAttachLongDesc();
 }
 
 void ContainerAttachCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ContainerCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCommand.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "ContainerCommand.h"
 
 using namespace wsl::windows::wslc::execution;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Root Command
@@ -42,12 +43,12 @@ std::vector<Argument> ContainerCommand::GetArguments() const
 
 std::wstring ContainerCommand::ShortDescription() const
 {
-    return {L"Container command."};
+    return Localization::WSLCCLI_ContainerCommandDesc();
 }
 
 std::wstring ContainerCommand::LongDescription() const
 {
-    return {L"Container command for demonstration purposes."};
+    return Localization::WSLCCLI_ContainerCommandLongDesc();
 }
 
 void ContainerCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ContainerCreateCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCreateCommand.cpp
@@ -23,7 +23,7 @@ using namespace wsl::windows::wslc::task;
 using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
-// Container CreateCommand
+// Container Create Command
 std::vector<Argument> ContainerCreateCommand::GetArguments() const
 {
     // clang-format off

--- a/src/windows/wslc/commands/ContainerCreateCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCreateCommand.cpp
@@ -20,9 +20,10 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
-// Container Create Command
+// Container CreateCommand
 std::vector<Argument> ContainerCreateCommand::GetArguments() const
 {
     // clang-format off
@@ -58,12 +59,12 @@ std::vector<Argument> ContainerCreateCommand::GetArguments() const
 
 std::wstring ContainerCreateCommand::ShortDescription() const
 {
-    return {L"Create a container."};
+    return Localization::WSLCCLI_ContainerCreateDesc();
 }
 
 std::wstring ContainerCreateCommand::LongDescription() const
 {
-    return {L"Creates a container."};
+    return Localization::WSLCCLI_ContainerCreateLongDesc();
 }
 
 // clang-format off

--- a/src/windows/wslc/commands/ContainerExecCommand.cpp
+++ b/src/windows/wslc/commands/ContainerExecCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Exec Command
@@ -28,11 +29,7 @@ std::vector<Argument> ContainerExecCommand::GetArguments() const
     return {
         Argument::Create(ArgType::ContainerId, true),
         Argument::Create(ArgType::Command, true),
-        Argument::Create(
-            ArgType::ForwardArgs,
-            std::nullopt,
-            std::nullopt,
-            L"Arguments to pass to the command being executed inside the container"),
+        Argument::Create(ArgType::ForwardArgs, std::nullopt, std::nullopt, Localization::WSLCCLI_ContainerExecForwardArgsDescription()),
         Argument::Create(ArgType::Detach),
         Argument::Create(ArgType::Env, false, NO_LIMIT),
         Argument::Create(ArgType::EnvFile, false, NO_LIMIT),
@@ -45,12 +42,12 @@ std::vector<Argument> ContainerExecCommand::GetArguments() const
 
 std::wstring ContainerExecCommand::ShortDescription() const
 {
-    return {L"Execute a command in a running container."};
+    return Localization::WSLCCLI_ContainerExecDesc();
 }
 
 std::wstring ContainerExecCommand::LongDescription() const
 {
-    return {L"Executes a command in a running container."};
+    return Localization::WSLCCLI_ContainerExecLongDesc();
 }
 // clang-format off
 void ContainerExecCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ContainerInspectCommand.cpp
+++ b/src/windows/wslc/commands/ContainerInspectCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Inspect Command
@@ -33,12 +34,12 @@ std::vector<Argument> ContainerInspectCommand::GetArguments() const
 
 std::wstring ContainerInspectCommand::ShortDescription() const
 {
-    return {L"Inspect a container."};
+    return Localization::WSLCCLI_ContainerInspectDesc();
 }
 
 std::wstring ContainerInspectCommand::LongDescription() const
 {
-    return {L"Display detailed information about a container."};
+    return Localization::WSLCCLI_ContainerInspectLongDesc();
 }
 
 // clang-format off

--- a/src/windows/wslc/commands/ContainerKillCommand.cpp
+++ b/src/windows/wslc/commands/ContainerKillCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Kill Command
@@ -28,18 +29,18 @@ std::vector<Argument> ContainerKillCommand::GetArguments() const
     return {
         Argument::Create(ArgType::ContainerId, true, NO_LIMIT),
         Argument::Create(ArgType::Session),
-        Argument::Create(ArgType::Signal, std::nullopt, std::nullopt, L"Signal to send (default: SIGKILL)"),
+        Argument::Create(ArgType::Signal),
     };
 }
 
 std::wstring ContainerKillCommand::ShortDescription() const
 {
-    return {L"Kill containers."};
+    return Localization::WSLCCLI_ContainerKillDesc();
 }
 
 std::wstring ContainerKillCommand::LongDescription() const
 {
-    return {L"Kills containers."};
+    return Localization::WSLCCLI_ContainerKillLongDesc();
 }
 
 // clang-format off

--- a/src/windows/wslc/commands/ContainerListCommand.cpp
+++ b/src/windows/wslc/commands/ContainerListCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 using namespace wsl::shared::string;
 
 namespace wsl::windows::wslc {
@@ -37,12 +38,12 @@ std::vector<Argument> ContainerListCommand::GetArguments() const
 
 std::wstring ContainerListCommand::ShortDescription() const
 {
-    return {L"List containers."};
+    return Localization::WSLCCLI_ContainerListDesc();
 }
 
 std::wstring ContainerListCommand::LongDescription() const
 {
-    return {L"Lists containers. By default, only running containers are shown; use --all to include all containers."};
+    return Localization::WSLCCLI_ContainerListLongDesc();
 }
 
 void ContainerListCommand::ValidateArgumentsInternal(const ArgMap& execArgs) const
@@ -52,7 +53,7 @@ void ContainerListCommand::ValidateArgumentsInternal(const ArgMap& execArgs) con
         auto format = execArgs.Get<ArgType::Format>();
         if (!IsEqual(format, L"json") && !IsEqual(format, L"table"))
         {
-            throw CommandException(L"Invalid format type specified. Supported format types are: json, table");
+            throw CommandException(Localization::WSLCCLI_InvalidFormatError());
         }
     }
 }

--- a/src/windows/wslc/commands/ContainerLogsCommand.cpp
+++ b/src/windows/wslc/commands/ContainerLogsCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Logs Command
@@ -34,12 +35,12 @@ std::vector<Argument> ContainerLogsCommand::GetArguments() const
 
 std::wstring ContainerLogsCommand::ShortDescription() const
 {
-    return {L"View container logs."};
+    return Localization::WSLCCLI_ContainerLogsDesc();
 }
 
 std::wstring ContainerLogsCommand::LongDescription() const
 {
-    return {L"View logs for a container."};
+    return Localization::WSLCCLI_ContainerLogsLongDesc();
 }
 
 void ContainerLogsCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ContainerRemoveCommand.cpp
+++ b/src/windows/wslc/commands/ContainerRemoveCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Remove Command
@@ -34,12 +35,12 @@ std::vector<Argument> ContainerRemoveCommand::GetArguments() const
 
 std::wstring ContainerRemoveCommand::ShortDescription() const
 {
-    return {L"Remove containers."};
+    return Localization::WSLCCLI_ContainerRemoveDesc();
 }
 
 std::wstring ContainerRemoveCommand::LongDescription() const
 {
-    return {L"Removes containers."};
+    return Localization::WSLCCLI_ContainerRemoveLongDesc();
 }
 
 void ContainerRemoveCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ContainerRunCommand.cpp
+++ b/src/windows/wslc/commands/ContainerRunCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Run Command
@@ -59,12 +60,12 @@ std::vector<Argument> ContainerRunCommand::GetArguments() const
 
 std::wstring ContainerRunCommand::ShortDescription() const
 {
-    return {L"Run a container."};
+    return Localization::WSLCCLI_ContainerRunDesc();
 }
 
 std::wstring ContainerRunCommand::LongDescription() const
 {
-    return {L"Runs a container. By default, the container is started in the background; use --detach to run in the foreground."};
+    return Localization::WSLCCLI_ContainerRunLongDesc();
 }
 
 // clang-format off

--- a/src/windows/wslc/commands/ContainerStartCommand.cpp
+++ b/src/windows/wslc/commands/ContainerStartCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Start Command
@@ -35,14 +36,12 @@ std::vector<Argument> ContainerStartCommand::GetArguments() const
 
 std::wstring ContainerStartCommand::ShortDescription() const
 {
-    return {L"Start a container."};
+    return Localization::WSLCCLI_ContainerStartDesc();
 }
 
 std::wstring ContainerStartCommand::LongDescription() const
 {
-    return {
-        L"Starts a container. Provides options to attach to the container's stdout and stderr streams and could be interactive "
-        L"to keep stdin open."};
+    return Localization::WSLCCLI_ContainerStartLongDesc();
 }
 
 void ContainerStartCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ContainerStopCommand.cpp
+++ b/src/windows/wslc/commands/ContainerStopCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Container Stop Command
@@ -28,19 +29,19 @@ std::vector<Argument> ContainerStopCommand::GetArguments() const
     return {
         Argument::Create(ArgType::ContainerId, std::nullopt, NO_LIMIT),
         Argument::Create(ArgType::Session),
-        Argument::Create(ArgType::Signal, std::nullopt, std::nullopt, L"Signal to send (default: SIGTERM)"),
+        Argument::Create(ArgType::Signal, std::nullopt, std::nullopt, Localization::WSLCCLI_SignalArgDescription(L"SIGTERM")),
         Argument::Create(ArgType::Time),
     };
 }
 
 std::wstring ContainerStopCommand::ShortDescription() const
 {
-    return {L"Stop containers."};
+    return Localization::WSLCCLI_ContainerStopDesc();
 }
 
 std::wstring ContainerStopCommand::LongDescription() const
 {
-    return {L"Stops containers."};
+    return Localization::WSLCCLI_ContainerStopLongDesc();
 }
 
 // clang-format off

--- a/src/windows/wslc/commands/ImageBuildCommand.cpp
+++ b/src/windows/wslc/commands/ImageBuildCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Image Build Command
@@ -37,12 +38,12 @@ std::vector<Argument> ImageBuildCommand::GetArguments() const
 
 std::wstring ImageBuildCommand::ShortDescription() const
 {
-    return {L"Build an image from a Dockerfile."};
+    return Localization::WSLCCLI_ImageBuildDesc();
 }
 
 std::wstring ImageBuildCommand::LongDescription() const
 {
-    return {L"Builds an image from a Dockerfile and a build context directory."};
+    return Localization::WSLCCLI_ImageBuildLongDesc();
 }
 
 void ImageBuildCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImageCommand.cpp
+++ b/src/windows/wslc/commands/ImageCommand.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "ImageCommand.h"
 
 using namespace wsl::windows::wslc::execution;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Image Root Command
@@ -38,12 +39,12 @@ std::vector<Argument> ImageCommand::GetArguments() const
 
 std::wstring ImageCommand::ShortDescription() const
 {
-    return {L"Image command."};
+    return Localization::WSLCCLI_ImageCommandDesc();
 }
 
 std::wstring ImageCommand::LongDescription() const
 {
-    return {L"Image command."};
+    return Localization::WSLCCLI_ImageCommandLongDesc();
 }
 
 void ImageCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImageInspectCommand.cpp
+++ b/src/windows/wslc/commands/ImageInspectCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 using namespace wsl::shared::string;
 
 namespace wsl::windows::wslc {
@@ -34,12 +35,12 @@ std::vector<Argument> ImageInspectCommand::GetArguments() const
 
 std::wstring ImageInspectCommand::ShortDescription() const
 {
-    return {L"Inspect images."};
+    return Localization::WSLCCLI_ImageInspectDesc();
 }
 
 std::wstring ImageInspectCommand::LongDescription() const
 {
-    return {L"Inspect images."};
+    return Localization::WSLCCLI_ImageInspectLongDesc();
 }
 
 void ImageInspectCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImageListCommand.cpp
+++ b/src/windows/wslc/commands/ImageListCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 using namespace wsl::shared::string;
 
 namespace wsl::windows::wslc {
@@ -36,12 +37,12 @@ std::vector<Argument> ImageListCommand::GetArguments() const
 
 std::wstring ImageListCommand::ShortDescription() const
 {
-    return {L"List images."};
+    return Localization::WSLCCLI_ImageListDesc();
 }
 
 std::wstring ImageListCommand::LongDescription() const
 {
-    return {L"Lists images."};
+    return Localization::WSLCCLI_ImageListLongDesc();
 }
 
 void ImageListCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImageLoadCommand.cpp
+++ b/src/windows/wslc/commands/ImageLoadCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Image Load Command
@@ -33,12 +34,12 @@ std::vector<Argument> ImageLoadCommand::GetArguments() const
 
 std::wstring ImageLoadCommand::ShortDescription() const
 {
-    return {L"Load images."};
+    return Localization::WSLCCLI_ImageLoadDesc();
 }
 
 std::wstring ImageLoadCommand::LongDescription() const
 {
-    return {L"Loads images."};
+    return Localization::WSLCCLI_ImageLoadLongDesc();
 }
 
 void ImageLoadCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImagePullCommand.cpp
+++ b/src/windows/wslc/commands/ImagePullCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Image Pull Command
@@ -35,12 +36,12 @@ std::vector<Argument> ImagePullCommand::GetArguments() const
 
 std::wstring ImagePullCommand::ShortDescription() const
 {
-    return {L"Pull images."};
+    return Localization::WSLCCLI_ImagePullDesc();
 }
 
 std::wstring ImagePullCommand::LongDescription() const
 {
-    return {L"Pulls images."};
+    return Localization::WSLCCLI_ImagePullLongDesc();
 }
 
 void ImagePullCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImageRemoveCommand.cpp
+++ b/src/windows/wslc/commands/ImageRemoveCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 using namespace wsl::shared::string;
 
 namespace wsl::windows::wslc {
@@ -36,12 +37,12 @@ std::vector<Argument> ImageRemoveCommand::GetArguments() const
 
 std::wstring ImageRemoveCommand::ShortDescription() const
 {
-    return {L"Remove images."};
+    return Localization::WSLCCLI_ImageRemoveDesc();
 }
 
 std::wstring ImageRemoveCommand::LongDescription() const
 {
-    return {L"Removes images."};
+    return Localization::WSLCCLI_ImageRemoveLongDesc();
 }
 
 void ImageRemoveCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/ImageSaveCommand.cpp
+++ b/src/windows/wslc/commands/ImageSaveCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Image Save Command
@@ -34,12 +35,12 @@ std::vector<Argument> ImageSaveCommand::GetArguments() const
 
 std::wstring ImageSaveCommand::ShortDescription() const
 {
-    return {L"Save images."};
+    return Localization::WSLCCLI_ImageSaveDesc();
 }
 
 std::wstring ImageSaveCommand::LongDescription() const
 {
-    return {L"Saves images."};
+    return Localization::WSLCCLI_ImageSaveLongDesc();
 }
 
 void ImageSaveCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -20,6 +20,7 @@ Abstract:
 #include "SettingsCommand.h"
 
 using namespace wsl::windows::wslc::execution;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
@@ -58,14 +59,12 @@ std::vector<Argument> RootCommand::GetArguments() const
 
 std::wstring RootCommand::ShortDescription() const
 {
-    return {L"WSLC is the Windows Subsystem for Linux Container CLI tool."};
+    return Localization::WSLCCLI_RootCommandDesc();
 }
 
 std::wstring RootCommand::LongDescription() const
 {
-    return {
-        L"WSLC is the Windows Subsystem for Linux Container CLI tool. It enables management and interaction with WSL containers "
-        L"from the command line."};
+    return Localization::WSLCCLI_RootCommandLongDesc();
 }
 
 void RootCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/SessionCommand.cpp
+++ b/src/windows/wslc/commands/SessionCommand.cpp
@@ -16,6 +16,7 @@ Abstract:
 #include "SessionCommand.h"
 
 using namespace wsl::windows::wslc::execution;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Session Root Command
@@ -35,12 +36,12 @@ std::vector<Argument> SessionCommand::GetArguments() const
 
 std::wstring SessionCommand::ShortDescription() const
 {
-    return {L"Session command."};
+    return Localization::WSLCCLI_SessionCommandDesc();
 }
 
 std::wstring SessionCommand::LongDescription() const
 {
-    return {L"Session command."};
+    return Localization::WSLCCLI_SessionCommandLongDesc();
 }
 
 void SessionCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/SessionListCommand.cpp
+++ b/src/windows/wslc/commands/SessionListCommand.cpp
@@ -18,24 +18,25 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Session List Command
 std::vector<Argument> SessionListCommand::GetArguments() const
 {
     return {
-        Argument::Create(ArgType::Verbose, std::nullopt, std::nullopt, L"Show detailed information about the listed sessions."),
+        Argument::Create(ArgType::Verbose, std::nullopt, std::nullopt, Localization::WSLCCLI_SessionListVerboseArgDescription()),
     };
 }
 
 std::wstring SessionListCommand::ShortDescription() const
 {
-    return {L"List sessions."};
+    return Localization::WSLCCLI_SessionListDesc();
 }
 
 std::wstring SessionListCommand::LongDescription() const
 {
-    return {L"Lists active session(s)."};
+    return Localization::WSLCCLI_SessionListLongDesc();
 }
 
 void SessionListCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/SessionShellCommand.cpp
+++ b/src/windows/wslc/commands/SessionShellCommand.cpp
@@ -18,6 +18,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Session Shell Command
@@ -30,12 +31,12 @@ std::vector<Argument> SessionShellCommand::GetArguments() const
 
 std::wstring SessionShellCommand::ShortDescription() const
 {
-    return {L"Attach to a session."};
+    return Localization::WSLCCLI_SessionShellDesc();
 }
 
 std::wstring SessionShellCommand::LongDescription() const
 {
-    return {L"Attaches to an active session. If no session ID is provided, the wslc default session will be used."};
+    return Localization::WSLCCLI_SessionShellLongDesc();
 }
 
 void SessionShellCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/SessionTerminateCommand.cpp
+++ b/src/windows/wslc/commands/SessionTerminateCommand.cpp
@@ -18,6 +18,7 @@ Abstract:
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 // Session Terminate Command
@@ -30,12 +31,12 @@ std::vector<Argument> SessionTerminateCommand::GetArguments() const
 
 std::wstring SessionTerminateCommand::ShortDescription() const
 {
-    return {L"Terminate a session."};
+    return Localization::WSLCCLI_SessionTerminateDesc();
 }
 
 std::wstring SessionTerminateCommand::LongDescription() const
 {
-    return {L"Terminates an active session. If no session is specified, the default session will be terminated."};
+    return Localization::WSLCCLI_SessionTerminateLongDesc();
 }
 
 void SessionTerminateCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/commands/SettingsCommand.cpp
+++ b/src/windows/wslc/commands/SettingsCommand.cpp
@@ -19,6 +19,7 @@ Abstract:
 using namespace wsl::windows::common::wslutil;
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::settings;
+using namespace wsl::shared;
 
 namespace wsl::windows::wslc {
 
@@ -37,14 +38,12 @@ std::vector<Argument> SettingsCommand::GetArguments() const
 
 std::wstring SettingsCommand::ShortDescription() const
 {
-    return {L"Open the settings file in the default editor."};
+    return Localization::WSLCCLI_SettingsCommandDesc();
 }
 
 std::wstring SettingsCommand::LongDescription() const
 {
-    return {
-        L"Opens the wslc user settings file in the system default editor for .yaml files.\n"
-        L"On first run, creates the file with all settings commented out at their defaults."};
+    return Localization::WSLCCLI_SettingsCommandLongDesc();
 }
 
 void SettingsCommand::ExecuteInternal(CLIExecutionContext& context) const
@@ -74,19 +73,19 @@ std::vector<Argument> SettingsResetCommand::GetArguments() const
 
 std::wstring SettingsResetCommand::ShortDescription() const
 {
-    return {L"Reset settings to built-in defaults."};
+    return Localization::WSLCCLI_SettingsResetDesc();
 }
 
 std::wstring SettingsResetCommand::LongDescription() const
 {
-    return {L"Overwrites the settings file with a commented-out defaults template."};
+    return Localization::WSLCCLI_SettingsResetLongDesc();
 }
 
 void SettingsResetCommand::ExecuteInternal(CLIExecutionContext& context) const
 {
     // TODO: do we need prompt support?
     settings::User().Reset();
-    PrintMessage(L"Settings reset to defaults.");
+    PrintMessage(Localization::WSLCCLI_SettingsResetConfirm());
 }
 
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/services/ContainerModel.cpp
+++ b/src/windows/wslc/services/ContainerModel.cpp
@@ -16,6 +16,7 @@ Abstract:
 
 namespace wsl::windows::wslc::models {
 
+using namespace wsl::shared;
 using namespace wsl::shared::string;
 
 PublishPort::PortRange PublishPort::PortRange::ParsePortPart(const std::string& portPart)
@@ -221,12 +222,12 @@ std::optional<std::wstring> EnvironmentVariable::Parse(const std::wstring& entry
 
     if (key.empty())
     {
-        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, L"Environment variable key cannot be empty");
+        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::WSLCCLI_EnvKeyEmptyError());
     }
 
     if (std::any_of(key.begin(), key.end(), std::iswspace))
     {
-        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, std::format(L"Environment variable key '{}' cannot contain whitespace", key));
+        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::WSLCCLI_EnvKeyWhitespaceError(key));
     }
 
     if (!value.has_value())

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -28,6 +28,7 @@ using wsl::windows::common::ClientRunningWSLCProcess;
 using wsl::windows::common::wslc_schema::InspectContainer;
 using wsl::windows::common::wslutil::PrintMessage;
 using namespace wsl::windows::common::wslutil;
+using namespace wsl::shared;
 using namespace wsl::windows::wslc::models;
 using namespace std::chrono_literals;
 
@@ -142,7 +143,7 @@ static wsl::windows::common::RunningWSLCContainer CreateInternal(
         {
             // Attempt to pull the image if not found
             PullImageCallback callback;
-            PrintMessage(L"Image '%hs' not found, pulling", stderr, image.c_str());
+            PrintMessage(Localization::WSLCCLI_ImageNotFoundPulling(wsl::shared::string::MultiByteToWide(image)), stderr);
             ImageService imageService;
             imageService.Pull(session, image, &callback);
         }
@@ -442,13 +443,15 @@ void ContainerService::Logs(Session& session, const std::string& id, bool follow
     THROW_IF_FAILED(container->Logs(flags, &stdoutHandle, &stderrHandle, 0, 0, 0));
 
     wsl::windows::common::relay::MultiHandleWait io;
-    io.AddHandle(std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
-        stdoutHandle.Release(), GetStdHandle(STD_OUTPUT_HANDLE)));
+    io.AddHandle(
+        std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
+            stdoutHandle.Release(), GetStdHandle(STD_OUTPUT_HANDLE)));
 
     if (!stderrHandle.Empty()) // This handle is only used for non-tty processes.
     {
-        io.AddHandle(std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
-            stderrHandle.Release(), GetStdHandle(STD_ERROR_HANDLE)));
+        io.AddHandle(
+            std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
+                stderrHandle.Release(), GetStdHandle(STD_ERROR_HANDLE)));
     }
 
     // TODO: Handle ctrl-c.

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -443,15 +443,13 @@ void ContainerService::Logs(Session& session, const std::string& id, bool follow
     THROW_IF_FAILED(container->Logs(flags, &stdoutHandle, &stderrHandle, 0, 0, 0));
 
     wsl::windows::common::relay::MultiHandleWait io;
-    io.AddHandle(
-        std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
-            stdoutHandle.Release(), GetStdHandle(STD_OUTPUT_HANDLE)));
+    io.AddHandle(std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
+        stdoutHandle.Release(), GetStdHandle(STD_OUTPUT_HANDLE)));
 
     if (!stderrHandle.Empty()) // This handle is only used for non-tty processes.
     {
-        io.AddHandle(
-            std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
-                stderrHandle.Release(), GetStdHandle(STD_ERROR_HANDLE)));
+        io.AddHandle(std::make_unique<wsl::windows::common::relay::RelayHandle<wsl::windows::common::relay::ReadHandle>>(
+            stderrHandle.Release(), GetStdHandle(STD_ERROR_HANDLE)));
     }
 
     // TODO: Handle ctrl-c.

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -163,7 +163,7 @@ void LoadImage(CLIExecutionContext& context)
     }
 
     // TODO Read from stdin if no input argument is provided.
-    THROW_HR_WITH_USER_ERROR(E_INVALIDARG, L"Requested load but no input provided.");
+    THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::WSLCCLI_ImageLoadNoInputError());
 }
 
 void InspectImages(CLIExecutionContext& context)

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -20,6 +20,7 @@ Abstract:
 #include <wil/resource.h>
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 using namespace WEX::Logging;
 
@@ -1076,7 +1077,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Creates a container.\r\n\r\n";
+        return Localization::WSLCCLI_ContainerCreateLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "WSLCE2EHelpers.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EContainerKillTests
 {
@@ -168,7 +169,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Kills containers.\r\n\r\n";
+        return Localization::WSLCCLI_ContainerKillLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
@@ -247,7 +247,7 @@ private:
         std::wstringstream options;
         options << L"The following options are available:\r\n"
                 << L"  -a,--all    Show all regardless of state.\r\n"
-                << L"  --format    Output formatting (json or table) (Default:table)\r\n"
+                << L"  --format    " << Localization::WSLCCLI_FormatArgDescription() << L"\r\n"
                 << L"  --no-trunc  Do not truncate output\r\n"
                 << L"  -q,--quiet  Outputs the container IDs only\r\n"
                 << L"  --session   Specify the session to use\r\n"

--- a/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include "WSLCE2EHelpers.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 using namespace wsl::windows::wslc::models;
 using namespace wsl::windows::common::string;
@@ -228,7 +229,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Lists containers. By default, only running containers are shown; use --all to include all containers.\r\n\r\n";
+        return Localization::WSLCCLI_ContainerListLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "WSLCE2EHelpers.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EContainerRemoveTests
 {
@@ -178,7 +179,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Removes containers.\r\n\r\n";
+        return Localization::WSLCCLI_ContainerRemoveLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "WSLCE2EHelpers.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EContainerStopTests
 {
@@ -272,7 +273,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Stops containers.\r\n\r\n";
+        return Localization::WSLCCLI_ContainerStopLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
@@ -91,7 +91,7 @@ private:
         }
 
         std::wstringstream commands;
-        commands << L"The following sub-commands are available:\r\n";
+        commands << Localization::WSLCCLI_AvailableSubcommands() << L"\r\n";
         for (const auto& [name, desc] : entries)
         {
             commands << L"  " << name << std::wstring(maxLen - name.size() + 2, L' ') << desc << L"\r\n";

--- a/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
@@ -15,8 +15,10 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCCLITestHelpers.h"
 #include "WSLCExecutor.h"
+#include "Argument.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EContainerTests
 {
@@ -58,7 +60,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Container command for demonstration purposes.\r\n\r\n";
+        return Localization::WSLCCLI_ContainerCommandLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const
@@ -68,21 +70,33 @@ private:
 
     std::wstring GetAvailableCommands() const
     {
+        std::vector<std::pair<std::wstring_view, std::wstring>> entries = {
+            {L"attach", Localization::WSLCCLI_ContainerAttachDesc()},
+            {L"create", Localization::WSLCCLI_ContainerCreateDesc()},
+            {L"exec", Localization::WSLCCLI_ContainerExecDesc()},
+            {L"inspect", Localization::WSLCCLI_ContainerInspectDesc()},
+            {L"kill", Localization::WSLCCLI_ContainerKillDesc()},
+            {L"logs", Localization::WSLCCLI_ContainerLogsDesc()},
+            {L"list", Localization::WSLCCLI_ContainerListDesc()},
+            {L"remove", Localization::WSLCCLI_ContainerRemoveDesc()},
+            {L"run", Localization::WSLCCLI_ContainerRunDesc()},
+            {L"start", Localization::WSLCCLI_ContainerStartDesc()},
+            {L"stop", Localization::WSLCCLI_ContainerStopDesc()},
+        };
+
+        size_t maxLen = 0;
+        for (const auto& [name, _] : entries)
+        {
+            maxLen = (std::max)(maxLen, name.size());
+        }
+
         std::wstringstream commands;
-        commands << L"The following sub-commands are available:\r\n"
-                 << L"  attach   Attach to a container.\r\n"
-                 << L"  create   Create a container.\r\n"
-                 << L"  exec     Execute a command in a running container.\r\n"
-                 << L"  inspect  Inspect a container.\r\n"
-                 << L"  kill     Kill containers.\r\n"
-                 << L"  logs     View container logs.\r\n"
-                 << L"  list     List containers.\r\n"
-                 << L"  remove   Remove containers.\r\n"
-                 << L"  run      Run a container.\r\n"
-                 << L"  start    Start a container.\r\n"
-                 << L"  stop     Stop containers.\r\n"
-                 << L"\r\n"
-                 << L"For more details on a specific command, pass it the help argument. [-h]\r\n\r\n";
+        commands << L"The following sub-commands are available:\r\n";
+        for (const auto& [name, desc] : entries)
+        {
+            commands << L"  " << name << std::wstring(maxLen - name.size() + 2, L' ') << desc << L"\r\n";
+        }
+        commands << L"\r\n" << Localization::WSLCCLI_HelpForDetails() << L" [" << WSLC_CLI_HELP_ARG_STRING << L"]\r\n\r\n";
         return commands.str();
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -16,10 +16,12 @@ Abstract:
 #include "WSLCCLITestHelpers.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "Argument.h"
 
 using namespace WEX::Logging;
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EGlobalTests
 {
@@ -411,31 +413,43 @@ private:
 
     std::wstring GetAvailableCommands() const
     {
+        std::vector<std::pair<std::wstring_view, std::wstring>> entries = {
+            {L"container", Localization::WSLCCLI_ContainerCommandDesc()},
+            {L"image", Localization::WSLCCLI_ImageCommandDesc()},
+            {L"session", Localization::WSLCCLI_SessionCommandDesc()},
+            {L"settings", Localization::WSLCCLI_SettingsCommandDesc()},
+            {L"attach", Localization::WSLCCLI_ContainerAttachDesc()},
+            {L"build", Localization::WSLCCLI_ImageBuildDesc()},
+            {L"create", Localization::WSLCCLI_ContainerCreateDesc()},
+            {L"exec", Localization::WSLCCLI_ContainerExecDesc()},
+            {L"images", Localization::WSLCCLI_ImageListDesc()},
+            {L"inspect", Localization::WSLCCLI_ContainerInspectDesc()},
+            {L"kill", Localization::WSLCCLI_ContainerKillDesc()},
+            {L"list", Localization::WSLCCLI_ContainerListDesc()},
+            {L"load", Localization::WSLCCLI_ImageLoadDesc()},
+            {L"logs", Localization::WSLCCLI_ContainerLogsDesc()},
+            {L"pull", Localization::WSLCCLI_ImagePullDesc()},
+            {L"remove", Localization::WSLCCLI_ContainerRemoveDesc()},
+            {L"rmi", Localization::WSLCCLI_ImageRemoveDesc()},
+            {L"run", Localization::WSLCCLI_ContainerRunDesc()},
+            {L"save", Localization::WSLCCLI_ImageSaveDesc()},
+            {L"start", Localization::WSLCCLI_ContainerStartDesc()},
+            {L"stop", Localization::WSLCCLI_ContainerStopDesc()},
+        };
+
+        size_t maxLen = 0;
+        for (const auto& [name, _] : entries)
+        {
+            maxLen = (std::max)(maxLen, name.size());
+        }
+
         std::wstringstream commands;
-        commands << L"The following commands are available:\r\n"
-                 << L"  container  Container command.\r\n"
-                 << L"  image      Image command.\r\n"
-                 << L"  session    Session command.\r\n"
-                 << L"  settings   Open the settings file in the default editor.\r\n"
-                 << L"  attach     Attach to a container.\r\n"
-                 << L"  build      Build an image from a Dockerfile.\r\n"
-                 << L"  create     Create a container.\r\n"
-                 << L"  exec       Execute a command in a running container.\r\n"
-                 << L"  images     List images.\r\n"
-                 << L"  inspect    Inspect a container.\r\n"
-                 << L"  kill       Kill containers.\r\n"
-                 << L"  list       List containers.\r\n"
-                 << L"  load       Load images.\r\n"
-                 << L"  logs       View container logs.\r\n"
-                 << L"  pull       Pull images.\r\n"
-                 << L"  remove     Remove containers.\r\n"
-                 << L"  rmi        Remove images.\r\n"
-                 << L"  run        Run a container.\r\n"
-                 << L"  save       Save images.\r\n"
-                 << L"  start      Start a container.\r\n"
-                 << L"  stop       Stop containers.\r\n"
-                 << L"\r\n"
-                 << L"For more details on a specific command, pass it the help argument. [-h]\r\n\r\n";
+        commands << L"The following commands are available:\r\n";
+        for (const auto& [name, desc] : entries)
+        {
+            commands << L"  " << name << std::wstring(maxLen - name.size() + 2, L' ') << desc << L"\r\n";
+        }
+        commands << L"\r\n" << Localization::WSLCCLI_HelpForDetails() << L" [" << WSLC_CLI_HELP_ARG_STRING << L"]\r\n\r\n";
         return commands.str();
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -444,7 +444,7 @@ private:
         }
 
         std::wstringstream commands;
-        commands << L"The following commands are available:\r\n";
+        commands << Localization::WSLCCLI_AvailableCommands() << L"\r\n";
         for (const auto& [name, desc] : entries)
         {
             commands << L"  " << name << std::wstring(maxLen - name.size() + 2, L' ') << desc << L"\r\n";

--- a/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "WSLCE2EHelpers.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EImageDeleteTests
 {
@@ -142,7 +143,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Removes images.\r\n\r\n";
+        return Localization::WSLCCLI_ImageRemoveLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EImageInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageInspectTests.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include <wslc_schema.h>
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EImageInspectTests
 {
@@ -92,7 +93,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Inspect images.\r\n\r\n";
+        return Localization::WSLCCLI_ImageInspectLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include "WSLCE2EHelpers.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 using namespace wsl::windows::wslc::models;
 
@@ -155,7 +156,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Lists images.\r\n\r\n";
+        return Localization::WSLCCLI_ImageListLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -173,7 +173,7 @@ private:
     {
         std::wstringstream options;
         options << L"The following options are available:\r\n"
-                << L"  --format      Output formatting (json or table) (Default:table)\r\n"
+                << L"  --format      " << Localization::WSLCCLI_FormatArgDescription() << L"\r\n"
                 << L"  --no-trunc    Do not truncate output\r\n"
                 << L"  -q,--quiet    Outputs the container IDs only\r\n"
                 << L"  --session     Specify the session to use\r\n"

--- a/test/windows/wslc/e2e/WSLCE2EImageSaveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageSaveTests.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "WSLCE2EHelpers.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EImageSaveTests
 {
@@ -125,7 +126,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Saves images.\r\n\r\n";
+        return Localization::WSLCCLI_ImageSaveLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const

--- a/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
@@ -15,8 +15,10 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "Argument.h"
 
 namespace WSLCE2ETests {
+using namespace wsl::shared;
 
 class WSLCE2EImageTests
 {
@@ -57,7 +59,7 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Image command.\r\n\r\n";
+        return Localization::WSLCCLI_ImageCommandLongDesc() + L"\r\n\r\n";
     }
 
     std::wstring GetUsage() const
@@ -67,18 +69,29 @@ private:
 
     std::wstring GetAvailableCommands() const
     {
+        std::vector<std::pair<std::wstring_view, std::wstring>> entries = {
+            {L"build", Localization::WSLCCLI_ImageBuildDesc()},
+            {L"remove", Localization::WSLCCLI_ImageRemoveDesc()},
+            {L"inspect", Localization::WSLCCLI_ImageInspectDesc()},
+            {L"list", Localization::WSLCCLI_ImageListDesc()},
+            {L"load", Localization::WSLCCLI_ImageLoadDesc()},
+            {L"pull", Localization::WSLCCLI_ImagePullDesc()},
+            {L"save", Localization::WSLCCLI_ImageSaveDesc()},
+        };
+
+        size_t maxLen = 0;
+        for (const auto& [name, _] : entries)
+        {
+            maxLen = (std::max)(maxLen, name.size());
+        }
+
         std::wstringstream commands;
-        commands << L"The following sub-commands are available:\r\n"
-                 << L"  build    Build an image from a Dockerfile.\r\n"
-                 << L"  remove   Remove images.\r\n"
-                 << L"  inspect  Inspect images.\r\n"
-                 << L"  list     List images.\r\n"
-                 << L"  load     Load images.\r\n"
-                 << L"  pull     Pull images.\r\n"
-                 << L"  save     Save images.\r\n"
-                 << L"\r\n"
-                 << L"For more details on a specific command, pass it the help argument. [-h]\r\n"
-                 << L"\r\n";
+        commands << L"The following sub-commands are available:\r\n";
+        for (const auto& [name, desc] : entries)
+        {
+            commands << L"  " << name << std::wstring(maxLen - name.size() + 2, L' ') << desc << L"\r\n";
+        }
+        commands << L"\r\n" << Localization::WSLCCLI_HelpForDetails() << L" [" << WSLC_CLI_HELP_ARG_STRING << L"]\r\n" << L"\r\n";
         return commands.str();
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
@@ -86,7 +86,7 @@ private:
         }
 
         std::wstringstream commands;
-        commands << L"The following sub-commands are available:\r\n";
+        commands << Localization::WSLCCLI_AvailableSubcommands() << L"\r\n";
         for (const auto& [name, desc] : entries)
         {
             commands << L"  " << name << std::wstring(maxLen - name.size() + 2, L' ') << desc << L"\r\n";


### PR DESCRIPTION
Localize all user-facing strings in the wslc.exe CLI tool.

Previously, most command descriptions and argument help strings were hardcoded English L"..." literals. Only 5 of 35 argument descriptions and none of the ~50 command descriptions used the localization system.

### Changes

**Resources.resw** (90 new entries):
- 55 command description entries (Short + Long for all 26 command classes)
- 31 argument description entries
- 4 settings-related entries
- All entries include {Locked=...} comments for CLI flags, filenames, and technical terms that shouldn't be translated

**ArgumentDefinitions.h**: All 30 previously-hardcoded argument descriptions now use Localization::WSLCCLI_*ArgDescription() calls

**26 command .cpp files**: All ShortDescription() and LongDescription() methods now use Localization::WSLCCLI_* calls

**E2E tests**: Updated baselines to match new description text

Builds and compiles clean (wslc.exe + wsltests.dll). Formatted with FormatSource.ps1.
