### PR TITLE
Fix mount test build in main

### DIFF
--- a/test/windows/MountTests.cpp
+++ b/test/windows/MountTests.cpp
@@ -438,10 +438,9 @@ class MountTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + absolutePath.wstring()), (DWORD)0);
     }
 
-    TEST_METHOD(AbsolutePathVhdUnmountAfterVMTimeout)
+    WSL2_TEST_METHOD(AbsolutePathVhdUnmountAfterVMTimeout)
     {
         SKIP_UNSUPPORTED_ARM64_MOUNT_TEST();
-        WSL2_TEST_ONLY();
 
         WslKeepAlive keepAlive;
 


### PR DESCRIPTION
## Summary

`AbsolutePathVhdUnmountAfterVMTimeout` was using the old `TEST_METHOD` + `WSL2_TEST_ONLY()` pattern which broke the build after the TAEF metadata refactor in #40140.

## Changes

- Replace `TEST_METHOD` + `WSL2_TEST_ONLY()` with `WSL2_TEST_METHOD` macro in `MountTests.cpp`, consistent with all other WSL2-only tests.

## Validation

- Clean build succeeds (x64 Debug)
- No other test methods use the old pattern