### PR TITLE
Fix various build issues if the repo path contains a space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ if (${SKIP_PACKAGE_SIGNING})
 else()
     if (NOT EXISTS ${PACKAGE_CERTIFICATE})
         execute_process(
-            COMMAND powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive ${CMAKE_CURRENT_LIST_DIR}/tools/create-dev-cert.ps1 -OutputPath ${PACKAGE_CERTIFICATE}
+            COMMAND powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "${CMAKE_CURRENT_LIST_DIR}/tools/create-dev-cert.ps1" -OutputPath "${PACKAGE_CERTIFICATE}"
             COMMAND_ERROR_IS_FATAL ANY)
     endif()
 

--- a/cmake/findNuget.cmake
+++ b/cmake/findNuget.cmake
@@ -31,7 +31,7 @@ endfunction()
 function (parse_nuget_packages_versions)
 
     # Parse the list of available packages
-    set(CMD "$packages=@{}; (Select-Xml -path ${CMAKE_SOURCE_DIR}/packages.config /packages).Node.ChildNodes | Where-Object { $_.name -ne '#whitespace'} | % {$packages.add($_.id, $_.Attributes['version'].Value) }; $packages | ConvertTo-Json | Write-Host")
+    set(CMD "$packages=@{}; (Select-Xml -path '${CMAKE_SOURCE_DIR}/packages.config' /packages).Node.ChildNodes | Where-Object { $_.name -ne '#whitespace'} | % {$packages.add($_.id, $_.Attributes['version'].Value) }; $packages | ConvertTo-Json | Write-Host")
 
     execute_process(
         COMMAND powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command "${CMD}"

--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LOCALIZATION_PS1 ${PROJECT_SOURCE_DIR}/tools/generateLocalizationHeader.ps1)
 set (MESSAGESHEAD ${GENERATED_DIR}/Localization.h)
 add_custom_command(
     OUTPUT ${MESSAGESHEAD} ${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/localization
-    COMMAND powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive  ${LOCALIZATION_PS1} -OutFile ${MESSAGESHEAD}
+    COMMAND powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "${LOCALIZATION_PS1}" -OutFile "${MESSAGESHEAD}"
     COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/localization"
     DEPENDS ${CMAKE_CURRENT_LIST_DIR}/strings/en-US/Resources.resw ${LOCALIZATION_PS1} # Make sure the head file is rebuilt if any of the resources change
     VERBATIM


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves various build issue that would fail the build if the repo path contains a space 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
