### PR TITLE
fix: use {} format specifier instead of %s in Linux LOG_ERROR path

### DIFF
--- a/src/shared/inc/SocketChannel.h
+++ b/src/shared/inc/SocketChannel.h
@@ -342,7 +342,7 @@ private:
 
             LOG_ERROR(
                 "Protocol error: Received message size: {}, type: {}, sequence: {}. Expected type: {}, expected sequence: {}, "
-                "channel: %s",
+                "channel: {}",
                 header.MessageSize,
                 header.MessageType,
                 header.SequenceNumber,


### PR DESCRIPTION
The Linux `#else` branch of `SocketChannel.h` uses `LOG_ERROR` which expects fmt-style `{}` placeholders, but the channel name field was using printf-style `%s`.

**Change:** Line 345: `channel: %s` → `channel: {}`