### PR TITLE
wslc: update devicehost dll to a version that properly supports device removal

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.10-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.14-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />

--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -75,10 +75,6 @@ void DeviceHostProxy::RemoveDevice(const GUID& Type, const GUID& InstanceId)
         m_devices.erase(InstanceId);
     }
 
-    // TODO: Add this back after the the hotplug issue with the most recent wsldevicehost.dll is resolved.
-    //       See https://github.com/microsoft/openvmm/issues/3077 for more details.
-    return;
-
     // N.B. Removing the FlexIov device is best effort since not all versions of Windows support it.
     try
     {


### PR DESCRIPTION
This change removes the workaround to disable device removal since the new devicehost package properly supports it. Removal is still best-effort but I am working on backporting a change to older versions of Windows to properly support this.