### PR TITLE
Add BUFFER_FIELD macro for safe pretty-printing of flexible array members

### DIFF
--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -579,7 +579,7 @@ typedef struct _LX_PROCESS_CRASH
 
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Timestamp), FIELD(Signal), FIELD(Pid), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(Timestamp), FIELD(Signal), FIELD(Pid), BUFFER_FIELD(Buffer));
 
 } LX_PROCESS_CRASH, *PLX_PROCESS_CRASH;
 
@@ -701,7 +701,7 @@ typedef struct _LX_INIT_CREATE_LOGIN_SESSION
     unsigned int Gid;
     char Buffer[]; // Contains username
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Uid), FIELD(Gid), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(Uid), FIELD(Gid), BUFFER_FIELD(Buffer));
 } LX_INIT_CREATE_LOGIN_SESSION, *PLX_INIT_CREATE_LOGIN_SESSION;
 
 //
@@ -716,7 +716,7 @@ typedef struct _LX_INIT_QUERY_ENVIRONMENT_VARIABLE
     MESSAGE_HEADER Header;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), BUFFER_FIELD(Buffer));
 } LX_INIT_QUERY_ENVIRONMENT_VARIABLE, *PLX_INIT_QUERY_ENVIRONMENT_VARIABLE;
 
 typedef struct _LX_GNS_RESULT
@@ -739,7 +739,7 @@ typedef struct _LX_GNS_INTERFACE_CONFIGURATION
     MESSAGE_HEADER Header;
     char Content[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Content));
+    PRETTY_PRINT(FIELD(Header), BUFFER_FIELD(Content));
 } LX_GNS_INTERFACE_CONFIGURATION, *PLX_GNS_INTERFACE_CONFIGURATION;
 
 typedef struct _LX_GNS_NOTIFICATION
@@ -751,7 +751,7 @@ typedef struct _LX_GNS_NOTIFICATION
     GUID AdapterId;
     char Content[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(AdapterId), FIELD(Content));
+    PRETTY_PRINT(FIELD(Header), FIELD(AdapterId), BUFFER_FIELD(Content));
 } LX_GNS_NOTIFICATION, *PLX_GNS_NOTIFICATION;
 
 typedef struct _LX_GNS_PORT_ALLOCATION_REQUEST
@@ -845,7 +845,7 @@ typedef struct _LX_GNS_JSON_MESSAGE
     MESSAGE_HEADER Header;
     char Content[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Content));
+    PRETTY_PRINT(FIELD(Header), BUFFER_FIELD(Content));
 } LX_GNS_JSON_MESSAGE, *PLX_GNS_JSON_MESSAGE;
 
 using PCLX_INIT_NETWORK_INFORMATION = const LX_INIT_NETWORK_INFORMATION*;
@@ -1288,7 +1288,7 @@ typedef struct _LX_MINI_INIT_TELEMETRY_MESSAGE
     bool ShowDrvFsNotification;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(ShowDrvFsNotification), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(ShowDrvFsNotification), BUFFER_FIELD(Buffer));
 
 } LX_MINI_INIT_TELEMETRY_MESSAGE, *PLX_MINI_INIT_TELEMETRY_MESSAGE;
 
@@ -1319,7 +1319,7 @@ typedef struct _LX_MINI_INIT_UNMOUNT_MESSAGE
     MESSAGE_HEADER Header;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), BUFFER_FIELD(Buffer));
 } LX_MINI_INIT_UNMOUNT_MESSAGE, *PLX_MINI_INIT_UNMOUNT_MESSAGE;
 
 typedef struct _LX_MINI_INIT_DETACH_MESSAGE
@@ -1368,7 +1368,7 @@ typedef struct _LX_INIT_GUEST_CAPABILITIES
     bool SeccompAvailable;
     char Buffer[]; // Contains the kernel version string
 
-    PRETTY_PRINT(FIELD(Header), FIELD(SeccompAvailable), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(SeccompAvailable), BUFFER_FIELD(Buffer));
 } LX_INIT_GUEST_CAPABILITIES, *PLX_INIT_GUEST_CAPABILITIES;
 
 typedef struct _LX_MINI_INIT_WAIT_FOR_PMEM_DEVICE_MESSAGE
@@ -1515,7 +1515,7 @@ typedef struct _LX_INIT_QUERY_VM_ID
     MESSAGE_HEADER Header;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), BUFFER_FIELD(Buffer));
 } LX_INIT_QUERY_VM_ID, *PLX_INIT_QUERY_VM_ID;
 
 template <>

--- a/src/shared/inc/prettyprintshared.h
+++ b/src/shared/inc/prettyprintshared.h
@@ -17,6 +17,8 @@ Abstract:
 #pragma once
 
 #include <sstream>
+#include <cstring>
+#include <string_view>
 
 #include "defs.h"
 #include "stringshared.h"
@@ -30,6 +32,22 @@ Abstract:
 #define FIELD(Name) #Name, Name
 
 #define STRING_FIELD(Name) #Name, (Name <= 0 ? "<empty>" : ((char*)(this)) + Name)
+
+// Safe pretty-print for flexible array members (char Buffer[]). Bounds the read
+// using the struct's Header.MessageSize so it never reads past the received data.
+#define BUFFER_FIELD(Name) #Name, PrettyPrintSafeBufferView(this, Header.MessageSize, Name)
+
+inline std::string_view PrettyPrintSafeBufferView(const void* structBase, unsigned int messageSize, const char* buffer)
+{
+    const auto offset = static_cast<size_t>(buffer - reinterpret_cast<const char*>(structBase));
+    if (offset >= messageSize)
+    {
+        return "<out-of-bounds>";
+    }
+
+    const size_t maxLen = messageSize - offset;
+    return std::string_view(buffer, strnlen(buffer, maxLen));
+}
 
 #define PRETTY_PRINT(...) \
     void PrettyPrintImpl(std::stringstream& Out) const \
@@ -47,7 +65,11 @@ Abstract:
 template <typename T>
 inline void PrettyPrint(std::stringstream& Out, const T& Value)
 {
-    if constexpr (std::is_same_v<T, const char*> || std::is_same_v<T, char[]>)
+    if constexpr (std::is_same_v<T, std::string_view>)
+    {
+        Out << Value;
+    }
+    else if constexpr (std::is_same_v<T, const char*> || std::is_same_v<T, char[]>)
     {
         if (Value == nullptr)
         {


### PR DESCRIPTION
Message structs with flexible array members (`char Buffer[]`, `char Content[]`) used `FIELD()` in `PRETTY_PRINT`, which streams the member as a C-string until a NUL byte is encountered. If the buffer happens to not be NUL-terminated (e.g. due to a truncated or malformed message), this could read past the intended bounds.

This PR adds:
- A `BUFFER_FIELD(Name)` macro that computes safe bounds from `Header.MessageSize`
- A `PrettyPrintSafeBufferView` helper that caps reads using `strnlen`
- A `std::string_view` branch in the `PrettyPrint` template
- Updates all 10 affected structs in `lxinitshared.h` to use `BUFFER_FIELD`

This matches the existing pattern in `LX_GNS_RESULT` which already excluded its `Buffer` from `PRETTY_PRINT` with the comment: *'Buffer' doesn't always contain a string, so don't pretty print it.*