### PR TITLE
Fix empty string UB in ParseSizeBytes and missing null check in PruneContainers

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1670,6 +1670,9 @@ try
 {
     COMServiceExecutionContext context;
 
+    RETURN_HR_IF_NULL(E_POINTER, Result);
+    ZeroMemory(Result, sizeof(*Result));
+
     DockerHTTPClient::PruneContainersFilters filters;
 
     if (FiltersCount > 0)

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -50,7 +50,7 @@ namespace {
         THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcMissingVolumeOption("SizeBytes"), it == DriverOpts.end());
 
         auto& value = it->second;
-        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageInvalidSize(value), value[0] == '-');
+        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageInvalidSize(value), value.empty() || value[0] == '-');
 
         errno = 0;
         char* end = nullptr;


### PR DESCRIPTION
## Bugs Fixed

### 1. Undefined behavior: empty string access in `ParseSizeBytes`
**File:** `src/windows/wslcsession/WSLCVhdVolume.cpp`

`ParseSizeBytes()` accesses `value[0]` to check for a leading minus sign without first checking if the string is empty. If a volume is created with `SizeBytes` mapped to an empty string, this is undefined behavior (out-of-bounds read).

**Fix:** Add `value.empty()` guard before accessing `value[0]`.

### 2. Null pointer dereference in `PruneContainers`
**File:** `src/windows/wslcsession/WSLCSession.cpp`

`PruneContainers()` dereferences the `Result` output parameter at line 1719 without any null validation. Compare with `PruneImages()` which correctly validates all output pointers with `RETURN_HR_IF_NULL(E_POINTER, ...)` and zero-initializes them.

**Fix:** Add `RETURN_HR_IF_NULL` and `ZeroMemory` initialization consistent with the `PruneImages` pattern.

## Testing

Both fixes are defensive validation — they guard against invalid inputs that would otherwise crash the service process.