### PR TITLE
Fix Wait-Process compatibility with PowerShell 5.1

### DIFF
--- a/tools/test/run-tests.ps1
+++ b/tools/test/run-tests.ps1
@@ -95,4 +95,5 @@ if ($AttachDebugger)
     Start-Process "WinDbgX.exe" -ArgumentList "-p $($teProcess.Id)"
 }
 
-exit ($teProcess | Wait-Process -PassThru).ExitCode
+$teProcess | Wait-Process
+exit $teProcess.ExitCode


### PR DESCRIPTION
## Problem

Running tests via `test.bat` fails with:

```
A parameter cannot be found that matches parameter name 'PassThru'.
FullyQualifiedErrorId : NamedParameterNotFound,run-tests.ps1
```

`test.bat` invokes `powershell.exe` (Windows PowerShell 5.1), but `run-tests.ps1` uses `Wait-Process -PassThru` which is only available in PowerShell 7+.

## Fix

Replace the single-line `Wait-Process -PassThru` pattern with a 5.1-compatible equivalent:

```powershell
# Before (PS 7+ only)
exit ($teProcess | Wait-Process -PassThru).ExitCode

# After (PS 5.1+)
$teProcess | Wait-Process
exit $teProcess.ExitCode
```

This is functionally identical — `Start-Process -PassThru` already returns the process object with `.ExitCode`, so `-PassThru` on `Wait-Process` was redundant.