### PR TITLE
Release COM DLLs before installer test MSI operations

### DIFF
--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -180,7 +180,7 @@ class InstallerTests
     // This avoids install failures on older Server SKUs where the RM has stricter silent-mode behavior.
     static void PrepareForMsiOperation()
     {
-        CoFreeUnusedLibrariesEx(0);
+        CoFreeUnusedLibrariesEx(0, 0);
     }
 
     void UninstallMsi()

--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -175,8 +175,17 @@ class InstallerTests
         return wsl::windows::common::registry::ReadString(m_lxssKey.get(), L"MSI", L"ProductCode", L"");
     }
 
+    // Release any in-process COM DLLs (e.g. wslserviceproxystub.dll loaded by prior tests)
+    // so the Restart Manager doesn't detect the test process as holding files.
+    // This avoids install failures on older Server SKUs where the RM has stricter silent-mode behavior.
+    static void PrepareForMsiOperation()
+    {
+        CoFreeUnusedLibrariesEx(0);
+    }
+
     void UninstallMsi()
     {
+        PrepareForMsiOperation();
         auto productCode = GetMsiProductCode();
         VERIFY_IS_FALSE(productCode.empty());
 
@@ -185,6 +194,7 @@ class InstallerTests
 
     void InstallMsi()
     {
+        PrepareForMsiOperation();
         CallMsiExec(std::format(L"/qn /norestart /i {} /L*V {}", m_msiPath, GenerateMsiLogPath()));
     }
 
@@ -367,6 +377,7 @@ class InstallerTests
         LogInfo("Installing: %ls", installerFile.c_str());
         if (wsl::shared::string::EndsWith<wchar_t>(installerFile, L".msi"))
         {
+            PrepareForMsiOperation();
             CallMsiExec(std::format(L"/qn /norestart /i {} /L*V {}", installerFile, GenerateMsiLogPath()));
         }
         else


### PR DESCRIPTION
This is a follow-up to https://github.com/microsoft/WSL/pull/40080 to resolve a test failure on older Windows OS versions.

Call CoFreeUnusedLibrariesEx before each msiexec invocation. This releases in-process COM DLLs like wslserviceproxystub.dll loaded by prior test classes, preventing the Restart Manager from detecting the test process as holding file locks and being terminated.