### PR TITLE
Disable shared compilation when building wslsettings

### DIFF
--- a/src/windows/wslsettings/directory.build.targets.in
+++ b/src/windows/wslsettings/directory.build.targets.in
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <!-- Disable the Roslyn shared compiler server (VBCSCompiler) to avoid intermittent CS0016 errors
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="${WINDOWS_SDK_DOTNET_VERSION}" TargetingPackVersion="${WINDOWS_SDK_DOTNET_VERSION}" />
     <!-- The below can be removed when the OneBranch pipeline container image is updated to use a newer version of the dotnet SDK -->

--- a/src/windows/wslsettings/directory.build.targets.in
+++ b/src/windows/wslsettings/directory.build.targets.in
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <!-- Disable the Roslyn shared compiler server (VBCSCompiler) to avoid intermittent CS0016 errors
+    <!-- Disable the Roslyn shared compiler server (VBCSCompiler) to avoid intermittent CS0016 errors -->
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change attempts to fix a recurring build error that the release pipeline hits when building wslsettings (CS0016).

I'm not 100% certain that this will resolve the issue, but it's worth trying. Will revert if we still see it after this is merged

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
