### PR TITLE
Don't return catch-all error messages for non-WSL specific error codes

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -853,6 +853,10 @@ For information please visit https://aka.ms/wslinstall</value>
     <value>Failed to create the swap disk in '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+    <data name="MessagedFailedToCreateDisk" xml:space="preserve">
+    <value>Failed to create disk '{}': {}</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="MessageNestedVirtualizationNotSupported" xml:space="preserve">
     <value>Nested virtualization is not supported on this machine.</value>
   </data>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -850,7 +850,7 @@ For information please visit https://aka.ms/wslinstall</value>
     <value>Failed to create the swap disk in '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
-  <data name="MessagedFailedToCreateDisk" xml:space="preserve">
+  <data name="MessageFailedToCreateDisk" xml:space="preserve">
     <value>Failed to create disk '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -853,7 +853,7 @@ For information please visit https://aka.ms/wslinstall</value>
     <value>Failed to create the swap disk in '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
-    <data name="MessagedFailedToCreateDisk" xml:space="preserve">
+  <data name="MessagedFailedToCreateDisk" xml:space="preserve">
     <value>Failed to create disk '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -217,9 +217,6 @@ Install using 'wsl.exe {} &lt;Distro&gt;'.
 To get a list of valid distributions, use 'wsl.exe --list --online'.</value>
     <comment>{FixedPlaceholder="{}"}{Locked="--list "}{Locked="--online'"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
-  <data name="MessageInstanceTerminated" xml:space="preserve">
-    <value>The Windows Subsystem for Linux instance has terminated.</value>
-  </data>
   <data name="MessageInvalidCommandLine" xml:space="preserve">
     <value>Invalid command line argument: {}
 Please use '{} --help' to get a list of supported arguments.</value>

--- a/src/windows/common/WslCoreFilesystem.cpp
+++ b/src/windows/common/WslCoreFilesystem.cpp
@@ -73,7 +73,7 @@ void wsl::core::filesystem::CreateVhd(_In_ LPCWSTR target, _In_ ULONGLONG maximu
     if (FAILED(result))
     {
         THROW_HR_WITH_USER_ERROR(
-            result, shared::Localization::MessagedFailedToCreateDisk(target, windows::common::wslutil::GetErrorString(result)));
+            result, shared::Localization::MessageFailedToCreateDisk(target, windows::common::wslutil::GetErrorString(result)));
     }
 }
 

--- a/src/windows/common/WslCoreFilesystem.cpp
+++ b/src/windows/common/WslCoreFilesystem.cpp
@@ -66,11 +66,15 @@ void wsl::core::filesystem::CreateVhd(_In_ LPCWSTR target, _In_ ULONGLONG maximu
     // N.B. This ensures that HcsGrantVmAccess is able to add the required ACL
     //      to the VHD because the operation is done while impersonating the user.
     auto sd = windows::common::security::CreateSecurityDescriptor(userSid);
+
     wil::unique_hfile vhd{};
-    THROW_IF_WIN32_ERROR_MSG(
-        ::CreateVirtualDisk(&storageType, target, VIRTUAL_DISK_ACCESS_NONE, &sd, flags, 0, &createVhdParameters, nullptr, &vhd),
-        "Path: %ls",
-        target);
+    auto result = HRESULT_FROM_WIN32(
+        ::CreateVirtualDisk(&storageType, target, VIRTUAL_DISK_ACCESS_NONE, &sd, flags, 0, &createVhdParameters, nullptr, &vhd));
+    if (FAILED(result))
+    {
+        THROW_HR_WITH_USER_ERROR(
+            result, shared::Localization::MessagedFailedToCreateDisk(target, windows::common::wslutil::GetErrorString(result)));
+    }
 }
 
 wil::unique_handle wsl::core::filesystem::OpenVhd(_In_ LPCWSTR Path, _In_ VIRTUAL_DISK_ACCESS_MASK Mask)

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -636,21 +636,11 @@ std::wstring wsl::windows::common::wslutil::GetErrorString(HRESULT result)
     case WSL_E_DEFAULT_DISTRO_NOT_FOUND:
         return Localization::MessageNoDefaultDistro();
 
-    case HRESULT_FROM_WIN32(WSAECONNABORTED):
-    case HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS):
-        return Localization::MessageInstanceTerminated();
-
     case WSL_E_DISTRO_NOT_FOUND:
         return Localization::MessageDistroNotFound();
 
-    case HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS):
-        return Localization::MessageDistroNameAlreadyExists();
-
     case WSL_E_DISTRIBUTION_NAME_NEEDED:
         return Localization::MessageDistributionNameNeeded();
-
-    case HRESULT_FROM_WIN32(ERROR_FILE_EXISTS):
-        return Localization::MessageDistroInstallPathAlreadyExists();
 
     case WSL_E_TOO_MANY_DISKS_ATTACHED:
         return Localization::MessageTooManyDisks();

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -3787,11 +3787,12 @@ void LxssUserSessionImpl::_ValidateDistributionNameAndPathNotInUse(
 
         if (Name != nullptr && wsl::shared::string::IsEqual(Name, configuration.Name, true))
         {
-            THROW_HR_MSG(
-                (configuration.State == LxssDistributionStateInstalled) ? HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS) : E_ILLEGAL_STATE_CHANGE,
-                "%ls already registered (state = %d)",
-                Name,
-                configuration.State);
+            THROW_HR_WITH_USER_ERROR_IF(
+                HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS),
+                wsl::shared::Localization::MessageDistroNameAlreadyExists(),
+                configuration.State == LxssDistributionStateInstalled);
+
+            THROW_HR_MSG(E_ILLEGAL_STATE_CHANGE, "%ls already registered (state = %d)", Name, configuration.State);
         }
 
         if (Path != nullptr)
@@ -3803,8 +3804,9 @@ void LxssUserSessionImpl::_ValidateDistributionNameAndPathNotInUse(
             }
 
             // Ensure another distribution by a different name is not already registered to the same location.
-            THROW_HR_IF(
+            THROW_HR_WITH_USER_ERROR_IF(
                 HRESULT_FROM_WIN32(ERROR_FILE_EXISTS),
+                wsl::shared::Localization::MessageDistroInstallPathAlreadyExists(),
                 wsl::windows::common::string::IsPathComponentEqual(error ? configuration.BasePath.native() : canonicalDistroPath.native(), Path));
         }
     }

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -999,7 +999,7 @@ class UnitTests
             auto basePath = wsl::windows::common::registry::ReadString(distroKey.get(), nullptr, L"BasePath", L"");
             VERIFY_IS_FALSE(basePath.empty());
 
-            commandLine = std::format(L"--import path-conflict-distro {} {} --version {}", basePath, tarFileName, version);
+            commandLine = std::format(L"--import path-conflict-distro \"{}\" \"{}\" --version {}", basePath, tarFileName, version);
             validateOutput(
                 commandLine.c_str(),
                 L"The supplied install location is already in use.\r\n"

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -970,10 +970,8 @@ class UnitTests
         auto commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, tarFileName, version);
         validateOutput(
             commandLine.c_str(),
-            std::format(
-                L"Failed to create disk '{}ext4.vhdx': The file exists. \r\n"
-                L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n",
-                LXSST_IMPORT_DISTRO_TEST_DIR));
+            L"The file exists. \r\n"
+            L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n");
 
         commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, vhdFileName, version);
         validateOutput(commandLine.c_str(), L"This looks like a VHD file. Use --vhd to import a VHD instead of a tar.\r\n");
@@ -5382,7 +5380,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND\r\n",
 
                 VERIFY_ARE_EQUAL(
                     out,
-                    L"A distribution with the supplied name already exists. Use --name to chose a different name.\r\n"
+                    L"Cannot create a file when that file already exists. \r\n"
                     L"Error code: Wsl/InstallDistro/ERROR_ALREADY_EXISTS\r\n");
 
                 VERIFY_ARE_EQUAL(err, L"");
@@ -5393,7 +5391,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND\r\n",
 
                 VERIFY_ARE_EQUAL(
                     out,
-                    L"A distribution with the supplied name already exists. Use --name to chose a different name.\r\n"
+                    L"Cannot create a file when that file already exists. \r\n"
                     L"Error code: Wsl/InstallDistro/ERROR_ALREADY_EXISTS\r\n");
 
                 VERIFY_ARE_EQUAL(err, L"");

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -970,8 +970,8 @@ class UnitTests
         auto commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, tarFileName, version);
         validateOutput(
             commandLine.c_str(),
-            L"The file exists. \r\n"
-            L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n");
+            std::format(L"Failed to create disk '{}ext4.vhdx': The file exists. \r\n"
+            L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n", LXSST_IMPORT_DISTRO_TEST_DIR));
 
         commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, vhdFileName, version);
         validateOutput(commandLine.c_str(), L"This looks like a VHD file. Use --vhd to import a VHD instead of a tar.\r\n");

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -960,7 +960,7 @@ class UnitTests
             VERIFY_IS_FALSE(!vhdFile);
         }
 
-        auto validateOutput = [](LPCWSTR commandLine, LPCWSTR expectedOutput, DWORD expectedExitCode = -1) {
+        auto validateOutput = [](LPCWSTR commandLine, const std::wstring& expectedOutput, DWORD expectedExitCode = -1) {
             auto [out, err] = LxsstuLaunchWslAndCaptureOutput(commandLine, expectedExitCode);
             VERIFY_ARE_EQUAL(expectedOutput, out);
             VERIFY_ARE_EQUAL(L"", err);
@@ -970,8 +970,10 @@ class UnitTests
         auto commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, tarFileName, version);
         validateOutput(
             commandLine.c_str(),
-            L"The supplied install location is already in use.\r\n"
-            L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n");
+            std::format(
+                L"Failed to create disk '{}ext4.vhdx': The file exists. \r\n"
+                L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n",
+                LXSST_IMPORT_DISTRO_TEST_DIR));
 
         commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, vhdFileName, version);
         validateOutput(commandLine.c_str(), L"This looks like a VHD file. Use --vhd to import a VHD instead of a tar.\r\n");
@@ -983,6 +985,25 @@ class UnitTests
                 commandLine.c_str(),
                 L"This operation is only supported by WSL2.\r\n"
                 L"Error code: Wsl/Service/RegisterDistro/WSL_E_WSL2_NEEDED\r\n");
+        }
+
+        //
+        // Verify that importing a distribution with a different name into the same path as an
+        // already registered distribution (test_distro) returns the path-already-exists error.
+        //
+
+        {
+            const auto distroKey = OpenDistributionKey(LXSS_DISTRO_NAME_TEST_L);
+            VERIFY_IS_TRUE(!!distroKey);
+
+            auto basePath = wsl::windows::common::registry::ReadString(distroKey.get(), nullptr, L"BasePath", L"");
+            VERIFY_IS_FALSE(basePath.empty());
+
+            commandLine = std::format(L"--import path-conflict-distro {} {} --version {}", basePath, tarFileName, version);
+            validateOutput(
+                commandLine.c_str(),
+                L"The supplied install location is already in use.\r\n"
+                L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n");
         }
 
         //

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -968,12 +968,22 @@ class UnitTests
 
         auto version = LxsstuVmMode() ? 2 : 1;
         auto commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, tarFileName, version);
-        validateOutput(
-            commandLine.c_str(),
-            std::format(
-                L"Failed to create disk '{}ext4.vhdx': The file exists. \r\n"
-                L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n",
-                LXSST_IMPORT_DISTRO_TEST_DIR));
+        if (LxsstuVmMode())
+        {
+            validateOutput(
+                commandLine.c_str(),
+                std::format(
+                    L"Failed to create disk '{}ext4.vhdx': The file exists. \r\n"
+                    L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n",
+                    LXSST_IMPORT_DISTRO_TEST_DIR));
+        }
+        else
+        {
+            validateOutput(
+                commandLine.c_str(),
+                L"The file exists. \r\n"
+                L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n");
+        }
 
         commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, vhdFileName, version);
         validateOutput(commandLine.c_str(), L"This looks like a VHD file. Use --vhd to import a VHD instead of a tar.\r\n");

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -970,8 +970,10 @@ class UnitTests
         auto commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, tarFileName, version);
         validateOutput(
             commandLine.c_str(),
-            std::format(L"Failed to create disk '{}ext4.vhdx': The file exists. \r\n"
-            L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n", LXSST_IMPORT_DISTRO_TEST_DIR));
+            std::format(
+                L"Failed to create disk '{}ext4.vhdx': The file exists. \r\n"
+                L"Error code: Wsl/Service/RegisterDistro/ERROR_FILE_EXISTS\r\n",
+                LXSST_IMPORT_DISTRO_TEST_DIR));
 
         commandLine = std::format(L"--import dummy {} {} --version {}", LXSST_IMPORT_DISTRO_TEST_DIR, vhdFileName, version);
         validateOutput(commandLine.c_str(), L"This looks like a VHD file. Use --vhd to import a VHD instead of a tar.\r\n");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates LxssUserSession to explicitly return error messages when hitting user errors on distribution registration and removes the catch-all logic in wslutil.

This will prevent WSL-specific errors from being displayed in WSLC 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
