### PR TITLE
CLI: Add image import command

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2287,6 +2287,12 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   <data name="WSLCCLI_ImageInspectLongDesc" xml:space="preserve">
     <value>Inspect images.</value>
   </data>
+  <data name="WSLCCLI_ImageImportDesc" xml:space="preserve">
+    <value>Import an image from a tarball.</value>
+  </data>
+  <data name="WSLCCLI_ImageImportLongDesc" xml:space="preserve">
+    <value>Imports the contents of a tarball to create a filesystem image. Optionally tag the image with a repository and tag name.</value>
+  </data>
   <data name="WSLCCLI_ImageListDesc" xml:space="preserve">
     <value>List images.</value>
   </data>
@@ -2528,6 +2534,9 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_ImageIdArgDescription" xml:space="preserve">
     <value>Image name</value>
+  </data>
+  <data name="WSLCCLI_ImportFileArgDescription" xml:space="preserve">
+    <value>File or - to read from stdin</value>
   </data>
   <data name="WSLCCLI_InputArgDescription" xml:space="preserve">
     <value>Provides path to the tar archive file containing the image</value>

--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -61,6 +61,7 @@ _(Help,           "help",                WSLC_CLI_HELP_ARG, Kind::Flag,        L
 _(Hostname,       "hostname",            L"h",              Kind::Value,       Localization::WSLCCLI_HostnameArgDescription()) \
 _(ImageForce,     "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_ImageForceArgDescription()) \
 _(ImageId,        "image",               NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_ImageIdArgDescription()) \
+_(ImportFile,     "file",                NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_ImportFileArgDescription()) \
 _(Input,          "input",               L"i",              Kind::Value,       Localization::WSLCCLI_InputArgDescription()) \
 _(Interactive,    "interactive",         L"i",              Kind::Flag,        Localization::WSLCCLI_InteractiveArgDescription()) \
 _(Label,          "label",               NO_ALIAS,          Kind::Value,       L"Volume metadata setting") \

--- a/src/windows/wslc/commands/ImageCommand.cpp
+++ b/src/windows/wslc/commands/ImageCommand.cpp
@@ -27,6 +27,7 @@ std::vector<std::unique_ptr<Command>> ImageCommand::GetCommands() const
     commands.push_back(std::make_unique<ImageInspectCommand>(FullName()));
     commands.push_back(std::make_unique<ImageListCommand>(FullName()));
     commands.push_back(std::make_unique<ImageLoadCommand>(FullName()));
+    commands.push_back(std::make_unique<ImageImportCommand>(FullName()));
     commands.push_back(std::make_unique<ImagePruneCommand>(FullName()));
     commands.push_back(std::make_unique<ImagePullCommand>(FullName()));
     commands.push_back(std::make_unique<ImagePushCommand>(FullName()));

--- a/src/windows/wslc/commands/ImageCommand.h
+++ b/src/windows/wslc/commands/ImageCommand.h
@@ -91,6 +91,22 @@ protected:
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
 
+// Import Command
+struct ImageImportCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"import";
+
+    ImageImportCommand(const std::wstring& parent) : Command(CommandName, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
+
 // Remove Command
 struct ImageRemoveCommand final : public Command
 {

--- a/src/windows/wslc/commands/ImageImportCommand.cpp
+++ b/src/windows/wslc/commands/ImageImportCommand.cpp
@@ -1,0 +1,52 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ImageImportCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+
+#include "ImageCommand.h"
+#include "CLIExecutionContext.h"
+#include "ImageTasks.h"
+#include "SessionTasks.h"
+#include "Task.h"
+
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
+
+namespace wsl::windows::wslc {
+// Image Import Command
+std::vector<Argument> ImageImportCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::ImportFile, true),
+        Argument::Create(ArgType::ImageId),
+        Argument::Create(ArgType::Session),
+    };
+}
+
+std::wstring ImageImportCommand::ShortDescription() const
+{
+    return Localization::WSLCCLI_ImageImportDesc();
+}
+
+std::wstring ImageImportCommand::LongDescription() const
+{
+    return Localization::WSLCCLI_ImageImportLongDesc();
+}
+
+void ImageImportCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    context              //
+        << CreateSession //
+        << ImportImage;
+}
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -41,6 +41,7 @@ std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
     commands.push_back(std::make_unique<ContainerCreateCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerExecCommand>(FullName()));
     commands.push_back(std::make_unique<ImageListCommand>(FullName(), true));
+    commands.push_back(std::make_unique<ImageImportCommand>(FullName()));
     commands.push_back(std::make_unique<InspectCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerKillCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerListCommand>(FullName()));

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -187,6 +187,32 @@ void ImageService::Load(wsl::windows::wslc::models::Session& session, const std:
     THROW_IF_FAILED(session.Get()->LoadImage(ToCOMInputHandle(imageFile.get()), nullptr, fileSize.QuadPart));
 }
 
+void ImageService::Import(wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName)
+{
+    HANDLE imageHandle = nullptr;
+    wil::unique_hfile imageFile;
+    ULONGLONG contentLength = 0;
+
+    if (input == L"-")
+    {
+        imageHandle = GetStdHandle(STD_INPUT_HANDLE);
+    }
+    else
+    {
+        imageFile.reset(
+            CreateFileW(input.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+        THROW_LAST_ERROR_IF(!imageFile);
+
+        LARGE_INTEGER fileSize{};
+        THROW_LAST_ERROR_IF(!GetFileSizeEx(imageFile.get(), &fileSize));
+
+        imageHandle = imageFile.get();
+        contentLength = fileSize.QuadPart;
+    }
+
+    THROW_IF_FAILED(session.Get()->ImportImage(ToCOMInputHandle(imageHandle), imageName.c_str(), nullptr, contentLength));
+}
+
 void ImageService::Delete(wsl::windows::wslc::models::Session& session, const std::string& image, bool force, bool noPrune)
 {
     WSLCDeleteImageOptions options{};

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -199,8 +199,7 @@ void ImageService::Import(wsl::windows::wslc::models::Session& session, const st
     }
     else
     {
-        imageFile.reset(
-            CreateFileW(input.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+        imageFile.reset(CreateFileW(input.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
         THROW_LAST_ERROR_IF(!imageFile);
 
         LARGE_INTEGER fileSize{};

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -34,6 +34,7 @@ public:
 
     static std::vector<wsl::windows::wslc::models::ImageInformation> List(wsl::windows::wslc::models::Session& session);
     static void Load(wsl::windows::wslc::models::Session& session, const std::wstring& input);
+    static void Import(wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName);
     static void Delete(wsl::windows::wslc::models::Session& session, const std::string& image, bool force, bool noPrune);
     static wsl::windows::common::wslc_schema::InspectImage Inspect(wsl::windows::wslc::models::Session& session, const std::string& image);
     static void Pull(wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback);

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -187,6 +187,22 @@ void LoadImage(CLIExecutionContext& context)
     THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::WSLCCLI_ImageLoadNoInputError());
 }
 
+void ImportImage(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Session));
+    WI_ASSERT(context.Args.Contains(ArgType::ImportFile));
+    auto& session = context.Data.Get<Data::Session>();
+
+    std::string imageName;
+    if (context.Args.Contains(ArgType::ImageId))
+    {
+        imageName = WideToMultiByte(context.Args.Get<ArgType::ImageId>());
+    }
+
+    auto& input = context.Args.Get<ArgType::ImportFile>();
+    services::ImageService::Import(session, input, imageName);
+}
+
 void InspectImages(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Data.Contains(Data::Session));

--- a/src/windows/wslc/tasks/ImageTasks.h
+++ b/src/windows/wslc/tasks/ImageTasks.h
@@ -21,6 +21,7 @@ void BuildImage(CLIExecutionContext& context);
 void GetImages(CLIExecutionContext& context);
 void ListImages(CLIExecutionContext& context);
 void LoadImage(CLIExecutionContext& context);
+void ImportImage(CLIExecutionContext& context);
 void PullImage(CLIExecutionContext& context);
 void PushImage(CLIExecutionContext& context);
 void DeleteImage(CLIExecutionContext& context);

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -534,6 +534,7 @@ private:
             {L"create", Localization::WSLCCLI_ContainerCreateDesc()},
             {L"exec", Localization::WSLCCLI_ContainerExecDesc()},
             {L"images", Localization::WSLCCLI_ImageListDesc()},
+            {L"import", Localization::WSLCCLI_ImageImportDesc()},
             {L"inspect", Localization::WSLCCLI_InspectDesc()},
             {L"kill", Localization::WSLCCLI_ContainerKillDesc()},
             {L"list", Localization::WSLCCLI_ContainerListDesc()},

--- a/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
@@ -1,0 +1,154 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WSLCE2EImageImportTests.cpp
+
+Abstract:
+
+    This file contains end-to-end tests for WSLC image import.
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCExecutor.h"
+#include "WSLCE2EHelpers.h"
+
+namespace WSLCE2ETests {
+using namespace wsl::shared;
+
+class WSLCE2EImageImportTests
+{
+    WSLC_TEST_CLASS(WSLCE2EImageImportTests)
+
+    TEST_CLASS_CLEANUP(ClassCleanup)
+    {
+        EnsureImageIsDeleted(DebianImage);
+        EnsureImageIsDeleted(ImportedImage);
+        return true;
+    }
+
+    TEST_METHOD_SETUP(MethodSetup)
+    {
+        EnsureImageIsLoaded(DebianImage);
+        EnsureImageIsDeleted(ImportedImage);
+        SavedArchivePath = wsl::windows::common::filesystem::GetTempFilename();
+        return true;
+    }
+
+    TEST_METHOD_CLEANUP(MethodCleanup)
+    {
+        DeleteFileW(SavedArchivePath.c_str());
+        return true;
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Import_HelpCommand)
+    {
+        auto result = RunWslc(L"image import --help");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Import_MissingFile)
+    {
+        const auto result = RunWslc(L"image import");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = L"Required argument not provided: 'file'\r\n", .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Import_Success)
+    {
+        // Save image as a tarball
+        auto saveResult = RunWslc(std::format(L"image save --output \"{}\" {}", SavedArchivePath.wstring(), DebianImage.NameAndTag()));
+        saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        // Import the tarball as a new image with a tag
+        auto importResult =
+            RunWslc(std::format(L"image import \"{}\" {}", SavedArchivePath.wstring(), ImportedImage.NameAndTag()));
+        importResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        // Verify the imported image is listed
+        VerifyImageIsListed(ImportedImage.NameAndTag());
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Import_WithoutTag)
+    {
+        // Save image as a tarball
+        auto saveResult = RunWslc(std::format(L"image save --output \"{}\" {}", SavedArchivePath.wstring(), DebianImage.NameAndTag()));
+        saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        // Import without specifying an image name
+        auto importResult = RunWslc(std::format(L"image import \"{}\"", SavedArchivePath.wstring()));
+        importResult.Verify({.Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Import_InvalidPath)
+    {
+        const auto result =
+            RunWslc(std::format(L"image import \"{}\" {}", L"C:\\nonexistent\\path\\image.tar", ImportedImage.NameAndTag()));
+        result.Verify({.ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Import_FromRoot)
+    {
+        // Save image as a tarball
+        auto saveResult = RunWslc(std::format(L"image save --output \"{}\" {}", SavedArchivePath.wstring(), DebianImage.NameAndTag()));
+        saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        // Import using the root 'import' alias
+        auto importResult =
+            RunWslc(std::format(L"import \"{}\" {}", SavedArchivePath.wstring(), ImportedImage.NameAndTag()));
+        importResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        // Verify the imported image is listed
+        VerifyImageIsListed(ImportedImage.NameAndTag());
+    }
+
+private:
+    const TestImage DebianImage = DebianTestImage();
+    const TestImage ImportedImage{L"wslc-test-imported", L"latest", L""};
+
+    std::filesystem::path SavedArchivePath{};
+
+    std::wstring GetHelpMessage() const
+    {
+        std::wstringstream output;
+        output << GetWslcHeader()        //
+               << GetDescription()       //
+               << GetUsage()             //
+               << GetAvailableCommands() //
+               << GetAvailableOptions();
+        return output.str();
+    }
+
+    std::wstring GetDescription() const
+    {
+        return Localization::WSLCCLI_ImageImportLongDesc() + L"\r\n\r\n";
+    }
+
+    std::wstring GetUsage() const
+    {
+        return L"Usage: wslc image import [<options>] <file> [<image>]\r\n\r\n";
+    }
+
+    std::wstring GetAvailableCommands() const
+    {
+        std::wstringstream commands;
+        commands << L"The following arguments are available:\r\n"                                             //
+                 << L"  file       " << Localization::WSLCCLI_ImportFileArgDescription() << L"\r\n"          //
+                 << L"  image      " << Localization::WSLCCLI_ImageIdArgDescription() << L"\r\n"             //
+                 << L"\r\n";
+        return commands.str();
+    }
+
+    std::wstring GetAvailableOptions() const
+    {
+        std::wstringstream options;
+        options << L"The following options are available:\r\n"                                                 //
+                << L"  --session  " << Localization::WSLCCLI_SessionIdArgDescription() << L"\r\n"             //
+                << L"  -?,--help  " << Localization::WSLCCLI_HelpArgDescription() << L"\r\n"                  //
+                << L"\r\n";
+        return options.str();
+    }
+};
+} // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
@@ -63,8 +63,7 @@ class WSLCE2EImageImportTests
         saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Import the tarball as a new image with a tag
-        auto importResult =
-            RunWslc(std::format(L"image import \"{}\" {}", SavedArchivePath.wstring(), ImportedImage.NameAndTag()));
+        auto importResult = RunWslc(std::format(L"image import \"{}\" {}", SavedArchivePath.wstring(), ImportedImage.NameAndTag()));
         importResult.Verify({.Stderr = L"", .ExitCode = 0});
 
         // Verify the imported image is listed
@@ -96,8 +95,7 @@ class WSLCE2EImageImportTests
         saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Import using the root 'import' alias
-        auto importResult =
-            RunWslc(std::format(L"import \"{}\" {}", SavedArchivePath.wstring(), ImportedImage.NameAndTag()));
+        auto importResult = RunWslc(std::format(L"import \"{}\" {}", SavedArchivePath.wstring(), ImportedImage.NameAndTag()));
         importResult.Verify({.Stderr = L"", .ExitCode = 0});
 
         // Verify the imported image is listed
@@ -134,9 +132,9 @@ private:
     std::wstring GetAvailableCommands() const
     {
         std::wstringstream commands;
-        commands << L"The following arguments are available:\r\n"                                             //
-                 << L"  file       " << Localization::WSLCCLI_ImportFileArgDescription() << L"\r\n"          //
-                 << L"  image      " << Localization::WSLCCLI_ImageIdArgDescription() << L"\r\n"             //
+        commands << L"The following arguments are available:\r\n"                                   //
+                 << L"  file       " << Localization::WSLCCLI_ImportFileArgDescription() << L"\r\n" //
+                 << L"  image      " << Localization::WSLCCLI_ImageIdArgDescription() << L"\r\n"    //
                  << L"\r\n";
         return commands.str();
     }
@@ -144,9 +142,9 @@ private:
     std::wstring GetAvailableOptions() const
     {
         std::wstringstream options;
-        options << L"The following options are available:\r\n"                                                 //
-                << L"  --session  " << Localization::WSLCCLI_SessionIdArgDescription() << L"\r\n"             //
-                << L"  -?,--help  " << Localization::WSLCCLI_HelpArgDescription() << L"\r\n"                  //
+        options << L"The following options are available:\r\n"                                    //
+                << L"  --session  " << Localization::WSLCCLI_SessionIdArgDescription() << L"\r\n" //
+                << L"  -?,--help  " << Localization::WSLCCLI_HelpArgDescription() << L"\r\n"      //
                 << L"\r\n";
         return options.str();
     }

--- a/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageTests.cpp
@@ -72,6 +72,7 @@ private:
             {L"inspect", Localization::WSLCCLI_ImageInspectDesc()},
             {L"list", Localization::WSLCCLI_ImageListDesc()},
             {L"load", Localization::WSLCCLI_ImageLoadDesc()},
+            {L"import", Localization::WSLCCLI_ImageImportDesc()},
             {L"prune", Localization::WSLCCLI_ImagePruneDesc()},
             {L"pull", Localization::WSLCCLI_ImagePullDesc()},
             {L"push", Localization::WSLCCLI_ImagePushDesc()},


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Added wslc image import command to create an image from a tarball, with an optional image name/tag argument. Also registered as a top-level wslc import alias.
 - Supports file path or stdin (-) as input
 - E2E tests covering import with/without tag, invalid path, stdin-style usage, and the root-level import alias.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
