### PR TITLE
Add E2E test for --version flag

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -56,6 +56,12 @@ class WSLCE2EGlobalTests
         WSL2_TEST_ONLY();
         RunWslcAndVerify(L"version", {.Stdout = GetVersionMessage(), .Stderr = L"", .ExitCode = 0});
     }
+
+    TEST_METHOD(WSLCE2E_VersionFlag)
+    {
+        WSL2_TEST_ONLY();
+        RunWslcAndVerify(L"--version", {.Stdout = GetVersionMessage(), .Stderr = L"", .ExitCode = 0});
+    }
     TEST_METHOD(WSLCE2E_Session_DefaultElevated)
     {
         WSL2_TEST_ONLY();

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -62,6 +62,7 @@ class WSLCE2EGlobalTests
         WSL2_TEST_ONLY();
         RunWslcAndVerify(L"--version", {.Stdout = GetVersionMessage(), .Stderr = L"", .ExitCode = 0});
     }
+
     TEST_METHOD(WSLCE2E_Session_DefaultElevated)
     {
         WSL2_TEST_ONLY();


### PR DESCRIPTION
Ensures both entry points (the 'version' subcommand and the '--version' flag) are covered by E2E tests, preventing the two paths from drifting.