### PR TITLE
Fix release build codesign failure by scoping targetGlob to binaries

### DIFF
--- a/.pipelines/wsl-build-release-onebranch.yml
+++ b/.pipelines/wsl-build-release-onebranch.yml
@@ -35,6 +35,10 @@ extends:
     globalSdl:
       credscan:
         enabled: true
+      codesign:
+        enabled: true
+        break: true
+        targetGlob: '**\*.dll;**\*.exe;**\*.sys;**\*.msi;**\*.msix;**\*.msixbundle;**\*.appx;**\*.nupkg'
       perStage:
         credscan:
           enabled: true


### PR DESCRIPTION
## Problem

The release build ([145356685](https://dev.azure.com/microsoft/Microsoft.WSL/_build/results?buildId=145356685)) failed in the \
uget\ stage at **Guardian: Post Analysis** with 14 \CodeSign.MissingSigningCert\ errors on unsigned PowerShell scripts.

The OneBranch \Microsoft.Official.yml\ template's Guardian codesign validation defaults to scanning \.ps1\, \.psm1\, \.vbs\, \.js\, and other script types. Since our tool/test/diagnostics scripts aren't code-signed, this breaks the build.

## Fix

Add \globalSdl.codesign.targetGlob\ to restrict codesign validation to only signed binary and package extensions:
- \.dll\, \.exe\, \.sys\, \.msi\, \.msix\, \.msixbundle\, \.appx\, \.nupkg\

This excludes script files from codesign validation while keeping enforcement for all shipped binaries and packages.

## Validation

- If \	argetGlob\ is not honored by the template, fallback is adding the 14 \.ps1\ signatures to \.gdnsuppress\.