### PR TITLE
Add logic to keep track of COM callbacks and cancel them if the sessi…

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -221,17 +221,17 @@ HANDLE UserHandle::Get() const noexcept
     return m_handle;
 }
 
-UserCOMCallback::UserCOMCallback(WSLCSession& Session) : m_session(&Session), m_threadId(GetCurrentThreadId())
+UserCOMCallback::UserCOMCallback(WSLCSession& Session) noexcept : m_session(&Session), m_threadId(GetCurrentThreadId())
 {
-    THROW_IF_FAILED(CoEnableCallCancellation(nullptr));
+    LOG_IF_FAILED(CoEnableCallCancellation(nullptr));
 }
 
-UserCOMCallback::UserCOMCallback(UserCOMCallback&& Other)
+UserCOMCallback::UserCOMCallback(UserCOMCallback&& Other) noexcept
 {
     *this = std::move(Other);
 }
 
-UserCOMCallback& UserCOMCallback::operator=(UserCOMCallback&& Other)
+UserCOMCallback& UserCOMCallback::operator=(UserCOMCallback&& Other) noexcept
 {
     if (this != &Other)
     {
@@ -245,7 +245,7 @@ UserCOMCallback& UserCOMCallback::operator=(UserCOMCallback&& Other)
     return *this;
 }
 
-void UserCOMCallback::Reset()
+void UserCOMCallback::Reset() noexcept
 {
     if (m_threadId != 0)
     {
@@ -254,11 +254,11 @@ void UserCOMCallback::Reset()
         m_session->UnregisterUserCOMCallback(m_threadId);
         m_threadId = 0;
 
-        THROW_IF_FAILED(CoDisableCallCancellation(nullptr));
+        LOG_IF_FAILED(CoDisableCallCancellation(nullptr));
     }
 }
 
-UserCOMCallback::~UserCOMCallback()
+UserCOMCallback::~UserCOMCallback() noexcept
 {
     Reset();
 }
@@ -2226,7 +2226,8 @@ UserCOMCallback WSLCSession::RegisterUserCOMCallback()
     THROW_HR_IF_MSG(
         E_ABORT, m_sessionTerminatingEvent.is_signaled(), "Refusing to make a COM callback while the session is terminating.");
 
-    m_userCOMCallbackThreads.emplace_back(GetCurrentThreadId());
+    auto [_, inserted] = m_userCOMCallbackThreads.insert(GetCurrentThreadId());
+    WI_ASSERT(inserted);
 
     return UserCOMCallback{*this};
 }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -223,7 +223,6 @@ HANDLE UserHandle::Get() const noexcept
 
 UserCOMCallback::UserCOMCallback(WSLCSession& Session) noexcept : m_session(&Session), m_threadId(GetCurrentThreadId())
 {
-    LOG_IF_FAILED(CoEnableCallCancellation(nullptr));
 }
 
 UserCOMCallback::UserCOMCallback(UserCOMCallback&& Other) noexcept
@@ -2225,6 +2224,8 @@ UserCOMCallback WSLCSession::RegisterUserCOMCallback()
     // N.B. This check must happen under m_userCOMCallbacksLock to synchronize with Terminate().
     THROW_HR_IF_MSG(
         E_ABORT, m_sessionTerminatingEvent.is_signaled(), "Refusing to make a COM callback while the session is terminating.");
+
+    THROW_IF_FAILED(CoEnableCallCancellation(nullptr));
 
     auto [_, inserted] = m_userCOMCallbackThreads.insert(GetCurrentThreadId());
     WI_ASSERT(inserted);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -21,6 +21,7 @@ Abstract:
 using namespace wsl::windows::common;
 using relay::MultiHandleWait;
 using wsl::shared::Localization;
+using wsl::windows::service::wslc::UserCOMCallback;
 using wsl::windows::service::wslc::UserHandle;
 using wsl::windows::service::wslc::WSLCSession;
 using wsl::windows::service::wslc::WSLCVirtualMachine;
@@ -218,6 +219,48 @@ UserHandle::~UserHandle()
 HANDLE UserHandle::Get() const noexcept
 {
     return m_handle;
+}
+
+UserCOMCallback::UserCOMCallback(WSLCSession& Session) : m_session(&Session), m_threadId(GetCurrentThreadId())
+{
+    THROW_IF_FAILED(CoEnableCallCancellation(nullptr));
+}
+
+UserCOMCallback::UserCOMCallback(UserCOMCallback&& Other)
+{
+    *this = std::move(Other);
+}
+
+UserCOMCallback& UserCOMCallback::operator=(UserCOMCallback&& Other)
+{
+    if (this != &Other)
+    {
+        Reset();
+        m_session = Other.m_session;
+        m_threadId = Other.m_threadId;
+
+        Other.m_threadId = 0;
+        Other.m_session = nullptr;
+    }
+    return *this;
+}
+
+void UserCOMCallback::Reset()
+{
+    if (m_threadId != 0)
+    {
+        WI_ASSERT(m_session != nullptr);
+
+        m_session->UnregisterUserCOMCallback(m_threadId);
+        m_threadId = 0;
+
+        THROW_IF_FAILED(CoDisableCallCancellation(nullptr));
+    }
+}
+
+UserCOMCallback::~UserCOMCallback()
+{
+    Reset();
 }
 
 HRESULT WSLCSession::GetProcessHandle(_Out_ HANDLE* ProcessHandle)
@@ -443,6 +486,12 @@ void WSLCSession::StreamImageOperation(DockerHTTPClient::HTTPRequestContext& req
         bool isJson = false;
     };
 
+    std::optional<UserCOMCallback> comCall;
+    if (ProgressCallback != nullptr)
+    {
+        comCall = RegisterUserCOMCallback();
+    }
+
     std::optional<Response> httpResponse;
 
     auto onHttpResponse = [&](const boost::beast::http::message<false, boost::beast::http::buffer_body>& response) {
@@ -588,6 +637,12 @@ try
         Options->Flags);
 
     auto buildFileHandle = OpenUserHandle(Options->DockerfileHandle);
+
+    std::optional<UserCOMCallback> comCall;
+    if (ProgressCallback != nullptr)
+    {
+        comCall = RegisterUserCOMCallback();
+    }
 
     auto lock = m_lock.lock_shared();
 
@@ -1918,6 +1973,14 @@ try
         CancelUserHandleIO();
     }
 
+    {
+        std::lock_guard comLock(m_userCOMCallbacksLock);
+
+        // Cancel any pending outgoing COM callback calls (e.g. IProgressCallback::OnProgress)
+        // to unblock operations waiting for cross-process COM responses.
+        CancelUserCOMCallbacks();
+    }
+
     // Acquire an exclusive lock to ensure that no operation is running.
     auto lock = m_lock.lock_exclusive();
     std::lock_guard containersLock(m_containersLock);
@@ -2151,6 +2214,38 @@ void WSLCSession::CancelUserHandleIO()
         {
             LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
         }
+    }
+}
+
+UserCOMCallback WSLCSession::RegisterUserCOMCallback()
+{
+    std::lock_guard lock(m_userCOMCallbacksLock);
+
+    // Don't allow new COM calls if the session is terminating.
+    // N.B. This check must happen under m_userCOMCallbacksLock to synchronize with Terminate().
+    THROW_HR_IF_MSG(
+        E_ABORT, m_sessionTerminatingEvent.is_signaled(), "Refusing to make a COM callback while the session is terminating.");
+
+    m_userCOMCallbackThreads.emplace_back(GetCurrentThreadId());
+
+    return UserCOMCallback{*this};
+}
+
+void WSLCSession::UnregisterUserCOMCallback(DWORD ThreadId)
+{
+    std::lock_guard lock(m_userCOMCallbacksLock);
+
+    auto it = std::ranges::find(m_userCOMCallbackThreads, ThreadId);
+    WI_ASSERT(it != m_userCOMCallbackThreads.end());
+
+    m_userCOMCallbackThreads.erase(it);
+}
+
+void WSLCSession::CancelUserCOMCallbacks()
+{
+    for (auto threadId : m_userCOMCallbackThreads)
+    {
+        LOG_IF_FAILED(CoCancelCall(threadId, 0));
     }
 }
 

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2228,7 +2228,7 @@ UserCOMCallback WSLCSession::RegisterUserCOMCallback()
     THROW_IF_FAILED(CoEnableCallCancellation(nullptr));
 
     auto [_, inserted] = m_userCOMCallbackThreads.insert(GetCurrentThreadId());
-    WI_ASSERT(inserted);
+    WI_VERIFY(inserted);
 
     return UserCOMCallback{*this};
 }
@@ -2237,8 +2237,8 @@ void WSLCSession::UnregisterUserCOMCallback(DWORD ThreadId)
 {
     std::lock_guard lock(m_userCOMCallbacksLock);
 
-    auto it = std::ranges::find(m_userCOMCallbackThreads, ThreadId);
-    WI_ASSERT(it != m_userCOMCallbackThreads.end());
+    auto it = m_userCOMCallbackThreads.find(ThreadId);
+    WI_VERIFY(it != m_userCOMCallbackThreads.end());
 
     m_userCOMCallbackThreads.erase(it);
 }

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -48,6 +48,24 @@ private:
     HANDLE m_handle{};
 };
 
+class UserCOMCallback
+{
+    NON_COPYABLE(UserCOMCallback);
+
+public:
+    UserCOMCallback(WSLCSession& Session);
+    UserCOMCallback(UserCOMCallback&& Other);
+
+    ~UserCOMCallback();
+
+    UserCOMCallback& operator=(UserCOMCallback&& Other);
+    void Reset();
+
+private:
+    WSLCSession* m_session{};
+    DWORD m_threadId{};
+};
+
 //
 // WSLCSession - Implements IWSLCSession for container management.
 // Runs in a per-user COM server process for security isolation.
@@ -125,10 +143,14 @@ public:
     UserHandle OpenUserHandle(WSLCHandle Handle);
     void ReleaseUserHandle(HANDLE Handle);
 
+    UserCOMCallback RegisterUserCOMCallback();
+    void UnregisterUserCOMCallback(DWORD ThreadId);
+
 private:
     ULONG m_id = 0;
 
     __requires_lock_held(m_userHandlesLock) void CancelUserHandleIO();
+    __requires_lock_held(m_userCOMCallbacksLock) void CancelUserCOMCallbacks();
     void ConfigureStorage(const WSLCSessionInitSettings& Settings, PSID UserSid);
     void Ext4Format(const std::string& Device);
     void OnContainerDeleted(const WSLCContainerImpl* Container);
@@ -168,6 +190,11 @@ private:
     // User-provided handles that the session is currently doing IO on.
     std::mutex m_userHandlesLock;
     __guarded_by(m_userHandlesLock) std::vector<HANDLE> m_userHandles;
+
+    // Threads currently inside an outgoing COM callback (e.g. IProgressCallback::OnProgress).
+    // Used by Terminate() to cancel stuck cross-process calls via CoCancelCall().
+    std::mutex m_userCOMCallbacksLock;
+    __guarded_by(m_userCOMCallbacksLock) std::vector<DWORD> m_userCOMCallbackThreads;
 
     // Used for testing only.
     std::mutex m_allocatedPortsLock;

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -192,8 +192,7 @@ private:
     __guarded_by(m_userHandlesLock) std::vector<HANDLE> m_userHandles;
 
     // Threads currently inside an outgoing COM callback (e.g. IProgressCallback::OnProgress).
-    // Used by Terminate() to cancel stuck cross-process calls via CoCancelCall().
-    std::mutex m_userCOMCallbacksLock;
+    std::recursive_mutex m_userCOMCallbacksLock;
     __guarded_by(m_userCOMCallbacksLock) std::set<DWORD> m_userCOMCallbackThreads;
 
     // Used for testing only.

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -53,13 +53,13 @@ class UserCOMCallback
     NON_COPYABLE(UserCOMCallback);
 
 public:
-    UserCOMCallback(WSLCSession& Session);
-    UserCOMCallback(UserCOMCallback&& Other);
+    UserCOMCallback(WSLCSession& Session) noexcept;
+    UserCOMCallback(UserCOMCallback&& Other) noexcept;
 
-    ~UserCOMCallback();
+    ~UserCOMCallback() noexcept;
 
-    UserCOMCallback& operator=(UserCOMCallback&& Other);
-    void Reset();
+    UserCOMCallback& operator=(UserCOMCallback&& Other) noexcept;
+    void Reset() noexcept;
 
 private:
     WSLCSession* m_session{};
@@ -194,7 +194,7 @@ private:
     // Threads currently inside an outgoing COM callback (e.g. IProgressCallback::OnProgress).
     // Used by Terminate() to cancel stuck cross-process calls via CoCancelCall().
     std::mutex m_userCOMCallbacksLock;
-    __guarded_by(m_userCOMCallbacksLock) std::vector<DWORD> m_userCOMCallbackThreads;
+    __guarded_by(m_userCOMCallbacksLock) std::set<DWORD> m_userCOMCallbackThreads;
 
     // Used for testing only.
     std::mutex m_allocatedPortsLock;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2569,6 +2569,7 @@ class WSLCTests
         // Terminate the session while the callback is stuck.
         // This should cancel the pending COM call and unblock BuildImage.
         VERIFY_SUCCEEDED(m_defaultSession->Terminate());
+        ResetTestSession();
 
         auto buildFuture = buildResult.get_future();
         auto buildStatus = buildFuture.wait_for(std::chrono::seconds(60));

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2553,7 +2553,8 @@ class WSLCTests
         auto callback = Microsoft::WRL::Make<StuckBuildProgressCallback>(callbackReached, exitEvent);
 
         std::promise<HRESULT> buildResult;
-        std::thread buildThread([&]() { buildResult.set_value(m_defaultSession->BuildImage(&options, callback.Get(), exitEvent.get())); });
+        std::thread buildThread(
+            [&]() { buildResult.set_value(m_defaultSession->BuildImage(&options, callback.Get(), exitEvent.get())); });
 
         auto joinThread = wil::scope_exit([&]() {
             exitEvent.SetEvent();

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2497,6 +2497,86 @@ class WSLCTests
         VERIFY_ARE_NOT_EQUAL(details, L"");
     }
 
+    WSLC_TEST_METHOD(BuildImageStuckCallbackCancellation)
+    {
+        class StuckBuildProgressCallback
+            : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IProgressCallback>
+        {
+        public:
+            StuckBuildProgressCallback(std::promise<void>& reachedPromise, wil::unique_event& exitEvent) :
+                m_reachedPromise(reachedPromise), m_exitEvent(exitEvent)
+            {
+            }
+
+            HRESULT OnProgress(LPCSTR, LPCSTR, ULONGLONG, ULONGLONG) override
+            {
+                if (!m_signaled)
+                {
+                    m_signaled = true;
+                    m_reachedPromise.set_value();
+                    m_exitEvent.wait(); // Block until this test case is complete.
+                }
+
+                return S_OK;
+            }
+
+        private:
+            std::promise<void>& m_reachedPromise;
+            wil::unique_event& m_exitEvent;
+            bool m_signaled{};
+        };
+
+        auto contextDir = std::filesystem::current_path() / "build-context-stuck-callback";
+        std::filesystem::create_directories(contextDir);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            std::error_code ec;
+            std::filesystem::remove_all(contextDir, ec);
+        });
+
+        {
+            std::ofstream dockerfile(contextDir / "Dockerfile");
+            dockerfile << "FROM debian:latest\n";
+            dockerfile << "RUN echo hello\n";
+        }
+
+        auto contextPathStr = contextDir.wstring();
+        auto dockerfileHandle = wil::open_file((contextDir / "Dockerfile").c_str());
+
+        WSLCBuildImageOptions options{
+            .ContextPath = contextPathStr.c_str(),
+            .DockerfileHandle = ToCOMInputHandle(dockerfileHandle.get()),
+            .Flags = WSLCBuildImageFlagsVerbose,
+        };
+
+        std::promise<void> callbackReached;
+        wil::unique_event exitEvent{wil::EventOptions::ManualReset};
+        auto callback = Microsoft::WRL::Make<StuckBuildProgressCallback>(callbackReached, exitEvent);
+
+        std::promise<HRESULT> buildResult;
+        std::thread buildThread([&]() { buildResult.set_value(m_defaultSession->BuildImage(&options, callback.Get(), nullptr)); });
+
+        auto joinThread = wil::scope_exit([&]() {
+            exitEvent.SetEvent();
+            buildThread.join();
+        });
+
+        // Wait for the progress callback to be called, proving the COM call is in flight.
+        auto reachedFuture = callbackReached.get_future();
+        auto reachedStatus = reachedFuture.wait_for(std::chrono::seconds(60));
+        VERIFY_ARE_EQUAL(reachedStatus, std::future_status::ready);
+
+        // Terminate the session while the callback is stuck.
+        // This should cancel the pending COM call and unblock BuildImage.
+        VERIFY_SUCCEEDED(m_defaultSession->Terminate());
+
+        auto buildFuture = buildResult.get_future();
+        auto buildStatus = buildFuture.wait_for(std::chrono::seconds(30));
+        VERIFY_ARE_EQUAL(buildStatus, std::future_status::ready);
+
+        // BuildImage should have failed due to COM call cancellation.
+        VERIFY_FAILED(buildFuture.get());
+    }
+
     WSLC_TEST_METHOD(InteractiveShell)
     {
         WSLCProcessLauncher launcher("/bin/sh", {"/bin/sh"}, {"TERM=xterm-256color"}, WSLCProcessFlagsTty | WSLCProcessFlagsStdin);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2553,7 +2553,7 @@ class WSLCTests
         auto callback = Microsoft::WRL::Make<StuckBuildProgressCallback>(callbackReached, exitEvent);
 
         std::promise<HRESULT> buildResult;
-        std::thread buildThread([&]() { buildResult.set_value(m_defaultSession->BuildImage(&options, callback.Get(), nullptr)); });
+        std::thread buildThread([&]() { buildResult.set_value(m_defaultSession->BuildImage(&options, callback.Get(), exitEvent.get())); });
 
         auto joinThread = wil::scope_exit([&]() {
             exitEvent.SetEvent();
@@ -2570,7 +2570,7 @@ class WSLCTests
         VERIFY_SUCCEEDED(m_defaultSession->Terminate());
 
         auto buildFuture = buildResult.get_future();
-        auto buildStatus = buildFuture.wait_for(std::chrono::seconds(30));
+        auto buildStatus = buildFuture.wait_for(std::chrono::seconds(60));
         VERIFY_ARE_EQUAL(buildStatus, std::future_status::ready);
 
         // BuildImage should have failed due to COM call cancellation.


### PR DESCRIPTION
…on is terminating

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to cancel user COM callbacks when the session terminates. This will prevent a session from being "stuck" if a user callback hangs during termination

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
