### PR TITLE
wslc: add network inspect

### DIFF
--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -113,4 +113,33 @@ struct InspectVolume
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectVolume, Name, Driver, CreatedAt, DriverOpts, Labels, Status);
 };
 
+struct InspectIPAMConfig
+{
+    std::string Subnet;
+    std::string Gateway;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectIPAMConfig, Subnet, Gateway);
+};
+
+struct InspectIPAM
+{
+    std::string Driver;
+    std::optional<std::vector<InspectIPAMConfig>> Config;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectIPAM, Driver, Config);
+};
+
+struct InspectNetwork
+{
+    std::string Id;
+    std::string Name;
+    std::string Driver;
+    std::string Scope;
+    bool Internal{};
+    InspectIPAM IPAM;
+    std::map<std::string, std::string> Labels;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectNetwork, Id, Name, Driver, Scope, Internal, IPAM, Labels);
+};
+
 } // namespace wsl::windows::common::wslc_schema

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -745,6 +745,7 @@ interface IWSLCSession : IUnknown
     HRESULT CreateNetwork([in] const WSLCNetworkOptions* Options);
     HRESULT DeleteNetwork([in] LPCSTR Name);
     HRESULT ListNetworks([out, size_is(, *Count)] WSLCNetworkInformation** Networks, [out] ULONG* Count);
+    HRESULT InspectNetwork([in] LPCSTR Name, [out] LPSTR* Output);
 }
 
 //

--- a/src/windows/wslcsession/DockerHTTPClient.cpp
+++ b/src/windows/wslcsession/DockerHTTPClient.cpp
@@ -448,6 +448,11 @@ std::vector<docker_schema::Network> DockerHTTPClient::ListNetworks()
     return Transaction<docker_schema::EmptyRequest, std::vector<docker_schema::Network>>(verb::get, URL::Create("/networks"));
 }
 
+docker_schema::Network DockerHTTPClient::InspectNetwork(const std::string& Name)
+{
+    return Transaction<docker_schema::EmptyRequest, docker_schema::Network>(verb::get, URL::Create("/networks/{}", Name));
+}
+
 wil::unique_socket DockerHTTPClient::ContainerLogs(const std::string& Id, WSLCLogsFlags Flags, ULONGLONG Since, ULONGLONG Until, ULONGLONG Tail)
 {
     auto url = URL::Create("/containers/{}/logs", Id);

--- a/src/windows/wslcsession/DockerHTTPClient.h
+++ b/src/windows/wslcsession/DockerHTTPClient.h
@@ -152,6 +152,7 @@ public:
     common::docker_schema::CreateNetworkResponse CreateNetwork(const common::docker_schema::CreateNetwork& Request);
     void RemoveNetwork(const std::string& Name);
     std::vector<common::docker_schema::Network> ListNetworks();
+    common::docker_schema::Network InspectNetwork(const std::string& Name);
 
     // Image management.
     struct ListImagesFilters

--- a/src/windows/wslcsession/WSLCNetworkMetadata.h
+++ b/src/windows/wslcsession/WSLCNetworkMetadata.h
@@ -14,8 +14,6 @@ Abstract:
 
 #pragma once
 
-#include <string>
-
 namespace wsl::windows::service::wslc {
 
 // Label key used to identify WSLC-managed Docker networks.
@@ -28,10 +26,26 @@ inline bool IsReservedNetworkName(const std::string& name)
     return name == "bridge" || name == "host" || name == "none";
 }
 
+struct NetworkIPAMConfig
+{
+    std::string Subnet;
+    std::string Gateway;
+};
+
+struct NetworkIPAM
+{
+    std::string Driver;
+    std::optional<std::vector<NetworkIPAMConfig>> Config;
+};
+
 struct NetworkEntry
 {
     std::string Id;
     std::string Driver;
+    std::string Scope;
+    bool Internal{false};
+    std::map<std::string, std::string> Labels;
+    NetworkIPAM IPAM;
 };
 
 } // namespace wsl::windows::service::wslc

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -54,7 +54,7 @@ std::string IndentLines(const std::string& input, const std::string& prefix)
     return result;
 }
 
-void ValidateName(LPCSTR Name, size_t maxLength = WSLC_MAX_CONTAINER_NAME_LENGTH)
+void ValidateName(LPCSTR Name, size_t maxLength)
 {
     const auto& locale = std::locale::classic();
     size_t i = 0;
@@ -1536,7 +1536,7 @@ try
     // Validate that name & images are valid.
     if (containerOptions->Name != nullptr)
     {
-        ValidateName(containerOptions->Name);
+        ValidateName(containerOptions->Name, WSLC_MAX_CONTAINER_NAME_LENGTH);
     }
 
     RETURN_HR_IF(E_INVALIDARG, strlen(containerOptions->Image) > WSLC_MAX_IMAGE_NAME_LENGTH);
@@ -1581,7 +1581,7 @@ try
 {
     COMServiceExecutionContext context;
 
-    ValidateName(Id);
+    ValidateName(Id, WSLC_MAX_CONTAINER_NAME_LENGTH);
 
     // Look for an exact ID match first.
     auto lock = m_lock.lock_shared();
@@ -1856,7 +1856,7 @@ try
 
     if (Options->Name != nullptr && Options->Name[0] != '\0')
     {
-        ValidateName(Options->Name);
+        ValidateName(Options->Name, WSLC_MAX_VOLUME_NAME_LENGTH);
         THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS), m_volumes.contains(Options->Name));
     }
 
@@ -1888,7 +1888,7 @@ try
 
     RETURN_HR_IF_NULL(E_POINTER, Name);
     std::string name = Name;
-    ValidateName(name.c_str());
+    ValidateName(name.c_str(), WSLC_MAX_VOLUME_NAME_LENGTH);
 
     auto lock = m_lock.lock_shared();
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);
@@ -1953,7 +1953,7 @@ try
     *Output = nullptr;
 
     std::string name = Name;
-    ValidateName(name.c_str());
+    ValidateName(name.c_str(), WSLC_MAX_VOLUME_NAME_LENGTH);
 
     auto lock = m_lock.lock_shared();
     std::lock_guard volumesLock(m_volumesLock);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -54,7 +54,7 @@ std::string IndentLines(const std::string& input, const std::string& prefix)
     return result;
 }
 
-void ValidateName(LPCSTR Name)
+void ValidateName(LPCSTR Name, size_t maxLength = WSLC_MAX_CONTAINER_NAME_LENGTH)
 {
     const auto& locale = std::locale::classic();
     size_t i = 0;
@@ -67,7 +67,7 @@ void ValidateName(LPCSTR Name)
         }
     }
 
-    THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcInvalidName(Name), i == 0 || i > WSLC_MAX_CONTAINER_NAME_LENGTH);
+    THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcInvalidName(Name), i == 0 || i > maxLength);
 }
 
 wslc_schema::InspectImage ConvertInspectImage(const docker_schema::InspectImage& dockerInspect)
@@ -1991,7 +1991,7 @@ try
     std::string name = Options->Name;
     std::string driver = Options->Driver;
 
-    ValidateName(name.c_str());
+    ValidateName(name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
 
     THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcInvalidName(name), IsReservedNetworkName(name));
     THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcInvalidNetworkDriver(driver), driver != WSLCBridgeNetworkDriver);
@@ -2055,7 +2055,7 @@ try
 
     RETURN_HR_IF_NULL(E_POINTER, Name);
     std::string name = Name;
-    ValidateName(name.c_str());
+    ValidateName(name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
 
     auto lock = m_lock.lock_shared();
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);
@@ -2117,6 +2117,68 @@ try
 
     *Networks = output.release();
     *Count = index;
+
+    return S_OK;
+}
+CATCH_RETURN();
+
+HRESULT WSLCSession::InspectNetwork(LPCSTR Name, LPSTR* Output)
+try
+{
+    COMServiceExecutionContext context;
+
+    RETURN_HR_IF_NULL(E_POINTER, Name);
+    RETURN_HR_IF_NULL(E_POINTER, Output);
+
+    *Output = nullptr;
+
+    std::string name = Name;
+    ValidateName(name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
+
+    auto lock = m_lock.lock_shared();
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);
+
+    {
+        std::lock_guard networksLock(m_networksLock);
+
+        auto it = m_networks.find(name);
+        THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), it == m_networks.end());
+    }
+
+    docker_schema::Network network;
+    try
+    {
+        network = m_dockerClient->InspectNetwork(name);
+    }
+    catch (const DockerHTTPException& e)
+    {
+        THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), e.StatusCode() == 404);
+        THROW_DOCKER_USER_ERROR_MSG(e, "Failed to inspect network '%hs'", name.c_str());
+    }
+
+    wslc_schema::InspectNetwork result;
+    result.Id = network.Id;
+    result.Name = network.Name;
+    result.Driver = network.Driver;
+    result.Scope = network.Scope;
+    result.Internal = network.Internal;
+    result.Labels = network.Labels;
+
+    result.IPAM.Driver = network.IPAM.Driver;
+    if (network.IPAM.Config)
+    {
+        auto& configs = result.IPAM.Config.emplace();
+        for (const auto& cfg : *network.IPAM.Config)
+        {
+            wslc_schema::InspectIPAMConfig inspectCfg;
+            inspectCfg.Subnet = cfg.Subnet;
+            inspectCfg.Gateway = cfg.Gateway;
+            configs.push_back(std::move(inspectCfg));
+        }
+    }
+
+    std::string json = wsl::shared::ToJson(result);
+    *Output = wil::make_unique_ansistring<wil::unique_cotaskmem_ansistring>(json.c_str()).release();
 
     return S_OK;
 }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2038,6 +2038,8 @@ try
         THROW_DOCKER_USER_ERROR_MSG(e, "Failed to create network '%hs'", name.c_str());
     }
 
+    auto removeNetworkCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [this, &name]() { m_dockerClient->RemoveNetwork(name); });
+
     // Inspect the newly created network to cache full properties (IPAM, Scope, etc.)
     // since CreateNetworkResponse only returns {Id, Warning}.
     docker_schema::Network full;
@@ -2070,6 +2072,8 @@ try
     WI_VERIFY(inserted);
 
     WSL_LOG("NetworkCreated", TraceLoggingValue(name.c_str(), "NetworkName"), TraceLoggingValue(full.Id.c_str(), "NetworkId"));
+
+    removeNetworkCleanup.release();
 
     return S_OK;
 }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2027,10 +2027,9 @@ try
         ipam.Config.emplace().push_back(std::move(ipamConfig));
     }
 
-    docker_schema::CreateNetworkResponse response;
     try
     {
-        response = m_dockerClient->CreateNetwork(request);
+        m_dockerClient->CreateNetwork(request);
     }
     catch (const DockerHTTPException& e)
     {
@@ -2039,10 +2038,38 @@ try
         THROW_DOCKER_USER_ERROR_MSG(e, "Failed to create network '%hs'", name.c_str());
     }
 
-    auto [it, inserted] = m_networks.insert({name, NetworkEntry{response.Id, driver}});
+    // Inspect the newly created network to cache full properties (IPAM, Scope, etc.)
+    // since CreateNetworkResponse only returns {Id, Warning}.
+    docker_schema::Network full;
+    try
+    {
+        full = m_dockerClient->InspectNetwork(name);
+    }
+    catch (const DockerHTTPException& e)
+    {
+        THROW_DOCKER_USER_ERROR_MSG(e, "Failed to inspect newly created network '%hs'", name.c_str());
+    }
+
+    NetworkEntry entry;
+    entry.Id = full.Id;
+    entry.Driver = full.Driver;
+    entry.Scope = full.Scope;
+    entry.Internal = full.Internal;
+    entry.Labels = full.Labels;
+    entry.IPAM.Driver = full.IPAM.Driver;
+    if (full.IPAM.Config)
+    {
+        auto& cfgs = entry.IPAM.Config.emplace();
+        for (const auto& c : *full.IPAM.Config)
+        {
+            cfgs.push_back({c.Subnet, c.Gateway});
+        }
+    }
+
+    auto [it, inserted] = m_networks.insert({name, std::move(entry)});
     WI_VERIFY(inserted);
 
-    WSL_LOG("NetworkCreated", TraceLoggingValue(name.c_str(), "NetworkName"), TraceLoggingValue(response.Id.c_str(), "NetworkId"));
+    WSL_LOG("NetworkCreated", TraceLoggingValue(name.c_str(), "NetworkName"), TraceLoggingValue(full.Id.c_str(), "NetworkId"));
 
     return S_OK;
 }
@@ -2136,39 +2163,26 @@ try
     ValidateName(name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
 
     auto lock = m_lock.lock_shared();
-    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);
+    std::lock_guard networksLock(m_networksLock);
 
-    {
-        std::lock_guard networksLock(m_networksLock);
+    auto it = m_networks.find(name);
+    THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), it == m_networks.end());
 
-        auto it = m_networks.find(name);
-        THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), it == m_networks.end());
-    }
-
-    docker_schema::Network network;
-    try
-    {
-        network = m_dockerClient->InspectNetwork(name);
-    }
-    catch (const DockerHTTPException& e)
-    {
-        THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), e.StatusCode() == 404);
-        THROW_DOCKER_USER_ERROR_MSG(e, "Failed to inspect network '%hs'", name.c_str());
-    }
+    const auto& entry = it->second;
 
     wslc_schema::InspectNetwork result;
-    result.Id = network.Id;
-    result.Name = network.Name;
-    result.Driver = network.Driver;
-    result.Scope = network.Scope;
-    result.Internal = network.Internal;
-    result.Labels = network.Labels;
+    result.Id = entry.Id;
+    result.Name = name;
+    result.Driver = entry.Driver;
+    result.Scope = entry.Scope;
+    result.Internal = entry.Internal;
+    result.Labels = entry.Labels;
 
-    result.IPAM.Driver = network.IPAM.Driver;
-    if (network.IPAM.Config)
+    result.IPAM.Driver = entry.IPAM.Driver;
+    if (entry.IPAM.Config)
     {
         auto& configs = result.IPAM.Config.emplace();
-        for (const auto& cfg : *network.IPAM.Config)
+        for (const auto& cfg : *entry.IPAM.Config)
         {
             wslc_schema::InspectIPAMConfig inspectCfg;
             inspectCfg.Subnet = cfg.Subnet;
@@ -2554,7 +2568,23 @@ void WSLCSession::RecoverExistingNetworks()
         {
             WI_ASSERT(!m_networks.contains(network.Name));
 
-            auto [_, inserted] = m_networks.insert({network.Name, NetworkEntry{network.Id, network.Driver}});
+            NetworkEntry entry;
+            entry.Id = network.Id;
+            entry.Driver = network.Driver;
+            entry.Scope = network.Scope;
+            entry.Internal = network.Internal;
+            entry.Labels = network.Labels;
+            entry.IPAM.Driver = network.IPAM.Driver;
+            if (network.IPAM.Config)
+            {
+                auto& cfgs = entry.IPAM.Config.emplace();
+                for (const auto& c : *network.IPAM.Config)
+                {
+                    cfgs.push_back({c.Subnet, c.Gateway});
+                }
+            }
+
+            auto [_, inserted] = m_networks.insert({network.Name, std::move(entry)});
             WI_VERIFY(inserted);
         }
         CATCH_LOG_MSG("Failed to recover network: %hs", network.Name.c_str());

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -133,6 +133,7 @@ public:
     IFACEMETHOD(CreateNetwork)(_In_ const WSLCNetworkOptions* Options) override;
     IFACEMETHOD(DeleteNetwork)(_In_ LPCSTR Name) override;
     IFACEMETHOD(ListNetworks)(_Out_ WSLCNetworkInformation** Networks, _Out_ ULONG* Count) override;
+    IFACEMETHOD(InspectNetwork)(_In_ LPCSTR Name, _Out_ LPSTR* Output) override;
 
     IFACEMETHOD(Terminate()) override;
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3901,6 +3901,69 @@ class WSLCTests
         VERIFY_ARE_EQUAL(2u, networks.size());
     }
 
+    WSLC_TEST_METHOD(NetworkInspectTest)
+    {
+        const std::string networkName = "test-inspect-network";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        WSLCNetworkOptions options{};
+        options.Name = networkName.c_str();
+        options.Driver = "bridge";
+        options.DriverOpts = nullptr;
+        options.DriverOptsCount = 0;
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options));
+
+        wil::unique_cotaskmem_ansistring output;
+        VERIFY_SUCCEEDED(m_defaultSession->InspectNetwork(networkName.c_str(), &output));
+        VERIFY_IS_NOT_NULL(output.get());
+
+        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::InspectNetwork>(output.get());
+        VERIFY_ARE_EQUAL(inspect.Name, networkName);
+        VERIFY_ARE_EQUAL(inspect.Driver, std::string("bridge"));
+        VERIFY_IS_FALSE(inspect.Id.empty());
+        VERIFY_IS_FALSE(inspect.Internal);
+    }
+
+    WSLC_TEST_METHOD(NetworkInspectWithSubnetTest)
+    {
+        const std::string networkName = "test-inspect-subnet-net";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        WSLCDriverOption subnetOpt[] = {{"Subnet", "172.30.0.0/16"}};
+
+        WSLCNetworkOptions options{};
+        options.Name = networkName.c_str();
+        options.Driver = "bridge";
+        options.DriverOpts = subnetOpt;
+        options.DriverOptsCount = ARRAYSIZE(subnetOpt);
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options));
+
+        wil::unique_cotaskmem_ansistring output;
+        VERIFY_SUCCEEDED(m_defaultSession->InspectNetwork(networkName.c_str(), &output));
+        VERIFY_IS_NOT_NULL(output.get());
+
+        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::InspectNetwork>(output.get());
+        VERIFY_ARE_EQUAL(inspect.Name, networkName);
+        VERIFY_ARE_EQUAL(inspect.Driver, std::string("bridge"));
+        VERIFY_IS_TRUE(inspect.IPAM.Config.has_value());
+        VERIFY_ARE_EQUAL(1u, inspect.IPAM.Config->size());
+        VERIFY_ARE_EQUAL(std::string("172.30.0.0/16"), inspect.IPAM.Config->at(0).Subnet);
+    }
+
+    WSLC_TEST_METHOD(NetworkInspectNotFoundTest)
+    {
+        wil::unique_cotaskmem_ansistring output;
+        auto hr = m_defaultSession->InspectNetwork("nonexistent-network", &output);
+        VERIFY_ARE_EQUAL(WSLC_E_NETWORK_NOT_FOUND, hr);
+        ValidateCOMErrorMessageContains(L"nonexistent-network");
+    }
+
     WSLC_TEST_METHOD(CreateContainer)
     {
         // Test a simple container start.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds the InspectNetwork method to the WSLC session, allowing callers to retrieve detailed information about a managed network (name, ID, driver, scope, IPAM config, labels). 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Added InspectNetwork to the IDL interface, returning a JSON string with network details
- Created dedicated InspectIPAMConfig, InspectIPAM, and InspectNetwork structs in wslc_schema.h (keeps it independent from docker_schema)
- Added InspectNetwork to DockerHTTPClient calling GET /networks/{name}

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- NetworkInspectTest - creates a network, inspects it, verifies name, driver, ID, and internal flag
- NetworkInspectWithSubnetTest - creates a network with a subnet, inspects it, verifies IPAM config and subnet value
- NetworkInspectNotFoundTest - verifies WSLC_E_NETWORK_NOT_FOUND is returned with correct error message for a non-existent network