### PR TITLE
Add wslcsession, wslrelay, and wslg to diagnostic log collection

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -304,7 +304,7 @@ if ($Dump)
     $dumpFolder = Join-Path (Resolve-Path "$folder") dumps
     New-Item -ItemType "directory" -Path "$dumpFolder"
 
-    $executables = "wsl", "wslservice", "wslhost", "msrdc", "dllhost"
+    $executables = "wsl", "wslservice", "wslhost", "wslcsession", "wslrelay", "wslg", "msrdc", "dllhost"
     foreach($process in Get-Process | Where-Object { $executables -contains $_.ProcessName})
     {
         $dumpFile =  "$dumpFolder/$($process.ProcessName).$($process.Id).dmp"


### PR DESCRIPTION
Include additional WSL executables in the list of processes that `collect-wsl-logs.ps1` captures memory dumps for:

- `wslcsession.exe`: WSLC session service (container diagnostics)
- `wslrelay.exe`: localhost network relay (networking diagnostics)
- `wslg.exe`: WSLg GUI support (graphics diagnostics)

Previously the script only collected dumps for `wsl`, `wslservice`, `wslhost`, `msrdc`, and `dllhost`.