### PR TITLE
Fix bugs found during code review of feature/wsl-for-apps

### DIFF
--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -790,7 +790,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_WATCH_PRO
                 }
                 else
                 {
-                    LOG_ERROR("Received SIGCHLD for process that was neither signaled nor exited. Pid: {}, Status: {}", result, status)
+                    LOG_ERROR("Received SIGCHLD for process that was neither signaled nor exited. Pid: {}, Status: {}", result, status);
                 }
 
                 Channel.SendMessage(message);

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2508,11 +2508,11 @@ Return Value:
 
             int Status{};
             auto Pid = waitpid(-1, &Status, WNOHANG);
-            if (Result == 0)
+            if (Pid == 0)
             {
                 continue;
             }
-            else if (Result > 0)
+            else if (Pid > 0)
             {
                 if (Pid == distroInitPid.value())
                 {

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5352,7 +5352,7 @@ class WSLCTests
 
                 VERIFY_ARE_EQUAL(launcher.LaunchNoThrow(session).first, HRESULT_FROM_WIN32(WSAEACCES));
 
-                // Validate that port 1234 is still available.
+                // Validate that port 1236 is still available (was cleaned up after failure).
                 VERIFY_IS_TRUE(!!bindSocket(1236));
             }
         }


### PR DESCRIPTION
Fix three bugs found during code review of the `feature/wsl-for-apps` branch:

### Fixes

1. **Fix wrong variable in waitpid check** (`src/linux/init/init.cpp`)
   Used `Result` (poll return value) instead of `Pid` (waitpid return value), causing incorrect SIGCHLD handling that could miss child exits or fail to detect init termination.

2. **Fix missing semicolon after LOG_ERROR** (`src/linux/init/WSLCInit.cpp`)
   Missing statement terminator would cause compilation failure on Linux builds (`-Werror`).

3. **Fix misleading test comment** (`test/windows/WSLCTests.cpp`)
   Comment referenced port 1234 but the test actually validates port 1236 cleanup after bind failure.