### PR TITLE
Fix malformed WSL_E_PLUGIN_REQUIRES_UPDATE HRESULT constant

### DIFF
--- a/src/windows/inc/WslPluginApi.h
+++ b/src/windows/inc/WslPluginApi.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 #define WSLPLUGINAPI_ENTRYPOINTV1 WSLPluginAPIV1_EntryPoint
-#define WSL_E_PLUGIN_REQUIRES_UPDATE ((HRESULT)0x8004032AL)
+#define WSL_E_PLUGIN_REQUIRES_UPDATE MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, 0x032A)
 
 #define WSL_PLUGIN_REQUIRE_VERSION(_Major, _Minor, _Revision, Api) \
     if (Api->Version.Major < (_Major) || (Api->Version.Major == (_Major) && Api->Version.Minor < (_Minor)) || \

--- a/src/windows/inc/WslPluginApi.h
+++ b/src/windows/inc/WslPluginApi.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 #define WSLPLUGINAPI_ENTRYPOINTV1 WSLPluginAPIV1_EntryPoint
-#define WSL_E_PLUGIN_REQUIRES_UPDATE MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, 0x8004032A)
+#define WSL_E_PLUGIN_REQUIRES_UPDATE ((HRESULT)0x8004032AL)
 
 #define WSL_PLUGIN_REQUIRE_VERSION(_Major, _Minor, _Revision, Api) \
     if (Api->Version.Major < (_Major) || (Api->Version.Major == (_Major) && Api->Version.Minor < (_Minor)) || \


### PR DESCRIPTION
MAKE_HRESULT expects a 16-bit code parameter, but the full 32-bit HRESULT value 0x8004032A was passed. The macro shifts and ORs the facility and code fields, so passing a full HRESULT as the code produces a corrupted value.

Since WslPluginApi.h is a standalone header without access to WSL_E_BASE, use the literal 0x8004032A directly instead of MAKE_HRESULT.

**Fix**: Replace the malformed MAKE_HRESULT call with the intended literal constant.