### PR TITLE
diagnostics: collect MSI verbose install logs in diagnostic bundle

### DIFF
--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -139,10 +139,8 @@ if (Test-Path $wslconfig)
 # Collect high-level WSL install log (written by WriteInstallLog() in install.cpp)
 Copy-Item "C:\Windows\temp\wsl-install-log.txt" $folder -ErrorAction ignore
 
-# Collect MSI verbose install log (preserved on failure).
-# Check both user temp (wsl --update) and system temp (WslInstaller service).
-Copy-Item "$env:TEMP/wsl-install-logs.txt" $folder -ErrorAction ignore
-Copy-Item "$env:WINDIR\Temp\wsl-install-logs.txt" "$folder\wsl-install-logs-service.txt" -ErrorAction ignore
+# Collect MSI verbose install log (preserved on failure by wsl --update or WslInstaller service).
+Copy-Item "$env:TEMP\wsl-install-logs.txt" $folder -ErrorAction ignore
 
 get-appxpackage MicrosoftCorporationII.WindowsSubsystemforLinux -ErrorAction Ignore > $folder/appxpackage.txt
 get-acl "C:\ProgramData\Microsoft\Windows\WindowsApps" -ErrorAction Ignore | Format-List > $folder/acl.txt

--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -136,7 +136,11 @@ if (Test-Path $wslconfig)
     Copy-Item $wslconfig $folder | Out-Null
 }
 
+# Collect high-level WSL install log (written by WriteInstallLog() in install.cpp)
 Copy-Item "C:\Windows\temp\wsl-install-log.txt" $folder -ErrorAction ignore
+
+# Collect MSI verbose install log (preserved on failed wsl --update)
+Copy-Item "$env:TEMP/wsl-install-logs.txt" $folder -ErrorAction ignore
 
 get-appxpackage MicrosoftCorporationII.WindowsSubsystemforLinux -ErrorAction Ignore > $folder/appxpackage.txt
 get-acl "C:\ProgramData\Microsoft\Windows\WindowsApps" -ErrorAction Ignore | Format-List > $folder/acl.txt

--- a/diagnostics/collect-wsl-logs.ps1
+++ b/diagnostics/collect-wsl-logs.ps1
@@ -139,8 +139,10 @@ if (Test-Path $wslconfig)
 # Collect high-level WSL install log (written by WriteInstallLog() in install.cpp)
 Copy-Item "C:\Windows\temp\wsl-install-log.txt" $folder -ErrorAction ignore
 
-# Collect MSI verbose install log (preserved on failed wsl --update)
+# Collect MSI verbose install log (preserved on failure).
+# Check both user temp (wsl --update) and system temp (WslInstaller service).
 Copy-Item "$env:TEMP/wsl-install-logs.txt" $folder -ErrorAction ignore
+Copy-Item "$env:WINDIR\Temp\wsl-install-logs.txt" "$folder\wsl-install-logs-service.txt" -ErrorAction ignore
 
 get-appxpackage MicrosoftCorporationII.WindowsSubsystemforLinux -ErrorAction Ignore > $folder/appxpackage.txt
 get-acl "C:\ProgramData\Microsoft\Windows\WindowsApps" -ErrorAction Ignore | Format-List > $folder/acl.txt

--- a/src/windows/wslinstaller/exe/WslInstaller.cpp
+++ b/src/windows/wslinstaller/exe/WslInstaller.cpp
@@ -91,7 +91,7 @@ std::pair<UINT, std::wstring> InstallMsipackageImpl()
 
     WSL_LOG("MSIUpgradeResult", TraceLoggingValue(result, "result"), TraceLoggingValue(errors.c_str(), "errorMessage"));
 
-    if (result != 0)
+    if (result != ERROR_SUCCESS && result != ERROR_SUCCESS_REBOOT_REQUIRED)
     {
         clearLogs.release();
     }

--- a/src/windows/wslinstaller/exe/WslInstaller.cpp
+++ b/src/windows/wslinstaller/exe/WslInstaller.cpp
@@ -31,7 +31,13 @@ std::wstring GetMsiPackagePath()
     return (wsl::windows::common::wslutil::GetBasePath() / L"wsl.msi").wstring();
 }
 
-std::optional<std::wstring> GetUpgradeLogFileLocation()
+struct UpgradeLogInfo
+{
+    std::wstring path;
+    bool fromRegistry; // true when the path was explicitly configured via UpgradeLogFile registry value
+};
+
+std::optional<UpgradeLogInfo> GetUpgradeLogFileLocation()
 try
 {
     const auto key = wsl::windows::common::registry::OpenLxssMachineKey();
@@ -40,11 +46,11 @@ try
     {
         // Default to the same path used by wsl --update so all MSI logs
         // are collected from one location by the diagnostic script.
-        return (std::filesystem::temp_directory_path() / L"wsl-install-logs.txt").wstring();
+        return UpgradeLogInfo{(std::filesystem::temp_directory_path() / L"wsl-install-logs.txt").wstring(), false};
     }
 
     // A canonical path is required because msiexec doesn't like symlinks.
-    return std::filesystem::weakly_canonical(path);
+    return UpgradeLogInfo{std::filesystem::weakly_canonical(path), true};
 }
 catch (...)
 {
@@ -56,11 +62,13 @@ std::pair<UINT, std::wstring> InstallMsipackageImpl()
 {
     const auto logFile = GetUpgradeLogFileLocation();
 
-    // Delete MSI log on success, preserve on failure for diagnostics (same as wsl --update)
+    // Delete MSI log on success, preserve on failure for diagnostics (same as wsl --update).
+    // When the UpgradeLogFile registry value is set, always keep the log — the registry key
+    // is explicitly designed to retain MSI logs across installs.
     auto clearLogs = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&logFile]() {
-        if (logFile.has_value())
+        if (logFile.has_value() && !logFile->fromRegistry)
         {
-            LOG_IF_WIN32_BOOL_FALSE(DeleteFile(logFile->c_str()));
+            LOG_IF_WIN32_BOOL_FALSE(DeleteFile(logFile->path.c_str()));
         }
     });
 
@@ -87,7 +95,7 @@ std::pair<UINT, std::wstring> InstallMsipackageImpl()
     };
 
     auto result = wsl::windows::common::install::UpgradeViaMsi(
-        GetMsiPackagePath().c_str(), L"SKIPMSIX=1", logFile.has_value() ? logFile->c_str() : nullptr, messageCallback);
+        GetMsiPackagePath().c_str(), L"SKIPMSIX=1", logFile.has_value() ? logFile->path.c_str() : nullptr, messageCallback);
 
     WSL_LOG("MSIUpgradeResult", TraceLoggingValue(result, "result"), TraceLoggingValue(errors.c_str(), "errorMessage"));
 

--- a/src/windows/wslinstaller/exe/WslInstaller.cpp
+++ b/src/windows/wslinstaller/exe/WslInstaller.cpp
@@ -38,7 +38,9 @@ try
     const auto path = wsl::windows::common::registry::ReadString(key.get(), L"MSI", L"UpgradeLogFile", L"");
     if (path.empty())
     {
-        return {};
+        // Default to the same path used by wsl --update so all MSI logs
+        // are collected from one location by the diagnostic script.
+        return (std::filesystem::temp_directory_path() / L"wsl-install-logs.txt").wstring();
     }
 
     // A canonical path is required because msiexec doesn't like symlinks.
@@ -53,6 +55,14 @@ catch (...)
 std::pair<UINT, std::wstring> InstallMsipackageImpl()
 {
     const auto logFile = GetUpgradeLogFileLocation();
+
+    // Delete MSI log on success, preserve on failure for diagnostics (same as wsl --update)
+    auto clearLogs = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&logFile]() {
+        if (logFile.has_value())
+        {
+            LOG_IF_WIN32_BOOL_FALSE(DeleteFile(logFile->c_str()));
+        }
+    });
 
     std::wstring errors;
     auto messageCallback = [&errors](INSTALLMESSAGE type, LPCWSTR message) {
@@ -80,6 +90,11 @@ std::pair<UINT, std::wstring> InstallMsipackageImpl()
         GetMsiPackagePath().c_str(), L"SKIPMSIX=1", logFile.has_value() ? logFile->c_str() : nullptr, messageCallback);
 
     WSL_LOG("MSIUpgradeResult", TraceLoggingValue(result, "result"), TraceLoggingValue(errors.c_str(), "errorMessage"));
+
+    if (result != 0)
+    {
+        clearLogs.release();
+    }
 
     return {result, errors};
 }


### PR DESCRIPTION
## Summary

Collect the MSI verbose install log in the diagnostic bundle so MSI-level failures can be diagnosed from user-uploaded logs.

### Before

- `wsl --update` writes MSI log to `%TEMP%\wsl-install-logs.txt` (delete on success, keep on failure)
- **Store/winget** upgrade path (`WslInstaller`) wrote **no MSI log** when registry `UpgradeLogFile` was empty (the default)
- Diagnostic collector did not collect the MSI log

```
BEFORE collector output:
  wsl-install-log.txt   (5 KB)    <- high-level WSL log only, no MSI detail
```

### After

- `WslInstaller.cpp` now defaults to `%TEMP%\wsl-install-logs.txt` (same path as `wsl --update`), with delete-on-success / preserve-on-failure
- Collector picks up the MSI log

All MSI upgrade paths now write to one location:
| Path | Log | Cleanup |
|------|-----|---------|
| `wsl --update` | `%TEMP%\wsl-install-logs.txt` | Already did (unchanged) |
| **Store/winget** | `%TEMP%\wsl-install-logs.txt` | **NEW** (was: no log) |
| Both | Same file | Delete on success, preserve on failure |

```
AFTER collector output (on failure):
  wsl-install-log.txt     (5 KB)
  wsl-install-logs.txt  (265 KB)  <- MSI verbose log with failure detail
```

### Tested

Installed MSI with active file lock contention on `WSL.lnk`. Collected log contains:
```
Warning 1946.Property 'System.AppUserModel.ID' for shortcut 'WSL.lnk' could not be set. HRESULT 32.
Warning 1946.Property 'System.AppUserModel.ToastActivatorCLSID' for shortcut 'WSL.lnk' could not be set. HRESULT 32.
```

## PR Checklist

- [x] **Refs:** #13469, #11276, #12759

## Changes

| File | Change |
|------|--------|
| `src/windows/wslinstaller/exe/WslInstaller.cpp` | Default log path + delete-on-success / preserve-on-failure |
| `diagnostics/collect-wsl-logs.ps1` | Collect `%TEMP%\wsl-install-logs.txt` |