### PR TITLE
Add dev environment setup with WinGet Configuration

### DIFF
--- a/.config/configuration.vsEnterprise.winget
+++ b/.config/configuration.vsEnterprise.winget
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/WSL/blob/master/doc/docs/dev-loop.md
+#
+# Usage: winget configure -f .config/configuration.vsEnterprise.winget
+#
+# Visual Studio 2022 Enterprise edition. For other editions use:
+#   .config/configuration.winget                   (Community, default)
+#   .config/configuration.vsProfessional.winget    (Professional)
+properties:
+  resources:
+    - resource: Microsoft.Windows.Settings/WindowsSettings
+      directives:
+        description: Enable Developer Mode (required for symbolic link support)
+        allowPrerelease: true
+        securityContext: elevated
+      settings:
+        DeveloperMode: true
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: cmake
+      directives:
+        description: Install CMake
+        securityContext: elevated
+      settings:
+        id: Kitware.CMake
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Enterprise
+        securityContext: elevated
+      settings:
+        id: Microsoft.VisualStudio.2022.Enterprise
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads from .vsconfig
+        allowPrerelease: true
+        securityContext: elevated
+      settings:
+        productId: Microsoft.VisualStudio.Product.Enterprise
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+  configurationVersion: 0.2.0

--- a/.config/configuration.vsProfessional.winget
+++ b/.config/configuration.vsProfessional.winget
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/WSL/blob/master/doc/docs/dev-loop.md
+#
+# Usage: winget configure -f .config/configuration.vsProfessional.winget
+#
+# Visual Studio 2022 Professional edition. For other editions use:
+#   .config/configuration.winget                (Community, default)
+#   .config/configuration.vsEnterprise.winget   (Enterprise)
+properties:
+  resources:
+    - resource: Microsoft.Windows.Settings/WindowsSettings
+      directives:
+        description: Enable Developer Mode (required for symbolic link support)
+        allowPrerelease: true
+        securityContext: elevated
+      settings:
+        DeveloperMode: true
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: cmake
+      directives:
+        description: Install CMake
+        securityContext: elevated
+      settings:
+        id: Kitware.CMake
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Professional
+        securityContext: elevated
+      settings:
+        id: Microsoft.VisualStudio.2022.Professional
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads from .vsconfig
+        allowPrerelease: true
+        securityContext: elevated
+      settings:
+        productId: Microsoft.VisualStudio.Product.Professional
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+  configurationVersion: 0.2.0

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/WSL/blob/master/doc/docs/dev-loop.md
+#
+# Usage: winget configure -f .config/configuration.winget
+#
+# This is the default configuration (VS Community). For other editions use:
+#   .config/configuration.vsProfessional.winget
+#   .config/configuration.vsEnterprise.winget
+properties:
+  resources:
+    - resource: Microsoft.Windows.Settings/WindowsSettings
+      directives:
+        description: Enable Developer Mode (required for symbolic link support)
+        allowPrerelease: true
+        securityContext: elevated
+      settings:
+        DeveloperMode: true
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: cmake
+      directives:
+        description: Install CMake
+        securityContext: elevated
+      settings:
+        id: Kitware.CMake
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Community
+        securityContext: elevated
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads from .vsconfig
+        allowPrerelease: true
+        securityContext: elevated
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+  configurationVersion: 0.2.0

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,21 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Component.VC.CoreIde",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.ATL.ARM64",
+    "Microsoft.VisualStudio.Component.VC.ATL.Spectre",
+    "Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
+    "Microsoft.VisualStudio.Component.Windows11SDK.26100",
+    "Microsoft.VisualStudio.Component.UWP.VC.ARM64",
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.Workload.Universal",
+    "Microsoft.VisualStudio.Workload.NativeDesktop"
+  ]
+}

--- a/doc/docs/dev-loop.md
+++ b/doc/docs/dev-loop.md
@@ -2,22 +2,35 @@
 
 ## Prerequisites 
 
-The following tools are required to build WSL: 
+All prerequisites can be installed automatically by running:
+
+```
+tools\setup-dev-env.ps1
+```
+
+This uses [WinGet Configuration](https://learn.microsoft.com/windows/package-manager/configuration/) to install Developer Mode, CMake, Visual Studio 2022, and the required workloads from [`.vsconfig`](https://github.com/microsoft/WSL/blob/master/.vsconfig). If VS 2022 is already installed, the script detects your edition (Community, Professional, or Enterprise) and uses the matching configuration. If no VS 2022 is found, it defaults to Community.
+
+You can also run a WinGet configuration directly for your edition:
+
+```
+winget configure -f .config/configuration.winget                   # Community (default)
+winget configure -f .config/configuration.vsProfessional.winget    # Professional
+winget configure -f .config/configuration.vsEnterprise.winget      # Enterprise
+```
+
+<details>
+<summary>Manual installation</summary>
+
+If you prefer to install prerequisites manually:
 
 - CMake >= 3.25
     - Can be installed with `winget install Kitware.CMake`
-- Visual Studio with the following components:
-    - Windows SDK 26100
-    - MSBuild
-    - Universal Windows platform support for v143 build tools (X64 and ARM64)
-    - MSVC v143 - VS 2022 C++ ARM64 build tools (Latest + Spectre) (X64 and ARM64)
-    - C++ core features
-    - C++ ATL for latest v143 tools (X64 and ARM64)
-    - C++ Clang compiler for Windows
-    - .NET desktop development
-    - .NET WinUI app development tools
+- Visual Studio 2022 with the required components:
+    - Use VS Installer → More → Import configuration and select [`.vsconfig`](https://github.com/microsoft/WSL/blob/master/.vsconfig)
+    - Or: `winget install Microsoft.VisualStudio.2022.Community --override "--wait --quiet --config .vsconfig"`
+- Enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) in Windows Settings, or run builds with Administrator privileges (required for symbolic link support)
 
-- Building WSL requires support for symbolic links. To ensure this capability, enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) in Windows Settings or execute the build process with Administrator privileges.
+</details>
 
 ### ARM64 development
 

--- a/doc/docs/dev-loop.md
+++ b/doc/docs/dev-loop.md
@@ -13,10 +13,13 @@ This uses [WinGet Configuration](https://learn.microsoft.com/windows/package-man
 You can also run a WinGet configuration directly for your edition:
 
 ```
+winget configure --enable
 winget configure -f .config/configuration.winget                   # Community (default)
 winget configure -f .config/configuration.vsProfessional.winget    # Professional
 winget configure -f .config/configuration.vsEnterprise.winget      # Enterprise
 ```
+
+> **Note:** `winget configure --enable` is required to enable the configuration feature. The `setup-dev-env.ps1` script runs this automatically.
 
 <details>
 <summary>Manual installation</summary>

--- a/tools/setup-dev-env.ps1
+++ b/tools/setup-dev-env.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+    Sets up the development environment for building WSL.
+.DESCRIPTION
+    Detects any existing Visual Studio 2022 installation and runs the
+    matching WinGet Configuration to install all prerequisites:
+    Developer Mode, CMake, Visual Studio 2022, and required workloads
+    from .vsconfig.
+
+    If VS 2022 is already installed, the script picks the configuration
+    matching that edition (Community, Professional, or Enterprise).
+    If no VS 2022 is found, it defaults to Community edition.
+.EXAMPLE
+    .\tools\setup-dev-env.ps1
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+$configDir = Join-Path $repoRoot ".config"
+
+# ── Detect existing VS 2022 edition ─────────────────────────────────
+$configFile = "configuration.winget" # default: Community
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if (Test-Path $vswhere)
+{
+    $productId = (& $vswhere -version "[17.0,18.0)" -products * -latest -property productId 2>$null |
+        Select-Object -First 1)
+
+    if ($productId) { $productId = $productId.Trim() }
+
+    switch ($productId)
+    {
+        "Microsoft.VisualStudio.Product.Professional" {
+            $configFile = "configuration.vsProfessional.winget"
+            Write-Host "Detected VS 2022 Professional - using $configFile" -ForegroundColor Green
+        }
+        "Microsoft.VisualStudio.Product.Enterprise" {
+            $configFile = "configuration.vsEnterprise.winget"
+            Write-Host "Detected VS 2022 Enterprise - using $configFile" -ForegroundColor Green
+        }
+        "Microsoft.VisualStudio.Product.Community" {
+            Write-Host "Detected VS 2022 Community - using $configFile" -ForegroundColor Green
+        }
+        default {
+            Write-Host "No VS 2022 found - will install Community edition" -ForegroundColor Yellow
+        }
+    }
+}
+else
+{
+    Write-Host "No VS 2022 found - will install Community edition" -ForegroundColor Yellow
+}
+
+$configPath = Join-Path $configDir $configFile
+
+# ── Run WinGet Configuration ────────────────────────────────────────
+Write-Host ""
+Write-Host "Running WinGet Configuration ($configFile)..." -ForegroundColor Cyan
+Write-Host "  This will install: Developer Mode, CMake, VS 2022 + required components"
+Write-Host ""
+
+winget configure --enable
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Host "Failed to enable WinGet configuration feature." -ForegroundColor Red
+    exit 1
+}
+
+winget configure -f "$configPath" --accept-configuration-agreements
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Host "Failed to apply WinGet configuration file: $configFile" -ForegroundColor Red
+    exit 1
+}
+
+# ── Done ────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "All prerequisites installed. Ready to build!" -ForegroundColor Green
+Write-Host ""
+Write-Host "  cmake ."
+Write-Host "  cmake --build . -- -m"
+Write-Host ""


### PR DESCRIPTION
## Summary

Adds a one-command developer environment setup using [WinGet Configuration](https://learn.microsoft.com/windows/package-manager/configuration/) with per-edition VS support, following the pattern used by [microsoft/winget-cli](https://github.com/microsoft/winget-cli/tree/master/.config) and [microsoft/terminal](https://github.com/microsoft/terminal/tree/main/.config).

### Quick start

```
tools\setup-dev-env.ps1
```

Or run a WinGet configuration directly:

```
winget configure -f tools/configuration.winget                   # Community (default)
winget configure -f tools/configuration.vsProfessional.winget    # Professional
winget configure -f tools/configuration.vsEnterprise.winget      # Enterprise
```

### How it works

**WinGet Configuration files** (3 self-contained configs, one per VS edition): Each declaratively installs Developer Mode, CMake, Visual Studio 2022, and all required workloads/components from `.vsconfig` using DSC resources. Idempotent and safe to re-run.

**Smart detection script** (`tools/setup-dev-env.ps1`): Uses `vswhere` to detect any existing VS 2022 installation and picks the matching configuration file. If no VS 2022 is found, defaults to Community edition. The script is a thin wrapper — all the real work is done by `winget configure`.

### What gets installed

| Prerequisite | Method |
|---|---|
| Developer Mode | `Microsoft.Windows.Settings/WindowsSettings` DSC resource |
| CMake | `Microsoft.WinGet.DSC/WinGetPackage` DSC resource |
| VS 2022 + components | `Microsoft.WinGet.DSC/WinGetPackage` + `Microsoft.VisualStudio.DSC/VSComponents` with `.vsconfig` |

### Files

- **`tools/configuration.winget`** — WinGet config (Community edition, default)
- **`tools/configuration.vsProfessional.winget`** — WinGet config (Professional)
- **`tools/configuration.vsEnterprise.winget`** — WinGet config (Enterprise)
- **`.vsconfig`** — Required VS workloads/components
- **`tools/setup-dev-env.ps1`** — Smart edition detection + `winget configure`
- **`doc/docs/dev-loop.md`** — Updated prerequisites documentation

### Developer flow

```
Fork -> Clone -> tools\setup-dev-env.ps1 -> cmake . -> cmake --build . -- -m
```