### PR TITLE
Add admin protection error message for shadow admin scenarios

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -744,6 +744,11 @@ For information please visit https://aka.ms/wslinstall</value>
   <data name="MessageAdministratorAccessRequiredForDebugShell" xml:space="preserve">
     <value>Running the debug shell requires running wsl.exe as Administrator.</value>
   </data>
+  <data name="MessageAdminProtectionEnabled" xml:space="preserve">
+    <value>Windows Admin Protection is enabled and your distributions may be registered under a different account.
+For more information on Admin Protection, please visit https://aka.ms/apdevguide</value>
+    <comment>{Locked="Windows Admin Protection"}{Locked="Admin Protection"}{Locked="https://aka.ms/apdevguide"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="MessageInstallProcessFailed" xml:space="preserve">
     <value>The installation process for distribution '{}' failed with exit code: {}.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -522,8 +522,7 @@ wsl::windows::common::wslutil::GetDefaultVersion(void)
     return version;
 }
 
-namespace
-{
+namespace {
 
 // Returns true if the current process is running as a shadow admin under
 // Windows Admin Protection. Caches the DLL lookup on first call.
@@ -539,8 +538,7 @@ bool IsAdminProtectionEnabled()
     static std::optional<LxssDynamicFunction<ShadowAdminEnabledFn>> s_fn;
     static std::once_flag s_initFlag;
 
-    std::call_once(s_initFlag, []()
-    {
+    std::call_once(s_initFlag, []() {
         LxssDynamicFunction<ShadowAdminEnabledFn> fn{DynamicFunctionErrorLogs::None};
         if (SUCCEEDED(fn.load(L"SecurityHealthUdk.dll", "Shield_LUAIsShadowAdminEnabled")))
         {

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -522,10 +522,42 @@ wsl::windows::common::wslutil::GetDefaultVersion(void)
     return version;
 }
 
+namespace
+{
+
+// Returns true if the current process is running as a shadow admin under
+// Windows Admin Protection. Caches the DLL lookup on first call.
+bool IsAdminProtectionEnabled()
+{
+    const auto token = wil::open_current_access_token();
+    if (!wsl::windows::common::security::IsTokenElevated(token.get()))
+    {
+        return false;
+    }
+
+    using ShadowAdminEnabledFn = BOOL(WINAPI)();
+    static std::optional<LxssDynamicFunction<ShadowAdminEnabledFn>> s_fn;
+    static std::once_flag s_initFlag;
+
+    std::call_once(s_initFlag, []()
+    {
+        LxssDynamicFunction<ShadowAdminEnabledFn> fn{DynamicFunctionErrorLogs::None};
+        if (SUCCEEDED(fn.load(L"SecurityHealthUdk.dll", "Shield_LUAIsShadowAdminEnabled")))
+        {
+            s_fn.emplace(std::move(fn));
+        }
+    });
+
+    return s_fn.has_value() && (*s_fn)();
+}
+
+} // anonymous namespace
+
 std::wstring wsl::windows::common::wslutil::GetErrorString(HRESULT result)
 {
     ULONG buildNumber = 0;
     std::wstring kbUrl;
+    std::wstring errorString;
 
     switch (result)
     {
@@ -545,14 +577,16 @@ std::wstring wsl::windows::common::wslutil::GetErrorString(HRESULT result)
         return Localization::MessageHigherIntegrity();
 
     case WSL_E_DEFAULT_DISTRO_NOT_FOUND:
-        return Localization::MessageNoDefaultDistro();
+        errorString = Localization::MessageNoDefaultDistro();
+        break;
 
     case HRESULT_FROM_WIN32(WSAECONNABORTED):
     case HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS):
         return Localization::MessageInstanceTerminated();
 
     case WSL_E_DISTRO_NOT_FOUND:
-        return Localization::MessageDistroNotFound();
+        errorString = Localization::MessageDistroNotFound();
+        break;
 
     case HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS):
         return Localization::MessageDistroNameAlreadyExists();
@@ -695,7 +729,26 @@ std::wstring wsl::windows::common::wslutil::GetErrorString(HRESULT result)
     }
     }
 
-    return GetSystemErrorString(result);
+    if (errorString.empty())
+    {
+        return GetSystemErrorString(result);
+    }
+
+    // If Admin Protection is enabled, prepend an informational message for
+    // errors that may be caused by the shadow admin's separate registry hive.
+    try
+    {
+        if (IsAdminProtectionEnabled())
+        {
+            auto message = Localization::MessageAdminProtectionEnabled();
+            message += L"\n\n";
+            message += errorString;
+            return message;
+        }
+    }
+    CATCH_LOG()
+
+    return errorString;
 }
 
 std::optional<std::pair<std::wstring, GitHubReleaseAsset>> wsl::windows::common::wslutil::GetGitHubAssetFromRelease(const GitHubRelease& Release)

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -524,16 +524,12 @@ wsl::windows::common::wslutil::GetDefaultVersion(void)
 
 namespace {
 
-// Returns true if the current process is running as a shadow admin under
-// Windows Admin Protection. Caches the DLL lookup on first call.
+// Returns true if Windows Admin Protection (shadow admin) is enabled on
+// this system. The message is shown for both elevated and non-elevated
+// callers because either side may be missing the other's distributions.
+// Caches the DLL lookup on first call.
 bool IsAdminProtectionEnabled()
 {
-    const auto token = wil::open_current_access_token();
-    if (!wsl::windows::common::security::IsTokenElevated(token.get()))
-    {
-        return false;
-    }
-
     using ShadowAdminEnabledFn = BOOL(WINAPI)();
     static std::optional<LxssDynamicFunction<ShadowAdminEnabledFn>> s_fn;
     static std::once_flag s_initFlag;


### PR DESCRIPTION
When Windows Admin Protection is enabled, the elevated process runs as a shadow admin with a different SID, so distributions registered under the real user are not visible.

This adds an informational message explaining Admin Protection in two cases:

1. **Launching a distribution by name** that is not found (WSL_E_DISTRO_NOT_FOUND)
2. **Listing distributions** when none are registered (WSL_E_DEFAULT_DISTRO_NOT_FOUND)

The message links to https://aka.ms/apdevguide for more details.