### PR TITLE
Fix API review issues in wslcsdk.h and wslcsdk.cpp

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -1263,16 +1263,16 @@ try
 }
 CATCH_RETURN();
 
-STDAPI WslcDeleteSessionImage(_In_ WslcSession session, _In_z_ PCSTR NameOrId, _Outptr_opt_result_z_ PWSTR* errorMessage)
+STDAPI WslcDeleteSessionImage(_In_ WslcSession session, _In_z_ PCSTR nameOrId, _Outptr_opt_result_z_ PWSTR* errorMessage)
 try
 {
     ErrorInfoWrapper errorInfoWrapper{errorMessage};
     auto internalType = CheckAndGetInternalType(session);
     RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), internalType->session);
-    RETURN_HR_IF_NULL(E_POINTER, NameOrId);
+    RETURN_HR_IF_NULL(E_POINTER, nameOrId);
 
     WSLCDeleteImageOptions options{};
-    options.Image = NameOrId;
+    options.Image = nameOrId;
     // TODO: Flags? (Force and NoPrune)
 
     wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImageInformation;

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -204,7 +204,7 @@ STDAPI WslcReleaseContainer(_In_ WslcContainer container);
 
 #define WSLC_CONTAINER_ID_BUFFER_SIZE 65 // 64 hex chars + null terminator
 
-STDAPI WslcGetContainerID(WslcContainer container, CHAR containerId[WSLC_CONTAINER_ID_BUFFER_SIZE]);
+STDAPI WslcGetContainerID(_In_ WslcContainer container, _Out_writes_(WSLC_CONTAINER_ID_BUFFER_SIZE) CHAR containerId[WSLC_CONTAINER_ID_BUFFER_SIZE]);
 
 STDAPI WslcGetContainerInitProcess(_In_ WslcContainer container, _Out_ WslcProcess* initProcess);
 
@@ -284,7 +284,7 @@ typedef enum WslcProcessIOHandle
 // Parameters:
 //   ioHandle
 //       The WslcProcessIOHandle that the IO callback is for.
-//       Only STDOUT and STDERR will recieve callbacks.
+//       Only STDOUT and STDERR will receive callbacks.
 //
 //   data
 //       Pointer to a buffer containing the bytes read. The buffer is owned
@@ -450,7 +450,7 @@ typedef struct WslcImageInfo
     uint64_t createdTimestamp;
 } WslcImageInfo;
 
-STDAPI WslcDeleteSessionImage(_In_ WslcSession session, _In_z_ PCSTR NameOrId, _Outptr_opt_result_z_ PWSTR* errorMessage);
+STDAPI WslcDeleteSessionImage(_In_ WslcSession session, _In_z_ PCSTR nameOrId, _Outptr_opt_result_z_ PWSTR* errorMessage);
 
 // Retrieves the list of container images
 // Parameters:


### PR DESCRIPTION
Fix three issues found during SDK API review:

- **Missing SAL annotations**: Add `_In_` and `_Out_writes_` to `WslcGetContainerID` parameters, which were the only public API function missing annotations entirely.
- **Typo**: Fix `recieve` to `receive` in `WslcStdIOCallback` documentation comment.
- **Parameter naming**: Rename `NameOrId` to `nameOrId` in `WslcDeleteSessionImage` to match the lowercase convention used by all other API parameters.