### PR TITLE
Fix missing return after accept4 failure in InteropServer::Accept

### DIFF
--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -172,6 +172,7 @@ Return Value:
     if (!InteropConnection)
     {
         LOG_ERROR("accept4 failed {}", errno);
+        return {};
     }
 
     timeval Timeout{};


### PR DESCRIPTION
When accept4 fails in InteropServer::Accept, the function logs an error but falls through to call setsockopt on the invalid file descriptor (-1) and returns it to the caller.

This `return {};` exists on master (added in 040f5e41) but was lost during a merge into feature/wsl-for-apps.

**Fix**: Add the missing early `return {};` to match master behavior.