### PR TITLE
Bump Microsoft.NETCore.App.Runtime to 10.0.6 (CVE-2026-32178)

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="10.0.0" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.4" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.4" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.6" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.6" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6676" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.251108.1" targetFramework="native" />


### PR DESCRIPTION
## Security

Bump `Microsoft.NETCore.App.Runtime.win-x64` and `Microsoft.NETCore.App.Runtime.win-arm64` from **10.0.4** to **10.0.6** to fix:

- **CVE-2026-32178** — .NET Spoofing Vulnerability (severity: low)

Resolves Dependabot alerts #12 and #13.

Cherry-picked from `copilot/fix/dependabot-netcore-cve` (PR #40203 targeting `feature/wsl-for-apps`).

## Testing

Package version bump only. No code changes.