### PR TITLE
Remove duplicate object inclusion for wslc executable

### DIFF
--- a/src/windows/wslc/CMakeLists.txt
+++ b/src/windows/wslc/CMakeLists.txt
@@ -23,7 +23,9 @@ target_precompile_headers(wslclib REUSE_FROM common)
 set_target_properties(wslclib PROPERTIES FOLDER windows)
 
 # Create wslc.exe
-add_executable(wslc $<TARGET_OBJECTS:wslclib>)
+# N.B. Linking wslclib (OBJECT library) brings both object files and
+# transitive dependencies. Do not also use $<TARGET_OBJECTS:wslclib>.
+add_executable(wslc)
 
 target_link_libraries(wslc wslclib)
 


### PR DESCRIPTION
wslclib is an OBJECT library. Both the TARGET_OBJECTS generator expression in add_executable() and target_link_libraries(wslc wslclib) include the same object files. In CMake 3.12+, linking an OBJECT library brings both objects and transitive dependencies, making the generator expression redundant. Remove it to avoid potential duplicate symbol issues.