### PR TITLE
Add try / CATCH_LOG() to the child logic when handling a WSLC_FORK message

### DIFF
--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -409,33 +409,37 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_FORK& Mes
 
     {
         auto childLogic = [ListenSocketFd = ListenSocket.get(), SocketAddress, &Channel, &Message, &childPid]() mutable {
-            wil::unique_fd ListenSocket;
-
-            // Close parent channel
-            if (Message.ForkType == WSLC_FORK::Process || Message.ForkType == WSLC_FORK::Pty)
+            try
             {
-                Channel.Close();
+                wil::unique_fd ListenSocket;
+
+                // Close parent channel
+                if (Message.ForkType == WSLC_FORK::Process || Message.ForkType == WSLC_FORK::Pty)
+                {
+                    Channel.Close();
+                }
+
+                if (Message.ForkType == WSLC_FORK::Thread)
+                {
+                    // If this is a thread, detach from the process' fd table.
+                    // This prevents other threads from creating child processes that could inherit fds that this thread could create.
+                    // N.B. This needs to happen before childPid is signalled to ensure that ListenSocket() is not closed by the parent before getting duplicated in the child's fd table.
+                    THROW_LAST_ERROR_IF(unshare(CLONE_FILES) < 0);
+                }
+
+                // ListenSocket should only be assigned after this thread is guaranteed to have its own fd table (either via unshare() or a child process).
+                ListenSocket.reset(ListenSocketFd);
+                childPid.set_value(getpid());
+
+                wil::unique_fd ProcessSocket{UtilAcceptVsock(ListenSocket.get(), SocketAddress, SESSION_LEADER_ACCEPT_TIMEOUT_MS)};
+                THROW_LAST_ERROR_IF(!ProcessSocket);
+
+                ListenSocket.reset();
+
+                auto subChannel = wsl::shared::SocketChannel{std::move(ProcessSocket), "ForkedChannel"};
+                ProcessMessages(subChannel);
             }
-
-            if (Message.ForkType == WSLC_FORK::Thread)
-            {
-                // If this is a thread, detach from the process' fd table.
-                // This prevents other threads from creating child processes that could inherit fds that this thread could create.
-                // N.B. This needs to happen before childPid is signalled to ensure that ListenSocket() is not closed by the parent before getting duplicated in the child's fd table.
-                THROW_LAST_ERROR_IF(unshare(CLONE_FILES) < 0);
-            }
-
-            // ListenSocket should only be assigned after this thread is guaranteed to have its own fd table (either via unshare() or a child process).
-            ListenSocket.reset(ListenSocketFd);
-            childPid.set_value(getpid());
-
-            wil::unique_fd ProcessSocket{UtilAcceptVsock(ListenSocket.get(), SocketAddress, SESSION_LEADER_ACCEPT_TIMEOUT_MS)};
-            THROW_LAST_ERROR_IF(!ProcessSocket);
-
-            ListenSocket.reset();
-
-            auto subChannel = wsl::shared::SocketChannel{std::move(ProcessSocket), "ForkedChannel"};
-            ProcessMessages(subChannel);
+            CATCH_LOG();
         };
 
         if (Message.ForkType == WSLC_FORK::Thread)

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -409,6 +409,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_FORK& Mes
 
     {
         auto childLogic = [ListenSocketFd = ListenSocket.get(), SocketAddress, &Channel, &Message, &childPid]() mutable {
+            bool futureSet = false;
             try
             {
                 wil::unique_fd ListenSocket;
@@ -430,6 +431,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_FORK& Mes
                 // ListenSocket should only be assigned after this thread is guaranteed to have its own fd table (either via unshare() or a child process).
                 ListenSocket.reset(ListenSocketFd);
                 childPid.set_value(getpid());
+                futureSet = true;
 
                 wil::unique_fd ProcessSocket{UtilAcceptVsock(ListenSocket.get(), SocketAddress, SESSION_LEADER_ACCEPT_TIMEOUT_MS)};
                 THROW_LAST_ERROR_IF(!ProcessSocket);
@@ -439,7 +441,14 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_FORK& Mes
                 auto subChannel = wsl::shared::SocketChannel{std::move(ProcessSocket), "ForkedChannel"};
                 ProcessMessages(subChannel);
             }
-            CATCH_LOG();
+            catch (...)
+            {
+                LOG_CAUGHT_EXCEPTION();
+                if (!futureSet)
+                {
+                    childPid.set_exception(std::current_exception());
+                }
+            }
         };
 
         if (Message.ForkType == WSLC_FORK::Thread)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the init logic to catch errors sent inside the child side of the fork logic, which prevents init from cashing if a child routine thrown an exception in the case where WSLC_FORK::Thread was used.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
