### PR TITLE
Always show container logs during image builds

### DIFF
--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -534,7 +534,7 @@ typedef struct _WSLCDeleteImageOptions
 typedef enum _WSLCBuildImageFlags
 {
     WSLCBuildImageFlagsNone = 0,
-    WSLCBuildImageFlagsVerbose = 1, // Show all build progress including internal steps and all statuses.
+    WSLCBuildImageFlagsVerbose = 1, // Show all build progress including internal steps.
     WSLCBuildImageFlagsNoCache = 2, // Do not use cache when building the image.
 } WSLCBuildImageFlags;
 

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -573,6 +573,8 @@ try
     std::set<std::string> reportedSteps;
     std::set<std::string> reportedErrors;
     std::map<std::string, std::string> digestToStageName;
+    bool needsNewline = false; // true when the last log chunk didn't end with \n
+    std::string lastLogVertex; // digest of the vertex that produced the last log output
 
     // Extract the named build stage from a BuildKit vertex name. Vertices within the same named stage
     // (e.g. "[builder 1/3]" and "[builder 2/3]") share a key. Returns empty for unnamed stages.
@@ -618,6 +620,14 @@ try
         }
     };
 
+    auto flushLine = [&]() {
+        if (needsNewline)
+        {
+            reportProgress("\n");
+            needsNewline = false;
+        }
+    };
+
     // Accumulate lines and use accept() to detect complete JSON objects. Check for non-JSON lines between JSON objects and add
     // them to the output in case they contain helpful information about the build.
     auto captureOutput = [&](const gsl::span<char>& content) {
@@ -650,14 +660,17 @@ try
                 continue;
             }
 
+            digestToStageName.try_emplace(vertex.digest, getStageName(vertex.name));
+
             if (!vertex.started.empty() && reportedSteps.insert(vertex.digest).second)
             {
-                digestToStageName[vertex.digest] = getStageName(vertex.name);
+                flushLine();
                 reportProgress(vertex.name + "\n");
             }
 
             if (!vertex.error.empty() && reportedErrors.insert(vertex.digest).second)
             {
+                flushLine();
                 reportProgress(vertex.error + "\n");
             }
         }
@@ -669,7 +682,26 @@ try
                 std::string decoded = wslutil::Base64Decode(log.data);
                 if (!decoded.empty())
                 {
-                    reportProgress(IndentLines(decoded, logPrefix(it->second)));
+                    if (log.vertex != lastLogVertex && decoded[0] != '\n')
+                    {
+                        flushLine();
+                    }
+
+                    // When continuing an unterminated line, emit the leading \n or \r directly
+                    // so it terminates/overwrites cleanly without a spurious prefix.
+                    if (needsNewline && (decoded[0] == '\n' || decoded[0] == '\r'))
+                    {
+                        reportProgress(decoded.substr(0, 1));
+                        decoded.erase(0, 1);
+                    }
+
+                    if (!decoded.empty())
+                    {
+                        reportProgress(IndentLines(decoded, logPrefix(it->second)));
+                    }
+
+                    needsNewline = !decoded.empty() && decoded.back() != '\n';
+                    lastLogVertex = log.vertex;
                 }
             }
         }
@@ -679,6 +711,7 @@ try
             if (auto it = digestToStageName.find(entry.vertex);
                 it != digestToStageName.end() && !entry.id.empty() && reportedSteps.insert(entry.id).second)
             {
+                flushLine();
                 reportProgress(logPrefix(it->second) + entry.id + "\n");
             }
         }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -757,6 +757,7 @@ try
     }
     catch (...)
     {
+        flushLine();
         LOG_IF_FAILED(buildProcess.Get().Signal(WSLCSignalSIGTERM));
         try
         {
@@ -779,6 +780,8 @@ try
         }
         throw;
     }
+
+    flushLine();
 
     THROW_HR_IF_MSG(E_ABORT, cancelled, "Cancellation handle was signaled");
 

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -29,73 +29,6 @@ constexpr auto c_containerdStorage = "/var/lib/docker";
 
 namespace {
 
-// Resolve \r overwrites: for each \n-delimited line, keep only the content after the last \r.
-// This collapses terminal progress updates (e.g. "50%\r75%\r100%") to their final state.
-std::string ResolveCarriageReturns(const std::string& input)
-{
-    if (input.empty())
-    {
-        return {};
-    }
-
-    std::string result;
-    size_t lineStart = 0;
-    while (lineStart < input.size())
-    {
-        size_t lineEnd = input.find('\n', lineStart);
-        if (lineEnd == std::string::npos)
-        {
-            lineEnd = input.size();
-        }
-
-        // Find the last \r in this line segment (skip empty segments to avoid rfind underflow).
-        size_t contentStart = lineStart;
-        if (lineEnd > lineStart)
-        {
-            size_t lastCr = input.rfind('\r', lineEnd - 1);
-            if (lastCr != std::string::npos && lastCr >= lineStart)
-            {
-                contentStart = lastCr + 1;
-            }
-        }
-
-        result.append(input, contentStart, lineEnd - contentStart);
-        if (lineEnd < input.size())
-        {
-            result.push_back('\n');
-        }
-
-        lineStart = lineEnd + 1;
-    }
-
-    return result;
-}
-
-std::string TailLines(const std::string& input, int lineCount)
-{
-    if (input.empty() || lineCount <= 0)
-    {
-        return {};
-    }
-
-    size_t pos = input.size();
-    if (input[pos - 1] == '\n')
-    {
-        pos--;
-    }
-
-    for (int i = 0; i < lineCount && pos > 0; i++)
-    {
-        pos = input.rfind('\n', pos - 1);
-        if (pos == std::string::npos)
-        {
-            return input;
-        }
-    }
-
-    return input.substr(pos + 1);
-}
-
 std::string IndentLines(const std::string& input, const std::string& prefix)
 {
     if (input.empty())
@@ -639,8 +572,44 @@ try
     std::string pendingJson;
     std::set<std::string> reportedSteps;
     std::set<std::string> reportedErrors;
-    std::string exportingVertexDigest;
-    std::map<std::string, std::string> vertexLogs; // digest -> accumulated log output
+    std::map<std::string, std::string> digestToStageName;
+
+    // Extract the named build stage from a BuildKit vertex name. Vertices within the same named stage
+    // (e.g. "[builder 1/3]" and "[builder 2/3]") share a key. Returns empty for unnamed stages.
+    auto getStageName = [](const std::string& name) -> std::string {
+        if (name.size() < 2 || name[0] != '[')
+        {
+            return {};
+        }
+
+        auto close = name.find(']');
+        if (close == std::string::npos)
+        {
+            return {};
+        }
+
+        // Pattern: "[name N/M]" or "[N/M]". The stage name is the part before "N/M".
+        std::string content = name.substr(1, close - 1);
+        auto slash = content.find('/');
+        if (slash != std::string::npos)
+        {
+            auto space = content.rfind(' ', slash);
+            if (space != std::string::npos)
+            {
+                return content.substr(0, space);
+            }
+        }
+
+        return {};
+    };
+
+    auto logPrefix = [](const std::string& name) -> std::string {
+        if (name.empty())
+        {
+            return "  | ";
+        }
+        return "  [" + name + "] ";
+    };
 
     auto reportProgress = [&](const std::string& message) {
         if (ProgressCallback != nullptr)
@@ -673,73 +642,44 @@ try
         docker_schema::BuildKitSolveStatus status{};
         from_json(json, status);
 
-        // Accumulate logs before processing vertices so the error tail includes all data from this payload.
-        for (const auto& log : status.logs)
+        // Process vertices before logs so digestToStageName is populated for log correlation.
+        for (const auto& vertex : status.vertexes)
         {
-            if (log.data.empty())
+            if (!verbose && vertex.name.find("[internal]") != std::string::npos)
             {
                 continue;
             }
 
-            std::string decoded = wslutil::Base64Decode(log.data);
-            if (!decoded.empty())
+            if (!vertex.started.empty() && reportedSteps.insert(vertex.digest).second)
             {
-                auto& logBuffer = vertexLogs[log.vertex];
-                logBuffer.append(decoded);
+                digestToStageName[vertex.digest] = getStageName(vertex.name);
+                reportProgress(vertex.name + "\n");
+            }
 
-                // Cap raw buffer size; we resolve \r and trim to last N lines at display time.
-                constexpr size_t c_maxLogBytes = 64 * 1024;
-                if (logBuffer.size() > c_maxLogBytes)
-                {
-                    logBuffer.erase(0, logBuffer.size() - c_maxLogBytes);
-                }
-
-                if (verbose)
-                {
-                    reportProgress(IndentLines(decoded, "  "));
-                }
+            if (!vertex.error.empty() && reportedErrors.insert(vertex.digest).second)
+            {
+                reportProgress(vertex.error + "\n");
             }
         }
 
-        for (const auto& vertex : status.vertexes)
+        for (const auto& log : status.logs)
         {
-            bool isInternal = vertex.name.find("[internal]") != std::string::npos;
-
-            if (!vertex.started.empty() && reportedSteps.insert(vertex.digest).second)
+            if (auto it = digestToStageName.find(log.vertex); it != digestToStageName.end() && !log.data.empty())
             {
-                if (verbose || (!isInternal && !vertex.name.empty() && vertex.name[0] == '['))
+                std::string decoded = wslutil::Base64Decode(log.data);
+                if (!decoded.empty())
                 {
-                    reportProgress(vertex.name + "\n");
+                    reportProgress(IndentLines(decoded, logPrefix(it->second)));
                 }
-
-                // Track the "exporting to image" vertex so we can report its statuses (image hash, tags)
-                // in non-verbose mode. This is a well-known BuildKit vertex name.
-                if (vertex.name == "exporting to image")
-                {
-                    exportingVertexDigest = vertex.digest;
-                }
-            }
-
-            if (!vertex.error.empty() && !isInternal && reportedErrors.insert(vertex.digest).second)
-            {
-                if (auto it = vertexLogs.find(vertex.digest); it != vertexLogs.end() && !it->second.empty())
-                {
-                    if (!verbose)
-                    {
-                        std::string tail = TailLines(ResolveCarriageReturns(it->second), 16);
-                        reportProgress(IndentLines(tail, "  "));
-                    }
-                }
-
-                reportProgress(vertex.error + "\n");
             }
         }
 
         for (const auto& entry : status.statuses)
         {
-            if (!entry.id.empty() && reportedSteps.insert(entry.id).second && (verbose || entry.vertex == exportingVertexDigest))
+            if (auto it = digestToStageName.find(entry.vertex);
+                it != digestToStageName.end() && !entry.id.empty() && reportedSteps.insert(entry.id).second)
             {
-                reportProgress(entry.id + "\n");
+                reportProgress(logPrefix(it->second) + entry.id + "\n");
             }
         }
     };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1444,6 +1444,7 @@ class WSLCTests
         WSLCBuildImageOptions options{.Tags = {&tag, 1}, .Flags = WSLCBuildImageFlagsNoCache};
         VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options, callback.Get()));
         VERIFY_IS_TRUE(output.find("[greeting] WSL containers") != std::string::npos);
+        VERIFY_IS_TRUE(output.find("[description] support multi-stage builds") != std::string::npos);
         ExpectImagePresent(*m_defaultSession, "wslc-test-build-multistage:latest");
 
         WSLCContainerLauncher launcher("wslc-test-build-multistage:latest", "wslc-build-multistage-container");

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1140,6 +1140,24 @@ class WSLCTests
         }
     }
 
+    class CapturingProgressCallback
+        : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IProgressCallback>
+    {
+    public:
+        CapturingProgressCallback(std::string& output) : m_output(output)
+        {
+        }
+
+        HRESULT OnProgress(LPCSTR status, LPCSTR, ULONGLONG, ULONGLONG) override
+        {
+            m_output.append(status);
+            return S_OK;
+        }
+
+    private:
+        std::string& m_output;
+    };
+
     HRESULT BuildImageFromContext(const std::filesystem::path& contextDir, const WSLCBuildImageOptions* options, IProgressCallback* callback = nullptr)
     {
         auto dockerfileHandle = wil::open_file((contextDir / "Dockerfile").c_str());
@@ -1408,10 +1426,10 @@ class WSLCTests
             // Two independent stages that can build in parallel, each producing
             // part of the final output.  The last stage combines them.
             dockerfile << "FROM debian:latest AS greeting\n";
-            dockerfile << "RUN echo -n 'WSL containers' > /part.txt\n";
+            dockerfile << "RUN echo -n 'WSL containers' | tee /part.txt\n";
             dockerfile << "\n";
             dockerfile << "FROM debian:latest AS description\n";
-            dockerfile << "RUN echo -n 'support multi-stage builds' > /part.txt\n";
+            dockerfile << "RUN echo -n 'support multi-stage builds' | tee /part.txt\n";
             dockerfile << "\n";
             dockerfile << "FROM debian:latest\n";
             dockerfile << "COPY --from=greeting /part.txt /greeting.txt\n";
@@ -1420,7 +1438,12 @@ class WSLCTests
                        << "\"echo \\\"$(cat /greeting.txt) $(cat /description.txt)\\\"\"]\n";
         }
 
-        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, "wslc-test-build-multistage:latest"));
+        std::string output;
+        auto callback = Microsoft::WRL::Make<CapturingProgressCallback>(output);
+        LPCSTR tag = "wslc-test-build-multistage:latest";
+        WSLCBuildImageOptions options{.Tags = {&tag, 1}, .Flags = WSLCBuildImageFlagsNoCache};
+        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options, callback.Get()));
+        VERIFY_IS_TRUE(output.find("[greeting] WSL containers") != std::string::npos);
         ExpectImagePresent(*m_defaultSession, "wslc-test-build-multistage:latest");
 
         WSLCContainerLauncher launcher("wslc-test-build-multistage:latest", "wslc-build-multistage-container");
@@ -1718,24 +1741,6 @@ class WSLCTests
 
     WSLC_TEST_METHOD(BuildImageNoCache)
     {
-        class CapturingProgressCallback
-            : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IProgressCallback>
-        {
-        public:
-            CapturingProgressCallback(std::string& output) : m_output(output)
-            {
-            }
-
-            HRESULT OnProgress(LPCSTR status, LPCSTR, ULONGLONG, ULONGLONG) override
-            {
-                m_output.append(status);
-                return S_OK;
-            }
-
-        private:
-            std::string& m_output;
-        };
-
         auto contextDir = std::filesystem::current_path() / "build-context-nocache";
         std::filesystem::create_directories(contextDir);
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1759,7 +1759,7 @@ class WSLCTests
             std::string output;
             auto callback = Microsoft::WRL::Make<CapturingProgressCallback>(output);
             LPCSTR tag = "wslc-test-nocache:latest";
-            WSLCBuildImageOptions options{.Tags = {&tag, 1}, .Flags = WSLCBuildImageFlagsVerbose};
+            WSLCBuildImageOptions options{.Tags = {&tag, 1}};
             VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options, callback.Get()));
             VERIFY_IS_TRUE(output.find("Imageisrebuilt") == std::string::npos);
         }
@@ -1769,7 +1769,7 @@ class WSLCTests
             std::string output;
             auto callback = Microsoft::WRL::Make<CapturingProgressCallback>(output);
             LPCSTR tag = "wslc-test-nocache:latest";
-            WSLCBuildImageOptions options{.Tags = {&tag, 1}, .Flags = WSLCBuildImageFlagsNoCache | WSLCBuildImageFlagsVerbose};
+            WSLCBuildImageOptions options{.Tags = {&tag, 1}, .Flags = WSLCBuildImageFlagsNoCache};
             VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options, callback.Get()));
             VERIFY_IS_TRUE(output.find("Imageisrebuilt") != std::string::npos);
         }


### PR DESCRIPTION
When a stage name is available, it is prefixed to each container log line, to help associate interleaved lines from parallel stages. A future change will show only the last few lines, except in verbose mode, and collapse on completion.