### PR TITLE
fix: use ssize_t for readlinkat return value in p9file.cpp

### DIFF
--- a/src/linux/plan9/p9file.cpp
+++ b/src/linux/plan9/p9file.cpp
@@ -850,7 +850,7 @@ Expected<UINT32> File::ReadLink(gsl::span<char> name)
 {
     const auto fileName = GetFileName();
     util::FsUserContext userContext{m_Root->Uid, m_Root->Gid, m_Root->Groups};
-    int result = readlinkat(m_Root->RootFd, fileName.c_str(), name.data(), name.size());
+    ssize_t result = readlinkat(m_Root->RootFd, fileName.c_str(), name.data(), name.size());
     if (result < 0)
     {
         return LxError{-errno};


### PR DESCRIPTION
`readlinkat()` returns `ssize_t`, not `int`. On 64-bit systems this could silently truncate the return value for very long symlink targets.

**Change:** Line 853: `int result` → `ssize_t result`