### PR TITLE
Add /attachdebugger option to automatically launch WinDbgX for test debugging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,7 +92,8 @@ Test execution:
 - **Requires Administrator privileges** - test.bat will fail without admin rights
 
 Test debugging:
-- Wait for debugger: `/waitfordebugger`
+- Attach WinDbgX automatically: `/attachdebugger`
+- Wait for debugger (manual attach): `/waitfordebugger`
 - Break on failure: `/breakonfailure`
 - Run in-process: `/inproc`
 

--- a/doc/docs/dev-loop.md
+++ b/doc/docs/dev-loop.md
@@ -96,7 +96,8 @@ bin\x64\debug\test.bat /name:*UnitTest* -f
 
 See [debugging](debugging.md) for general debugging instructions.
 
-To attach a debugger to the unit test process, use: `/waitfordebugger` when calling `test.bat`. 
+To automatically attach WinDbgX to the unit test process, use: `/attachdebugger` when calling `test.bat`.
+To wait for a debugger to be manually attached, use: `/waitfordebugger`.
 Use `/breakonfailure` to automatically break on the first test failure. 
 
 ## Tips and tricks

--- a/test/README.md
+++ b/test/README.md
@@ -18,7 +18,7 @@ The following options are handled by `test.bat` / `run-tests.ps1` before invokin
 
 ### **/attachdebugger**
 
-Automatically launches WinDbgX and attaches it to the test host process. Requires [WinDbg](https://aka.ms/windbg) to be installed (`winget install Microsoft.WinDbg`). Under the hood it passes `/waitfordebugger` to TE.exe, finds the `TE.ProcessHost.exe` child process, and attaches WinDbgX to it. When combined with `/inproc`, WinDbgX attaches to `TE.exe` directly instead.
+Automatically launches WinDbgX and attaches it to the test host process. Requires [WinDbg](https://aka.ms/windbg) to be installed (`winget install Microsoft.WinDbg`). Under the hood it passes `/waitfordebugger /inproc` to TE.exe so tests run in-process, then attaches WinDbgX directly to `TE.exe`.
 
 `test.bat /attachdebugger /name:*MyTest*`
 

--- a/test/README.md
+++ b/test/README.md
@@ -12,6 +12,16 @@ Executing tests with TAEF is done by invoking the `TE.exe` binary:
 2. Navigate to the subdirectory containing the built test binaries (`bin/<X64|Arm64>/<Debug|Release>/`)
 3. Execute the binaries via invoking TE and passing the test dll/s as arguments: `TE.exe test1.dll test2.dll test3.dll`
 
+## test.bat Options
+
+The following options are handled by `test.bat` / `run-tests.ps1` before invoking TE.exe:
+
+### **/attachdebugger**
+
+Automatically launches WinDbgX and attaches it to the test host process. Requires [WinDbg](https://aka.ms/windbg) to be installed (`winget install Microsoft.WinDbg`). Under the hood it passes `/waitfordebugger` to TE.exe, finds the `TE.ProcessHost.exe` child process, and attaches WinDbgX to it. When combined with `/inproc`, WinDbgX attaches to `TE.exe` directly instead.
+
+`test.bat /attachdebugger /name:*MyTest*`
+
 ## Useful **TE.exe** Command Line Parameters for Debugging/Executing Tests
 
 Command Line parameters are passed to `TE.exe` after supplying the target `.dll`:

--- a/tools/test/run-tests.ps1
+++ b/tools/test/run-tests.ps1
@@ -54,6 +54,12 @@ if ($TeArgs -and ($TeArgs -icontains '/attachdebugger'))
     {
         $AttachDebugger = $true
         $TeArgs += '/waitfordebugger'
+        # Run in-process so WinDbgX can attach directly to TE.exe without
+        # polling for a TE.ProcessHost.exe child process.
+        if (-not ($TeArgs -icontains '/inproc'))
+        {
+            $TeArgs += '/inproc'
+        }
     }
     else
     {
@@ -67,30 +73,9 @@ $teProcess = Start-Process -FilePath "te.exe" -ArgumentList $teArgList -PassThru
 
 if ($AttachDebugger)
 {
-    $targetPid = if ($TeArgs -icontains '/inproc') { $teProcess.Id } else { $null }
-
-    if (-not $targetPid)
-    {
-        for ($i = 0; $i -lt 120 -and -not $teProcess.HasExited; $i++)
-        {
-            Start-Sleep -Milliseconds 500
-            $child = Get-CimInstance Win32_Process -Filter "ParentProcessId = $($teProcess.Id) AND Name = 'TE.ProcessHost.exe'" -ErrorAction SilentlyContinue
-            if ($child) { $targetPid = $child[0].ProcessId; break }
-        }
-    }
-
-    if ($targetPid)
-    {
-        $targetName = if ($targetPid -eq $teProcess.Id) { "TE.exe" } else { "TE.ProcessHost.exe" }
-        Write-Host "Launching WinDbgX attached to $targetName (PID: $targetPid)..."
-        Start-Process "WinDbgX.exe" -ArgumentList "-p $targetPid"
-    }
-    else
-    {
-        Write-Warning "Could not find TE.ProcessHost.exe within 60 seconds."
-        Write-Host "Attach a debugger manually to TE.exe (PID: $($teProcess.Id))."
-    }
+    # /inproc is always added above, so attach directly to TE.exe.
+    Write-Host "Launching WinDbgX attached to TE.exe (PID: $($teProcess.Id))..."
+    Start-Process "WinDbgX.exe" -ArgumentList "-p $($teProcess.Id)"
 }
 
-$teProcess | Wait-Process
-if ($teProcess.ExitCode -ne 0) { exit 1 }
+exit ($teProcess | Wait-Process -PassThru).ExitCode

--- a/tools/test/run-tests.ps1
+++ b/tools/test/run-tests.ps1
@@ -45,9 +45,52 @@ if ($Fast)
     $SetupScript = $null
 }
 
-te.exe $TestDllPath /p:SetupScript=$SetupScript  /p:Version=$Version /p:DistroPath=$DistroPath /p:Package=$Package /p:UnitTestsPath=$UnitTestsPath /p:PullRequest=$PullRequest /p:AllowUnsigned=1 @TeArgs
-
-if (!$?)
+# Handle /attachdebugger: verify WinDbgX is available, then add /waitfordebugger so we can find and attach to the test host.
+$AttachDebugger = $false
+if ($TeArgs -and ($TeArgs -icontains '/attachdebugger'))
 {
-    exit 1
+    $TeArgs = @($TeArgs | Where-Object { $_ -ine '/attachdebugger' })
+    if (Get-Command "WinDbgX.exe" -ErrorAction SilentlyContinue)
+    {
+        $AttachDebugger = $true
+        $TeArgs += '/waitfordebugger'
+    }
+    else
+    {
+        Write-Warning "/attachdebugger was requested, but WinDbgX.exe was not found. Continuing without debugger."
+    }
 }
+
+$teArgList = @($TestDllPath, "/p:SetupScript=$SetupScript", "/p:Version=$Version", "/p:DistroPath=$DistroPath",
+    "/p:Package=$Package", "/p:UnitTestsPath=$UnitTestsPath", "/p:PullRequest=$PullRequest", "/p:AllowUnsigned=1") + $TeArgs
+$teProcess = Start-Process -FilePath "te.exe" -ArgumentList $teArgList -PassThru -NoNewWindow
+
+if ($AttachDebugger)
+{
+    $targetPid = if ($TeArgs -icontains '/inproc') { $teProcess.Id } else { $null }
+
+    if (-not $targetPid)
+    {
+        for ($i = 0; $i -lt 120 -and -not $teProcess.HasExited; $i++)
+        {
+            Start-Sleep -Milliseconds 500
+            $child = Get-CimInstance Win32_Process -Filter "ParentProcessId = $($teProcess.Id) AND Name = 'TE.ProcessHost.exe'" -ErrorAction SilentlyContinue
+            if ($child) { $targetPid = $child[0].ProcessId; break }
+        }
+    }
+
+    if ($targetPid)
+    {
+        $targetName = if ($targetPid -eq $teProcess.Id) { "TE.exe" } else { "TE.ProcessHost.exe" }
+        Write-Host "Launching WinDbgX attached to $targetName (PID: $targetPid)..."
+        Start-Process "WinDbgX.exe" -ArgumentList "-p $targetPid"
+    }
+    else
+    {
+        Write-Warning "Could not find TE.ProcessHost.exe within 60 seconds."
+        Write-Host "Attach a debugger manually to TE.exe (PID: $($teProcess.Id))."
+    }
+}
+
+$teProcess | Wait-Process
+if ($teProcess.ExitCode -ne 0) { exit 1 }


### PR DESCRIPTION
## Summary

Adds a new `/attachdebugger` option to `test.bat` that automatically launches WinDbgX and attaches it to the test host process, replacing the manual `/waitfordebugger` workflow.

## Usage

```
bin\x64\debug\test.bat /attachdebugger /name:*UnitTest*
bin\x64\debug\test.bat /attachdebugger /inproc /name:*MyTest*
```

## How it works

When `/attachdebugger` is passed:
1. Strips it from the args and adds `/waitfordebugger` (so TAEF pauses the test host)
2. Starts `te.exe` in the background with output in the current console
3. Polls WMI for the `TE.ProcessHost.exe` child process
4. Launches `WinDbgX.exe -p <pid>` to attach directly — no child-debugging noise
5. With `/inproc`, attaches to `TE.exe` itself instead

Falls back gracefully if WinDbgX isn't installed or the child process can't be found.

## Changes
- `tools/test/run-tests.ps1` — Core implementation
- `doc/docs/dev-loop.md` — Updated debugging docs
- `.github/copilot-instructions.md` — Updated developer instructions
- `test/README.md` — Added `/attachdebugger` section
