### PR TITLE
cleanup: extract SkipSignal helper to deduplicate signal skip lists

### DIFF
--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -2594,6 +2594,24 @@ int UtilSaveBlockedSignals(const sigset_t& SignalMask)
     return sigprocmask(SIG_BLOCK, &SignalMask, &g_originalSignals);
 }
 
+static bool SkipSignal(unsigned int Signal)
+{
+    switch (Signal)
+    {
+    case SIGKILL:
+    case SIGSTOP:
+    case SIGCONT:
+    case SIGHUP:
+    case 32:
+    case 33:
+    case 34:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
 int UtilSaveSignalHandlers(struct sigaction* SavedSignalActions)
 
 /*++
@@ -2615,15 +2633,8 @@ Return Value:
 {
     for (unsigned int Index = 1; Index < _NSIG; Index += 1)
     {
-        switch (Index)
+        if (SkipSignal(Index))
         {
-        case SIGKILL:
-        case SIGSTOP:
-        case SIGCONT:
-        case SIGHUP:
-        case 32:
-        case 33:
-        case 34:
             continue;
         }
 
@@ -2662,15 +2673,8 @@ Return Value:
 
     for (unsigned int Index = 1; Index < _NSIG; Index += 1)
     {
-        switch (Index)
+        if (SkipSignal(Index))
         {
-        case SIGKILL:
-        case SIGSTOP:
-        case SIGCONT:
-        case SIGHUP:
-        case 32:
-        case 33:
-        case 34:
             continue;
         }
 

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -2594,6 +2594,12 @@ int UtilSaveBlockedSignals(const sigset_t& SignalMask)
     return sigprocmask(SIG_BLOCK, &SignalMask, &g_originalSignals);
 }
 
+// Returns true for signals that should not be saved/restored:
+// SIGKILL/SIGSTOP — not settable per POSIX.
+// SIGCONT — left at default to allow process resumption.
+// SIGHUP — handled separately by the caller.
+// 32-34 — internal NPTL signals (__SIGRTMIN through __SIGRTMIN+2) reserved
+//         by glibc for thread cancellation and other runtime use.
 static bool SkipSignal(unsigned int Signal)
 {
     switch (Signal)
@@ -2618,7 +2624,8 @@ int UtilSaveSignalHandlers(struct sigaction* SavedSignalActions)
 
 Routine Description:
 
-    This routine saves all settable signal handlers except SIGHUP.
+    This routine saves all settable signal handlers, skipping signals
+    listed in SkipSignal() (non-settable, SIGHUP, and internal NPTL signals).
 
 Arguments:
 
@@ -2653,8 +2660,8 @@ int UtilSetSignalHandlers(struct sigaction* SavedSignalActions, bool Ignore)
 
 Routine Description:
 
-    This routine sets all settable signal handlers except SIGHUP to the given
-    handler.
+    This routine sets all settable signal handlers to the given handler,
+    skipping signals listed in SkipSignal().
 
 Arguments:
 


### PR DESCRIPTION
`UtilSaveSignalHandlers` and `UtilSetSignalHandlers` in `src/linux/init/util.cpp` had identical switch statements for skipping non-settable signals (SIGKILL, SIGSTOP, SIGCONT, SIGHUP, 32-34). Extract a shared `SkipSignal()` helper to keep the skip list in one place, reducing maintenance risk if the list ever needs to change.