### PR TITLE
Fix data race on crash flags in HcsVirtualMachine::OnCrash

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -634,7 +634,7 @@ void HcsVirtualMachine::OnExit(const HCS_EVENT* Event)
 
 void HcsVirtualMachine::OnCrash(const HCS_EVENT* Event)
 {
-    if (m_crashLogCaptured && m_vmSavedStateCaptured)
+    if (m_crashLogCaptured.load() && m_vmSavedStateCaptured.load())
     {
         return;
     }
@@ -643,13 +643,22 @@ void HcsVirtualMachine::OnCrash(const HCS_EVENT* Event)
 
     if (crashReport.GuestCrashSaveInfo.has_value() && crashReport.GuestCrashSaveInfo->SaveStateFile.has_value())
     {
-        m_vmSavedStateCaptured = true;
-        EnforceVmSavedStateFileLimit();
+        if (!m_vmSavedStateCaptured.exchange(true))
+        {
+            auto resetFlag = wil::scope_exit([&]() noexcept { m_vmSavedStateCaptured.store(false); });
+            EnforceVmSavedStateFileLimit();
+            resetFlag.release();
+        }
     }
 
-    if (!m_crashLogCaptured && !crashReport.CrashLog.empty())
+    if (!crashReport.CrashLog.empty())
     {
-        WriteCrashLog(crashReport.CrashLog);
+        if (!m_crashLogCaptured.exchange(true))
+        {
+            auto resetFlag = wil::scope_exit([&]() noexcept { m_crashLogCaptured.store(false); });
+            WriteCrashLog(crashReport.CrashLog);
+            resetFlag.release();
+        }
     }
 }
 
@@ -716,7 +725,6 @@ void HcsVirtualMachine::WriteCrashLog(const std::wstring& crashLog)
     }
 
     THROW_IF_WIN32_BOOL_FALSE(SetFileAttributesW(filePath.c_str(), FILE_ATTRIBUTE_TEMPORARY));
-    m_crashLogCaptured = true;
 }
 
 ULONG HcsVirtualMachine::AllocateLun()

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -15,6 +15,7 @@ Abstract:
 
 #pragma once
 
+#include <atomic>
 #include "wslc.h"
 #include "hcs.hpp"
 #include "GuestDeviceManager.h"
@@ -93,8 +94,8 @@ private:
 
     std::filesystem::path m_vmSavedStateFile;
     std::filesystem::path m_crashDumpFolder;
-    bool m_vmSavedStateCaptured = false;
-    bool m_crashLogCaptured = false;
+    std::atomic<bool> m_vmSavedStateCaptured = false;
+    std::atomic<bool> m_crashLogCaptured = false;
 
     wil::com_ptr<ITerminationCallback> m_terminationCallback;
 };


### PR DESCRIPTION
m_crashLogCaptured and m_vmSavedStateCaptured are plain bool members written from HCS event callbacks without synchronization. Change to `std::atomic<bool>` and use `exchange()` to ensure only one thread performs WriteCrashLog or EnforceVmSavedStateFileLimit per crash event.