### PR TITLE
Fix epoll_event union misuse in DnsServer TCP connection setup

### DIFF
--- a/src/linux/init/DnsServer.cpp
+++ b/src/linux/init/DnsServer.cpp
@@ -191,9 +191,10 @@ try
 
     // Register the new connection with epoll. EPOLLIN is used to get epoll notifications
     // whenever there is new data on the TCP connection.
+    // N.B. epoll_event.data is a union — only set data.ptr since the dispatch loop
+    // identifies TCP connections via the else branch after checking known fds.
     epoll_event event{};
     event.events = EPOLLIN;
-    event.data.fd = localContext->m_tcpConnection.get();
     event.data.ptr = localContext.get();
     Syscall(epoll_ctl, m_epollFd.get(), EPOLL_CTL_ADD, localContext->m_tcpConnection.get(), &event);
 


### PR DESCRIPTION
\poll_event.data\ is a union — setting both \.fd\ and \.ptr\ means \.ptr\ overwrites \.fd\. The dispatch loop compares \data.fd\ for the listening/UDP sockets but uses \data.ptr\ for TCP connections, so this works by accident but is incorrect.

Master only sets \data.ptr\ for TCP connections; the spurious \data.fd\ assignment was introduced on the feature branch.

**Fix**: Remove the \data.fd\ assignment for TCP connections to match master's pattern.