### PR TITLE
Fix UtilExec: remove premature Result check that breaks output capture

### DIFF
--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -786,10 +786,6 @@ Return Value:
         if (Output)
         {
             (*Output) += Buffer.data();
-            if (Result < 0)
-            {
-                goto ErrorExit;
-            }
         }
         else
         {


### PR DESCRIPTION
On the feature branch, an `if (Result < 0) { goto ErrorExit; }` check was added inside the fgets loop in UtilExec. Since Result is initialized to -1 and not set until after the loop (via pclose()), this fires on the first iteration, making output capture dead code.

This bug does not exist on master — it was introduced on the feature branch.

**Fix**: Remove the erroneous 4-line check.