### PR TITLE
wslc: implement dns tunneling for virtio proxy networking mode

### DIFF
--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -15,13 +15,29 @@ static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
 VirtioNetworking::VirtioNetworking(
-    GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
+    GnsChannel&& gnsChannel,
+    VirtioNetworkingFlags flags,
+    LPCWSTR dnsOptions,
+    std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+    wil::shared_handle userToken,
+    wil::unique_socket&& dnsHvsocket) :
     m_guestDeviceManager(std::move(guestDeviceManager)),
     m_userToken(std::move(userToken)),
     m_gnsChannel(std::move(gnsChannel)),
     m_flags(flags),
     m_dnsOptions(dnsOptions)
 {
+    THROW_HR_IF_MSG(
+        E_INVALIDARG,
+        ((!!dnsHvsocket != WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunnelingSocket)) ||
+         (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunnelingSocket) && WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))),
+        "Incompatible DNS settings");
+
+    if (dnsHvsocket)
+    {
+        networking::DnsResolverFlags resolverFlags{};
+        m_dnsTunnelingResolver.emplace(std::move(dnsHvsocket), resolverFlags);
+    }
 }
 
 VirtioNetworking::~VirtioNetworking()
@@ -195,6 +211,10 @@ try
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))
     {
         currentDns = networking::HostDnsInfo::GetDnsTunnelingSettings(default_route);
+    }
+    else if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunnelingSocket))
+    {
+        currentDns = networking::HostDnsInfo::GetDnsTunnelingSettings(TEXT(LX_INIT_DNS_TUNNELING_IP_ADDRESS));
     }
     else
     {

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -4,6 +4,7 @@
 
 #include "INetworkingEngine.h"
 #include "GnsChannel.h"
+#include "DnsResolver.h"
 #include "WslCoreHostDnsInfo.h"
 #include "GnsPortTrackerChannel.h"
 #include "GuestDeviceManager.h"
@@ -16,13 +17,21 @@ enum class VirtioNetworkingFlags
     LocalhostRelay = 0x1,
     DnsTunneling = 0x2,
     Ipv6 = 0x4,
+    DnsTunnelingSocket = 0x8,
 };
 DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
 
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
+    VirtioNetworking(
+        GnsChannel&& gnsChannel,
+        VirtioNetworkingFlags flags,
+        LPCWSTR dnsOptions,
+        std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+        wil::shared_handle userToken,
+        wil::unique_socket&& dnsHvsocket = {});
+
     ~VirtioNetworking();
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.
@@ -61,6 +70,7 @@ private:
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
     VirtioNetworkingFlags m_flags = VirtioNetworkingFlags::None;
     LPCWSTR m_dnsOptions = nullptr;
+    std::optional<networking::DnsResolver> m_dnsTunnelingResolver;
     std::optional<GUID> m_localhostAdapterId;
     std::optional<GUID> m_adapterId;
 

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -419,26 +419,14 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
     {
         try
         {
-            // Open a handle to the service control manager and check if the inbox service is registered.
-            const wil::unique_schandle manager{OpenSCManager(nullptr, nullptr, SC_MANAGER_ENUMERATE_SERVICE)};
-            THROW_LAST_ERROR_IF(!manager);
-
-            // Check if the service is running.
-            const wil::unique_schandle service{OpenServiceW(manager.get(), L"GlobalSecureAccessTunnelingService", SERVICE_QUERY_STATUS)};
-            if (service)
+            if (wsl::windows::common::helpers::IsServiceRunning(L"GlobalSecureAccessTunnelingService"))
             {
-                SERVICE_STATUS status;
-                THROW_IF_WIN32_BOOL_FALSE(QueryServiceStatus(service.get(), &status));
-
-                if (status.dwCurrentState != SERVICE_STOPPED)
+                if (DnsTunnelingConfigPresence == ConfigKeyPresence::Present)
                 {
-                    if (DnsTunnelingConfigPresence == ConfigKeyPresence::Present)
-                    {
-                        EMIT_USER_WARNING(wsl::shared::Localization::MessageDnsTunnelingDisabled());
-                    }
-
-                    EnableDnsTunneling = false;
+                    EMIT_USER_WARNING(wsl::shared::Localization::MessageDnsTunnelingDisabled());
                 }
+
+                EnableDnsTunneling = false;
             }
         }
         CATCH_LOG()
@@ -474,9 +462,12 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
         EnableVirtio9p = false;
     }
 
-    if (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored)
+    if (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::VirtioProxy)
     {
-        VALIDATE_CONFIG_OPTION((NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored), EnableDnsTunneling, false);
+        VALIDATE_CONFIG_OPTION(
+            (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::VirtioProxy),
+            EnableDnsTunneling,
+            false);
     }
 
     if (!EnableDnsTunneling)

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -475,6 +475,29 @@ bool wsl::windows::common::helpers::IsServicePresent(_In_ LPCWSTR ServiceName)
     return !!service;
 }
 
+bool wsl::windows::common::helpers::IsServiceRunning(_In_ LPCWSTR ServiceName)
+{
+    const wil::unique_schandle manager{OpenSCManager(nullptr, nullptr, SC_MANAGER_CONNECT)};
+    if (!manager)
+    {
+        return false;
+    }
+
+    const wil::unique_schandle service{OpenServiceW(manager.get(), ServiceName, SERVICE_QUERY_STATUS)};
+    if (!service)
+    {
+        return false;
+    }
+
+    SERVICE_STATUS status;
+    if (!QueryServiceStatus(service.get(), &status))
+    {
+        return false;
+    }
+
+    return status.dwCurrentState != SERVICE_STOPPED;
+}
+
 bool wsl::windows::common::helpers::IsVirtioSerialConsoleSupported()
 {
     // See if the Windows version has the required platform change.

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -153,6 +153,8 @@ bool IsPackageInstalled(_In_ LPCWSTR PackageFamilyName);
 
 bool IsServicePresent(_In_ LPCWSTR ServiceName);
 
+bool IsServiceRunning(_In_ LPCWSTR ServiceName);
+
 bool IsVirtioSerialConsoleSupported();
 
 bool IsVmemmSuffixSupported();

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -43,7 +43,7 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
     THROW_IF_FAILED(CoCreateGuid(&m_vmId));
     m_vmIdString = wsl::shared::string::GuidToString<wchar_t>(m_vmId, wsl::shared::string::GuidToStringFlags::Uppercase);
-    m_featureFlags = static_cast<WSLCFeatureFlags>(Settings->FeatureFlags);
+    m_featureFlags = Settings->FeatureFlags;
     m_networkingMode = Settings->NetworkingMode;
     m_bootTimeoutMs = Settings->BootTimeoutMs;
 
@@ -369,8 +369,6 @@ try
     if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
     {
         THROW_HR_IF(E_INVALIDARG, DnsSocket == nullptr);
-        THROW_HR_IF_MSG(
-            E_NOTIMPL, m_networkingMode == WSLCNetworkingModeVirtioProxy, "DNS tunneling not supported for VirtioProxy");
 
         THROW_IF_FAILED(wsl::core::networking::DnsResolver::LoadDnsResolverMethods());
         dnsSocketHandle.reset(reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(*DnsSocket)));
@@ -383,34 +381,39 @@ try
     if (m_networkingMode == WSLCNetworkingModeNAT)
     {
         // TODO: refactor this to avoid using wsl config
-        wsl::core::Config config(nullptr);
-        if (!wsl::core::NatNetworking::IsHyperVFirewallSupported(config))
+        m_natConfig.emplace(nullptr);
+        if (!wsl::core::NatNetworking::IsHyperVFirewallSupported(*m_natConfig))
         {
-            config.FirewallConfig.reset();
+            m_natConfig->FirewallConfig.reset();
         }
 
         // Enable DNS tunneling if a DNS socket was provided
         if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
         {
-            config.EnableDnsTunneling = true;
+            m_natConfig->EnableDnsTunneling = true;
             in_addr address{};
             WI_VERIFY(inet_pton(AF_INET, LX_INIT_DNS_TUNNELING_IP_ADDRESS, &address) == 1);
-            config.DnsTunnelingIpAddress = address.S_un.S_addr;
+            m_natConfig->DnsTunnelingIpAddress = address.S_un.S_addr;
         }
 
         m_networkEngine = std::make_unique<wsl::core::NatNetworking>(
             m_computeSystem.get(),
-            wsl::core::NatNetworking::CreateNetwork(config),
+            wsl::core::NatNetworking::CreateNetwork(*m_natConfig),
             wsl::core::GnsChannel(std::move(gnsSocketHandle)),
-            config,
+            *m_natConfig,
             std::move(dnsSocketHandle),
             nullptr);
     }
     else if (m_networkingMode == WSLCNetworkingModeVirtioProxy)
     {
         wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::Ipv6;
+        if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
+        {
+            WI_SetFlag(flags, wsl::core::VirtioNetworkingFlags::DnsTunnelingSocket);
+        }
+
         m_networkEngine = std::make_unique<wsl::core::VirtioNetworking>(
-            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken);
+            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken, std::move(dnsSocketHandle));
     }
     else
     {

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -370,8 +370,16 @@ try
     {
         THROW_HR_IF(E_INVALIDARG, DnsSocket == nullptr);
 
-        THROW_IF_FAILED(wsl::core::networking::DnsResolver::LoadDnsResolverMethods());
-        dnsSocketHandle.reset(reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(*DnsSocket)));
+        const auto result = wsl::core::networking::DnsResolver::LoadDnsResolverMethods();
+        if (FAILED(result))
+        {
+            LOG_HR_MSG(result, "Failed to load DNS resolver methods, DNS tunneling will be disabled");
+            WI_ClearFlag(m_featureFlags, WslcFeatureFlagsDnsTunneling);
+        }
+        else
+        {
+            dnsSocketHandle.reset(reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(*DnsSocket)));
+        }
     }
     else
     {
@@ -390,6 +398,8 @@ try
         // Enable DNS tunneling if a DNS socket was provided
         if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
         {
+            WI_ASSERT(dnsSocketHandle);
+
             m_natConfig->EnableDnsTunneling = true;
             in_addr address{};
             WI_VERIFY(inet_pton(AF_INET, LX_INIT_DNS_TUNNELING_IP_ADDRESS, &address) == 1);

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -20,6 +20,7 @@ Abstract:
 #include "GuestDeviceManager.h"
 #include "Dmesg.h"
 #include "INetworkingEngine.h"
+#include "WslCoreConfig.h"
 #include <filesystem>
 #include <map>
 
@@ -79,6 +80,7 @@ private:
     wil::unique_socket m_listenSocket;
     std::shared_ptr<DmesgCollector> m_dmesgCollector;
     std::shared_ptr<GuestDeviceManager> m_guestDeviceManager;
+    std::optional<wsl::core::Config> m_natConfig;
     std::unique_ptr<wsl::core::INetworkingEngine> m_networkEngine;
 
     wil::unique_event m_vmExitEvent{wil::EventOptions::ManualReset};

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -571,8 +571,9 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             {
                 wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::Ipv6;
                 WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::LocalhostRelay, m_vmConfig.EnableLocalhostRelay);
+                WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::DnsTunnelingSocket, m_vmConfig.EnableDnsTunneling);
                 m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
-                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);
+                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken, std::move(dnsTunnelingSocket));
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::Bridged)
             {
@@ -1890,7 +1891,9 @@ bool WslCoreVm::InitializeDrvFsLockHeld(_In_ HANDLE UserToken)
 
 bool WslCoreVm::IsDnsTunnelingSupported() const
 {
-    WI_ASSERT(m_vmConfig.NetworkingMode == NetworkingMode::Nat || m_vmConfig.NetworkingMode == NetworkingMode::Mirrored);
+    WI_ASSERT(
+        m_vmConfig.NetworkingMode == NetworkingMode::Nat || m_vmConfig.NetworkingMode == NetworkingMode::Mirrored ||
+        m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy);
 
     return SUCCEEDED_LOG(wsl::core::networking::DnsResolver::LoadDnsResolverMethods());
 }

--- a/src/windows/wslc/services/SessionModel.cpp
+++ b/src/windows/wslc/services/SessionModel.cpp
@@ -42,6 +42,11 @@ SessionOptions::SessionOptions()
     {
         WI_SetFlag(m_sessionSettings.FeatureFlags, WslcFeatureFlagsVirtioFs);
     }
+
+    if (settings::User().Get<settings::Setting::SessionDnsTunneling>())
+    {
+        WI_SetFlag(m_sessionSettings.FeatureFlags, WslcFeatureFlagsDnsTunneling);
+    }
 }
 
 bool SessionOptions::IsElevated()

--- a/src/windows/wslc/settings/UserSettings.cpp
+++ b/src/windows/wslc/settings/UserSettings.cpp
@@ -114,6 +114,11 @@ namespace details {
         return std::nullopt;
     }
 
+    WSLC_VALIDATE_SETTING(SessionDnsTunneling)
+    {
+        return value;
+    }
+
 #undef WSLC_VALIDATE_SETTING
 
 } // namespace details

--- a/src/windows/wslc/settings/UserSettings.h
+++ b/src/windows/wslc/settings/UserSettings.h
@@ -41,6 +41,7 @@ enum class Setting : size_t
     SessionStoragePath,
     SessionNetworkingMode,
     SessionHostFileShareMode,
+    SessionDnsTunneling,
 
     Max
 };
@@ -81,6 +82,7 @@ namespace details {
     DEFINE_SETTING_MAPPING(SessionStoragePath,       std::string, std::wstring,       {},                            "session.defaultStoragePath")
     DEFINE_SETTING_MAPPING(SessionNetworkingMode,    std::string, WSLCNetworkingMode, WSLCNetworkingModeVirtioProxy, "session.networkingMode")
     DEFINE_SETTING_MAPPING(SessionHostFileShareMode, std::string, HostFileShareMode,  HostFileShareMode::VirtioFs,   "session.hostFileShareMode")
+    DEFINE_SETTING_MAPPING(SessionDnsTunneling,      bool,        bool,               false,                         "session.dnsTunneling")
 
 #undef DEFINE_SETTING_MAPPING
     // clang-format on

--- a/src/windows/wslc/settings/UserSettings.h
+++ b/src/windows/wslc/settings/UserSettings.h
@@ -82,7 +82,7 @@ namespace details {
     DEFINE_SETTING_MAPPING(SessionStoragePath,       std::string, std::wstring,       {},                            "session.defaultStoragePath")
     DEFINE_SETTING_MAPPING(SessionNetworkingMode,    std::string, WSLCNetworkingMode, WSLCNetworkingModeVirtioProxy, "session.networkingMode")
     DEFINE_SETTING_MAPPING(SessionHostFileShareMode, std::string, HostFileShareMode,  HostFileShareMode::VirtioFs,   "session.hostFileShareMode")
-    DEFINE_SETTING_MAPPING(SessionDnsTunneling,      bool,        bool,               false,                         "session.dnsTunneling")
+    DEFINE_SETTING_MAPPING(SessionDnsTunneling,      bool,        bool,               true,                          "session.dnsTunneling")
 
 #undef DEFINE_SETTING_MAPPING
     // clang-format on

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -5041,5 +5041,32 @@ class VirtioProxyTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = false}));
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
+
+    TEST_METHOD(DnsResolutionBasicDnsTunneling)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+        DNS_TUNNELING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+        NetworkTests::VerifyDnsResolutionBasic();
+    }
+
+    TEST_METHOD(DnsResolutionDigDnsTunneling)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+        DNS_TUNNELING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+        NetworkTests::VerifyDnsResolutionDig();
+    }
+
+    TEST_METHOD(DnsResolutionRecordTypesDnsTunneling)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+        DNS_TUNNELING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+        NetworkTests::VerifyDnsResolutionRecordTypes();
+    }
 };
 } // namespace NetworkTests

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2326,6 +2326,12 @@ class WSLCTests
 
             VERIFY_ARE_EQUAL(result.Output[1], std::format("nameserver {}\n", LX_INIT_DNS_TUNNELING_IP_ADDRESS));
         }
+
+        // Verify DNS resolution.
+        // Note: without DNS tunneling, NAT mode uses the ICS SharedAccess DNS proxy which only supports UDP.
+        // TCP DNS queries (dig +tcp) will time out without tunneling.
+        VerifyDigDnsResolution(session.get(), "getent ahosts bing.com");
+        VerifyDnsQueries(session.get(), mode, enableDnsTunneling);
     }
 
     TEST_METHOD(NATNetworking)
@@ -2342,6 +2348,77 @@ class WSLCTests
     TEST_METHOD(VirtioProxyNetworking)
     {
         ValidateNetworking(WSLCNetworkingModeVirtioProxy);
+    }
+
+    TEST_METHOD(VirtioProxyNetworkingWithDnsTunneling)
+    {
+        WINDOWS_11_TEST_ONLY();
+        ValidateNetworking(WSLCNetworkingModeVirtioProxy, true);
+    }
+
+    // DNS test helpers
+
+    void VerifyDigDnsResolution(IWSLCSession* session, const std::string& digCommandLine)
+    {
+        auto result = ExpectCommandResult(session, {"/bin/sh", "-c", digCommandLine}, 0);
+        VERIFY_IS_FALSE(result.Output[1].empty());
+    }
+
+    void VerifyDnsResolutionDig(IWSLCSession* session, WSLCNetworkingMode mode, bool enableDnsTunneling)
+    {
+        // TCP DNS works except for NAT without tunneling (ICS SharedAccess DNS proxy is UDP-only).
+        const bool includeTcp = (mode != WSLCNetworkingModeNAT) || enableDnsTunneling;
+
+        // Test A record resolution (IPv4) and reverse DNS lookup over UDP
+        VerifyDigDnsResolution(session, "dig +short +time=5 A bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 -x 8.8.8.8");
+
+        if (includeTcp)
+        {
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 A bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 -x 8.8.8.8");
+        }
+    }
+
+    void VerifyDnsResolutionRecordTypes(IWSLCSession* session)
+    {
+        VerifyDigDnsResolution(session, "dig +short +time=5 MX bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 NS bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 TXT bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 SOA bing.com");
+    }
+
+    void VerifyDnsQueries(IWSLCSession* session, WSLCNetworkingMode mode, bool enableDnsTunneling)
+    {
+        // TCP DNS works except for NAT without tunneling (ICS SharedAccess DNS proxy is UDP-only).
+        const bool includeTcp = (mode != WSLCNetworkingModeNAT) || enableDnsTunneling;
+
+        // UDP queries for all record types
+        VerifyDigDnsResolution(session, "dig +short +time=5 A bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 AAAA bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 MX bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 NS bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 -x 8.8.8.8");
+        VerifyDigDnsResolution(session, "dig +short +time=5 SOA bing.com");
+        VerifyDigDnsResolution(session, "dig +short +time=5 TXT bing.com");
+        VerifyDigDnsResolution(session, "dig +time=5 CNAME bing.com");
+        VerifyDigDnsResolution(session, "dig +time=5 SRV bing.com");
+
+        if (includeTcp)
+        {
+            // ANY - dig expects a large response so it queries directly over TCP
+            VerifyDigDnsResolution(session, "dig +short +time=5 ANY bing.com");
+
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 A bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 AAAA bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 MX bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 NS bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 -x 8.8.8.8");
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 SOA bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 TXT bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +time=5 CNAME bing.com");
+            VerifyDigDnsResolution(session, "dig +tcp +time=5 SRV bing.com");
+        }
     }
 
     void ValidatePortMapping(WSLCNetworkingMode networkingMode)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2364,30 +2364,6 @@ class WSLCTests
         VERIFY_IS_FALSE(result.Output[1].empty());
     }
 
-    void VerifyDnsResolutionDig(IWSLCSession* session, WSLCNetworkingMode mode, bool enableDnsTunneling)
-    {
-        // TCP DNS works except for NAT without tunneling (ICS SharedAccess DNS proxy is UDP-only).
-        const bool includeTcp = (mode != WSLCNetworkingModeNAT) || enableDnsTunneling;
-
-        // Test A record resolution (IPv4) and reverse DNS lookup over UDP
-        VerifyDigDnsResolution(session, "dig +short +time=5 A bing.com");
-        VerifyDigDnsResolution(session, "dig +short +time=5 -x 8.8.8.8");
-
-        if (includeTcp)
-        {
-            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 A bing.com");
-            VerifyDigDnsResolution(session, "dig +tcp +short +time=5 -x 8.8.8.8");
-        }
-    }
-
-    void VerifyDnsResolutionRecordTypes(IWSLCSession* session)
-    {
-        VerifyDigDnsResolution(session, "dig +short +time=5 MX bing.com");
-        VerifyDigDnsResolution(session, "dig +short +time=5 NS bing.com");
-        VerifyDigDnsResolution(session, "dig +short +time=5 TXT bing.com");
-        VerifyDigDnsResolution(session, "dig +short +time=5 SOA bing.com");
-    }
-
     void VerifyDnsQueries(IWSLCSession* session, WSLCNetworkingMode mode, bool enableDnsTunneling)
     {
         // TCP DNS works except for NAT without tunneling (ICS SharedAccess DNS proxy is UDP-only).


### PR DESCRIPTION
This change implements dns tunneling for the virtioproxy networking mode. This will go through the same path as dnstunneling for NAT until the built in dns support is fixed in the device host dll.