### PR TITLE
fix: implement IDisposable on WslConfigService to dispose FileSystemWatcher

### DIFF
--- a/src/windows/wslsettings/Services/WslConfigService.cs
+++ b/src/windows/wslsettings/Services/WslConfigService.cs
@@ -11,7 +11,6 @@ public class WslConfigService : IWslConfigService, IDisposable
     private WslConfig? _wslConfigDefaults { get; init; }
     private readonly object? _wslCoreConfigInterfaceLockObj = null;
     private FileSystemWatcher? _wslConfigFileSystemWatcher = null;
-    private bool _disposed = false;
 
     public WslConfigService()
     {
@@ -43,16 +42,20 @@ public class WslConfigService : IWslConfigService, IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        if (!_disposed)
+        lock (_wslCoreConfigInterfaceLockObj!)
         {
-            if (disposing)
+            if (disposing && _wslConfigFileSystemWatcher != null)
             {
-                _wslConfigFileSystemWatcher?.Dispose();
+                _wslConfigFileSystemWatcher.EnableRaisingEvents = false;
+                _wslConfigFileSystemWatcher.Changed -= OnWslConfigFileChanged;
+                _wslConfigFileSystemWatcher.Deleted -= OnWslConfigFileChanged;
+                _wslConfigFileSystemWatcher.Renamed -= OnWslConfigFileChanged;
+                _wslConfigFileSystemWatcher.Dispose();
+                _wslConfigFileSystemWatcher = null;
             }
 
             WslCoreConfigInterface.FreeWslConfig(_wslConfig);
             WslCoreConfigInterface.FreeWslConfig(_wslConfigDefaults);
-            _disposed = true;
         }
     }
 

--- a/src/windows/wslsettings/Services/WslConfigService.cs
+++ b/src/windows/wslsettings/Services/WslConfigService.cs
@@ -5,12 +5,13 @@ using static WslSettings.Contracts.Services.IWslConfigService;
 
 namespace WslSettings.Services;
 
-public class WslConfigService : IWslConfigService
+public class WslConfigService : IWslConfigService, IDisposable
 {
     private WslConfig? _wslConfig { get; set; }
     private WslConfig? _wslConfigDefaults { get; init; }
     private readonly object? _wslCoreConfigInterfaceLockObj = null;
     private FileSystemWatcher? _wslConfigFileSystemWatcher = null;
+    private bool _disposed = false;
 
     public WslConfigService()
     {
@@ -31,8 +32,28 @@ public class WslConfigService : IWslConfigService
 
     ~WslConfigService()
     {
-        WslCoreConfigInterface.FreeWslConfig(_wslConfig);
-        WslCoreConfigInterface.FreeWslConfig(_wslConfigDefaults);
+        Dispose(false);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                _wslConfigFileSystemWatcher?.Dispose();
+            }
+
+            WslCoreConfigInterface.FreeWslConfig(_wslConfig);
+            WslCoreConfigInterface.FreeWslConfig(_wslConfigDefaults);
+            _disposed = true;
+        }
     }
 
     public IWslConfigSetting GetWslConfigSetting(WslConfigEntry wslConfigEntry, bool defaultSetting)


### PR DESCRIPTION
## Problem

\\WslConfigService\\ creates a \\FileSystemWatcher\\ but never disposes it. The existing finalizer only frees unmanaged WslConfig objects — the managed \\FileSystemWatcher\\ and its OS handles leak until the GC finalizes them (which is non-deterministic and not guaranteed).

## Fix

Implement the standard \\IDisposable\\ pattern:
- Class now implements \\IDisposable\\
- \\Dispose(bool)\\ handles both managed (\\FileSystemWatcher\\) and unmanaged (\\FreeWslConfig\\) cleanup
- Finalizer calls \\Dispose(false)\\ (skips managed objects)
- \\Dispose()\\ calls \\Dispose(true)\\ + \\GC.SuppressFinalize(this)\\

This follows the [standard .NET dispose pattern](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose) and ensures deterministic cleanup of the file watcher's OS handles.