### PR TITLE
Initialize user option support and added E2E tests

### DIFF
--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -77,7 +77,7 @@ _(Tag,            "tag",                 L"t",              Kind::Value,       L
 _(Time,           "time",                L"t",              Kind::Value,       L"Time in seconds to wait before executing (default 5)") \
 /*_(TMPFS,          "tmpfs",               NO_ALIAS,          Kind::Value,       L"Mount tmpfs to the container at the given path")*/ \
 _(TTY,            "tty",                 L"t",              Kind::Flag,        L"Open a TTY with the container process.") \
-/*_(User,           "user",                L"u",              Kind::Value,       L"User ID for the process (name|uid|uid:gid)")*/ \
+_(User,           "user",                L"u",              Kind::Value,       L"User ID for the process (name|uid|uid:gid)") \
 _(Verbose,        "verbose",             L"v",              Kind::Flag,        L"Output verbose details") \
 _(Version,        "version",             L"v",              Kind::Flag,        L"Show version information for this tool") \
 /*_(Virtual,        "virtualization",      NO_ALIAS,          Kind::Value,       L"Expose virtualization capabilities to the container")*/ \

--- a/src/windows/wslc/commands/ContainerCreateCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCreateCommand.cpp
@@ -49,7 +49,7 @@ std::vector<Argument> ContainerCreateCommand::GetArguments() const
         Argument::Create(ArgType::Session),
         // Argument::Create(ArgType::TMPFS),
         Argument::Create(ArgType::TTY),
-        // Argument::Create(ArgType::User),
+        Argument::Create(ArgType::User),
         Argument::Create(ArgType::Volume, false, NO_LIMIT),
         // Argument::Create(ArgType::Virtual),
     };

--- a/src/windows/wslc/commands/ContainerExecCommand.cpp
+++ b/src/windows/wslc/commands/ContainerExecCommand.cpp
@@ -39,7 +39,7 @@ std::vector<Argument> ContainerExecCommand::GetArguments() const
         Argument::Create(ArgType::Interactive),
         Argument::Create(ArgType::Session),
         Argument::Create(ArgType::TTY),
-        // Argument::Create(ArgType::User),
+        Argument::Create(ArgType::User),
     };
 }
 

--- a/src/windows/wslc/commands/ContainerRunCommand.cpp
+++ b/src/windows/wslc/commands/ContainerRunCommand.cpp
@@ -50,7 +50,7 @@ std::vector<Argument> ContainerRunCommand::GetArguments() const
         Argument::Create(ArgType::Session),
         // Argument::Create(ArgType::TMPFS),
         Argument::Create(ArgType::TTY),
-        // Argument::Create(ArgType::User),
+        Argument::Create(ArgType::User),
         Argument::Create(ArgType::Volume, false, NO_LIMIT),
         // Argument::Create(ArgType::Virtual),
     };

--- a/src/windows/wslc/services/ConsoleService.h
+++ b/src/windows/wslc/services/ConsoleService.h
@@ -20,7 +20,7 @@ namespace wsl::windows::wslc::services {
 class ConsoleService
 {
 public:
-    int AttachToCurrentConsole(wsl::windows::common::ClientRunningWSLCProcess&& process);
+    static int AttachToCurrentConsole(wsl::windows::common::ClientRunningWSLCProcess&& process);
     static bool RelayInteractiveTty(wsl::windows::common::ClientRunningWSLCProcess& process, HANDLE tty, bool triggerRefresh = false);
     static void RelayNonTtyProcess(wil::unique_handle&& Stdin, wil::unique_handle&& Stdout, wil::unique_handle&& Stderr);
 };

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -39,6 +39,7 @@ struct ContainerOptions
     std::vector<std::string> Ports;
     std::vector<std::wstring> Volumes;
     std::vector<std::string> Entrypoint;
+    std::optional<std::string> User{};
 };
 
 struct CreateContainerResult

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -135,6 +135,12 @@ static wsl::windows::common::RunningWSLCContainer CreateInternal(
         containerLauncher.SetEntrypoint(std::move(entrypoints));
     }
 
+    if (options.User.has_value())
+    {
+        auto user = options.User.value();
+        containerLauncher.SetUser(std::move(user));
+    }
+
     auto [result, runningContainer] = containerLauncher.CreateNoThrow(*session.Get());
     if (result == WSLC_E_IMAGE_NOT_FOUND)
     {
@@ -414,9 +420,14 @@ int ContainerService::Exec(Session& session, const std::string& id, ContainerOpt
     WI_SetFlagIf(execFlags, WSLCProcessFlagsStdin, options.Interactive);
     WI_SetFlagIf(execFlags, WSLCProcessFlagsTty, options.TTY);
 
-    ConsoleService consoleService;
-    return consoleService.AttachToCurrentConsole(
-        wsl::windows::common::WSLCProcessLauncher({}, options.Arguments, options.EnvironmentVariables, execFlags).Launch(*container));
+    auto processLauncher = wsl::windows::common::WSLCProcessLauncher({}, options.Arguments, options.EnvironmentVariables, execFlags);
+    if (options.User.has_value())
+    {
+        auto user = options.User.value();
+        processLauncher.SetUser(std::move(user));
+    }
+
+    return ConsoleService::AttachToCurrentConsole(processLauncher.Launch(*container));
 }
 
 InspectContainer ContainerService::Inspect(Session& session, const std::string& id)

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -278,6 +278,11 @@ void SetContainerOptionsFromArgs(CLIExecutionContext& context)
         options.Entrypoint.push_back(WideToMultiByte(context.Args.Get<ArgType::Entrypoint>()));
     }
 
+    if (context.Args.Contains(ArgType::User))
+    {
+        options.User = WideToMultiByte(context.Args.Get<ArgType::User>());
+    }
+
     if (context.Args.Contains(ArgType::ForwardArgs))
     {
         auto const& forwardArgs = context.Args.Get<ArgType::ForwardArgs>();

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1033,6 +1033,88 @@ class WSLCE2EContainerCreateTests
         result.Verify({.Stderr = L"Port mappings with ephemeral host ports, specific host IPs, or UDP protocol are not currently supported\r\nError code: ERROR_NOT_SUPPORTED\r\n", .ExitCode = 1});
     }
 
+    TEST_METHOD(WSLCE2E_Container_Create_UserOption_UidRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container create --name {} -u 0 {} sh -c \"id -u; id -g\"",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = S_OK});
+
+        result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
+        result.Verify({.Stdout = L"0\n0\n", .Stderr = L"", .ExitCode = S_OK});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Create_UserOption_NameGroupRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container create --name {} -u root:root {} sh -c \"id -un; id -u; id -g\"",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = S_OK});
+
+        result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
+        result.Verify({.Stdout = L"root\n0\n0\n", .Stderr = L"", .ExitCode = S_OK});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Create_UserOption_UnknownUser_Fails)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container create --name {} -u user_does_not_exist {} id -u",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
+        result.Verify({.Stderr = L"unable to find user user_does_not_exist: no matching entries in passwd file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Exec_UserOption_UidRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = S_OK});
+
+        result = RunWslc(std::format(
+            L"container exec -u 0 {} sh -c \"id -u; id -g\"",
+            WslcContainerName));
+        result.Verify({.Stdout = L"0\n0\n", .Stderr = L"", .ExitCode = S_OK});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Exec_UserOption_NameGroupRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = S_OK});
+
+        result = RunWslc(std::format(
+            L"container exec -u root:root {} sh -c \"id -un; id -u; id -g\"",
+            WslcContainerName));
+        result.Verify({.Stdout = L"root\n0\n0\n", .Stderr = L"", .ExitCode = S_OK});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Exec_UserOption_InvalidGroup_Fails)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = S_OK});
+
+        result = RunWslc(std::format(
+            L"container exec -u root:badgid {} id -u",
+            WslcContainerName));
+        result.Dump();
+        result.Verify({.Stderr = L"unable to find group badgid: no matching entries in group file\r\n", .ExitCode = 126});
+    }
+
 private:
     // Test container name
     const std::wstring WslcContainerName = L"wslc-test-container";
@@ -1108,7 +1190,9 @@ private:
                 << L"  --session         Specify the session to use\r\n"
                 << L"  -t,--tty          Open a TTY with the container process.\r\n"
                 << L"  -v,--volume       Bind mount a volume to the container\r\n"
-                << L"  -h,--help         Shows help about the selected command\r\n\r\n";
+                << L"  -h,--help         Shows help about the selected command\r\n"
+                << L"  -u,--user         User ID for the process (name|uid|uid:gid)\r\n"
+                << L"\r\n";
         return options.str();
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1037,10 +1037,8 @@ class WSLCE2EContainerCreateTests
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container create --name {} -u 0 {} sh -c \"id -u; id -g\"",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} -u 0 {} sh -c \"id -u; id -g\"", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -1052,9 +1050,7 @@ class WSLCE2EContainerCreateTests
         WSL2_TEST_ONLY();
 
         auto result = RunWslc(std::format(
-            L"container create --name {} -u root:root {} sh -c \"id -un; id -u; id -g\"",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+            L"container create --name {} -u root:root {} sh -c \"id -un; id -u; id -g\"", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -1065,14 +1061,13 @@ class WSLCE2EContainerCreateTests
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container create --name {} -u user_does_not_exist {} id -u",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} -u user_does_not_exist {} id -u", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
-        result.Verify({.Stderr = L"unable to find user user_does_not_exist: no matching entries in passwd file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
+        result.Verify(
+            {.Stderr = L"unable to find user user_does_not_exist: no matching entries in passwd file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
     }
 
     TEST_METHOD(WSLCE2E_Container_Exec_UserOption_UidRoot)
@@ -1082,9 +1077,7 @@ class WSLCE2EContainerCreateTests
         auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
 
-        result = RunWslc(std::format(
-            L"container exec -u 0 {} sh -c \"id -u; id -g\"",
-            WslcContainerName));
+        result = RunWslc(std::format(L"container exec -u 0 {} sh -c \"id -u; id -g\"", WslcContainerName));
         result.Verify({.Stdout = L"0\n0\n", .Stderr = L"", .ExitCode = S_OK});
     }
 
@@ -1095,9 +1088,7 @@ class WSLCE2EContainerCreateTests
         auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
 
-        result = RunWslc(std::format(
-            L"container exec -u root:root {} sh -c \"id -un; id -u; id -g\"",
-            WslcContainerName));
+        result = RunWslc(std::format(L"container exec -u root:root {} sh -c \"id -un; id -u; id -g\"", WslcContainerName));
         result.Verify({.Stdout = L"root\n0\n0\n", .Stderr = L"", .ExitCode = S_OK});
     }
 
@@ -1108,9 +1099,7 @@ class WSLCE2EContainerCreateTests
         auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = S_OK});
 
-        result = RunWslc(std::format(
-            L"container exec -u root:badgid {} id -u",
-            WslcContainerName));
+        result = RunWslc(std::format(L"container exec -u root:badgid {} id -u", WslcContainerName));
         result.Verify({.Stdout = L"unable to find group badgid: no matching entries in group file\r\n", .ExitCode = 126});
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1111,8 +1111,7 @@ class WSLCE2EContainerCreateTests
         result = RunWslc(std::format(
             L"container exec -u root:badgid {} id -u",
             WslcContainerName));
-        result.Dump();
-        result.Verify({.Stderr = L"unable to find group badgid: no matching entries in group file\r\n", .ExitCode = 126});
+        result.Verify({.Stdout = L"unable to find group badgid: no matching entries in group file\r\n", .ExitCode = 126});
     }
 
 private:

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1177,9 +1177,9 @@ private:
                 << L"  --rm              Remove the container after it stops\r\n"
                 << L"  --session         Specify the session to use\r\n"
                 << L"  -t,--tty          Open a TTY with the container process.\r\n"
+                << L"  -u,--user         User ID for the process (name|uid|uid:gid)\r\n"
                 << L"  -v,--volume       Bind mount a volume to the container\r\n"
                 << L"  -h,--help         Shows help about the selected command\r\n"
-                << L"  -u,--user         User ID for the process (name|uid|uid:gid)\r\n"
                 << L"\r\n";
         return options.str();
     }

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -132,7 +132,7 @@ class WSLCE2EContainerRunTests
             {.Stderr = L"unable to find user user_does_not_exist: no matching entries in passwd file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
     }
 
-    TEST_METHOD(WSLCE2E_Container_Run_UserOption_InvalidFormat_Fails)
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_UnknownGroup_Fails)
     {
         WSL2_TEST_ONLY();
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -99,6 +99,74 @@ class WSLCE2EContainerRunTests
         VerifyContainerIsListed(WslcContainerName, L"running");
     }
 
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_NameRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container run --rm -u root {} sh -c \"id -un; id -u; id -g\"",
+            DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"root\n0\n0\n", .Stderr = L"", .ExitCode = 0});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_UidRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container run --rm -u 0 {} id -u",
+            DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"0\n", .Stderr = L"", .ExitCode = 0});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_UidGidRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(L"container run --rm -u 0:0 {} sh -c \"id -u; id -g\"", DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"0\n0\n", .Stderr = L"", .ExitCode = 0});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_UnknownUser_Fails)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container run --rm -u user_does_not_exist {} id -u",
+            DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"unable to find user user_does_not_exist: no matching entries in passwd file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_InvalidFormat_Fails)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container run --rm -u root:badgid {} id -u",
+            DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"unable to find group badgid: no matching entries in group file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_NameGroupRoot)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container run --rm -u root:root {} sh -c \"id -un; id -u; id -g\"",
+            DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"root\n0\n0\n", .Stderr = L"", .ExitCode = 0});
+    }
+
+    TEST_METHOD(WSLCE2E_Container_Run_UserOption_NonRootUser_Succeeds)
+    {
+        WSL2_TEST_ONLY();
+
+        auto result = RunWslc(std::format(
+            L"container run --rm -u nobody {} sh -c \"id -un; id -u; id -g\"",
+            DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"nobody\n65534\n65534\n", .Stderr = L"", .ExitCode = 0});
+    }
+
 private:
     const std::wstring WslcContainerName = L"wslc-test-container";
     const TestImage& DebianImage = DebianTestImage();

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -103,9 +103,7 @@ class WSLCE2EContainerRunTests
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container run --rm -u root {} sh -c \"id -un; id -u; id -g\"",
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(L"container run --rm -u root {} sh -c \"id -un; id -u; id -g\"", DebianImage.NameAndTag()));
         result.Verify({.Stdout = L"root\n0\n0\n", .Stderr = L"", .ExitCode = 0});
     }
 
@@ -113,9 +111,7 @@ class WSLCE2EContainerRunTests
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container run --rm -u 0 {} id -u",
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(L"container run --rm -u 0 {} id -u", DebianImage.NameAndTag()));
         result.Verify({.Stdout = L"0\n", .Stderr = L"", .ExitCode = 0});
     }
 
@@ -131,19 +127,16 @@ class WSLCE2EContainerRunTests
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container run --rm -u user_does_not_exist {} id -u",
-            DebianImage.NameAndTag()));
-        result.Verify({.Stderr = L"unable to find user user_does_not_exist: no matching entries in passwd file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
+        auto result = RunWslc(std::format(L"container run --rm -u user_does_not_exist {} id -u", DebianImage.NameAndTag()));
+        result.Verify(
+            {.Stderr = L"unable to find user user_does_not_exist: no matching entries in passwd file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
     }
 
     TEST_METHOD(WSLCE2E_Container_Run_UserOption_InvalidFormat_Fails)
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container run --rm -u root:badgid {} id -u",
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(L"container run --rm -u root:badgid {} id -u", DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"unable to find group badgid: no matching entries in group file\r\nError code: E_FAIL\r\n", .ExitCode = 1});
     }
 
@@ -151,9 +144,8 @@ class WSLCE2EContainerRunTests
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container run --rm -u root:root {} sh -c \"id -un; id -u; id -g\"",
-            DebianImage.NameAndTag()));
+        auto result =
+            RunWslc(std::format(L"container run --rm -u root:root {} sh -c \"id -un; id -u; id -g\"", DebianImage.NameAndTag()));
         result.Verify({.Stdout = L"root\n0\n0\n", .Stderr = L"", .ExitCode = 0});
     }
 
@@ -161,9 +153,7 @@ class WSLCE2EContainerRunTests
     {
         WSL2_TEST_ONLY();
 
-        auto result = RunWslc(std::format(
-            L"container run --rm -u nobody {} sh -c \"id -un; id -u; id -g\"",
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(L"container run --rm -u nobody {} sh -c \"id -un; id -u; id -g\"", DebianImage.NameAndTag()));
         result.Verify({.Stdout = L"nobody\n65534\n65534\n", .Stderr = L"", .ExitCode = 0});
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -208,6 +208,7 @@ private:
                 << L"  --rm              Remove the container after it stops\r\n"
                 << L"  --session         Specify the session to use\r\n"
                 << L"  -t,--tty          Open a TTY with the container process.\r\n"
+                << L"  -u,--user         User ID for the process (name|uid|uid:gid)\r\n"
                 << L"  -v,--volume       Bind mount a volume to the container\r\n"
                 << L"  -h,--help         Shows help about the selected command\r\n"
                 << L"\r\n";


### PR DESCRIPTION
## Summary of the Pull Request
- Initialize user option support for create/run/exec
- Renamed E2E test `WSLCE2E_Container_Run_UserOption_InvalidFormat_Fails` to `WSLCE2E_Container_Run_UserOption_UnknownGroup_Fails` to accurately reflect the failure mode (non-existent group, not invalid format)

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx


## Detailed Description of the Pull Request / Additional comments


## Validation Steps Performed