### PR TITLE
Fix UnicodeEncodeError in create-release.py on cp1252 consoles

### DIFF
--- a/tools/devops/create-release.py
+++ b/tools/devops/create-release.py
@@ -83,7 +83,7 @@ def main(version: str, previous: str, max_message_lines: int, publish: bool, ass
         print(f'\n{changes}')
 
 @backoff.on_exception(backoff.expo, (requests.exceptions.Timeout, requests.exceptions.ConnectionError, requests.exceptions.RequestException), max_time=600)
-def get_github_pr_message(token: str, message: str) -> str:
+def get_github_pr_message(token: str, message: str) -> tuple[str | None, str | None]:
     match = re.search(r'\(#([0-9]+)\)', message)
     if match is None:
         print(f'Warning: failed to extract GitHub PR number from message: {message}', file=sys.stderr)

--- a/tools/devops/create-release.py
+++ b/tools/devops/create-release.py
@@ -10,6 +10,11 @@ import functools
 from git import Repo
 from urllib.parse import urlparse
 
+# Reconfigure stdout/stderr to handle unencodable characters (e.g. Unicode in
+# commit messages) on consoles that use legacy code-pages such as cp1252.
+sys.stdout.reconfigure(errors='backslashreplace')
+sys.stderr.reconfigure(errors='backslashreplace')
+
 @click.command()
 @click.argument('version', required=True)
 @click.argument('assets', default=None, nargs=-1)
@@ -81,7 +86,7 @@ def main(version: str, previous: str, max_message_lines: int, publish: bool, ass
 def get_github_pr_message(token: str, message: str) -> str:
     match = re.search(r'\(#([0-9]+)\)', message)
     if match is None:
-        print(f'Warning: failed to extract GitHub PR number from message: {message}')
+        print(f'Warning: failed to extract GitHub PR number from message: {message}', file=sys.stderr)
         return None, None
 
     pr_number = match.group(1)


### PR DESCRIPTION
The `create-release.py` script crashes during CI when a commit message contains characters outside the console's code-page (e.g. U+2225 on cp1252):

`
UnicodeEncodeError: 'charmap' codec can't encode character '\u2225' in position 275: character maps to <undefined>
`

**Changes:**
- Reconfigure `stdout`/`stderr` with `errors='backslashreplace'` so unencodable characters are escaped instead of raising.
- Redirect the 'failed to extract PR number' warning to `stderr` for consistency with other warnings in the script.
