### PR TITLE
Remove Advertise=yes from MSI shortcuts

### DIFF
--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -20,7 +20,7 @@
             <Component Id="wsl" Guid="F0C8D6BA-1502-41E7-BF72-D93DFA134730" UninstallWhenSuperseded="yes" DisableRegistryReflection="yes" Bitness="always64">
                 <RemoveFile Id="CleanUpWSLShortCut" Directory="ProgramMenuFolder" Name="WSL" On="uninstall"/>
                 <File Id="wsl.exe" Name="wsl.exe" Source="${PACKAGE_INPUT_DIR}/wsl.exe" KeyPath="yes">
-                    <Shortcut Id="WSLShortcut" Name="WSL" Description="Windows Subsystem for Linux" Arguments="--cd ~" Advertise="yes" Directory="ProgramMenuFolder" Icon="wsl.ico">
+                    <Shortcut Id="WSLShortcut" Name="WSL" Description="Windows Subsystem for Linux" Arguments="--cd ~" Directory="ProgramMenuFolder" Icon="wsl.ico">
                         <ShortcutProperty Key="System.AppUserModel.ID" Value="Microsoft.WSL"/>
                         <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{2B9C59C3-98F1-45C8-B87B-12AE3C7927E8}"/>
                     </Shortcut>
@@ -285,9 +285,7 @@
                 <Component Id="wslsettingsnonserver" Guid="AB166073-8855-492B-95C8-C6E5939B66A5" Bitness="always64" DisableRegistryReflection="yes" UninstallWhenSuperseded="yes" Condition="MsiNTProductType = 1">
                     <RemoveFile Id="CleanUpWSLSettingsShortCutNonServer" Directory="ProgramMenuFolder" Name="WSLSettings" On="uninstall"/>
                     <File Id="wslsettings.exe_nonserver" Source="${PACKAGE_INPUT_DIR}/wslsettings/wslsettings.exe" KeyPath="yes" ShortName="kyk8fs6a.exe">
-                        <Shortcut Id="WSLSettingsShortcutNonServer" Name="WSL Settings" Description="Windows Subsystem for Linux Settings" Advertise="yes" Directory="ProgramMenuFolder" Icon="wsl.ico">
-                            <ShortcutProperty Key="System.AppUserModel.IsSystemComponent" Value="true"/>
-                        </Shortcut>
+                        <Shortcut Id="WSLSettingsShortcutNonServer" Name="WSL Settings" Description="Windows Subsystem for Linux Settings" Directory="ProgramMenuFolder" Icon="wsl.ico"/>
                     </File>
                     <!-- Protocol registration -->
                     <RegistryKey Root="HKLM" Key="Software">
@@ -316,7 +314,7 @@
                 <Component Id="wslsettingsserver" Guid="EE2D69A0-4F55-4EC5-9576-4FAD70BC798E" Bitness="always64" DisableRegistryReflection="yes" UninstallWhenSuperseded="yes" Condition="MsiNTProductType &gt; 1">
                     <RemoveFile Id="CleanUpWSLSettingsShortCutServer" Directory="ProgramMenuFolder" Name="WSLSettings" On="uninstall"/>
                     <File Id="wslsettings.exe_server" Source="${PACKAGE_INPUT_DIR}/wslsettings/wslsettings.exe" KeyPath="yes" ShortName="kyk8fs6b.exe">
-                        <Shortcut Id="WSLSettingsShortcutServer" Name="WSL Settings" Description="Windows Subsystem for Linux Settings" Advertise="yes" Directory="ProgramMenuFolder" Icon="wsl.ico"/>
+                        <Shortcut Id="WSLSettingsShortcutServer" Name="WSL Settings" Description="Windows Subsystem for Linux Settings" Directory="ProgramMenuFolder" Icon="wsl.ico"/>
                     </File>
                     <!-- Protocol registration -->
                     <RegistryKey Root="HKLM" Key="Software">


### PR DESCRIPTION
Removes `Advertise=yes` from all MSI shortcuts (WSL, WSL Settings non-server, WSL Settings server) and drops the matching `IsSystemComponent` ShortcutProperty.

## Why

Originally posted as a fix for installer Warning 1946 (`System.AppUserModel.ToastActivatorCLSID for shortcut 'WSL.lnk' could not be set`). Per @OneBlue's review, removing `Advertise=yes` does **not** actually clear that warning, so the change is no longer framed as a Warning 1946 fix.

We still want this change because:

- Advertised shortcuts cause confusing UX when the shortcut gets leaked or the MSI ends up in a bad state (the shortcut tries to repair/install-on-demand instead of just running the binary).
- The WSL MSI has a single feature at `Level=1` (always installed) with `ARPNOMODIFY=yes` and `ARPSYSTEMCOMPONENT=yes`, so MSI advertising (install-on-demand / self-repair) provides no value here.
- `System.AppUserModel.IsSystemComponent` was attached to an advertised shortcut whose Darwin descriptor can't store all property types; removing it alongside the advertise flag avoids any ambiguity about which properties survive.

## Changes

- Drop `Advertise=yes` from the three `<Shortcut>` elements in `msipackage/package.wix.in`.
- Drop the now-unnecessary `IsSystemComponent` `<ShortcutProperty>` from `WSLSettingsShortcutNonServer`.

## Verification

- [x] Toast notifications still work (`System.AppUserModel.ToastActivatorCLSID` set on the WSL shortcut).
- [x] `System.AppUserModel.ID` remains set.
- [x] WSL shortcut visible in Start Menu with the correct icon.
- [x] Build succeeds (C++ and WiX MSI).