### PR TITLE
Fix wslc port relay buffer size to match non-WSLC relay path

### DIFF
--- a/src/windows/wslrelay/localhost.cpp
+++ b/src/windows/wslrelay/localhost.cpp
@@ -397,7 +397,7 @@ struct PortRelay
         message.BufferSize = LOCALHOST_RELAY_BUFFER_SIZE;
         channel.SendMessage(message);
 
-        wsl::windows::common::relay::SocketRelay(WindowsSocket, channel.Socket(), LOCALHOST_RELAY_BUFFER_SIZE);
+        wsl::windows::common::relay::SocketRelay(WindowsSocket, channel.Socket(), message.BufferSize);
     }
 
     void CompleteAccept()

--- a/src/windows/wslrelay/localhost.cpp
+++ b/src/windows/wslrelay/localhost.cpp
@@ -391,13 +391,13 @@ struct PortRelay
         wsl::shared::SocketChannel channel(wsl::windows::common::hvsocket::Connect(VmId, RelayPort), "SocketRelay");
 
         WI_VERIFY(Family == AF_INET || Family == AF_INET6);
-        LX_INIT_START_SOCKET_RELAY message;
+        LX_INIT_START_SOCKET_RELAY message{};
         message.Port = LinuxPort;
         message.Family = Family == AF_INET ? LX_AF_INET : LX_AF_INET6;
-        message.BufferSize = 4096;
+        message.BufferSize = LOCALHOST_RELAY_BUFFER_SIZE;
         channel.SendMessage(message);
 
-        wsl::windows::common::relay::SocketRelay(WindowsSocket, channel.Socket());
+        wsl::windows::common::relay::SocketRelay(WindowsSocket, channel.Socket(), LOCALHOST_RELAY_BUFFER_SIZE);
     }
 
     void CompleteAccept()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix wslc port relay (wslc run -p) to use the correct buffer size, matching the non-WSLC relay path. The WSLC path was hardcoding a 4KB buffer while the non-WSLC path uses LOCALHOST_RELAY_BUFFER_SIZE (128KB), causing intermittent data truncation during TCP relay.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- BufferSize was hardcoded to 4096 instead of using LOCALHOST_RELAY_BUFFER_SIZE (128KB), which is already used in the non-WSLC path (line 320). The smaller buffer increases the chance of data getting cut off when one side closes the connection while data is still being sent
- SocketRelay was called without a buffer size argument, so it defaulted to LX_RELAY_BUFFER_SIZE (4KB). Updated to pass message.BufferSize so both sides use the same size
- LX_INIT_START_SOCKET_RELAY message was not value-initialized, so SequenceNumber could be left uninitialized. Changed to message{}

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
