### PR TITLE
Fix random "ERROR_FILE_NOT_FOUND" when unmounting with absolute path

### DIFF
--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1218,9 +1218,8 @@ int Unmount(_In_ const std::wstring& arg)
     wsl::windows::common::SvcComm service;
     const HRESULT result = wil::ResultFromException([&] { value = service.DetachDisk(disk); });
 
-    // support relative paths in unmount
-    // check is the result is the error code for "file not found" and the path is relative
-    if (result == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) && PathIsRelative(disk))
+    // Retry with the normalized path to handle relative paths and \\?\ prefix mismatches.
+    if (result == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
     {
         // retry dismounting with the absolute path
         const auto absoluteDisk = wsl::windows::common::filesystem::GetFullPath(filesystem::UnquotePath(disk).c_str());

--- a/test/windows/MountTests.cpp
+++ b/test/windows/MountTests.cpp
@@ -450,6 +450,29 @@ class MountTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + absolutePath.wstring()), (DWORD)0);
     }
 
+    TEST_METHOD(AbsolutePathVhdUnmountAfterVMTimeout)
+    {
+        SKIP_UNSUPPORTED_ARM64_MOUNT_TEST();
+        WSL2_TEST_ONLY();
+
+        WslKeepAlive keepAlive;
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--mount " TEST_MOUNT_VHD L" --vhd --bare"), (DWORD)0);
+
+        const auto disk = GetBlockDeviceInWsl();
+        VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
+
+        WaitForVmTimeout(keepAlive);
+
+        const auto absolutePath = std::filesystem::absolute(TEST_MOUNT_VHD);
+
+        // Validate that the vhd path doesn't start with '\\?'
+        VERIFY_IS_FALSE(absolutePath.wstring().starts_with(L"\\"));
+
+        // Validate the unmounting by absolute path is successful
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + absolutePath.wstring()), (DWORD)0);
+    }
+
     // Attach a disk, but don't mount it
     TEST_METHOD(TestBareMount)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix this random issue where sometimes unmount with the absolute path results in ERROR_FILE_NOT_FOUND
```
PS D:\tmp> wsl --mount "D:\tmp\test.vhdx" --vhd --bare
wsl: The .wslconfig setting 'wsl2.kernelCommandLine' is disabled by the computer policy.
The operation completed successfully.
PS D:\tmp> wsl --unmount  "D:\tmp\test.vhdx"
The system cannot find the file specified.
Error code: Wsl/Service/DetachDisk/ERROR_FILE_NOT_FOUND
PS D:\tmp> wsl --unmount  "\\?\D:\tmp\test.vhdx"
The operation completed successfully.
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

This PR adds the MountTests::MountTests::AbsolutePathVhdUnmountAfterVMTimeout test case. This test case waits for the VM to timeout before unmounting the vhd. Which will trigger the original issue w/o this patch.
