### PR TITLE
Fixed leaked container in NamedVolumesVhdSessionRecovery causing test failures in OpenContainer

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3670,6 +3670,7 @@ class WSLCTests
 
     WSLC_TEST_METHOD(NamedVolumesVhdSessionRecovery)
     {
+
         WSLCDriverOption driverOpts[] = {{"SizeBytes", "1073741824"}};
         ValidateNamedVolumeRecoveryContract("vhd", driverOpts, ARRAYSIZE(driverOpts));
 
@@ -3677,6 +3678,12 @@ class WSLCTests
         // can test the "delete VHD while session is down" scenario.
         const std::string volumeName = "wslc-test-named-volume-vhd";
         const std::string containerName = "wslc-test-container-vhd";
+
+        // Prune containers on exit so this test doesn't leak "wslc-test-named-volume-vhd" on exit.
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            PruneResult result;
+            LOG_IF_FAILED(m_defaultSession->PruneContainers(nullptr, 0, 0, &result.result));
+        });
 
         WSLCVolumeOptions volumeOptions{};
         volumeOptions.Name = volumeName.c_str();

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3679,7 +3679,7 @@ class WSLCTests
         const std::string volumeName = "wslc-test-named-volume-vhd";
         const std::string containerName = "wslc-test-container-vhd";
 
-        // Prune containers on exit so this test doesn't leak "wslc-test-named-volume-vhd" on exit.
+        // Prune containers on exit so this test doesn't leak "wslc-test-container-vhd" on exit.
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
             PruneResult result;
             LOG_IF_FAILED(m_defaultSession->PruneContainers(nullptr, 0, 0, &result.result));


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a leaked container in the `NamedVolumesVhdSessionRecovery` test case. If the first character of the container ID collided with the one that OpenContainer() creates, this would create a test failure du to an ambiguous prefix 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
