### PR TITLE
Fix std::format type mismatch mixing std::wstring and std::string

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1191,7 +1191,9 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         volumes.push_back(WSLCVolumeMount{hostPath, parentVMPath, volume.ContainerPath, static_cast<bool>(volume.ReadOnly), sourceFilename});
 
         auto options = volume.ReadOnly ? "ro" : "rw";
-        auto bindSource = sourceFilename.empty() ? parentVMPath : std::format("{}/{}", parentVMPath, sourceFilename);
+        auto bindSource = sourceFilename.empty()
+                             ? parentVMPath
+                             : std::format("{}/{}", parentVMPath, wsl::shared::string::WideToMultiByte(sourceFilename));
         auto bind = std::format("{}:{}:{}", bindSource, volume.ContainerPath, options);
 
         binds.push_back(std::move(bind));


### PR DESCRIPTION
## Problem

In `WSLCContainer::Create()`, the bind source path for file mounts is constructed using `std::format` with a narrow format string but passing `sourceFilename` (`std::wstring`) alongside `parentVMPath` (`std::string`).

`std::format` with a narrow format string does not accept `std::wstring` arguments in standard C++20. This is a type mismatch that could cause compilation failures or undefined behavior.

## Fix

Convert `sourceFilename` from `std::wstring` to `std::string` via `WideToMultiByte()` before passing it to `std::format`, consistent with how the codebase handles wide-to-narrow conversions elsewhere.

## Testing

Type-correctness fix in the volume bind path construction for file mounts (introduced in #40137).