### PR TITLE
Fix SDK tests to use new WSLC_E_CONTAINER error codes

### DIFF
--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2048,7 +2048,7 @@ class WslcSdkTests
         VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&execSettings, execArgv, ARRAYSIZE(execArgv)));
 
         UniqueProcess execProcess;
-        VERIFY_ARE_EQUAL(WslcCreateContainerProcess(container.get(), &execSettings, &execProcess, nullptr), static_cast<HRESULT>(0x8007139f)); // ERROR_CONTAINER_STOPPED
+        VERIFY_ARE_EQUAL(WslcCreateContainerProcess(container.get(), &execSettings, &execProcess, nullptr), WSLC_E_CONTAINER_NOT_RUNNING);
     }
 
     WSLC_TEST_METHOD(DuplicateContainerName)
@@ -2088,7 +2088,7 @@ class WslcSdkTests
         VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_NONE, nullptr));
 
         // Deleting a running container without force flag should fail
-        VERIFY_ARE_EQUAL(WslcDeleteContainer(container.get(), WSLC_DELETE_CONTAINER_FLAG_NONE, nullptr), static_cast<HRESULT>(0x8007139f)); // ERROR_CONTAINER_STOPPED
+        VERIFY_ARE_EQUAL(WslcDeleteContainer(container.get(), WSLC_DELETE_CONTAINER_FLAG_NONE, nullptr), WSLC_E_CONTAINER_IS_RUNNING);
     }
 
     WSLC_TEST_METHOD(DeleteNonExistentImage)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
PR #40147 changed container state errors from `HRESULT_FROM_WIN32(ERROR_INVALID_STATE)` to `WSLC_E_CONTAINER_IS_RUNNING` and `WSLC_E_CONTAINER_NOT_RUNNING`. PR #40152, which added SDK negative tests, was validated by CI before #40147 merged but landed after, so the tests used the old error codes.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
