### PR TITLE
CLI: Initialize volume prune functionality

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2721,6 +2721,24 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_VolumeListLongDesc" xml:space="preserve">
     <value>Lists all volumes in the session.</value>
   </data>
+  <data name="WSLCCLI_VolumePruneAllArgDescription" xml:space="preserve">
+    <value>Remove all unused volumes, not just anonymous ones.</value>
+  </data>
+  <data name="WSLCCLI_VolumePruneDeleted" xml:space="preserve">
+    <value>Deleted: {}</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_VolumePruneDesc" xml:space="preserve">
+    <value>Remove unused volumes.</value>
+  </data>
+  <data name="WSLCCLI_VolumePruneLongDesc" xml:space="preserve">
+    <value>Removes all unused local volumes. Unused volumes are those which are not referenced by any containers. If --all is specified, removes all unused volumes, not just anonymous ones.</value>
+    <comment>{Locked="--all "}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_VolumePruneSpaceReclaimed" xml:space="preserve">
+    <value>Total reclaimed space: {:.2f} MB</value>
+    <comment>{FixedPlaceholder="{:.2f}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="WSLCCLI_VolumeNameArgDescription" xml:space="preserve">
     <value>Volume name</value>
   </data>

--- a/src/windows/wslc/commands/VolumeCommand.cpp
+++ b/src/windows/wslc/commands/VolumeCommand.cpp
@@ -26,6 +26,7 @@ std::vector<std::unique_ptr<Command>> VolumeCommand::GetCommands() const
     commands.push_back(std::make_unique<VolumeRemoveCommand>(FullName()));
     commands.push_back(std::make_unique<VolumeInspectCommand>(FullName()));
     commands.push_back(std::make_unique<VolumeListCommand>(FullName()));
+    commands.push_back(std::make_unique<VolumePruneCommand>(FullName()));
     return commands;
 }
 

--- a/src/windows/wslc/commands/VolumeCommand.h
+++ b/src/windows/wslc/commands/VolumeCommand.h
@@ -92,4 +92,19 @@ protected:
     void ValidateArgumentsInternal(const ArgMap& execArgs) const override;
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
+
+// Prune Command
+struct VolumePruneCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"prune";
+    VolumePruneCommand(const std::wstring& parent) : Command(CommandName, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/VolumePruneCommand.cpp
+++ b/src/windows/wslc/commands/VolumePruneCommand.cpp
@@ -1,0 +1,51 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    VolumePruneCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+
+#include "VolumeCommand.h"
+#include "CLIExecutionContext.h"
+#include "VolumeTasks.h"
+#include "SessionTasks.h"
+#include "Task.h"
+
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
+
+namespace wsl::windows::wslc {
+// Volume Prune Command
+std::vector<Argument> VolumePruneCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::All, std::nullopt, std::nullopt, Localization::WSLCCLI_VolumePruneAllArgDescription()),
+        Argument::Create(ArgType::Session),
+    };
+}
+
+std::wstring VolumePruneCommand::ShortDescription() const
+{
+    return Localization::WSLCCLI_VolumePruneDesc();
+}
+
+std::wstring VolumePruneCommand::LongDescription() const
+{
+    return Localization::WSLCCLI_VolumePruneLongDesc();
+}
+
+void VolumePruneCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    context              //
+        << CreateSession //
+        << PruneVolumes;
+}
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/services/VolumeModel.h
+++ b/src/windows/wslc/services/VolumeModel.h
@@ -27,4 +27,10 @@ struct CreateVolumeOptions
     std::vector<std::pair<std::string, std::string>> Labels{};
 };
 
+struct PruneVolumesResult
+{
+    std::vector<std::string> DeletedVolumes;
+    ULONGLONG SpaceReclaimed{};
+};
+
 } // namespace wsl::windows::wslc::models

--- a/src/windows/wslc/services/VolumeService.cpp
+++ b/src/windows/wslc/services/VolumeService.cpp
@@ -81,4 +81,22 @@ wsl::windows::common::wslc_schema::InspectVolume VolumeService::Inspect(models::
     THROW_IF_FAILED(session.Get()->InspectVolume(name.c_str(), &output));
     return FromJson<wsl::windows::common::wslc_schema::InspectVolume>(output.get());
 }
+
+models::PruneVolumesResult VolumeService::Prune(models::Session& session, bool all)
+{
+    WSLCPruneVolumesOptions options{};
+    options.All = all;
+
+    WSLCPruneVolumesResults results{};
+    THROW_IF_FAILED(session.Get()->PruneVolumes(&options, &results));
+
+    models::PruneVolumesResult result;
+    result.SpaceReclaimed = results.SpaceReclaimed;
+    for (ULONG i = 0; i < results.VolumesCount; ++i)
+    {
+        result.DeletedVolumes.push_back(results.Volumes[i]);
+    }
+
+    return result;
+}
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/services/VolumeService.h
+++ b/src/windows/wslc/services/VolumeService.h
@@ -24,5 +24,6 @@ struct VolumeService
     static void Delete(models::Session& session, const std::string& name);
     static std::vector<WSLCVolumeInformation> List(models::Session& session);
     static wsl::windows::common::wslc_schema::InspectVolume Inspect(models::Session& session, const std::string& name);
+    static models::PruneVolumesResult Prune(models::Session& session, bool all);
 };
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -14,6 +14,7 @@ Abstract:
 #include "Argument.h"
 #include "ArgumentValidation.h"
 #include "CLIExecutionContext.h"
+#include "ImageModel.h"
 #include "VolumeModel.h"
 #include "VolumeService.h"
 #include "VolumeTasks.h"
@@ -202,5 +203,22 @@ void ListVolumes(CLIExecutionContext& context)
     default:
         THROW_HR(E_UNEXPECTED);
     }
+}
+
+void PruneVolumes(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Session));
+    auto& session = context.Data.Get<Data::Session>();
+
+    bool all = context.Args.Contains(ArgType::All);
+    auto result = VolumeService::Prune(session, all);
+
+    for (const auto& volume : result.DeletedVolumes)
+    {
+        PrintMessage(Localization::WSLCCLI_VolumePruneDeleted(volume));
+    }
+
+    PrintMessage(L"");
+    PrintMessage(Localization::WSLCCLI_VolumePruneSpaceReclaimed(static_cast<double>(result.SpaceReclaimed) / WSLC_IMAGE_1MB));
 }
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslc/tasks/VolumeTasks.h
+++ b/src/windows/wslc/tasks/VolumeTasks.h
@@ -21,4 +21,5 @@ void DeleteVolumes(wsl::windows::wslc::execution::CLIExecutionContext& context);
 void GetVolumes(wsl::windows::wslc::execution::CLIExecutionContext& context);
 void InspectVolumes(wsl::windows::wslc::execution::CLIExecutionContext& context);
 void ListVolumes(wsl::windows::wslc::execution::CLIExecutionContext& context);
+void PruneVolumes(wsl::windows::wslc::execution::CLIExecutionContext& context);
 } // namespace wsl::windows::wslc::task

--- a/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
@@ -102,10 +102,8 @@ class WSLCE2EVolumePruneTests
     {
         // Create a volume and a container using it
         RunWslc(std::format(L"volume create --name {}", TestVolumeName1)).Verify({.Stderr = L"", .ExitCode = 0});
-        RunWslc(std::format(L"container run -d --name {} -v {}:/data {} sleep infinity",
-                            TestContainerName,
-                            TestVolumeName1,
-                            DebianImage.NameAndTag()))
+        RunWslc(std::format(
+                    L"container run -d --name {} -v {}:/data {} sleep infinity", TestContainerName, TestVolumeName1, DebianImage.NameAndTag()))
             .Verify({.Stderr = L"", .ExitCode = 0});
 
         auto cleanup = wil::scope_exit([&]() {

--- a/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
@@ -1,0 +1,186 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WSLCE2EVolumePruneTests.cpp
+
+Abstract:
+
+    This file contains end-to-end tests for WSLC volume prune command.
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCExecutor.h"
+#include "WSLCE2EHelpers.h"
+
+namespace WSLCE2ETests {
+using namespace wsl::shared;
+
+class WSLCE2EVolumePruneTests
+{
+    WSLC_TEST_CLASS(WSLCE2EVolumePruneTests)
+
+    static constexpr auto TestVolumeName1 = L"prune-test-vol-1";
+    static constexpr auto TestVolumeName2 = L"prune-test-vol-2";
+    static constexpr auto TestContainerName = L"prune-vol-test-ctr";
+
+    TEST_CLASS_SETUP(ClassSetup)
+    {
+        EnsureImageIsLoaded(DebianImage);
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(ClassCleanup)
+    {
+        EnsureContainerDoesNotExist(TestContainerName);
+        EnsureVolumeDoesNotExist(TestVolumeName1);
+        EnsureVolumeDoesNotExist(TestVolumeName2);
+        return true;
+    }
+
+    TEST_METHOD_SETUP(MethodSetup)
+    {
+        EnsureContainerDoesNotExist(TestContainerName);
+        EnsureVolumeDoesNotExist(TestVolumeName1);
+        EnsureVolumeDoesNotExist(TestVolumeName2);
+        return true;
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Prune_HelpCommand)
+    {
+        const auto result = RunWslc(L"volume prune --help");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Prune_NoUnusedVolumes)
+    {
+        const auto result = RunWslc(L"volume prune");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VerifyStdoutContains(result, L"Total reclaimed space:");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Prune_AllFlag)
+    {
+        // Create a named volume, then prune with --all
+        RunWslc(std::format(L"volume create --name {}", TestVolumeName1)).Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyVolumeIsListed(TestVolumeName1);
+
+        const auto result = RunWslc(L"volume prune --all");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VerifyStdoutContains(result, L"Deleted:");
+        VerifyStdoutContains(result, L"Total reclaimed space:");
+
+        // Verify the volume was actually removed
+        VerifyVolumeIsNotListed(TestVolumeName1);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Prune_MultipleVolumes)
+    {
+        // Create two named volumes, prune with --all
+        RunWslc(std::format(L"volume create --name {}", TestVolumeName1)).Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"volume create --name {}", TestVolumeName2)).Verify({.Stderr = L"", .ExitCode = 0});
+
+        VerifyVolumeIsListed(TestVolumeName1);
+        VerifyVolumeIsListed(TestVolumeName2);
+
+        const auto result = RunWslc(L"volume prune --all");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VerifyStdoutContains(result, L"Total reclaimed space:");
+
+        // Verify both volumes were removed
+        VerifyVolumeIsNotListed(TestVolumeName1);
+        VerifyVolumeIsNotListed(TestVolumeName2);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Prune_VolumeInUseNotPruned)
+    {
+        // Create a volume and a container using it
+        RunWslc(std::format(L"volume create --name {}", TestVolumeName1)).Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"container run -d --name {} -v {}:/data {} sleep infinity",
+                            TestContainerName,
+                            TestVolumeName1,
+                            DebianImage.NameAndTag()))
+            .Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureContainerDoesNotExist(TestContainerName);
+            EnsureVolumeDoesNotExist(TestVolumeName1);
+        });
+
+        // Prune with --all should not remove the volume in use
+        const auto result = RunWslc(L"volume prune --all");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        // Volume should still exist because it is mounted by a running container
+        VerifyVolumeIsListed(TestVolumeName1);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Prune_IdempotentSecondPrune)
+    {
+        // Create a volume, prune it, then prune again
+        RunWslc(std::format(L"volume create --name {}", TestVolumeName1)).Verify({.Stderr = L"", .ExitCode = 0});
+
+        RunWslc(L"volume prune --all").Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyVolumeIsNotListed(TestVolumeName1);
+
+        // Second prune should succeed with nothing to prune
+        const auto result = RunWslc(L"volume prune --all");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VerifyStdoutContains(result, L"Total reclaimed space:");
+    }
+
+private:
+    const TestImage& DebianImage = DebianTestImage();
+
+    static void VerifyStdoutContains(const WSLCExecutionResult& result, const std::wstring& substring)
+    {
+        for (const auto& line : result.GetStdoutLines())
+        {
+            if (line.find(substring) != std::wstring::npos)
+            {
+                return;
+            }
+        }
+
+        VERIFY_FAIL(std::format(L"Expected stdout to contain '{}'", substring).c_str());
+    }
+
+    std::wstring GetHelpMessage() const
+    {
+        std::wstringstream output;
+        output << GetWslcHeader()  //
+               << GetDescription() //
+               << GetUsage()       //
+               << GetAvailableOptions();
+        return output.str();
+    }
+
+    std::wstring GetDescription() const
+    {
+        return Localization::WSLCCLI_VolumePruneLongDesc() + L"\r\n\r\n";
+    }
+
+    std::wstring GetUsage() const
+    {
+        return L"Usage: wslc volume prune [<options>]\r\n\r\n";
+    }
+
+    std::wstring GetAvailableOptions() const
+    {
+        std::wstringstream options;
+        options << L"The following options are available:\r\n"
+                << L"  -a,--all   " << Localization::WSLCCLI_VolumePruneAllArgDescription() << L"\r\n"
+                << L"  --session  " << Localization::WSLCCLI_SessionIdArgDescription() << L"\r\n"
+                << L"  -?,--help  " << Localization::WSLCCLI_HelpArgDescription() << L"\r\n"
+                << L"\r\n";
+        return options.str();
+    }
+};
+} // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EVolumeTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeTests.cpp
@@ -71,6 +71,7 @@ private:
             {L"remove", Localization::WSLCCLI_VolumeRemoveDesc()},
             {L"inspect", Localization::WSLCCLI_VolumeInspectDesc()},
             {L"list", Localization::WSLCCLI_VolumeListDesc()},
+            {L"prune", Localization::WSLCCLI_VolumePruneDesc()},
         };
 
         size_t maxLen = 0;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Added wslc volume prune command
- Volumes in use are preserved
- E2E tests covering no-op prune, --all with single/multiple volumes, in-use volume protection, and idempotent re-prune.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
