### PR TITLE
Reuse virtiofs shares when possible

### DIFF
--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -951,7 +951,11 @@ try
     THROW_HR_IF_MSG(
         HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), !std::filesystem::is_directory(path), "Path is not a directory: '%ls'", WindowsPath);
 
+    const bool readOnly = WI_IsFlagSet(Flags, WSLCMountFlagsReadOnly);
+    auto normalizedPath = path.lexically_normal().wstring();
     GUID shareGuid{};
+    bool reusingShare = false;
+
     {
         std::lock_guard lock(m_lock);
 
@@ -959,8 +963,27 @@ try
         auto it = m_mountedWindowsFolders.find(LinuxPath);
         THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS), it != m_mountedWindowsFolders.end());
 
-        // Delegate to IWSLCVirtualMachine for the privileged share creation
-        THROW_IF_FAILED(m_vm->AddShare(WindowsPath, WI_IsFlagSet(Flags, WSLCMountFlagsReadOnly), &shareGuid));
+        // In VirtioFs mode, try to reuse an existing share for the same Windows path and access mode.
+        if (FeatureEnabled(WslcFeatureFlagsVirtioFs))
+        {
+            auto shareIt = m_virtioFsShares.find({normalizedPath, readOnly});
+            if (shareIt != m_virtioFsShares.end())
+            {
+                shareGuid = shareIt->second;
+                reusingShare = true;
+            }
+        }
+
+        if (!reusingShare)
+        {
+            // Delegate to IWSLCVirtualMachine for the privileged share creation
+            THROW_IF_FAILED(m_vm->AddShare(WindowsPath, readOnly, &shareGuid));
+
+            if (FeatureEnabled(WslcFeatureFlagsVirtioFs))
+            {
+                m_virtioFsShares[{normalizedPath, readOnly}] = shareGuid;
+            }
+        }
 
         m_mountedWindowsFolders.emplace(LinuxPath, shareGuid);
     }
@@ -971,7 +994,15 @@ try
         if (WI_VERIFY(mountIt != m_mountedWindowsFolders.end()))
         {
             m_mountedWindowsFolders.erase(mountIt);
-            LOG_IF_FAILED(m_vm->RemoveShare(shareGuid));
+            if (!reusingShare)
+            {
+                if (FeatureEnabled(WslcFeatureFlagsVirtioFs))
+                {
+                    m_virtioFsShares.erase({normalizedPath, readOnly});
+                }
+
+                LOG_IF_FAILED(m_vm->RemoveShare(shareGuid));
+            }
         }
     });
 
@@ -988,18 +1019,13 @@ try
         THROW_HR_IF_MSG(E_FAIL, fd < 0, "WSLC_CONNECT failed with %i", fd);
 
         auto mountOptions = std::format(
-            "{},msize={},trans=fd,rfdno={},wfdno={},aname={},cache=mmap",
-            WI_IsFlagSet(Flags, WSLCMountFlagsReadOnly) ? "ro" : "rw",
-            LX_INIT_UTILITY_VM_PLAN9_BUFFER_SIZE,
-            fd,
-            fd,
-            shareName);
+            "{},msize={},trans=fd,rfdno={},wfdno={},aname={},cache=mmap", readOnly ? "ro" : "rw", LX_INIT_UTILITY_VM_PLAN9_BUFFER_SIZE, fd, fd, shareName);
 
         Mount(channel, shareName.c_str(), LinuxPath, "9p", mountOptions.c_str(), Flags);
     }
     else
     {
-        std::string options = WI_IsFlagSet(Flags, WSLCMountFlagsReadOnly) ? "ro" : "rw";
+        std::string options = readOnly ? "ro" : "rw";
         Mount(m_initChannel, shareName.c_str(), LinuxPath, "virtiofs", options.c_str(), Flags);
     }
 
@@ -1024,8 +1050,13 @@ try
 
     auto shareId = it->second;
 
-    // Delegate to IWSLCVirtualMachine for the privileged share removal
-    THROW_IF_FAILED(m_vm->RemoveShare(shareId));
+    // Keep the share mounted in virtiofs mode to avoid accumulating devices, which can cause a hang when reached.
+    // TODO: Actually remove the device once this is supported by the device host.
+    if (!FeatureEnabled(WslcFeatureFlagsVirtioFs))
+    {
+        // Delegate to IWSLCVirtualMachine for the privileged share removal
+        THROW_IF_FAILED(m_vm->RemoveShare(shareId));
+    }
 
     m_mountedWindowsFolders.erase(it);
 

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -952,7 +952,7 @@ try
         HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), !std::filesystem::is_directory(path), "Path is not a directory: '%ls'", WindowsPath);
 
     const bool readOnly = WI_IsFlagSet(Flags, WSLCMountFlagsReadOnly);
-    auto normalizedPath = path.lexically_normal().wstring();
+    auto normalizedPath = std::filesystem::weakly_canonical(path).wstring();
     GUID shareGuid{};
     bool reusingShare = false;
 
@@ -994,13 +994,9 @@ try
         if (WI_VERIFY(mountIt != m_mountedWindowsFolders.end()))
         {
             m_mountedWindowsFolders.erase(mountIt);
-            if (!reusingShare)
+            if (!FeatureEnabled(WslcFeatureFlagsVirtioFs))
             {
-                if (FeatureEnabled(WslcFeatureFlagsVirtioFs))
-                {
-                    m_virtioFsShares.erase({normalizedPath, readOnly});
-                }
-
+                m_virtioFsShares.erase({normalizedPath, readOnly});
                 LOG_IF_FAILED(m_vm->RemoveShare(shareGuid));
             }
         }

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -227,6 +227,11 @@ private:
 
     std::map<ULONG, AttachedDisk> m_attachedDisks;
     std::map<std::string, GUID> m_mountedWindowsFolders;
+
+    // VirtioFs share cache: maps (normalized WindowsPath, readOnly) to share GUID.
+    // Shares are kept alive after unmount for reuse on subsequent mounts of the same folder.
+    std::map<std::pair<std::wstring, bool>, GUID> m_virtioFsShares;
+
     std::recursive_mutex m_lock;
     std::mutex m_portRelaylock;
 };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3163,6 +3163,59 @@ class WSLCTests
         ValidateWindowsMounts(true);
     }
 
+    // Validates that VirtioFs shares are reused across mount/unmount cycles for the same Windows folder.
+    WSLC_TEST_METHOD(WindowsMountsVirtioFsShareReuse)
+    {
+        auto settings = GetDefaultSessionSettings(L"virtiofs-share-reuse-test");
+        WI_SetFlag(settings.FeatureFlags, WslcFeatureFlagsVirtioFs);
+
+        auto createNewSession = !WI_IsFlagSet(m_defaultSessionSettings.FeatureFlags, WslcFeatureFlagsVirtioFs);
+        auto session = createNewSession ? CreateSession(settings) : m_defaultSession;
+
+        auto testFolder = std::filesystem::current_path() / "test-folder-share-reuse";
+        std::filesystem::create_directories(testFolder);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testFolder); });
+
+        auto getMountSource = [&](const char* mountPoint) -> std::string {
+            auto cmd = std::format("findmnt -n -o SOURCE {}", mountPoint);
+            auto result = ExpectCommandResult(session.get(), {"/bin/sh", "-c", cmd}, 0);
+            return result.Output[1];
+        };
+
+        // Mount, capture the source (share GUID), unmount, remount, verify same GUID is reused.
+        {
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", false));
+            auto firstSource = getMountSource("/win-path");
+            VERIFY_IS_FALSE(firstSource.empty());
+
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+            ExpectMount(session.get(), "/win-path", {});
+
+            // Remount the same folder - should reuse the same share GUID.
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", false));
+            auto secondSource = getMountSource("/win-path");
+
+            VERIFY_ARE_EQUAL(firstSource, secondSource);
+
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+        }
+
+        // Verify that changing the read-only flag produces a different share GUID.
+        {
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", false));
+            auto rwSource = getMountSource("/win-path");
+
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", true));
+            auto roSource = getMountSource("/win-path");
+
+            VERIFY_ARE_NOT_EQUAL(rwSource, roSource);
+
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+        }
+    }
+
     // This test case validates that no file descriptors are leaked to user processes.
     WSLC_TEST_METHOD(Fd)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to reuse virtiofs shares whenever possible, making it less likely that we hit the device limit

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
