### PR TITLE
Detect unexpected VM exit and terminate wslcsession.exe

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -581,6 +581,15 @@ try
 }
 CATCH_RETURN()
 
+HRESULT HcsVirtualMachine::GetTerminationEvent(_Out_ HANDLE* Event)
+try
+{
+    *Event = wslutil::DuplicateHandle(m_vmExitEvent.get());
+
+    return S_OK;
+}
+CATCH_RETURN()
+
 void CALLBACK HcsVirtualMachine::OnVmExitCallback(HCS_EVENT* Event, void* Context)
 try
 {

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -44,6 +44,7 @@ public:
     IFACEMETHOD(DetachDisk)(_In_ ULONG Lun) override;
     IFACEMETHOD(AddShare)(_In_ LPCWSTR WindowsPath, _In_ BOOL ReadOnly, _Out_ GUID* ShareId) override;
     IFACEMETHOD(RemoveShare)(_In_ REFGUID ShareId) override;
+    IFACEMETHOD(GetTerminationEvent)(_Out_ HANDLE* Event) override;
 
 private:
     struct DiskInfo

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -437,6 +437,9 @@ interface IWSLCVirtualMachine : IUnknown
 
     // Removes a previously added filesystem share.
     HRESULT RemoveShare([in] REFGUID ShareId);
+
+    // Returns an event that is signaled when the VM exits (graceful or forced).
+    HRESULT GetTerminationEvent([out, system_handle(sh_event)] HANDLE* Event);
 }
 
 typedef enum _WSLCSessionStorageFlags

--- a/src/windows/wslcsession/IORelay.cpp
+++ b/src/windows/wslcsession/IORelay.cpp
@@ -61,7 +61,8 @@ void IORelay::Stop()
     m_exit = true;
     m_refreshEvent.SetEvent();
 
-    if (m_thread.joinable())
+    // Skip join if called from the IORelay thread itself (e.g., from a handle callback).
+    if (m_thread.joinable() && m_thread.get_id() != std::this_thread::get_id())
     {
         m_thread.join();
     }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2360,7 +2360,9 @@ try
 
     // Check if the VM has already exited (e.g., killed externally).
     // If so, skip operations that require a live VM to avoid unnecessary waits.
-    if (m_vmExitedEvent.is_signaled())
+    // N.B. m_vmExitedEvent may be uninitialized if Terminate() is called from the
+    // Initialize() error path before GetTerminationEvent() succeeds.
+    if (m_vmExitedEvent && m_vmExitedEvent.is_signaled())
     {
         WSL_LOG("SkippingGracefulShutdown_VmDead", TraceLoggingValue(m_id, "SessionId"));
     }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2302,8 +2302,10 @@ CATCH_RETURN();
 HRESULT WSLCSession::Terminate()
 try
 {
-    // Ensure only one Terminate() runs to completion. OnVmExited() can race
-    // with an external Terminate() call; the second caller is a no-op.
+    // Ensure only one Terminate() runs. This must be checked before taking m_lock
+    // because OnVmExited() is called from the IORelay thread — if an external Terminate()
+    // holds m_lock and calls m_ioRelay.Stop(), the relay thread must not re-enter
+    // Terminate() and deadlock on m_lock.
     if (m_terminating.exchange(true))
     {
         return S_OK;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -240,6 +240,9 @@ try
 
     m_virtualMachine->Initialize();
 
+    // Get an event from the service that is signaled when the VM exits.
+    THROW_IF_FAILED(Vm->GetTerminationEvent(&m_vmExitedEvent));
+
     // Configure storage.
     ConfigureStorage(*Settings, tokenInfo->User.Sid);
 
@@ -259,6 +262,10 @@ try
 
     //  Start the event tracker.
     m_eventTracker.emplace(m_dockerClient.value(), m_id, m_ioRelay);
+
+    // Monitor for unexpected VM exit.
+    m_ioRelay.AddHandle(
+        std::make_unique<windows::common::relay::EventHandle>(m_vmExitedEvent.get(), std::bind(&WSLCSession::OnVmExited, this)));
 
     // Recover any existing containers from storage.
     RecoverExistingNetworks();
@@ -374,6 +381,18 @@ void WSLCSession::OnContainerdExited()
     {
         WSL_LOG("UnexpectedContainerdExit", TraceLoggingValue(m_displayName.c_str(), "Name"));
     }
+}
+
+void WSLCSession::OnVmExited()
+{
+    WSL_LOG(
+        "VmExited",
+        TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+        TraceLoggingValue(m_id, "SessionId"),
+        TraceLoggingValue(m_displayName.c_str(), "Name"),
+        TraceLoggingValue(!m_sessionTerminatingEvent.is_signaled(), "Unexpected"));
+
+    LOG_IF_FAILED(Terminate());
 }
 
 void WSLCSession::OnProcessLog(const gsl::span<char>& Buffer, PCSTR Source)
@@ -2283,6 +2302,12 @@ CATCH_RETURN();
 HRESULT WSLCSession::Terminate()
 try
 {
+    // Ensure only one Terminate() runs to completion. OnVmExited() can race
+    // with an external Terminate() call; the second caller is a no-op.
+    if (m_terminating.exchange(true))
+    {
+        return S_OK;
+    }
 
     {
         std::lock_guard lock(m_userHandlesLock);
@@ -2331,33 +2356,42 @@ try
     m_eventTracker.reset();
     m_dockerClient.reset();
 
-    // Stop dockerd first, then containerd (dockerd is a client of containerd).
-    // N.B. dockerd waits a couple seconds if there are any outstanding HTTP request sockets opened.
-    if (m_dockerdProcess.has_value())
+    // Check if the VM has already exited (e.g., killed externally).
+    // If so, skip operations that require a live VM to avoid unnecessary waits.
+    if (m_vmExitedEvent.is_signaled())
     {
-        auto dockerdExitCode = StopProcess(m_dockerdProcess.value(), c_processTerminateTimeoutMs, c_processKillTimeoutMs);
-        WSL_LOG("DockerdExit", TraceLoggingValue(dockerdExitCode, "code"));
-        m_dockerdProcess.reset();
+        WSL_LOG("SkippingGracefulShutdown_VmDead", TraceLoggingValue(m_id, "SessionId"));
     }
-
-    if (m_containerdProcess.has_value())
+    else
     {
-        auto containerdExitCode = StopProcess(m_containerdProcess.value(), c_processTerminateTimeoutMs, c_processKillTimeoutMs);
-        WSL_LOG("ContainerdExit", TraceLoggingValue(containerdExitCode, "code"));
-        m_containerdProcess.reset();
-    }
-
-    if (m_virtualMachine)
-    {
-        // N.B. dockerd has exited by this point, so unmounting the VHD is safe since no container can be running.
-        try
+        // Stop dockerd first, then containerd (dockerd is a client of containerd).
+        // N.B. dockerd waits a couple seconds if there are any outstanding HTTP request sockets opened.
+        if (m_dockerdProcess.has_value())
         {
-            m_virtualMachine->Unmount(c_containerdStorage);
+            auto dockerdExitCode = StopProcess(m_dockerdProcess.value(), c_processTerminateTimeoutMs, c_processKillTimeoutMs);
+            WSL_LOG("DockerdExit", TraceLoggingValue(dockerdExitCode, "code"));
         }
-        CATCH_LOG();
 
-        m_virtualMachine.reset();
+        if (m_containerdProcess.has_value())
+        {
+            auto containerdExitCode = StopProcess(m_containerdProcess.value(), c_processTerminateTimeoutMs, c_processKillTimeoutMs);
+            WSL_LOG("ContainerdExit", TraceLoggingValue(containerdExitCode, "code"));
+        }
+
+        if (m_virtualMachine)
+        {
+            // N.B. dockerd has exited by this point, so unmounting the VHD is safe since no container can be running.
+            try
+            {
+                m_virtualMachine->Unmount(c_containerdStorage);
+            }
+            CATCH_LOG();
+        }
     }
+
+    m_dockerdProcess.reset();
+    m_containerdProcess.reset();
+    m_virtualMachine.reset();
 
     m_terminated = true;
     return S_OK;

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -167,6 +167,7 @@ private:
     void OnProcessLog(const gsl::span<char>& Data, PCSTR Source);
     void OnContainerdExited();
     void OnDockerdExited();
+    void OnVmExited();
     ServiceRunningProcess StartProcess(
         const std::string& Executable, const std::vector<std::string>& Args, PCSTR LogSource, std::function<void()>&& ExitCallback);
     void StartContainerd();
@@ -198,12 +199,14 @@ private:
     std::mutex m_networksLock;
     std::unordered_map<std::string, NetworkEntry> m_networks;
     wil::unique_event m_sessionTerminatingEvent{wil::EventOptions::ManualReset};
+    wil::unique_event m_vmExitedEvent;
     wil::srwlock m_lock;
     IORelay m_ioRelay;
     std::optional<ServiceRunningProcess> m_containerdProcess;
     std::optional<ServiceRunningProcess> m_dockerdProcess;
     WSLCFeatureFlags m_featureFlags{};
     std::function<void()> m_destructionCallback;
+    std::atomic<bool> m_terminating{false};
     std::atomic<bool> m_terminated{false};
 
     // User-provided handles that the session is currently doing IO on.

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -438,44 +438,51 @@ class WSLCTests
         }
     }
 
-    // Returns the set of VM owner names currently reported by hcsdiag.
-    static std::vector<std::wstring> ListVmOwners()
+    struct VmInfo
     {
-        std::wstring commandLine = L"hcsdiag list -raw";
-        wsl::windows::common::SubProcess process(nullptr, commandLine.c_str());
+        std::wstring Id;
+        std::wstring Owner;
+    };
+
+    // Returns VM info (Id + Owner) for all running VMs via hcsdiag.
+    static std::vector<VmInfo> ListVms()
+    {
+        wsl::windows::common::SubProcess process(nullptr, L"hcsdiag list -raw");
         auto output = process.RunAndCaptureOutput(10000);
 
-        std::vector<std::wstring> owners;
+        std::vector<VmInfo> vms;
         auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(output.Stdout), nullptr, false);
         if (!json.is_array())
         {
-            return owners;
+            return vms;
         }
 
         for (const auto& entry : json)
         {
-            if (entry.contains("Owner") && entry["Owner"].is_string())
+            if (entry.contains("Owner") && entry["Owner"].is_string() && entry.contains("Id") && entry["Id"].is_string())
             {
-                owners.push_back(wsl::shared::string::MultiByteToWide(entry["Owner"].get<std::string>()));
+                vms.push_back(
+                    {wsl::shared::string::MultiByteToWide(entry["Id"].get<std::string>()),
+                     wsl::shared::string::MultiByteToWide(entry["Owner"].get<std::string>())});
             }
         }
 
-        return owners;
+        return vms;
     }
 
     WSLC_TEST_METHOD(VmOwnerMatchesSessionDisplayName)
     {
         // The default session (c_testSessionName) is already running from class setup.
         // Verify its display name appears as a VM owner in hcsdiag output.
-        auto owners = ListVmOwners();
+        auto vms = ListVms();
 
-        auto found = std::ranges::find(owners, c_testSessionName);
-        if (found == owners.end())
+        auto found = std::ranges::find_if(vms, [](const auto& vm) { return vm.Owner == c_testSessionName; });
+        if (found == vms.end())
         {
             LogError("Expected VM owner '%ws' not found. Owners:", c_testSessionName);
-            for (const auto& owner : owners)
+            for (const auto& vm : vms)
             {
-                LogError("  '%ws'", owner.c_str());
+                LogError("  '%ws'", vm.Owner.c_str());
             }
 
             VERIFY_FAIL();
@@ -8134,5 +8141,70 @@ class WSLCTests
         auto initProcess = container.GetInitProcess();
 
         ValidateProcessOutput(initProcess, {{1, "OK\n"}});
+    }
+
+    // Kills all VMs matching the given owner name via hcsdiag.
+    static void KillVmByOwner(const std::wstring& owner)
+    {
+        bool found = false;
+        for (const auto& vm : ListVms())
+        {
+            if (vm.Owner == owner)
+            {
+                found = true;
+                VERIFY_ARE_EQUAL(wsl::windows::common::SubProcess(nullptr, std::format(L"hcsdiag.exe kill {}", vm.Id).c_str()).Run(10000), 0u);
+            }
+        }
+
+        VERIFY_IS_TRUE(found, std::format(L"VM with owner '{}' not found", owner).c_str());
+    }
+
+    // Waits for a session to report the terminated state.
+    static void WaitForSessionTermination(IWSLCSession* session)
+    {
+        wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() {
+                WSLCSessionState state{};
+                THROW_IF_FAILED(session->GetState(&state));
+                THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_RETRY), state != WSLCSessionStateTerminated);
+            },
+            std::chrono::seconds{1},
+            std::chrono::seconds{10});
+    }
+
+    // Returns true if any running VM is owned by the given name.
+    static bool IsVmRunning(const std::wstring& owner)
+    {
+        return std::ranges::any_of(ListVms(), [&](const auto& vm) { return vm.Owner == owner; });
+    }
+
+    WSLC_TEST_METHOD(VmKillTerminatesSession)
+    {
+        constexpr auto c_sessionName = L"wslc-vm-kill-test";
+        auto settings = GetDefaultSessionSettings(c_sessionName);
+        auto session = CreateSession(settings);
+
+        KillVmByOwner(c_sessionName);
+
+        WaitForSessionTermination(session.get());
+        VERIFY_IS_FALSE(IsVmRunning(c_sessionName));
+    }
+
+    WSLC_TEST_METHOD(VmKillFailsInFlightOperations)
+    {
+        constexpr auto c_sessionName = L"wslc-vm-kill-inflight-test";
+        auto settings = GetDefaultSessionSettings(c_sessionName);
+        auto session = CreateSession(settings);
+
+        WSLCProcessLauncher launcher("/bin/sleep", {"/bin/sleep", "60"});
+        auto process = launcher.Launch(*session);
+
+        KillVmByOwner(c_sessionName);
+
+        // The process and session should both terminate (not hang).
+        WaitForSessionTermination(session.get());
+        VERIFY_IS_TRUE(process.GetExitEvent().wait(10000));
+
+        VERIFY_IS_FALSE(IsVmRunning(c_sessionName));
     }
 };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8169,7 +8169,7 @@ class WSLCTests
                 THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_RETRY), state != WSLCSessionStateTerminated);
             },
             std::chrono::seconds{1},
-            std::chrono::seconds{10});
+            std::chrono::minutes{2});
     }
 
     // Returns true if any running VM is owned by the given name.


### PR DESCRIPTION
Detect unexpected VM exits and terminate wslcsession.exe cleanly instead of hanging.

## Changes

- **GetTerminationEvent** (IDL): Added `GetTerminationEvent([out, system_handle(sh_event)] HANDLE* Event)` to `IWSLCVirtualMachine`. The service creates a manual-reset event (`m_vmExitEvent`) in the HcsVirtualMachine constructor and signals it when the HCS VM exits. `GetTerminationEvent` duplicates the handle to the caller so both sides share the same kernel event object.

- **OnVmExited handler**: The session registers `m_vmExitedEvent` with the IO relay during `Initialize()`. When the VM exits unexpectedly, `OnVmExited()` logs and calls `Terminate()`. The IO relay's `Stop()` method detects self-stop (called from its own thread) and skips the join to avoid deadlock.

- **Hardened Terminate()**: An `m_terminating` atomic guard prevents double-execution (`OnVmExited` can race with an explicit `Terminate()` call). When the VM is already dead, `Terminate()` skips `StopProcess`/`Unmount` calls that would hang waiting for a dead VM, but always resets process/VM resources.

## Tests

- **VmKillTerminatesSession**: Creates a session, kills its VM via `hcsdiag kill` (identified by owner name), verifies the session reaches the terminated state and the VM is gone.

- **VmKillFailsInFlightOperations**: Creates a session with a running `sleep` process, kills the VM, verifies both the session terminates and the in-flight process exits cleanly.