### PR TITLE
Remove unreachable else branch in TTY stdin relay

### DIFF
--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -277,14 +277,9 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_TTY_RELAY
             }
             else
             {
-                if (bytesWritten <= pendingStdin.size()) // Partial or complete write
-                {
-                    pendingStdin.erase(pendingStdin.begin(), pendingStdin.begin() + bytesWritten);
-                }
-                else
-                {
-                    LOG_ERROR("Unexpected write result {}, pending={}", bytesWritten, pendingStdin.size());
-                }
+                // write() returns 0..pendingStdin.size(), so this is always a
+                // partial or complete write. Erase the bytes that were written.
+                pendingStdin.erase(pendingStdin.begin(), pendingStdin.begin() + bytesWritten);
             }
         }
 

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -263,7 +263,7 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_TTY_RELAY
 
     while (true)
     {
-        int bytesWritten = 0;
+        ssize_t bytesWritten = 0;
         auto result = poll(pollDescriptors, COUNT_OF(pollDescriptors), pendingStdin.empty() ? -1 : 100);
         if (!pendingStdin.empty())
         {
@@ -277,8 +277,8 @@ void HandleMessageImpl(wsl::shared::SocketChannel& Channel, const WSLC_TTY_RELAY
             }
             else
             {
-                // write() returns 0..pendingStdin.size(), so this is always a
-                // partial or complete write. Erase the bytes that were written.
+                WI_ASSERT(static_cast<size_t>(bytesWritten) <= pendingStdin.size());
+
                 pendingStdin.erase(pendingStdin.begin(), pendingStdin.begin() + bytesWritten);
             }
         }


### PR DESCRIPTION
write() on success returns a value in [0, count]. The condition (bytesWritten <= pendingStdin.size()) is therefore always true, making the else branch dead code. Simplify to unconditional erase.