### PR TITLE
Fix incorrect --detach description in container run help text

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2202,7 +2202,7 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>Run a container.</value>
   </data>
   <data name="WSLCCLI_ContainerRunLongDesc" xml:space="preserve">
-    <value>Runs a container. By default, the container is started in the background; use --detach to run in the foreground.</value>
+    <value>Runs a container. By default, the container is started in the foreground; use --detach to run in the background.</value>
     <comment>{Locked="--detach "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_ContainerStartDesc" xml:space="preserve">

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -187,8 +187,8 @@ private:
 
     std::wstring GetDescription() const
     {
-        return L"Runs a container. By default, the container is started in the background; use --detach to run in the "
-               L"foreground.\r\n\r\n";
+        return L"Runs a container. By default, the container is started in the foreground; use --detach to run in the "
+               L"background.\r\n\r\n";
     }
 
     std::wstring GetUsage() const


### PR DESCRIPTION
The help text for `wslc container run` incorrectly stated that containers start in the background by default and `--detach` runs in the foreground. The actual behavior (confirmed by `ContainerService.cpp` line 299: `WI_SetFlagIf(startFlags, WSLCContainerStartFlagsAttach, !runOptions.Detach)`) is the opposite: containers start attached (foreground) by default, and `--detach` runs them in the background.

This fix updates the en-US locale string. Other locales will pick up the correction through the standard localization pipeline.

---

**Before:** *Runs a container. By default, the container is started in the background; use --detach to run in the foreground.*

**After:** *Runs a container. By default, the container is started in the foreground; use --detach to run in the background.*