### PR TITLE
Reset m_dockerdProcess when terminating a session

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1815,6 +1815,7 @@ try
         }
 
         WSL_LOG("DockerdExit", TraceLoggingValue(exitCode, "code"));
+        m_dockerdProcess.reset();
     }
 
     if (m_virtualMachine)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to reset `m_dockerdProcess` when a session terminates. Without that change, if Terminate() is called multiple times, we'll try to terminate dockerd twice, which leads to this error: 

```
Microsoft.Windows.Wslc	Error	04-09-2026 13:13:03.186	"HRESULTString: 	ERROR_INVALID_STATE
code: 	m_vm == nullptr || m_exitEvent.is_signaled()
failurecount: 	2
file: 	src\windows\wslcsession\WSLCProcessControl.cpp
function: 	wsl::windows::service::wslc::VMProcessControl::Signal
hr: 	0x8007139F
linenumber: 	228
message: 	
threadid: 	46688
type: 	0"	src\windows\wslcsession\WSLCProcessControl.cpp		wsl::windows::service::wslc::VMProcessControl::Signal	51888	46688	2		eaf9b827-2b13-4dea-9478-22fe9b5370d0		
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
