### PR TITLE
CLI: Added volumes option to container remove command

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2600,6 +2600,9 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_VolumeArgDescription" xml:space="preserve">
     <value>Bind mount a volume to the container</value>
   </data>
+  <data name="WSLCCLI_RemoveVolumesArgDescription" xml:space="preserve">
+    <value>Remove anonymous volumes associated with the container</value>
+  </data>
   <data name="WSLCCLI_WorkingDirArgDescription" xml:space="preserve">
     <value>Working directory inside the container</value>
   </data>

--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -100,6 +100,7 @@ _(Verbose,        "verbose",             NO_ALIAS,          Kind::Flag,        L
 _(Version,        "version",             L"v",              Kind::Flag,        Localization::WSLCCLI_VersionArgDescription()) \
 /*_(Virtual,        "virtualization",      NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_VirtualArgDescription())*/ \
 _(Volume,         "volume",              L"v",              Kind::Value,       Localization::WSLCCLI_VolumeArgDescription()) \
+_(Volumes,        "volumes",             L"v",              Kind::Flag,        Localization::WSLCCLI_RemoveVolumesArgDescription()) \
 _(VolumeName,     "volume-name",         NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_VolumeNameArgDescription()) \
 _(WorkDir,        "workdir",             L"w",              Kind::Value,       Localization::WSLCCLI_WorkingDirArgDescription()) \
 // clang-format on

--- a/src/windows/wslc/commands/ContainerRemoveCommand.cpp
+++ b/src/windows/wslc/commands/ContainerRemoveCommand.cpp
@@ -29,6 +29,7 @@ std::vector<Argument> ContainerRemoveCommand::GetArguments() const
     return {
         Argument::Create(ArgType::ContainerId, true, NO_LIMIT),
         Argument::Create(ArgType::Force),
+        Argument::Create(ArgType::Volumes),
         Argument::Create(ArgType::Session),
     };
 }

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -397,11 +397,23 @@ void ContainerService::Kill(Session& session, const std::string& id, WSLCSignal 
     THROW_IF_FAILED(container->Kill(signal));
 }
 
-void ContainerService::Delete(Session& session, const std::string& id, bool force)
+void ContainerService::Delete(Session& session, const std::string& id, bool force, bool removeVolumes)
 {
     wil::com_ptr<IWSLCContainer> container;
     THROW_IF_FAILED(session.Get()->OpenContainer(id.c_str(), &container));
-    THROW_IF_FAILED(container->Delete(force ? WSLCDeleteFlagsForce : WSLCDeleteFlagsNone));
+
+    WSLCDeleteFlags flags = WSLCDeleteFlagsNone;
+    if (force)
+    {
+        WI_SetFlag(flags, WSLCDeleteFlagsForce);
+    }
+
+    if (removeVolumes)
+    {
+        WI_SetFlag(flags, WSLCDeleteFlagsDeleteVolumes);
+    }
+
+    THROW_IF_FAILED(container->Delete(flags));
 }
 
 std::vector<ContainerInformation> ContainerService::List(Session& session)

--- a/src/windows/wslc/services/ContainerService.h
+++ b/src/windows/wslc/services/ContainerService.h
@@ -28,7 +28,7 @@ struct ContainerService
     static int Start(models::Session& session, const std::string& id, bool attach = false);
     static void Stop(models::Session& session, const std::string& id, models::StopContainerOptions options);
     static void Kill(models::Session& session, const std::string& id, WSLCSignal signal = WSLCSignalSIGKILL);
-    static void Delete(models::Session& session, const std::string& id, bool force);
+    static void Delete(models::Session& session, const std::string& id, bool force, bool removeVolumes = false);
     static std::vector<models::ContainerInformation> List(models::Session& session);
     static int Exec(models::Session& session, const std::string& id, models::ContainerOptions options);
     static wsl::windows::common::wslc_schema::InspectContainer Inspect(models::Session& session, const std::string& id);

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -178,9 +178,10 @@ void RemoveContainers(CLIExecutionContext& context)
     auto& session = context.Data.Get<Data::Session>();
     auto containerIds = context.Args.GetAll<ArgType::ContainerId>();
     bool force = context.Args.Contains(ArgType::Force);
+    bool removeVolumes = context.Args.Contains(ArgType::Volumes);
     for (const auto& id : containerIds)
     {
-        ContainerService::Delete(session, WideToMultiByte(id), force);
+        ContainerService::Delete(session, WideToMultiByte(id), force, removeVolumes);
     }
 }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -33,6 +33,7 @@ class WSLCE2EContainerRemoveTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcContainerName2);
+        EnsureVolumeDoesNotExist(WslcVolumeName);
         EnsureImageIsDeleted(DebianImage);
         return true;
     }
@@ -41,6 +42,7 @@ class WSLCE2EContainerRemoveTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcContainerName2);
+        EnsureVolumeDoesNotExist(WslcVolumeName);
         return true;
     }
 
@@ -156,9 +158,61 @@ class WSLCE2EContainerRemoveTests
         VerifyContainerIsNotListed(WslcContainerName2);
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Container_Remove_WithVolumes)
+    {
+        // Create a named volume and a container that uses it
+        RunWslc(std::format(L"volume create --name {}", WslcVolumeName)).Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureContainerDoesNotExist(WslcContainerName);
+            EnsureVolumeDoesNotExist(WslcVolumeName);
+        });
+
+        auto result = RunWslc(
+            std::format(L"container create --name {} -v {}:/data {}", WslcContainerName, WslcVolumeName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto containerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(containerId.empty());
+
+        VerifyContainerIsListed(containerId, L"created");
+        VerifyVolumeIsListed(WslcVolumeName);
+
+        // Remove with --volumes should remove the container and its volumes
+        result = RunWslc(std::format(L"container remove --volumes {}", containerId));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        VerifyContainerIsNotListed(containerId);
+        VerifyVolumeIsNotListed(WslcVolumeName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Remove_WithoutVolumesFlag_KeepsVolumes)
+    {
+        // Create a named volume and a container that uses it
+        RunWslc(std::format(L"volume create --name {}", WslcVolumeName)).Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureContainerDoesNotExist(WslcContainerName);
+            EnsureVolumeDoesNotExist(WslcVolumeName);
+        });
+
+        auto result = RunWslc(
+            std::format(L"container create --name {} -v {}:/data {}", WslcContainerName, WslcVolumeName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto containerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(containerId.empty());
+
+        // Remove without --volumes should keep the volume
+        result = RunWslc(std::format(L"container remove {}", containerId));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        VerifyContainerIsNotListed(containerId);
+        VerifyVolumeIsListed(WslcVolumeName);
+    }
+
 private:
     const std::wstring WslcContainerName = L"wslc-test-container";
     const std::wstring WslcContainerName2 = L"wslc-test-container-2";
+    const std::wstring WslcVolumeName = L"wslc-test-rm-volume";
     const TestImage& DebianImage = DebianTestImage();
 
     std::wstring GetHelpMessage() const
@@ -200,6 +254,7 @@ private:
         std::wstringstream options;
         options << L"The following options are available:\r\n" //
                 << L"  -f,--force      Delete containers even if they are running\r\n"
+                << L"  -v,--volumes    " << Localization::WSLCCLI_RemoveVolumesArgDescription() << L"\r\n"
                 << L"  --session       Specify the session to use\r\n"
                 << L"  -?,--help       Shows help about the selected command\r\n"
                 << L"\r\n";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Added --volumes (-v) flag to wslc container remove
- E2E tests verifying that `--volumes` removes associated volumes and that omitting it keeps them intact.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
