### PR TITLE
Use WSLC_E_CONTAINER_NOT_FOUND when a container is not found

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1978,6 +1978,10 @@ Usage:
     <value>Container '{}' is running.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcContainerNotFound" xml:space="preserve">
+    <value>Container '{}' not found.</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="WSLCCLI_UnrecognizedCommandError" xml:space="preserve">
     <value>Unrecognized command: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1601,7 +1601,7 @@ try
         }
         catch (DockerHTTPException& e)
         {
-            RETURN_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), e.StatusCode() == 404, "Container not found: '%hs'", Id);
+            THROW_HR_WITH_USER_ERROR_IF(WSLC_E_CONTAINER_NOT_FOUND, Localization::MessageWslcContainerNotFound(Id), e.StatusCode() == 404);
             RETURN_HR_IF_MSG(WSLC_E_CONTAINER_PREFIX_AMBIGUOUS, e.StatusCode() == 400, "Ambiguous prefix: '%hs'", Id);
 
             THROW_HR_MSG(E_FAIL, "Unexpected error inspecting container '%hs': %hs", Id, e.what());
@@ -1614,8 +1614,8 @@ try
 
     auto result = wil::ResultFromException([&]() { (*it)->CopyTo(Container); });
 
-    // Return ERROR_NOT_FOUND if the container was found, but is being deleted for consistency.
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), result == RPC_E_DISCONNECTED);
+    // Return WSLC_E_CONTAINER_NOT_FOUND if the container was found, but is being deleted for consistency.
+    THROW_HR_WITH_USER_ERROR_IF(WSLC_E_CONTAINER_NOT_FOUND, Localization::MessageWslcContainerNotFound(Id), result == RPC_E_DISCONNECTED);
 
     return result;
 }

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4175,7 +4175,8 @@ class WSLCTests
             expectOpen("", E_INVALIDARG);
             ValidateCOMErrorMessage(L"Invalid name: ''");
 
-            expectOpen("non-existing-container", HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            expectOpen("non-existing-container", WSLC_E_CONTAINER_NOT_FOUND);
+            ValidateCOMErrorMessage(L"Container 'non-existing-container' not found.");
 
             expectOpen("/", E_INVALIDARG);
             ValidateCOMErrorMessage(L"Invalid name: '/'");
@@ -4371,7 +4372,7 @@ class WSLCTests
         // Verify that trying to open a non existing container fails.
         {
             wil::com_ptr<IWSLCContainer> sameContainer;
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("does-not-exist", &sameContainer), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("does-not-exist", &sameContainer), WSLC_E_CONTAINER_NOT_FOUND);
         }
 
         // Validate that container names are unique.
@@ -5861,7 +5862,7 @@ class WSLCTests
 
             // Verify container is no longer accessible
             wil::com_ptr<IWSLCContainer> notFound;
-            VERIFY_ARE_EQUAL(session->OpenContainer(containerName.c_str(), &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(session->OpenContainer(containerName.c_str(), &notFound), WSLC_E_CONTAINER_NOT_FOUND);
         }
 
         // Phase 3: Create new session from same storage, verify the container is not listed.
@@ -5870,7 +5871,7 @@ class WSLCTests
 
             // Verify container is no longer accessible
             wil::com_ptr<IWSLCContainer> notFound;
-            VERIFY_ARE_EQUAL(session->OpenContainer(containerName.c_str(), &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(session->OpenContainer(containerName.c_str(), &notFound), WSLC_E_CONTAINER_NOT_FOUND);
         }
     }
 
@@ -5938,7 +5939,7 @@ class WSLCTests
         wil::com_ptr<IWSLCContainer> container;
         auto hr = session->OpenContainer(containerName.c_str(), &container);
 
-        VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+        VERIFY_ARE_EQUAL(hr, WSLC_E_CONTAINER_NOT_FOUND);
     }
 
     TEST_METHOD(ContainerRecoveryFromStorageInvalidMetadata)
@@ -6550,7 +6551,7 @@ class WSLCTests
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLCContainer> notFound;
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), WSLC_E_CONTAINER_NOT_FOUND);
         }
 
         // Test that a container with the Rm flag is automatically deleted when the init process is killed.
@@ -6569,7 +6570,7 @@ class WSLCTests
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLCContainer> notFound;
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), WSLC_E_CONTAINER_NOT_FOUND);
         }
 
         // Test that a container with the Rm flag is automatically deleted when the container is killed.
@@ -6588,7 +6589,7 @@ class WSLCTests
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLCContainer> notFound;
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove-kill", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove-kill", &notFound), WSLC_E_CONTAINER_NOT_FOUND);
         }
 
         // Test that the container autoremove flag is applied when the container exits on its own.
@@ -6603,7 +6604,7 @@ class WSLCTests
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLCContainer> notFound;
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), WSLC_E_CONTAINER_NOT_FOUND);
         }
 
         // Test that the Rm flag is persisted across wslc sessions.
@@ -6628,8 +6629,8 @@ class WSLCTests
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), RPC_E_DISCONNECTED);
 
             wil::com_ptr<IWSLCContainer> notFound;
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer(id.c_str(), &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove", &notFound), WSLC_E_CONTAINER_NOT_FOUND);
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer(id.c_str(), &notFound), WSLC_E_CONTAINER_NOT_FOUND);
 
             wil::unique_cotaskmem_array_ptr<WSLCContainerEntry> containers;
             wil::unique_cotaskmem_array_ptr<WSLCContainerPortMapping> ports;
@@ -6664,7 +6665,7 @@ class WSLCTests
 
         // Validate that the container is not found if we try to open it by name or id, or found in the container list.
         wil::com_ptr<IWSLCContainer> notFound;
-        VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove-stdout", &notFound), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+        VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer("test-auto-remove-stdout", &notFound), WSLC_E_CONTAINER_NOT_FOUND);
 
         wil::unique_cotaskmem_array_ptr<WSLCContainerEntry> containers;
         wil::unique_cotaskmem_array_ptr<WSLCContainerPortMapping> ports;
@@ -7037,7 +7038,7 @@ class WSLCTests
 
             // Validate that the container can't be opened anymore.
             wil::com_ptr<IWSLCContainer> dummy;
-            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer(containerId.c_str(), &dummy), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+            VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer(containerId.c_str(), &dummy), WSLC_E_CONTAINER_NOT_FOUND);
 
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), RPC_E_DISCONNECTED);
         }

--- a/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
@@ -115,7 +115,7 @@ class WSLCE2EContainerAttachTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Attach_ContainerNotFound)
     {
         auto result = RunWslc(std::format(L"container attach {}", WslcContainerName));
-        result.Verify({.Stderr = L"Element not found. \r\nError code: ERROR_NOT_FOUND\r\n", .ExitCode = 1});
+        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
     }
 
 private:

--- a/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
@@ -115,7 +115,9 @@ class WSLCE2EContainerAttachTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Attach_ContainerNotFound)
     {
         auto result = RunWslc(std::format(L"container attach {}", WslcContainerName));
-        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
+        result.Verify(
+            {.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName),
+             .ExitCode = 1});
     }
 
 private:

--- a/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
@@ -82,7 +82,9 @@ class WSLCE2EContainerExecTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Exec_ContainerNotFound)
     {
         auto result = RunWslc(std::format(L"container exec {} echo hello", WslcContainerName));
-        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
+        result.Verify(
+            {.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName),
+             .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Exec_SimpleCommand)

--- a/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
@@ -82,7 +82,7 @@ class WSLCE2EContainerExecTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Exec_ContainerNotFound)
     {
         auto result = RunWslc(std::format(L"container exec {} echo hello", WslcContainerName));
-        result.Verify({.Stderr = L"Element not found. \r\nError code: ERROR_NOT_FOUND\r\n", .ExitCode = 1});
+        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Exec_SimpleCommand)

--- a/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
@@ -93,7 +93,7 @@ class WSLCE2EContainerKillTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         auto result = RunWslc(std::format(L"container kill {}", WslcContainerName));
-        result.Verify({.Stderr = L"Element not found. \r\nError code: ERROR_NOT_FOUND\r\n", .ExitCode = 1});
+        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Kill_InvalidSignal)

--- a/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
@@ -93,7 +93,9 @@ class WSLCE2EContainerKillTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         auto result = RunWslc(std::format(L"container kill {}", WslcContainerName));
-        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
+        result.Verify(
+            {.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName),
+             .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Kill_InvalidSignal)

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -55,7 +55,10 @@ class WSLCE2EContainerRemoveTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         auto result = RunWslc(std::format(L"container remove {}", WslcContainerName));
-        result.Verify({.Stdout = L"", .Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
+        result.Verify(
+            {.Stdout = L"",
+             .Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName),
+             .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Remove_Valid)

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -55,7 +55,7 @@ class WSLCE2EContainerRemoveTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         auto result = RunWslc(std::format(L"container remove {}", WslcContainerName));
-        result.Verify({.Stdout = L"", .Stderr = L"Element not found. \r\nError code: ERROR_NOT_FOUND\r\n", .ExitCode = 1});
+        result.Verify({.Stdout = L"", .Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Remove_Valid)

--- a/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
@@ -128,7 +128,9 @@ class WSLCE2EContainerStopTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         auto result = RunWslc(std::format(L"container stop {} -t 0", WslcContainerName));
-        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
+        result.Verify(
+            {.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName),
+             .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Stop_TargetedContainerOnly)

--- a/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
@@ -128,7 +128,7 @@ class WSLCE2EContainerStopTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         auto result = RunWslc(std::format(L"container stop {} -t 0", WslcContainerName));
-        result.Verify({.Stderr = L"Element not found. \r\nError code: ERROR_NOT_FOUND\r\n", .ExitCode = 1});
+        result.Verify({.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName), .ExitCode = 1});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Stop_TargetedContainerOnly)

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -250,7 +250,8 @@ void EnsureContainerDoesNotExist(const std::wstring& containerName)
             {
                 auto result = RunWslc(std::format(L"container kill {}", containerName));
                 // Tolerate WSLC_E_CONTAINER_NOT_FOUND - container already stopped/removed
-                if (result.ExitCode != 0 && (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))
+                if (result.ExitCode != 0 &&
+                    (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))
                 {
                     result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
                 }
@@ -258,7 +259,8 @@ void EnsureContainerDoesNotExist(const std::wstring& containerName)
 
             auto result = RunWslc(std::format(L"container remove --force {}", containerName));
             // Tolerate WSLC_E_CONTAINER_NOT_FOUND - container already removed
-            if (result.ExitCode != 0 && (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))
+            if (result.ExitCode != 0 &&
+                (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))
             {
                 result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
             }

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -249,16 +249,16 @@ void EnsureContainerDoesNotExist(const std::wstring& containerName)
             if (line.find(L"running") != std::wstring::npos)
             {
                 auto result = RunWslc(std::format(L"container kill {}", containerName));
-                // Tolerate ERROR_NOT_FOUND - container already stopped/removed
-                if (result.ExitCode != 0 && (!result.Stderr.has_value() || result.Stderr.value().find(L"ERROR_NOT_FOUND") == std::wstring::npos))
+                // Tolerate WSLC_E_CONTAINER_NOT_FOUND - container already stopped/removed
+                if (result.ExitCode != 0 && (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))
                 {
                     result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
                 }
             }
 
             auto result = RunWslc(std::format(L"container remove --force {}", containerName));
-            // Tolerate ERROR_NOT_FOUND - container already removed
-            if (result.ExitCode != 0 && (!result.Stderr.has_value() || result.Stderr.value().find(L"ERROR_NOT_FOUND") == std::wstring::npos))
+            // Tolerate WSLC_E_CONTAINER_NOT_FOUND - container already removed
+            if (result.ExitCode != 0 && (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))
             {
                 result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change switches the service logic to return `WSLC_E_CONTAINER_NOT_FOUND`when a container is not found.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
