### PR TITLE
Add wslc shell script for WSL interop

### DIFF
--- a/msipackage/CMakeLists.txt
+++ b/msipackage/CMakeLists.txt
@@ -27,6 +27,9 @@ foreach(binary ${WINDOWS_BINARIES})
     list(APPEND BINARIES_DEPENDENCIES "${PACKAGE_INPUT_DIR}/${binary}")
 endforeach()
 
+# Shell script for WSL interop (allows running 'wslc' without the .exe extension inside WSL)
+list(APPEND BINARIES_DEPENDENCIES "${CMAKE_SOURCE_DIR}/src/windows/wslc/wslc")
+
 set(LINUX_BINARIES init;initrd.img)
 foreach(binary ${LINUX_BINARIES})
     list(APPEND BINARIES_DEPENDENCIES "${BIN}/${binary}")

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -28,6 +28,7 @@
 
                 <File Id="wslg.exe" Name="wslg.exe" Source="${PACKAGE_INPUT_DIR}/wslg.exe" />
                 <File Id="wslc.exe" Name="wslc.exe" Source="${PACKAGE_INPUT_DIR}/wslc.exe" />
+                <File Id="wslc" Name="wslc" Source="${CMAKE_SOURCE_DIR}/src/windows/wslc/wslc" />
                 <File Id="wslhost.exe" Name="wslhost.exe" Source="${PACKAGE_INPUT_DIR}/wslhost.exe" />
                 <File Id="wslrelay.exe" Name="wslrelay.exe" Source="${PACKAGE_INPUT_DIR}/wslrelay.exe" />
                 <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${PACKAGE_INPUT_DIR}/wslserviceproxystub.dll" />

--- a/src/windows/wslc/.gitattributes
+++ b/src/windows/wslc/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must keep Unix (LF) line endings to work in WSL
+wslc text eol=lf

--- a/src/windows/wslc/wslc
+++ b/src/windows/wslc/wslc
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+#
+# Copyright (c) Microsoft. All rights reserved.
+#
+# Shell script to allow running wslc from within a WSL distribution
+# without needing the .exe extension (e.g. 'wslc' instead of 'wslc.exe').
+
+WSL_PATH="$(dirname "$(realpath "$0")")"
+WSLC_EXE="$WSL_PATH/wslc.exe"
+
+"$WSLC_EXE" "$@"
+exit $?

--- a/src/windows/wslc/wslc
+++ b/src/windows/wslc/wslc
@@ -8,5 +8,4 @@
 WSL_PATH="$(dirname "$(realpath "$0")")"
 WSLC_EXE="$WSL_PATH/wslc.exe"
 
-"$WSLC_EXE" "$@"
-exit $?
+exec "$WSLC_EXE" "$@"

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -302,6 +302,7 @@ class SimpleTests
         auto [exeOutput, exeErr] = LxsstuLaunchWslAndCaptureOutput(L"wslc.exe version");
         auto [scriptOutput, scriptErr] = LxsstuLaunchWslAndCaptureOutput(L"wslc version");
         VERIFY_ARE_EQUAL(exeOutput, scriptOutput);
+        VERIFY_ARE_EQUAL(exeErr, scriptErr);
     }
 };
 } // namespace SimpleTests

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -295,12 +295,16 @@ class SimpleTests
         VERIFY_IS_TRUE(output.find(L"/mnt/c/Users/Test User/AppData/Local/Programs/Microsoft VS Code/bin") != std::wstring::npos);
     }
 
-    TEST_METHOD(WslcShellScript)
+    WSLC_TEST_METHOD(WslcShellScript)
     {
         // Verify that the 'wslc' shell script (no .exe extension) invokes wslc.exe
         // and produces the same output as calling wslc.exe directly.
-        auto [exeOutput, exeErr] = LxsstuLaunchWslAndCaptureOutput(L"wslc.exe version");
-        auto [scriptOutput, scriptErr] = LxsstuLaunchWslAndCaptureOutput(L"wslc version");
+        // Use the full install path since the MSI directory may not be on %PATH% in CI.
+        auto installPath = wsl::windows::common::wslutil::GetMsiPackagePath().value();
+        auto exeCmd = std::format(L"$(wslpath '{}wslc.exe') version", installPath);
+        auto scriptCmd = std::format(L"$(wslpath '{}wslc') version", installPath);
+        auto [exeOutput, exeErr] = LxsstuLaunchWslAndCaptureOutput(exeCmd);
+        auto [scriptOutput, scriptErr] = LxsstuLaunchWslAndCaptureOutput(scriptCmd);
         VERIFY_ARE_EQUAL(exeOutput, scriptOutput);
         VERIFY_ARE_EQUAL(exeErr, scriptErr);
     }

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -294,5 +294,14 @@ class SimpleTests
         VERIFY_IS_TRUE(output.find(L"/mnt/c/Program Files (x86)/Common Files") != std::wstring::npos);
         VERIFY_IS_TRUE(output.find(L"/mnt/c/Users/Test User/AppData/Local/Programs/Microsoft VS Code/bin") != std::wstring::npos);
     }
+
+    TEST_METHOD(WslcShellScript)
+    {
+        // Verify that the 'wslc' shell script (no .exe extension) invokes wslc.exe
+        // and produces the same output as calling wslc.exe directly.
+        auto [exeOutput, exeErr] = LxsstuLaunchWslAndCaptureOutput(L"wslc.exe version");
+        auto [scriptOutput, scriptErr] = LxsstuLaunchWslAndCaptureOutput(L"wslc version");
+        VERIFY_ARE_EQUAL(exeOutput, scriptOutput);
+    }
 };
 } // namespace SimpleTests


### PR DESCRIPTION
## Summary

Add a shell script that allows WSL users to run `wslc` instead of `wslc.exe` from within a WSL distribution, similar to how VS Code ships a `code` script alongside `code.exe`.

## Changes

- **`src/windows/wslc/wslc`** — New shell script that resolves `wslc.exe` relative to its own location and forwards all arguments
- **`src/windows/wslc/.gitattributes`** — Enforces LF line endings so the script works in WSL
- **`msipackage/package.wix.in`** — Adds the script to the MSI package (installed to `Program Files\WSL`)
- **`msipackage/CMakeLists.txt`** — Adds the script as a build dependency for the MSI
- **`test/windows/SimpleTests.cpp`** — Adds `WslcShellScript` smoke test that verifies `wslc` and `wslc.exe` produce identical output inside WSL

## How it works

Since `Program Files\WSL` is already on the system PATH (added by the MSI), and WSL appends Windows PATH entries by default, the extensionless `wslc` script is found automatically when a user types `wslc` inside a WSL distribution.