### PR TITLE
Make VMPortMapping::Unmap idempotent

### DIFF
--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -145,6 +145,7 @@ void VMPortMapping::Unmap()
     if (Vm)
     {
         Vm->UnmapPort(*this);
+        Vm = nullptr;
     }
 }
 

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -144,8 +144,8 @@ void VMPortMapping::Unmap()
 {
     if (Vm)
     {
+        auto clearVm = wil::scope_exit([&] { Vm = nullptr; });
         Vm->UnmapPort(*this);
-        Vm = nullptr;
     }
 }
 


### PR DESCRIPTION
Null out Vm after UnmapPort() so a second call to Unmap() is a no-op.

This matches the pattern already used by UnmountVolumes (which checks volume.Mounted). Without this, if ReleaseRuntimeResources is called twice (e.g. from OnEvent(Stop) and a concurrent Delete(Force) path), UnmapPort would be called on an already-unmapped relay.
