### PR TITLE
Add WSLCContainerNetworkTypeCustom support

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2027,7 +2027,7 @@ Usage:
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageWslcContainerNetworkNameRequired" xml:space="preserve">
-    <value>Container network name is required for custom network type</value>
+    <value>Container network name is required for custom network type.</value>
   </data>
   <data name="WSLCCLI_UnrecognizedCommandError" xml:space="preserve">
     <value>Unrecognized command: '{}'</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2026,6 +2026,9 @@ Usage:
     <value>Container '{}' not found.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcContainerNetworkNameRequired" xml:space="preserve">
+    <value>Container network name is required for custom network type</value>
+  </data>
   <data name="WSLCCLI_UnrecognizedCommandError" xml:space="preserve">
     <value>Unrecognized command: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/common/WSLCContainerLauncher.cpp
+++ b/src/windows/common/WSLCContainerLauncher.cpp
@@ -139,6 +139,11 @@ void WSLCContainerLauncher::SetContainerFlags(WSLCContainerFlags Flags)
     m_containerFlags = Flags;
 }
 
+void WSLCContainerLauncher::SetContainerNetworkName(std::string&& name)
+{
+    m_containerNetworkName = std::move(name);
+}
+
 void WSLCContainerLauncher::SetHostname(std::string&& Hostname)
 {
     m_hostname = std::move(Hostname);
@@ -250,6 +255,7 @@ std::pair<HRESULT, std::optional<RunningWSLCContainer>> WSLCContainerLauncher::C
     auto [processOptions, commandLinePtrs, environmentPtrs] = CreateProcessOptions();
     options.InitProcessOptions = processOptions;
     options.ContainerNetwork.ContainerNetworkType = m_containerNetworkType;
+    options.ContainerNetwork.ContainerNetworkName = m_containerNetworkName.empty() ? nullptr : m_containerNetworkName.c_str();
     options.Ports = m_ports.data();
     options.PortsCount = static_cast<ULONG>(m_ports.size());
     options.StopSignal = m_stopSignal;

--- a/src/windows/common/WSLCContainerLauncher.cpp
+++ b/src/windows/common/WSLCContainerLauncher.cpp
@@ -139,9 +139,9 @@ void WSLCContainerLauncher::SetContainerFlags(WSLCContainerFlags Flags)
     m_containerFlags = Flags;
 }
 
-void WSLCContainerLauncher::SetContainerNetworkName(std::string&& name)
+void WSLCContainerLauncher::SetContainerNetworkName(std::string&& Name)
 {
-    m_containerNetworkName = std::move(name);
+    m_containerNetworkName = std::move(Name);
 }
 
 void WSLCContainerLauncher::SetHostname(std::string&& Hostname)

--- a/src/windows/common/WSLCContainerLauncher.h
+++ b/src/windows/common/WSLCContainerLauncher.h
@@ -73,6 +73,7 @@ public:
     void SetEntrypoint(std::vector<std::string>&& entrypoint);
     void SetDefaultStopSignal(WSLCSignal Signal);
     void SetContainerFlags(WSLCContainerFlags Flags);
+    void SetContainerNetworkName(std::string&& name);
     void SetHostname(std::string&& Hostname);
     void SetDomainname(std::string&& Domainame);
     void SetDnsServers(std::vector<std::string>&& DnsServers);
@@ -93,6 +94,7 @@ private:
     std::deque<std::string> m_volumeNames;
     std::deque<std::string> m_containerPaths;
     WSLCContainerNetworkType m_containerNetworkType;
+    std::string m_containerNetworkName;
     std::vector<std::string> m_entrypoint;
     WSLCSignal m_stopSignal = WSLCSignalNone;
     WSLCContainerFlags m_containerFlags = WSLCContainerFlagsNone;

--- a/src/windows/common/WSLCContainerLauncher.h
+++ b/src/windows/common/WSLCContainerLauncher.h
@@ -73,7 +73,7 @@ public:
     void SetEntrypoint(std::vector<std::string>&& entrypoint);
     void SetDefaultStopSignal(WSLCSignal Signal);
     void SetContainerFlags(WSLCContainerFlags Flags);
-    void SetContainerNetworkName(std::string&& name);
+    void SetContainerNetworkName(std::string&& Name);
     void SetHostname(std::string&& Hostname);
     void SetDomainname(std::string&& Domainame);
     void SetDnsServers(std::vector<std::string>&& DnsServers);

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -231,7 +231,7 @@ typedef enum _WSLCContainerNetworkType
     WSLCContainerNetworkTypeNone = 0,
     WSLCContainerNetworkTypeHost = 1,
     WSLCContainerNetworkTypeBridged = 2,
-    // WSLCContainerNetworkTypeCustom = 3 // TODO: Implement when implementing custom networks
+    WSLCContainerNetworkTypeCustom = 3
 } WSLCContainerNetworkType;
 
 typedef struct _WSLCContainerNetwork

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -147,7 +147,7 @@ uint16_t AllocateEphemeralPort(int family, const char* address)
 
 // Builds port mapping list from container options and returns the network mode string.
 std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
-    std::vector<_WSLCPortMapping>& requestedPorts, WSLCContainerNetworkType networkType, WSLCVirtualMachine& virtualMachine)
+    std::vector<_WSLCPortMapping>& requestedPorts, WSLCContainerNetworkType networkType, WSLCVirtualMachine& virtualMachine, WSLCSession& session, LPCSTR containerNetworkName)
 {
     // Determine network mode string.
     std::string networkMode;
@@ -162,6 +162,16 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
     else if (networkType == WSLCContainerNetworkTypeNone)
     {
         networkMode = "none";
+    }
+    else if (networkType == WSLCContainerNetworkTypeCustom)
+    {
+        THROW_HR_WITH_USER_ERROR_IF(
+            E_INVALIDARG, Localization::MessageWslcContainerNetworkNameRequired(), !containerNetworkName || strlen(containerNetworkName) == 0);
+
+        THROW_HR_WITH_USER_ERROR_IF(
+            WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(containerNetworkName), !session.HasNetwork(containerNetworkName));
+
+        networkMode = containerNetworkName;
     }
     else
     {
@@ -186,8 +196,8 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
 
         auto& entry = ports.emplace_back(VMPortMapping::FromWSLCPortMapping(e), e.ContainerPort);
 
-        // Only allocate port for bridged network. Host mode ports are allocated when the container starts.
-        if (networkType == WSLCContainerNetworkTypeBridged)
+        // Allocate VM ports for bridged and custom networks. Host mode ports are allocated when the container starts.
+        if (networkType == WSLCContainerNetworkTypeBridged || networkType == WSLCContainerNetworkTypeCustom)
         {
             entry.VmMapping.AssignVmPort(virtualMachine.AllocatePort(e.Family, e.Protocol));
         }
@@ -269,7 +279,8 @@ WSLCContainerNetworkType DockerNetworkModeToWSLCNetworkType(const std::string& m
         return WSLCContainerNetworkTypeNone;
     }
 
-    THROW_HR_MSG(E_INVALIDARG, "Invalid networking mode: %hs", mode.c_str());
+    // Any unrecognized mode is a custom user-defined network.
+    return WSLCContainerNetworkTypeCustom;
 }
 
 std::uint64_t ParseDockerTimestamp(const std::string& timestamp)
@@ -1362,7 +1373,12 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
     }
 
     // Process port mappings from container options.
-    auto [mappedPorts, networkMode] = ProcessPortMappings(ports, containerOptions.ContainerNetwork.ContainerNetworkType, virtualMachine);
+    auto [mappedPorts, networkMode] = ProcessPortMappings(
+        ports,
+        containerOptions.ContainerNetwork.ContainerNetworkType,
+        virtualMachine,
+        wslcSession,
+        containerOptions.ContainerNetwork.ContainerNetworkName);
 
     request.HostConfig.NetworkMode = networkMode;
 
@@ -1470,7 +1486,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
     {
         auto& inserted = ports.emplace_back(ContainerPortMapping{VMPortMapping::FromContainerMetaData(e), e.ContainerPort});
 
-        if (networkingMode == WSLCContainerNetworkTypeBridged)
+        if (networkingMode == WSLCContainerNetworkTypeBridged || networkingMode == WSLCContainerNetworkTypeCustom)
         {
             auto allocation = virtualMachine.TryAllocatePort(e.VmPort, e.Family, e.Protocol);
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -279,7 +279,10 @@ WSLCContainerNetworkType DockerNetworkModeToWSLCNetworkType(const std::string& m
         return WSLCContainerNetworkTypeNone;
     }
 
-    // Any unrecognized mode is a custom user-defined network.
+    // Reject Docker special syntaxes (container:<id>, service:<name>, etc.);
+    // any plain name is treated as a user-defined custom network.
+    THROW_HR_IF_MSG(E_INVALIDARG, mode.empty() || mode.find(':') != std::string::npos, "Unsupported Docker network mode: %hs", mode.c_str());
+
     return WSLCContainerNetworkTypeCustom;
 }
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -32,6 +32,7 @@ using wsl::windows::common::relay::ReadHandle;
 using wsl::windows::common::relay::RelayHandle;
 using wsl::windows::service::wslc::ContainerPortMapping;
 using wsl::windows::service::wslc::IWSLCVolume;
+using wsl::windows::service::wslc::NetworkEntry;
 using wsl::windows::service::wslc::RelayedProcessIO;
 using wsl::windows::service::wslc::TypedHandle;
 using wsl::windows::service::wslc::unique_com_disconnect;
@@ -147,8 +148,17 @@ uint16_t AllocateEphemeralPort(int family, const char* address)
 
 // Builds port mapping list from container options and returns the network mode string.
 std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
-    std::vector<_WSLCPortMapping>& requestedPorts, WSLCContainerNetworkType networkType, WSLCVirtualMachine& virtualMachine, WSLCSession& session, LPCSTR containerNetworkName)
+    std::vector<_WSLCPortMapping>& requestedPorts,
+    WSLCContainerNetworkType networkType,
+    WSLCVirtualMachine& virtualMachine,
+    const std::unordered_map<std::string, NetworkEntry>& sessionNetworks,
+    LPCSTR containerNetworkName)
 {
+    THROW_HR_IF_MSG(
+        E_INVALIDARG,
+        containerNetworkName != nullptr && networkType != WSLCContainerNetworkTypeCustom,
+        "ContainerNetworkName must be null when network type is not Custom");
+
     // Determine network mode string.
     std::string networkMode;
     if (networkType == WSLCContainerNetworkTypeBridged)
@@ -169,7 +179,7 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
             E_INVALIDARG, Localization::MessageWslcContainerNetworkNameRequired(), !containerNetworkName || strlen(containerNetworkName) == 0);
 
         THROW_HR_WITH_USER_ERROR_IF(
-            WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(containerNetworkName), !session.HasNetwork(containerNetworkName));
+            WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(containerNetworkName), !sessionNetworks.contains(containerNetworkName));
 
         networkMode = containerNetworkName;
     }
@@ -1156,6 +1166,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
     WSLCSession& wslcSession,
     WSLCVirtualMachine& virtualMachine,
     const std::unordered_map<std::string, std::unique_ptr<IWSLCVolume>>& sessionVolumes,
+    const std::unordered_map<std::string, NetworkEntry>& sessionNetworks,
     std::function<void(const WSLCContainerImpl*)>&& OnDeleted,
     ContainerEventTracker& EventTracker,
     DockerHTTPClient& DockerClient,
@@ -1380,7 +1391,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         ports,
         containerOptions.ContainerNetwork.ContainerNetworkType,
         virtualMachine,
-        wslcSession,
+        sessionNetworks,
         containerOptions.ContainerNetwork.ContainerNetworkName);
 
     request.HostConfig.NetworkMode = networkMode;

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -289,9 +289,15 @@ WSLCContainerNetworkType DockerNetworkModeToWSLCNetworkType(const std::string& m
         return WSLCContainerNetworkTypeNone;
     }
 
+    // Docker treats empty NetworkMode as the default (bridged).
+    if (mode.empty())
+    {
+        return WSLCContainerNetworkTypeBridged;
+    }
+
     // Reject Docker special syntaxes (container:<id>, service:<name>, etc.);
     // any plain name is treated as a user-defined custom network.
-    THROW_HR_IF_MSG(E_INVALIDARG, mode.empty() || mode.find(':') != std::string::npos, "Unsupported Docker network mode: %hs", mode.c_str());
+    THROW_HR_IF_MSG(E_INVALIDARG, mode.find(':') != std::string::npos, "Unsupported Docker network mode: %hs", mode.c_str());
 
     return WSLCContainerNetworkTypeCustom;
 }

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -23,6 +23,7 @@ Abstract:
 #include "COMImplClass.h"
 #include "wslc_schema.h"
 #include "WSLCContainerMetadata.h"
+#include "WSLCNetworkMetadata.h"
 #include "WSLCVhdVolume.h"
 #include <unordered_map>
 
@@ -127,6 +128,7 @@ public:
         WSLCSession& wslcSession,
         WSLCVirtualMachine& virtualMachine,
         const std::unordered_map<std::string, std::unique_ptr<IWSLCVolume>>& SessionVolumes,
+        const std::unordered_map<std::string, NetworkEntry>& SessionNetworks,
         std::function<void(const WSLCContainerImpl*)>&& OnDeleted,
         ContainerEventTracker& EventTracker,
         DockerHTTPClient& DockerClient,

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2201,8 +2201,9 @@ try
     }
     catch (const DockerHTTPException& e)
     {
+        // Docker returns 403 when the network has active endpoints.
         THROW_HR_WITH_USER_ERROR_IF(
-            HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION), Localization::MessageWslcNetworkInUse(name), e.StatusCode() == 409);
+            HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION), Localization::MessageWslcNetworkInUse(name), e.StatusCode() == 403);
         THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), e.StatusCode() == 404);
         THROW_DOCKER_USER_ERROR_MSG(e, "Failed to delete network '%hs'", name.c_str());
     }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2301,6 +2301,7 @@ CATCH_RETURN();
 
 bool WSLCSession::HasNetwork(const std::string& Name)
 {
+    ValidateName(Name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
     std::lock_guard networksLock(m_networksLock);
     return m_networks.contains(Name);
 }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1605,13 +1605,14 @@ try
 
     try
     {
-        std::scoped_lock lock(m_containersLock, m_volumesLock);
+        std::scoped_lock lock(m_containersLock, m_volumesLock, m_networksLock);
 
         auto& it = m_containers.emplace_back(WSLCContainerImpl::Create(
             *containerOptions,
             *this,
             m_virtualMachine.value(),
             m_volumes,
+            m_networks,
             std::bind(&WSLCSession::OnContainerDeleted, this, std::placeholders::_1),
             m_eventTracker.value(),
             m_dockerClient.value(),
@@ -2298,13 +2299,6 @@ try
     return S_OK;
 }
 CATCH_RETURN();
-
-bool WSLCSession::HasNetwork(const std::string& Name)
-{
-    ValidateName(Name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
-    std::lock_guard networksLock(m_networksLock);
-    return m_networks.contains(Name);
-}
 
 HRESULT WSLCSession::Terminate()
 try

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2299,6 +2299,12 @@ try
 }
 CATCH_RETURN();
 
+bool WSLCSession::HasNetwork(const std::string& Name)
+{
+    std::lock_guard networksLock(m_networksLock);
+    return m_networks.contains(Name);
+}
+
 HRESULT WSLCSession::Terminate()
 try
 {

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -137,6 +137,7 @@ public:
     IFACEMETHOD(ListNetworks)(_Out_ WSLCNetworkInformation** Networks, _Out_ ULONG* Count) override;
     IFACEMETHOD(InspectNetwork)(_In_ LPCSTR Name, _Out_ LPSTR* Output) override;
 
+    // N.B. Caller must hold m_lock (shared) before calling this method.
     bool HasNetwork(const std::string& Name);
 
     IFACEMETHOD(Terminate()) override;

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -137,6 +137,8 @@ public:
     IFACEMETHOD(ListNetworks)(_Out_ WSLCNetworkInformation** Networks, _Out_ ULONG* Count) override;
     IFACEMETHOD(InspectNetwork)(_In_ LPCSTR Name, _Out_ LPSTR* Output) override;
 
+    bool HasNetwork(const std::string& Name);
+
     IFACEMETHOD(Terminate()) override;
 
     // ISupportErrorInfo

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -138,7 +138,7 @@ public:
     IFACEMETHOD(InspectNetwork)(_In_ LPCSTR Name, _Out_ LPSTR* Output) override;
 
     // N.B. Caller must hold m_lock (shared) before calling this method.
-    bool HasNetwork(const std::string& Name);
+    __requires_lock_held(m_lock) bool HasNetwork(const std::string& Name);
 
     IFACEMETHOD(Terminate()) override;
 

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -137,9 +137,6 @@ public:
     IFACEMETHOD(ListNetworks)(_Out_ WSLCNetworkInformation** Networks, _Out_ ULONG* Count) override;
     IFACEMETHOD(InspectNetwork)(_In_ LPCSTR Name, _Out_ LPSTR* Output) override;
 
-    // N.B. Caller must hold m_lock (shared) before calling this method.
-    __requires_lock_held(m_lock) bool HasNetwork(const std::string& Name);
-
     IFACEMETHOD(Terminate()) override;
 
     // ISupportErrorInfo

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5356,7 +5356,7 @@ class WSLCTests
 
         LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
 
-        WSLCDriverOption opts[] = {{"Subnet", "172.30.0.0/16"}};
+        WSLCDriverOption opts[] = {{"Subnet", "172.35.0.0/16"}};
 
         WSLCNetworkOptions networkOptions{};
         networkOptions.Name = networkName.c_str();
@@ -5399,6 +5399,171 @@ class WSLCTests
         auto retVal = launcher.LaunchNoThrow(*m_defaultSession);
         VERIFY_ARE_EQUAL(E_INVALIDARG, retVal.first);
         ValidateCOMErrorMessageContains(L"Container network name is required");
+    }
+
+    WSLC_TEST_METHOD(ContainerCustomNetworkEmptyNameTest)
+    {
+        WSLCContainerLauncher launcher(
+            "debian:latest", "test-custom-network-empty", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher.SetContainerNetworkName(std::string(""));
+
+        auto retVal = launcher.LaunchNoThrow(*m_defaultSession);
+        VERIFY_ARE_EQUAL(E_INVALIDARG, retVal.first);
+        ValidateCOMErrorMessageContains(L"Container network name is required");
+    }
+
+    WSLC_TEST_METHOD(ContainerCustomNetworkMultipleContainersTest)
+    {
+        const std::string networkName = "custom-net-multi";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        WSLCDriverOption opts[] = {{"Subnet", "172.36.0.0/16"}};
+
+        WSLCNetworkOptions networkOptions{};
+        networkOptions.Name = networkName.c_str();
+        networkOptions.Driver = "bridge";
+        networkOptions.DriverOpts = opts;
+        networkOptions.DriverOptsCount = ARRAYSIZE(opts);
+
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&networkOptions));
+
+        auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        WSLCContainerLauncher launcher1(
+            "debian:latest", "test-custom-multi-1", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher1.SetContainerNetworkName(std::string(networkName));
+
+        WSLCContainerLauncher launcher2(
+            "debian:latest", "test-custom-multi-2", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher2.SetContainerNetworkName(std::string(networkName));
+
+        auto container1 = launcher1.Launch(*m_defaultSession);
+        VERIFY_ARE_EQUAL(container1.State(), WslcContainerStateRunning);
+        VERIFY_ARE_EQUAL(container1.Inspect().HostConfig.NetworkMode, networkName);
+
+        auto container2 = launcher2.Launch(*m_defaultSession);
+        VERIFY_ARE_EQUAL(container2.State(), WslcContainerStateRunning);
+        VERIFY_ARE_EQUAL(container2.Inspect().HostConfig.NetworkMode, networkName);
+
+        VERIFY_SUCCEEDED(container1.Get().Stop(WSLCSignalSIGTERM, 0));
+        VERIFY_SUCCEEDED(container1.Get().Delete(WSLCDeleteFlagsNone));
+        VERIFY_SUCCEEDED(container2.Get().Stop(WSLCSignalSIGTERM, 0));
+        VERIFY_SUCCEEDED(container2.Get().Delete(WSLCDeleteFlagsNone));
+    }
+
+    WSLC_TEST_METHOD(ContainerCustomNetworkDeleteWhileInUseTest)
+    {
+        const std::string networkName = "custom-net-inuse";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        WSLCDriverOption opts[] = {{"Subnet", "172.37.0.0/16"}};
+
+        WSLCNetworkOptions networkOptions{};
+        networkOptions.Name = networkName.c_str();
+        networkOptions.Driver = "bridge";
+        networkOptions.DriverOpts = opts;
+        networkOptions.DriverOptsCount = ARRAYSIZE(opts);
+
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&networkOptions));
+
+        auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        WSLCContainerLauncher launcher(
+            "debian:latest", "test-custom-net-inuse", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher.SetContainerNetworkName(std::string(networkName));
+
+        auto container = launcher.Launch(*m_defaultSession);
+        VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+
+        VERIFY_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGTERM, 0));
+        VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
+    }
+
+    WSLC_TEST_METHOD(ContainerCustomNetworkPortMappingTest)
+    {
+        const std::string networkName = "custom-net-ports";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        WSLCDriverOption opts[] = {{"Subnet", "172.38.0.0/16"}};
+
+        WSLCNetworkOptions networkOptions{};
+        networkOptions.Name = networkName.c_str();
+        networkOptions.Driver = "bridge";
+        networkOptions.DriverOpts = opts;
+        networkOptions.DriverOptsCount = ARRAYSIZE(opts);
+
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&networkOptions));
+
+        auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        WSLCContainerLauncher launcher(
+            "python:3.12-alpine", "test-custom-net-ports", {"python3", "-m", "http.server"}, {"PYTHONUNBUFFERED=1"}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher.SetContainerNetworkName(std::string(networkName));
+        launcher.AddPort(1251, 8000, AF_INET);
+
+        auto container = launcher.Launch(*m_defaultSession);
+        auto initProcess = container.GetInitProcess();
+        WaitForOutput(initProcess.GetStdHandle(1), "Serving HTTP on");
+
+        ExpectHttpResponse(L"http://127.0.0.1:1251", 200);
+
+        VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
+        VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
+    }
+
+    WSLC_TEST_METHOD(ContainerCustomNetworkRecoveryTest)
+    {
+        auto restore = ResetTestSession();
+
+        const std::string networkName = "custom-net-recovery";
+        const std::string containerName = "test-custom-net-recovery";
+
+        {
+            auto session = CreateSession(GetDefaultSessionSettings(L"recovery-test-custom-net", true, WSLCNetworkingModeNAT));
+
+            LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str()));
+
+            WSLCDriverOption opts[] = {{"Subnet", "172.39.0.0/16"}};
+
+            WSLCNetworkOptions networkOptions{};
+            networkOptions.Name = networkName.c_str();
+            networkOptions.Driver = "bridge";
+            networkOptions.DriverOpts = opts;
+            networkOptions.DriverOptsCount = ARRAYSIZE(opts);
+
+            VERIFY_SUCCEEDED(session->CreateNetwork(&networkOptions));
+
+            WSLCContainerLauncher launcher(
+                "debian:latest", containerName, {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+            launcher.SetContainerNetworkName(std::string(networkName));
+
+            auto container = launcher.Create(*session);
+            container.SetDeleteOnClose(false);
+
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
+        }
+
+        {
+            auto session = CreateSession(GetDefaultSessionSettings(L"recovery-test-custom-net", true, WSLCNetworkingModeNAT));
+            auto container = OpenContainer(session.get(), containerName);
+            container.SetDeleteOnClose(false);
+
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
+            VERIFY_SUCCEEDED(container.Get().Start(WSLCContainerStartFlagsAttach, nullptr));
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+
+            VERIFY_ARE_EQUAL(container.Inspect().HostConfig.NetworkMode, networkName);
+
+            VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
+
+            LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str()));
+        }
     }
 
     WSLC_TEST_METHOD(ContainerInspect)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5350,6 +5350,57 @@ class WSLCTests
         }
     }
 
+    WSLC_TEST_METHOD(ContainerCustomNetworkTest)
+    {
+        const std::string networkName = "custom-net-test";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        WSLCDriverOption opts[] = {{"Subnet", "172.30.0.0/16"}};
+
+        WSLCNetworkOptions networkOptions{};
+        networkOptions.Name = networkName.c_str();
+        networkOptions.Driver = "bridge";
+        networkOptions.DriverOpts = opts;
+        networkOptions.DriverOptsCount = ARRAYSIZE(opts);
+
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&networkOptions));
+
+        auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        WSLCContainerLauncher launcher(
+            "debian:latest", "test-custom-network", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher.SetContainerNetworkName(std::string(networkName));
+
+        auto container = launcher.Launch(*m_defaultSession);
+        VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+        VERIFY_ARE_EQUAL(container.Inspect().HostConfig.NetworkMode, networkName);
+        VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGTERM, 0));
+        VERIFY_ARE_EQUAL(container.State(), WslcContainerStateExited);
+        VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
+    }
+
+    WSLC_TEST_METHOD(ContainerCustomNetworkNotFoundTest)
+    {
+        WSLCContainerLauncher launcher(
+            "debian:latest", "test-custom-network-notfound", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher.SetContainerNetworkName(std::string("nonexistent-net"));
+
+        auto retVal = launcher.LaunchNoThrow(*m_defaultSession);
+        VERIFY_ARE_EQUAL(WSLC_E_NETWORK_NOT_FOUND, retVal.first);
+        ValidateCOMErrorMessageContains(L"nonexistent-net");
+    }
+
+    WSLC_TEST_METHOD(ContainerCustomNetworkMissingNameTest)
+    {
+        WSLCContainerLauncher launcher(
+            "debian:latest", "test-custom-network-noname", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+
+        auto retVal = launcher.LaunchNoThrow(*m_defaultSession);
+        VERIFY_ARE_EQUAL(E_INVALIDARG, retVal.first);
+        ValidateCOMErrorMessageContains(L"Container network name is required");
+    }
+
     WSLC_TEST_METHOD(ContainerInspect)
     {
         // Helper to verify port mappings.

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5478,7 +5478,7 @@ class WSLCTests
         auto container = launcher.Launch(*m_defaultSession);
         VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
 
-        VERIFY_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+        VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION), m_defaultSession->DeleteNetwork(networkName.c_str()));
     }
 
     WSLC_TEST_METHOD(ContainerCustomNetworkPortMappingTest)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5375,9 +5375,6 @@ class WSLCTests
         auto container = launcher.Launch(*m_defaultSession);
         VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
         VERIFY_ARE_EQUAL(container.Inspect().HostConfig.NetworkMode, networkName);
-        VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGTERM, 0));
-        VERIFY_ARE_EQUAL(container.State(), WslcContainerStateExited);
-        VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
     }
 
     WSLC_TEST_METHOD(ContainerCustomNetworkNotFoundTest)
@@ -5513,56 +5510,41 @@ class WSLCTests
 
     WSLC_TEST_METHOD(ContainerCustomNetworkRecoveryTest)
     {
-        auto restore = ResetTestSession();
-
         const std::string networkName = "custom-net-recovery";
         const std::string containerName = "test-custom-net-recovery";
 
-        {
-            auto session = CreateSession(GetDefaultSessionSettings(L"recovery-test-custom-net", true, WSLCNetworkingModeNAT));
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
 
-            LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str()));
+        WSLCDriverOption opts[] = {{"Subnet", "172.39.0.0/16"}};
 
-            WSLCDriverOption opts[] = {{"Subnet", "172.39.0.0/16"}};
+        WSLCNetworkOptions networkOptions{};
+        networkOptions.Name = networkName.c_str();
+        networkOptions.Driver = "bridge";
+        networkOptions.DriverOpts = opts;
+        networkOptions.DriverOptsCount = ARRAYSIZE(opts);
 
-            WSLCNetworkOptions networkOptions{};
-            networkOptions.Name = networkName.c_str();
-            networkOptions.Driver = "bridge";
-            networkOptions.DriverOpts = opts;
-            networkOptions.DriverOptsCount = ARRAYSIZE(opts);
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&networkOptions));
 
-            VERIFY_SUCCEEDED(session->CreateNetwork(&networkOptions));
+        auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
 
-            auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str())); });
+        WSLCContainerLauncher launcher("debian:latest", containerName, {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
+        launcher.SetContainerNetworkName(std::string(networkName));
 
-            WSLCContainerLauncher launcher(
-                "debian:latest", containerName, {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
-            launcher.SetContainerNetworkName(std::string(networkName));
+        auto container = launcher.Create(*m_defaultSession);
+        container.SetDeleteOnClose(false);
 
-            auto container = launcher.Create(*session);
-            container.SetDeleteOnClose(false);
+        VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
 
-            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
+        // Restart the session and verify the container is recovered with its custom network.
+        ResetTestSession();
 
-            networkCleanup.release();
-        }
+        auto recoveredContainer = OpenContainer(m_defaultSession.get(), containerName);
 
-        {
-            auto session = CreateSession(GetDefaultSessionSettings(L"recovery-test-custom-net", true, WSLCNetworkingModeNAT));
-            auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str())); });
+        VERIFY_ARE_EQUAL(recoveredContainer.State(), WslcContainerStateCreated);
+        VERIFY_SUCCEEDED(recoveredContainer.Get().Start(WSLCContainerStartFlagsAttach, nullptr));
+        VERIFY_ARE_EQUAL(recoveredContainer.State(), WslcContainerStateRunning);
 
-            auto container = OpenContainer(session.get(), containerName);
-            container.SetDeleteOnClose(false);
-
-            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
-            VERIFY_SUCCEEDED(container.Get().Start(WSLCContainerStartFlagsAttach, nullptr));
-            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
-
-            VERIFY_ARE_EQUAL(container.Inspect().HostConfig.NetworkMode, networkName);
-
-            VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
-            VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
-        }
+        VERIFY_ARE_EQUAL(recoveredContainer.Inspect().HostConfig.NetworkMode, networkName);
     }
 
     WSLC_TEST_METHOD(ContainerInspect)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5530,10 +5530,12 @@ class WSLCTests
         WSLCContainerLauncher launcher("debian:latest", containerName, {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
         launcher.SetContainerNetworkName(std::string(networkName));
 
-        auto container = launcher.Create(*m_defaultSession);
-        container.SetDeleteOnClose(false);
+        {
+            auto container = launcher.Create(*m_defaultSession);
+            container.SetDeleteOnClose(false);
 
-        VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
+        }
 
         // Restart the session and verify the container is recovered with its custom network.
         ResetTestSession();

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5403,12 +5403,18 @@ class WSLCTests
 
     WSLC_TEST_METHOD(ContainerCustomNetworkEmptyNameTest)
     {
-        WSLCContainerLauncher launcher(
-            "debian:latest", "test-custom-network-empty", {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
-        launcher.SetContainerNetworkName(std::string(""));
+        LPCSTR args[] = {"sleep", "99999"};
 
-        auto retVal = launcher.LaunchNoThrow(*m_defaultSession);
-        VERIFY_ARE_EQUAL(E_INVALIDARG, retVal.first);
+        WSLCContainerOptions options{};
+        options.Image = "debian:latest";
+        options.Name = "test-custom-network-empty";
+        options.InitProcessOptions.CommandLine = {.Values = args, .Count = ARRAYSIZE(args)};
+        options.ContainerNetwork.ContainerNetworkType = WSLCContainerNetworkTypeCustom;
+        options.ContainerNetwork.ContainerNetworkName = "";
+
+        wil::com_ptr<IWSLCContainer> container;
+        auto hr = m_defaultSession->CreateContainer(&options, &container);
+        VERIFY_ARE_EQUAL(E_INVALIDARG, hr);
         ValidateCOMErrorMessageContains(L"Container network name is required");
     }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5451,11 +5451,6 @@ class WSLCTests
         auto container2 = launcher2.Launch(*m_defaultSession);
         VERIFY_ARE_EQUAL(container2.State(), WslcContainerStateRunning);
         VERIFY_ARE_EQUAL(container2.Inspect().HostConfig.NetworkMode, networkName);
-
-        VERIFY_SUCCEEDED(container1.Get().Stop(WSLCSignalSIGTERM, 0));
-        VERIFY_SUCCEEDED(container1.Get().Delete(WSLCDeleteFlagsNone));
-        VERIFY_SUCCEEDED(container2.Get().Stop(WSLCSignalSIGTERM, 0));
-        VERIFY_SUCCEEDED(container2.Get().Delete(WSLCDeleteFlagsNone));
     }
 
     WSLC_TEST_METHOD(ContainerCustomNetworkDeleteWhileInUseTest)
@@ -5484,9 +5479,6 @@ class WSLCTests
         VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
 
         VERIFY_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
-
-        VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGTERM, 0));
-        VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
     }
 
     WSLC_TEST_METHOD(ContainerCustomNetworkPortMappingTest)
@@ -5517,9 +5509,6 @@ class WSLCTests
         WaitForOutput(initProcess.GetStdHandle(1), "Serving HTTP on");
 
         ExpectHttpResponse(L"http://127.0.0.1:1251", 200);
-
-        VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
-        VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
     }
 
     WSLC_TEST_METHOD(ContainerCustomNetworkRecoveryTest)
@@ -5544,6 +5533,8 @@ class WSLCTests
 
             VERIFY_SUCCEEDED(session->CreateNetwork(&networkOptions));
 
+            auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str())); });
+
             WSLCContainerLauncher launcher(
                 "debian:latest", containerName, {"sleep", "99999"}, {}, WSLCContainerNetworkType::WSLCContainerNetworkTypeCustom);
             launcher.SetContainerNetworkName(std::string(networkName));
@@ -5552,10 +5543,14 @@ class WSLCTests
             container.SetDeleteOnClose(false);
 
             VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
+
+            networkCleanup.release();
         }
 
         {
             auto session = CreateSession(GetDefaultSessionSettings(L"recovery-test-custom-net", true, WSLCNetworkingModeNAT));
+            auto networkCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str())); });
+
             auto container = OpenContainer(session.get(), containerName);
             container.SetDeleteOnClose(false);
 
@@ -5567,8 +5562,6 @@ class WSLCTests
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
             VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
-
-            LOG_IF_FAILED(session->DeleteNetwork(networkName.c_str()));
         }
     }
 


### PR DESCRIPTION


<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add support for WSLCContainerNetworkTypeCustom, allowing containers to attach to user-created WSLC networks.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Uncommented WSLCContainerNetworkTypeCustom = 3 in wslc.idl
- Extended ProcessPortMappings with a Custom branch that validates the network name, checks existence against the session networks map, and sets the network mode to the custom name. Custom networks allocate VM ports like bridged
- DockerNetworkModeToWSLCNetworkType now returns Custom for unrecognized modes instead of throwing, so container recovery works for custom networks
- Recovery port loop extended to allocate ports for Custom alongside Bridged

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
