### PR TITLE
Fix test cleanup by deleting a file left behind

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -169,8 +169,7 @@ class WSLCE2EImageBuildTests
         // Deny read access so wslc cannot open the file.
         SetPathAccess(containerfilePath, GENERIC_READ, DENY_ACCESS);
 
-        auto restore = wil::scope_exit_log(
-            WI_DIAGNOSTICS_INFO, [containerfilePath]() { SetPathAccess(containerfilePath, GENERIC_READ, GRANT_ACCESS); });
+        auto restore = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [containerfilePath]() { DeleteFileW(containerfilePath.c_str()); });
 
         auto absoluteContainerfilePath = std::filesystem::absolute(containerfilePath);
         auto buildResult = RunWslc(std::format(L"build \"{}\"", testRoot.wstring()));


### PR DESCRIPTION
WSLCE2E_Image_Build_ContainerfileAccessDenied_Fails fails on second run because the Containerfile is not cleaned up. Deleting the file at the end of the test is simpler than restoring access due to the deny ACE.