### PR TITLE
Add preview disclaimer to WSLC SDK header and NuGet package

### DIFF
--- a/nuget/Microsoft.WSL.Containers.nuspec.in
+++ b/nuget/Microsoft.WSL.Containers.nuspec.in
@@ -5,7 +5,7 @@
     <version>${WSL_NUGET_PACKAGE_VERSION}</version>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/WSL</projectUrl>
-    <description>WSL Containers SDK</description>
+    <description>WSL Containers SDK (Preview - API subject to breaking changes)</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>WSL</tags>
     <language>en-us</language>

--- a/nuget/Microsoft.WSL.Containers/docs/README.MD
+++ b/nuget/Microsoft.WSL.Containers/docs/README.MD
@@ -1,3 +1,7 @@
 # WSL Containers
 
-This package contains the `WSLCApi.h` header which defines the WSL Containers interface.
+> **⚠️ Preview:** This SDK is currently in preview and is subject to breaking changes
+> in future releases without prior notice. Do not rely on API stability for production
+> workloads.
+
+This package contains the `wslcsdk.h` header which defines the WSL Containers interface.

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -10,6 +10,11 @@ Abstract:
 
     This file contains the public WSL Container SDK api definitions.
 
+    PREVIEW NOTICE: This API is currently in preview and is subject to breaking
+    changes in future releases without prior notice. Do not rely on API stability
+    for production workloads. Features, function signatures, and behaviors may
+    change between releases during the preview period.
+
 --*/
 #pragma once
 #include <winsock2.h>


### PR DESCRIPTION
Add preview notice to communicate that the WSLC SDK API is subject to breaking changes during the preview period.

Changes:
- `wslcsdk.h`: Add PREVIEW NOTICE block to the header comment
- `Microsoft.WSL.Containers.nuspec.in`: Update description to include "(Preview - API subject to breaking changes)"