### PR TITLE
Zero-initialize PruneVolumes output before returning E_NOTIMPL

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1949,8 +1949,13 @@ try
 }
 CATCH_RETURN();
 
-HRESULT WSLCSession::PruneVolumes(const WSLCPruneVolumesOptions* /*Options*/, WSLCPruneVolumesResults* /*Results*/)
+HRESULT WSLCSession::PruneVolumes(const WSLCPruneVolumesOptions* /*Options*/, WSLCPruneVolumesResults* Results)
 {
+    if (Results != nullptr)
+    {
+        ZeroMemory(Results, sizeof(*Results));
+    }
+
     // TODO: Implement volume pruning. Docker's volume prune API skips bind-mount volumes,
     // so WSLC VHD volumes require custom handling.
     return E_NOTIMPL;


### PR DESCRIPTION
## Issue

`PruneVolumes()` is a stub that returns `E_NOTIMPL`, but the `Results` output parameter is left uninitialized. A COM caller that reads `Results` before checking the return code would see garbage data for `VolumesCount`, `Volumes`, and `SpaceReclaimed`.

## Fix

Zero-initialize `Results` before returning, consistent with how other `Prune*` methods (`PruneContainers`, `PruneImages`) initialize their output parameters.