### PR TITLE
Add boot check for ipv6 disabled via registry in mirrored mode

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -879,6 +879,10 @@ Falling back to NAT networking.</value>
     <value>Windows version {}.{} does not have the required features</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageMirroredNetworkingNotSupportedIpv6Disabled" xml:space="preserve">
+    <value>IPv6 is disabled on the host (HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters DisabledComponents=0xff)</value>
+    <comment>{Locked="HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters"}{Locked="DisabledComponents"}{Locked="0xff"}</comment>
+  </data>
   <data name="MessageHyperVFirewallNotSupported" xml:space="preserve">
     <value>Hyper-V firewall is not supported</value>
   </data>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -880,7 +880,7 @@ Falling back to NAT networking.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageMirroredNetworkingNotSupportedIpv6Disabled" xml:space="preserve">
-    <value>IPv6 is disabled on the host (HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters DisabledComponents=0xff)</value>
+    <value>IPv6 is disabled on the host in an unsupported way (HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters DisabledComponents=0xff)</value>
     <comment>{Locked="HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters"}{Locked="DisabledComponents"}{Locked="0xff"}</comment>
   </data>
   <data name="MessageHyperVFirewallNotSupported" xml:space="preserve">

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2830,16 +2830,16 @@ void WslCoreVm::ValidateNetworkingMode()
         }
     }
 
-    // If mirrored networking was requested, ensure IPv6 is not disabled on the host.
-    // Mirrored mode requires IPv6 to mirror host interfaces. When the DisabledComponents registry value
-    // is set to 0xFF, all IPv6 components are disabled and mirrored networking cannot function.
+    // If mirrored networking was requested, ensure IPv6 is not disabled on the host using registry,
+    // as this is not supported by mirrored networking.
+    // Note: Disabling IPv6 using Set-NetAdapterBinding is supported.
     if (m_vmConfig.NetworkingMode == NetworkingMode::Mirrored)
     {
-        constexpr DWORD c_ipv6DisabledAll = 0xFF;
+        constexpr DWORD c_ipv6Disabled = 0xFF;
         const auto disabledComponents = wsl::windows::common::registry::ReadDword(
             HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", 0);
 
-        if (disabledComponents == c_ipv6DisabledAll)
+        if (disabledComponents == c_ipv6Disabled)
         {
             m_vmConfig.NetworkingMode = NetworkingMode::Nat;
             EMIT_USER_WARNING(Localization::MessageMirroredNetworkingNotSupportedReason(

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2836,8 +2836,9 @@ void WslCoreVm::ValidateNetworkingMode()
     if (m_vmConfig.NetworkingMode == NetworkingMode::Mirrored)
     {
         constexpr DWORD c_ipv6Disabled = 0xFF;
-        const auto disabledComponents = wsl::windows::common::registry::ReadDword(
-            HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", 0);
+        DWORD disabledComponents = 0;
+        wil::reg::get_value_dword_nothrow(
+            HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", &disabledComponents);
 
         if (disabledComponents == c_ipv6Disabled)
         {

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2830,6 +2830,23 @@ void WslCoreVm::ValidateNetworkingMode()
         }
     }
 
+    // If mirrored networking was requested, ensure IPv6 is not disabled on the host.
+    // Mirrored mode requires IPv6 to mirror host interfaces. When the DisabledComponents registry value
+    // is set to 0xFF, all IPv6 components are disabled and mirrored networking cannot function.
+    if (m_vmConfig.NetworkingMode == NetworkingMode::Mirrored)
+    {
+        constexpr DWORD c_ipv6DisabledAll = 0xFF;
+        const auto disabledComponents = wsl::windows::common::registry::ReadDword(
+            HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", 0);
+
+        if (disabledComponents == c_ipv6DisabledAll)
+        {
+            m_vmConfig.NetworkingMode = NetworkingMode::Nat;
+            EMIT_USER_WARNING(Localization::MessageMirroredNetworkingNotSupportedReason(
+                Localization::MessageMirroredNetworkingNotSupportedIpv6Disabled()));
+        }
+    }
+
     // If mirrored networking was requested, ensure it is supported by the OS and guest kernel.
     if (m_vmConfig.NetworkingMode == NetworkingMode::Mirrored)
     {

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4559,8 +4559,6 @@ class MirroredTests
             HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", 0xFF);
 
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
-        // Force a restart so we re-evaluate the networking mode with the regkey set.
-        WslShutdown();
 
         // Verify WSL is actually running in NAT mode.
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"wslinfo --networking-mode | grep -iF 'nat'"), 0u);

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4559,6 +4559,8 @@ class MirroredTests
             HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", 0xFF);
 
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+        // Force a restart so we re-evaluate the networking mode with the regkey set.
+        WslShutdown();
 
         // Verify WSL is actually running in NAT mode.
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"wslinfo --networking-mode | grep -iF 'nat'"), 0u);

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4558,8 +4558,9 @@ class MirroredTests
         RegistryKeyChange<DWORD> disableIpv6(
             HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", 0xFF);
 
-        // Request mirrored mode - this should fall back to NAT since IPv6 is disabled.
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+        // Force a restart so we re-evaluate the networking mode with the regkey set.
+        WslShutdown();
 
         // Verify WSL is actually running in NAT mode.
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"wslinfo --networking-mode | grep -iF 'nat'"), 0u);

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4549,6 +4549,21 @@ class MirroredTests
 
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
+
+    WSL2_TEST_METHOD(MirroredFallbackToNatWhenIpv6Disabled)
+    {
+        MIRRORED_NETWORKING_TEST_ONLY();
+
+        // Set the registry key to disable IPv6 globally on the host.
+        RegistryKeyChange<DWORD> disableIpv6(
+            HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters", L"DisabledComponents", 0xFF);
+
+        // Request mirrored mode - this should fall back to NAT since IPv6 is disabled.
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+
+        // Verify WSL is actually running in NAT mode.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"wslinfo --networking-mode | grep -iF 'nat'"), 0u);
+    }
 };
 
 class BridgedTests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Mirrored networking mode does not support IPv6 being disabled using this old registry key: SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters (DisabledComponents)
The recommended way to disabled IPv6 is using Set-NetAdapterBinding for component ms_tcpip6, which is supported by mirrored mode.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Fallback to NAT mode if this registry key is enabled

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual testing + added automated test in NetworkTests.cpp