### PR TITLE
Fix sizeof typo in MessageWriter::GetRelativeIndex

### DIFF
--- a/src/shared/inc/message.h
+++ b/src/shared/inc/message.h
@@ -171,7 +171,7 @@ private:
         const auto* bufferStart = reinterpret_cast<char*>(m_buffer.data());
 
         // Validate that 'Index' is actually within the bounds of our buffer
-        assert(indexPtr >= bufferStart && indexPtr + sizeof(index) <= bufferStart + m_buffer.size());
+        assert(indexPtr >= bufferStart && indexPtr + sizeof(Index) <= bufferStart + m_buffer.size());
 
         return static_cast<size_t>(indexPtr - bufferStart);
     }


### PR DESCRIPTION
`sizeof(index)` incorrectly resolved to a C library function type (`::index` from `<strings.h>`) instead of the `Index` parameter, causing a build error on Linux:

```
message.h(174,60): error G62009F68: invalid application of 'sizeof' to a function type
```

Fix: `sizeof(index)` → `sizeof(Index)` to match the parameter name.

Introduced in 58bd525a (#40197).