### PR TITLE
Fix race condition when building multiple IDL files

### DIFF
--- a/cmake/FindIDL.cmake
+++ b/cmake/FindIDL.cmake
@@ -36,7 +36,7 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
             VERBATIM
         )
 
-        set(PREVIOUS_OUTPUT ${MIDL_OUTPUT})
+        set(PREVIOUS_OUTPUT ${IDL_HEADER})
 
         set_source_files_properties(${MIDL_OUTPUT} PROPERTIES GENERATED TRUE)
         list(APPEND TARGET_OUTPUTS ${MIDL_OUTPUT})

--- a/cmake/FindIDL.cmake
+++ b/cmake/FindIDL.cmake
@@ -28,9 +28,8 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
         set(MIDL_OUTPUT ${IDL_HEADER} ${IDL_I} ${IDL_P} ${IDL_DLLDATA})
 
         add_custom_command(
-            OUTPUT ${MIDL_OUTPUT} ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}
+            OUTPUT ${MIDL_OUTPUT}
             COMMAND midl /nologo /target NT100 /env "${IDL_ENV}" /Zp8 /char unsigned /ms_ext /c_ext /h ${IDL_HEADER} /iid ${IDL_I} /proxy ${IDL_P} /dlldata ${IDL_DLLDATA} ${idl_file} ${IDL_DEFINITIONS}
-            COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
             DEPENDS ${idl_file} ${PREVIOUS_OUTPUT}
             MAIN_DEPENDENCY ${idl_file}
@@ -51,9 +50,8 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
         set(IDL_HEADER ${OUTPUT_DIR}/${IDL_NAME}.h)
 
         add_custom_command(
-            OUTPUT ${IDL_HEADER} ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}
+            OUTPUT ${IDL_HEADER}
             COMMAND midl /nologo /target NT100 /env "${IDL_ENV}" /Zp8 /char unsigned /ms_ext /c_ext /h ${IDL_HEADER} ${idl_file} ${IDL_DEFINITIONS}
-            COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
             DEPENDS ${idl_file}
             MAIN_DEPENDENCY ${idl_file}
@@ -65,6 +63,13 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
 
     endforeach()
 
-    add_custom_target(${target} DEPENDS ${TARGET_OUTPUTS} SOURCES ${idl_files_with_proxy} ${idl_files_no_proxy})
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}
+        COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}"
+        DEPENDS ${TARGET_OUTPUTS}
+        VERBATIM
+    )
+
+    add_custom_target(${target} DEPENDS ${TARGET_OUTPUTS} ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target} SOURCES ${idl_files_with_proxy} ${idl_files_no_proxy})
 
 endfunction()

--- a/cmake/FindIDL.cmake
+++ b/cmake/FindIDL.cmake
@@ -63,13 +63,6 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
 
     endforeach()
 
-    add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}
-        COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}"
-        DEPENDS ${TARGET_OUTPUTS}
-        VERBATIM
-    )
-
-    add_custom_target(${target} DEPENDS ${TARGET_OUTPUTS} ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target} SOURCES ${idl_files_with_proxy} ${idl_files_no_proxy})
+    add_custom_target(${target} DEPENDS ${TARGET_OUTPUTS} SOURCES ${idl_files_with_proxy} ${idl_files_no_proxy})
 
 endfunction()

--- a/cmake/FindIDL.cmake
+++ b/cmake/FindIDL.cmake
@@ -11,6 +11,7 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
     endforeach()
 
     string(TOLOWER ${TARGET_PLATFORM} IDL_ENV)
+    set(PREVIOUS_OUTPUT "")
 
     foreach(idl_file ${idl_files_with_proxy})
 

--- a/cmake/FindIDL.cmake
+++ b/cmake/FindIDL.cmake
@@ -31,10 +31,12 @@ function(add_idl target idl_files_with_proxy idl_files_no_proxy)
             COMMAND midl /nologo /target NT100 /env "${IDL_ENV}" /Zp8 /char unsigned /ms_ext /c_ext /h ${IDL_HEADER} /iid ${IDL_I} /proxy ${IDL_P} /dlldata ${IDL_DLLDATA} ${idl_file} ${IDL_DEFINITIONS}
             COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/${target}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-            DEPENDS ${idl_file}
+            DEPENDS ${idl_file} ${PREVIOUS_OUTPUT}
             MAIN_DEPENDENCY ${idl_file}
             VERBATIM
         )
+
+        set(PREVIOUS_OUTPUT ${MIDL_OUTPUT})
 
         set_source_files_properties(${MIDL_OUTPUT} PROPERTIES GENERATED TRUE)
         list(APPEND TARGET_OUTPUTS ${MIDL_OUTPUT})

--- a/src/windows/WslcSDK/CMakeLists.txt
+++ b/src/windows/WslcSDK/CMakeLists.txt
@@ -15,7 +15,7 @@ set(HEADERS
 
 add_library(wslcsdk SHARED ${SOURCES} ${HEADERS} wslcsdk.def)
 set_target_properties(wslcsdk PROPERTIES EXCLUDE_FROM_ALL FALSE)
-add_dependencies(wslcsdk wslcidl)
+add_dependencies(wslcsdk wslserviceidl)
 target_link_libraries(wslcsdk ${COMMON_LINK_LIBRARIES} legacy_stdio_definitions common)
 target_precompile_headers(wslcsdk REUSE_FROM common)
 set_target_properties(wslcsdk PROPERTIES FOLDER windows)

--- a/src/windows/common/CMakeLists.txt
+++ b/src/windows/common/CMakeLists.txt
@@ -133,7 +133,7 @@ set(HEADERS
     )
 
 add_library(common STATIC ${SOURCES} ${HEADERS})
-add_dependencies(common wslserviceidl wslcidl localization wslservicemc wslinstalleridl)
+add_dependencies(common wslserviceidl localization wslservicemc wslinstalleridl)
 
 target_precompile_headers(common PRIVATE precomp.h)
 set_target_properties(common PROPERTIES FOLDER windows)

--- a/src/windows/service/exe/CMakeLists.txt
+++ b/src/windows/service/exe/CMakeLists.txt
@@ -56,7 +56,7 @@ set(HEADERS
     WSLCSessionManagerFactory.h)
 
 add_executable(wslservice ${SOURCES} ${HEADERS})
-add_dependencies(wslservice wslserviceidl wslcidl wslservicemc)
+add_dependencies(wslservice wslserviceidl wslservicemc)
 add_compile_definitions(__WRL_CLASSIC_COM__)
 add_compile_definitions(__WRL_DISABLE_STATIC_INITIALIZE__)
 add_compile_definitions(USE_COM_CONTEXT_DEF=1)

--- a/src/windows/service/inc/CMakeLists.txt
+++ b/src/windows/service/inc/CMakeLists.txt
@@ -1,4 +1,3 @@
-add_idl(wslserviceidl "wslservice.idl" "windowsdefs.idl")
-add_idl(wslcidl "wslc.idl" "")
+add_idl(wslserviceidl "wslservice.idl;wslc.idl" "windowsdefs.idl")
+
 set_target_properties(wslserviceidl PROPERTIES FOLDER windows)
-set_target_properties(wslcidl PROPERTIES FOLDER windows)

--- a/src/windows/service/stub/CMakeLists.txt
+++ b/src/windows/service/stub/CMakeLists.txt
@@ -10,6 +10,6 @@ set(SOURCES
 set_source_files_properties(${SOURCES} PROPERTIES GENERATED TRUE)
 
 add_library(wslserviceproxystub SHARED ${SOURCES})
-add_dependencies(wslserviceproxystub wslserviceidl wslcidl)
+add_dependencies(wslserviceproxystub wslserviceidl)
 target_link_libraries(wslserviceproxystub ${COMMON_LINK_LIBRARIES})
 set_target_properties(wslserviceproxystub PROPERTIES FOLDER windows)

--- a/src/windows/wslcsession/CMakeLists.txt
+++ b/src/windows/wslcsession/CMakeLists.txt
@@ -45,7 +45,7 @@ set(HEADERS
     WSLCVolumeMetadata.h)
 
 add_executable(wslcsession WIN32 ${SOURCES} ${HEADERS})
-add_dependencies(wslcsession wslcidl)
+add_dependencies(wslcsession wslserviceidl)
 add_compile_definitions(__WRL_CLASSIC_COM__)
 add_compile_definitions(USE_COM_CONTEXT_DEF=1)
 target_link_libraries(wslcsession


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a build failure that happens because multiple processes write do `dlldata*.c` as the same time. This change solves the issue by making sure that they don't run at the same time 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
