### PR TITLE
fix: use correct GetAddrInfoTestEntry handler for get_addr_info test

### DIFF
--- a/test/linux/unit_tests/unittests.c
+++ b/test/linux/unit_tests/unittests.c
@@ -33,7 +33,7 @@ static const LXT_TEST LxtTests[] = {
     {"fscommon", false, FsCommonTestEntry},
     {"fstab", false, FstabTestEntry},
     {"get_set_id", false, GetSetIdTestEntry},
-    {"get_addr_info", false, GetSetIdTestEntry},
+    {"get_addr_info", false, GetAddrInfoTestEntry},
     {"get_time", false, GetTimeTestEntry},
     {"inotify", false, InotifyTestEntry},
     {"interop", false, InteropTestEntry},


### PR DESCRIPTION
The `get_addr_info` test entry in `test/linux/unit_tests/unittests.c` was incorrectly mapped to `GetSetIdTestEntry` instead of `GetAddrInfoTestEntry`, causing the wrong test handler to run.

**Change:** Line 36: `GetSetIdTestEntry` → `GetAddrInfoTestEntry`