### PR TITLE
CLI: Unit test to ensure no argument name or alias collisions exist

### DIFF
--- a/test/windows/wslc/WSLCCLICommandUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLICommandUnitTests.cpp
@@ -170,45 +170,87 @@ class WSLCCLICommandUnitTests
         VERIFY_IS_TRUE(found, L"RootCommand should contain VersionCommand");
     }
 
-    // Walk every command in the root tree and verify no name or alias argument collisions.
+    // Walk every command in the root tree and verify no argument collisions.
     TEST_METHOD(AllCommands_NoAmbiguousArgumentNamesOrAliases)
     {
-        // Starting with the Root command, verify no argument collisions.
-        std::vector<std::unique_ptr<Command>> queue;
-        queue.push_back(std::make_unique<RootCommand>());
+        // Build a lookup table from ArgType -> enum name string using the same X-macro.
+        static constexpr const wchar_t* c_argTypeNames[] = {
+#define WSLC_ARG_ENUM(EnumName, Name, Alias, Kind, Desc) L## #EnumName,
+            WSLC_ARGUMENTS(WSLC_ARG_ENUM)
+#undef WSLC_ARG_ENUM
+        };
 
-        while (!queue.empty())
+        const auto ArgTypeName = [](argument::ArgType type) -> std::wstring_view {
+            const auto index = static_cast<size_t>(type);
+            const auto max = static_cast<size_t>(argument::ArgType::Max);
+            if (index < max)
+            {
+                return c_argTypeNames[index];
+            }
+
+            return L"<unknown>";
+        };
+
+        // Starting with the Root command, verify no argument collisions.
+        std::vector<std::unique_ptr<Command>> commands;
+        commands.push_back(std::make_unique<RootCommand>());
+
+        while (!commands.empty())
         {
-            auto current = std::move(queue.back());
-            queue.pop_back();
+            auto current = std::move(commands.back());
+            commands.pop_back();
             VERIFY_IS_NOT_NULL(current.get());
 
             const std::wstring commandFullName(current->FullName());
-            std::unordered_set<std::wstring> seenNames;
-            std::unordered_set<std::wstring> seenAliases;
+            std::unordered_set<size_t> seenTypes;
+            std::unordered_map<std::wstring, argument::ArgType> seenNames;
+            std::unordered_map<std::wstring, argument::ArgType> seenAliases;
 
             for (const auto& arg : current->GetAllArguments())
             {
-                // Check name collision.
-                const auto& name = arg.Name();
-                VERIFY_IS_TRUE(
-                    seenNames.emplace(name).second,
-                    std::format(L"Command '{}' has no duplicate name '--{}'", commandFullName, name).c_str());
+                // Check for duplicate ArgType registration.
+                if (!seenTypes.emplace(static_cast<size_t>(arg.Type())).second)
+                {
+                    VERIFY_FAIL(std::format(L"Command '{}' registers ArgType '{}' more than once", commandFullName, ArgTypeName(arg.Type()))
+                                    .c_str());
+                }
 
-                // Check alias collision; skip empty aliases (NO_ALIAS).
+                // Check name collision between distinct ArgTypes.
+                const auto& name = arg.Name();
+                auto [nameIt, nameInserted] = seenNames.emplace(name, arg.Type());
+                if (!nameInserted)
+                {
+                    VERIFY_FAIL(std::format(
+                                    L"Command '{}' has duplicate name '--{}' (ArgType '{}' conflicts with ArgType '{}')",
+                                    commandFullName,
+                                    name,
+                                    ArgTypeName(arg.Type()),
+                                    ArgTypeName(nameIt->second))
+                                    .c_str());
+                }
+
+                // Check alias collision between distinct ArgTypes; skip empty aliases (NO_ALIAS).
                 const auto& alias = arg.Alias();
                 if (!alias.empty())
                 {
-                    VERIFY_IS_TRUE(
-                        seenAliases.emplace(alias).second,
-                        std::format(L"Command '{}' has no duplicate alias '-{}'", commandFullName, alias).c_str());
+                    auto [aliasIt, aliasInserted] = seenAliases.emplace(alias, arg.Type());
+                    if (!aliasInserted)
+                    {
+                        VERIFY_FAIL(std::format(
+                                        L"Command '{}' has duplicate alias '-{}' (ArgType '{}' conflicts with ArgType '{}')",
+                                        commandFullName,
+                                        alias,
+                                        ArgTypeName(arg.Type()),
+                                        ArgTypeName(aliasIt->second))
+                                        .c_str());
+                    }
                 }
             }
 
-            // Add any subcommands of this command to the queue.
+            // Add any subcommands of this command for validation.
             for (auto& sub : current->GetCommands())
             {
-                queue.push_back(std::move(sub));
+                commands.push_back(std::move(sub));
             }
         }
     }

--- a/test/windows/wslc/WSLCCLICommandUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLICommandUnitTests.cpp
@@ -169,6 +169,47 @@ class WSLCCLICommandUnitTests
 
         VERIFY_IS_TRUE(found, L"RootCommand should contain VersionCommand");
     }
+
+    // Walk every command in the root tree and verify no name or alias argument collisions.
+    TEST_METHOD(AllCommands_NoAmbiguousArgumentNamesOrAliases)
+    {
+        // Starting with the Root command, verify no argument collisions.
+        std::vector<std::unique_ptr<Command>> queue;
+        queue.push_back(std::make_unique<RootCommand>());
+
+        while (!queue.empty())
+        {
+            auto current = std::move(queue.back());
+            queue.pop_back();
+            VERIFY_IS_NOT_NULL(current.get());
+
+            const std::wstring commandFullName(current->FullName());
+            std::unordered_map<std::wstring, std::wstring> seenNames;   // name  -> first arg that claimed it
+            std::unordered_map<std::wstring, std::wstring> seenAliases; // alias  -> first arg that claimed it
+
+            for (const auto& arg : current->GetAllArguments())
+            {
+                // Check name collision.
+                const auto& name = arg.Name();
+                auto [it, inserted] = seenNames.emplace(name, name);
+                VERIFY_IS_TRUE(inserted, std::format(L"Command '{}' has no duplicate name '--{}'", commandFullName, name).c_str());
+
+                // Check alias collision; skip empty aliases (NO_ALIAS).
+                const auto& alias = arg.Alias();
+                if (!alias.empty())
+                {
+                    auto [it, inserted] = seenAliases.emplace(alias, name);
+                    VERIFY_IS_TRUE(inserted, std::format(L"Command '{}' has no duplicate alias '-{}'", commandFullName, alias).c_str());
+                }
+            }
+
+            // Add any subcommands of this command to the queue.
+            for (auto& sub : current->GetCommands())
+            {
+                queue.push_back(std::move(sub));
+            }
+        }
+    }
 };
 
 } // namespace WSLCCLICommandUnitTests

--- a/test/windows/wslc/WSLCCLICommandUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLICommandUnitTests.cpp
@@ -184,22 +184,24 @@ class WSLCCLICommandUnitTests
             VERIFY_IS_NOT_NULL(current.get());
 
             const std::wstring commandFullName(current->FullName());
-            std::unordered_map<std::wstring, std::wstring> seenNames;   // name  -> first arg that claimed it
-            std::unordered_map<std::wstring, std::wstring> seenAliases; // alias  -> first arg that claimed it
+            std::unordered_set<std::wstring> seenNames;
+            std::unordered_set<std::wstring> seenAliases;
 
             for (const auto& arg : current->GetAllArguments())
             {
                 // Check name collision.
                 const auto& name = arg.Name();
-                auto [it, inserted] = seenNames.emplace(name, name);
-                VERIFY_IS_TRUE(inserted, std::format(L"Command '{}' has no duplicate name '--{}'", commandFullName, name).c_str());
+                VERIFY_IS_TRUE(
+                    seenNames.emplace(name).second,
+                    std::format(L"Command '{}' has no duplicate name '--{}'", commandFullName, name).c_str());
 
                 // Check alias collision; skip empty aliases (NO_ALIAS).
                 const auto& alias = arg.Alias();
                 if (!alias.empty())
                 {
-                    auto [it, inserted] = seenAliases.emplace(alias, name);
-                    VERIFY_IS_TRUE(inserted, std::format(L"Command '{}' has no duplicate alias '-{}'", commandFullName, alias).c_str());
+                    VERIFY_IS_TRUE(
+                        seenAliases.emplace(alias).second,
+                        std::format(L"Command '{}' has no duplicate alias '-{}'", commandFullName, alias).c_str());
                 }
             }
 

--- a/test/windows/wslc/WSLCCLICommandUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLICommandUnitTests.cpp
@@ -13,6 +13,8 @@ Abstract:
 --*/
 
 #include "precomp.h"
+#include <unordered_map>
+#include <unordered_set>
 #include "windows/Common.h"
 #include "WSLCCLITestHelpers.h"
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Simple test that walks the CLI command tree and ensures no commands have ambiguous names or aliases that map to different arguments.

Example of finding a collision (I intentionally gave session the same alias as help to force a collision)
<img width="1709" height="298" alt="image" src="https://github.com/user-attachments/assets/0720673a-6a55-41d0-8a8a-60a8428fded7" />

Example of no collisions (the above alias removed)
<img width="1613" height="204" alt="image" src="https://github.com/user-attachments/assets/3f43140c-2a67-4785-b40a-0097485d737e" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Walks the command tree from the Root and examines arguments of each command and ensures there are no duplicate names or aliases in any of them.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Test passes!