### PR TITLE
Add response size limit to Docker HTTP client

### DIFF
--- a/src/windows/wslcsession/DockerHTTPClient.cpp
+++ b/src/windows/wslcsession/DockerHTTPClient.cpp
@@ -482,9 +482,22 @@ std::pair<DockerHTTPClient::HTTPResponse, std::string> DockerHTTPClient::SendReq
     auto context = SendRequestImpl(Method, Url, Body, {});
 
     // Read the response header and body.
+    // Limit response size to prevent unbounded memory growth from pathological responses.
+    // All callers expect JSON metadata (list, inspect, create, etc.), not large binary payloads.
+    constexpr size_t MaxResponseSize = 64 * _1MB;
+
     std::optional<HTTPResponse> responseHeader;
     std::string responseBody;
-    auto OnResponse = [&responseBody](const gsl::span<char>& span) { responseBody.append(span.data(), span.size()); };
+    const auto& url = Url;
+    auto OnResponse = [&responseBody, &url](const gsl::span<char>& span) {
+        THROW_HR_IF_MSG(
+            HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE),
+            span.size() > MaxResponseSize - responseBody.size(),
+            "Docker API response exceeds maximum size (%zu bytes) for %hs",
+            MaxResponseSize,
+            url.Get().c_str());
+        responseBody.append(span.data(), span.size());
+    };
 
     auto onHttpResponse = [&](const auto& response) { responseHeader = response; };
     MultiHandleWait io;


### PR DESCRIPTION
SendRequestAndReadResponse accumulates the entire Docker API response body into a std::string with no size limit. While all current callers expect small JSON metadata (list, inspect, create), a pathological or malformed response could cause unbounded memory growth.

Adds a 64 MB limit. This is generous for JSON metadata (typically <1 MB) while catching runaway responses early. Large-payload operations (export, save, attach, logs, pull, import, load) already use streaming via SendRequest and are unaffected.
