### PR TITLE
Correctly handle empty arguments & entrypoint when launching containers

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -145,8 +145,8 @@ struct CreateContainer
     std::string Domainname;
     std::optional<std::string> StopSignal;
     std::optional<std::string> WorkingDir;
-    std::vector<std::string> Cmd;
-    std::vector<std::string> Entrypoint; // TODO: Find a way to omit if the caller wants the default entrypoint.
+    std::optional<std::vector<std::string>> Cmd;
+    std::optional<std::vector<std::string>> Entrypoint;
     std::vector<std::string> Env;
     std::map<std::string, EmptyObject> ExposedPorts;
     std::map<std::string, std::string> Labels;

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1042,7 +1042,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         request.Cmd = StringArrayToVector(containerOptions.InitProcessOptions.CommandLine);
     }
 
-    if (containerOptions.Entrypoint.Count)
+    if (containerOptions.Entrypoint.Count > 0)
     {
         request.Entrypoint = StringArrayToVector(containerOptions.Entrypoint);
     }

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1037,8 +1037,16 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         request.OpenStdin = true;
     }
 
-    request.Cmd = StringArrayToVector(containerOptions.InitProcessOptions.CommandLine);
-    request.Entrypoint = StringArrayToVector(containerOptions.Entrypoint);
+    if (containerOptions.InitProcessOptions.CommandLine.Count > 0)
+    {
+        request.Cmd = StringArrayToVector(containerOptions.InitProcessOptions.CommandLine);
+    }
+
+    if (containerOptions.Entrypoint.Count)
+    {
+        request.Entrypoint = StringArrayToVector(containerOptions.Entrypoint);
+    }
+
     request.Env = StringArrayToVector(containerOptions.InitProcessOptions.Environment);
 
     if (containerOptions.StopSignal != WSLCSignalNone)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1061,6 +1061,65 @@ class WSLCTests
         VERIFY_IS_TRUE(result.Output[1].find("Hello from a WSL container!") != std::string::npos);
     }
 
+    // This test validate both that we can build an image with an empty CMD, and that we can run such as an image.
+    TEST_METHOD(BuildImageEntrypoint)
+    {
+        WSL2_TEST_ONLY();
+
+        auto contextDir = std::filesystem::current_path() / "build-context-entrypoint";
+        std::filesystem::create_directories(contextDir);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow("wslc-test-entrypoint:latest", WSLCDeleteImageFlagsForce).first);
+
+            std::error_code ec;
+            std::filesystem::remove_all(contextDir, ec);
+        });
+
+        {
+            std::ofstream dockerfile(contextDir / "Dockerfile");
+            dockerfile << "FROM debian:latest\n";
+            dockerfile << "CMD []\n";
+            dockerfile << "ENTRYPOINT [\"/bin/echo\", \"Entrypoint\"]\n";
+        }
+
+        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, "wslc-test-entrypoint:latest"));
+        ExpectImagePresent(*m_defaultSession, "wslc-test-entrypoint:latest");
+
+        // Validate that the entrypoint is started by default.
+        {
+            WSLCContainerLauncher launcher("wslc-test-entrypoint:latest", "wslc-entrypoint-test-1");
+            auto container = launcher.Launch(*m_defaultSession);
+            auto initProcess = container.GetInitProcess();
+            ValidateProcessOutput(initProcess, {{1, "Entrypoint\n"}});
+        }
+
+        // Validate that arguments are passed to the entrypoint, and don't override it.
+        {
+            WSLCContainerLauncher launcher("wslc-test-entrypoint:latest", "wslc-entrypoint-test-2", {"extra-arg"});
+            auto container = launcher.Launch(*m_defaultSession);
+            auto initProcess = container.GetInitProcess();
+            ValidateProcessOutput(initProcess, {{1, "Entrypoint extra-arg\n"}});
+        }
+
+        // Validate that the entrypoint can be overridden.
+        {
+            WSLCContainerLauncher launcher("wslc-test-entrypoint:latest", "wslc-entrypoint-test-3");
+            launcher.SetEntrypoint({"/bin/echo", "OverriddenEntrypoint"});
+            auto container = launcher.Launch(*m_defaultSession);
+            auto initProcess = container.GetInitProcess();
+            ValidateProcessOutput(initProcess, {{1, "OverriddenEntrypoint\n"}});
+        }
+
+        // Validate that the entrypoint can be overridden and that CMD args are passed to the entrypoint.
+        {
+            WSLCContainerLauncher launcher("wslc-test-entrypoint:latest", "wslc-entrypoint-test-4", {"extra-arg"});
+            launcher.SetEntrypoint({"/bin/echo", "OverriddenEntrypoint"});
+            auto container = launcher.Launch(*m_defaultSession);
+            auto initProcess = container.GetInitProcess();
+            ValidateProcessOutput(initProcess, {{1, "OverriddenEntrypoint extra-arg\n"}});
+        }
+    }
+
     TEST_METHOD(BuildImageWithContext)
     {
         WSL2_TEST_ONLY();

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1061,7 +1061,7 @@ class WSLCTests
         VERIFY_IS_TRUE(result.Output[1].find("Hello from a WSL container!") != std::string::npos);
     }
 
-    // This test validate both that we can build an image with an empty CMD, and that we can run such as an image.
+    // This test validates both that we can build an image with an empty CMD, and that we can run such an image.
     TEST_METHOD(BuildImageEntrypoint)
     {
         WSL2_TEST_ONLY();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the container creation logic to correctly specify null arguments. This solves the scenario of running `wslc run <image>` where <image> doesn't have a CMD 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
