### PR TITLE
Add option to block zone identifier creation when accessing Linux files from Windows

### DIFF
--- a/src/linux/init/WslDistributionConfig.cpp
+++ b/src/linux/init/WslDistributionConfig.cpp
@@ -45,6 +45,7 @@ WslDistributionConfig::WslDistributionConfig(const char* configFilePath)
         ConfigKey("fileServer.logFile", Plan9LogFile),
         ConfigKey("fileServer.logLevel", Plan9LogLevel),
         ConfigKey("fileServer.logTruncate", Plan9LogTruncate),
+        ConfigKey("fileServer.blockZoneIdentifier", Plan9BlockZoneIdentifier),
 
         ConfigKey(c_ConfigGpuEnabledOption, GpuEnabled),
         ConfigKey(c_ConfigAppendGpuLibPathOption, AppendGpuLibPath),

--- a/src/linux/init/WslDistributionConfig.h
+++ b/src/linux/init/WslDistributionConfig.h
@@ -73,6 +73,7 @@ struct WslDistributionConfig
     std::optional<std::string> Plan9LogFile;
     int Plan9LogLevel = TRACE_LEVEL_INFORMATION;
     bool Plan9LogTruncate = true;
+    bool Plan9BlockZoneIdentifier = false;
     int Umask = 0022;
     bool AppendGpuLibPath = true;
     bool GpuEnabled = true;

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -3246,10 +3246,11 @@ Return Value:
 
 unsigned int StartPlan9(int Argc, char** Argv)
 {
-    constexpr auto* Usage = "Usage: plan9 " LX_INIT_PLAN9_CONTROL_SOCKET_ARG " fd " LX_INIT_PLAN9_SOCKET_PATH_ARG
-                            " path " LX_INIT_PLAN9_SERVER_FD_ARG " fd " LX_INIT_PLAN9_LOG_FILE_ARG
-                            " log-file " LX_INIT_PLAN9_LOG_LEVEL_ARG " level " LX_INIT_PLAN9_PIPE_FD_ARG " fd [--log-truncate]"
-                            " [" LX_INIT_PLAN9_BLOCK_ZONE_IDENTIFIER_ARG "]\n";
+    constexpr auto* Usage =
+        "Usage: plan9 " LX_INIT_PLAN9_CONTROL_SOCKET_ARG " fd " LX_INIT_PLAN9_SOCKET_PATH_ARG " path " LX_INIT_PLAN9_SERVER_FD_ARG
+        " fd " LX_INIT_PLAN9_LOG_FILE_ARG " log-file " LX_INIT_PLAN9_LOG_LEVEL_ARG " level " LX_INIT_PLAN9_PIPE_FD_ARG
+        " fd [--log-truncate]"
+        " [" LX_INIT_PLAN9_BLOCK_ZONE_IDENTIFIER_ARG "]\n";
 
     bool LogTruncate = false;
     bool BlockZoneIdentifier = false;

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -3251,6 +3251,7 @@ unsigned int StartPlan9(int Argc, char** Argv)
                             " log-file " LX_INIT_PLAN9_LOG_LEVEL_ARG " level " LX_INIT_PLAN9_PIPE_FD_ARG " fd [--log-truncate]\n";
 
     bool LogTruncate = false;
+    bool BlockZoneIdentifier = false;
     int LogLevel = TRACE_LEVEL_INFORMATION;
     wil::unique_fd PipeFd;
     const char* SocketPath{};
@@ -3266,6 +3267,7 @@ unsigned int StartPlan9(int Argc, char** Argv)
     parser.AddArgument(Integer{LogLevel}, LX_INIT_PLAN9_LOG_LEVEL_ARG);
     parser.AddArgument(UniqueFd{PipeFd}, LX_INIT_PLAN9_PIPE_FD_ARG);
     parser.AddArgument(LogTruncate, LX_INIT_PLAN9_TRUNCATE_LOG_ARG);
+    parser.AddArgument(BlockZoneIdentifier, LX_INIT_PLAN9_BLOCK_ZONE_IDENTIFIER_ARG);
 
     try
     {
@@ -3277,7 +3279,7 @@ unsigned int StartPlan9(int Argc, char** Argv)
         return 1;
     }
 
-    RunPlan9Server(SocketPath, LogFile, LogLevel, LogTruncate, ControlSocket.get(), ServerFd.get(), PipeFd);
+    RunPlan9Server(SocketPath, LogFile, LogLevel, LogTruncate, ControlSocket.get(), ServerFd.get(), PipeFd, BlockZoneIdentifier);
 
     return 0;
 }

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -3248,7 +3248,8 @@ unsigned int StartPlan9(int Argc, char** Argv)
 {
     constexpr auto* Usage = "Usage: plan9 " LX_INIT_PLAN9_CONTROL_SOCKET_ARG " fd " LX_INIT_PLAN9_SOCKET_PATH_ARG
                             " path " LX_INIT_PLAN9_SERVER_FD_ARG " fd " LX_INIT_PLAN9_LOG_FILE_ARG
-                            " log-file " LX_INIT_PLAN9_LOG_LEVEL_ARG " level " LX_INIT_PLAN9_PIPE_FD_ARG " fd [--log-truncate]\n";
+                            " log-file " LX_INIT_PLAN9_LOG_LEVEL_ARG " level " LX_INIT_PLAN9_PIPE_FD_ARG " fd [--log-truncate]"
+                            " [" LX_INIT_PLAN9_BLOCK_ZONE_IDENTIFIER_ARG "]\n";
 
     bool LogTruncate = false;
     bool BlockZoneIdentifier = false;

--- a/src/linux/init/plan9.cpp
+++ b/src/linux/init/plan9.cpp
@@ -171,7 +171,7 @@ CATCH_LOG();
 
 } // namespace
 
-void RunPlan9Server(const char* socketPath, const char* logFile, int logLevel, bool truncateLog, int controlSocket, int serverFd, wil::unique_fd& pipeFd)
+void RunPlan9Server(const char* socketPath, const char* logFile, int logLevel, bool truncateLog, int controlSocket, int serverFd, wil::unique_fd& pipeFd, bool blockZoneIdentifier)
 {
     // Initialize logging.
     InitializeLogging(false, LogPlan9Exception);
@@ -190,6 +190,8 @@ void RunPlan9Server(const char* socketPath, const char* logFile, int logLevel, b
     // Open the root.
     wil::unique_fd rootFd{open("/", O_PATH | O_DIRECTORY | O_CLOEXEC)};
     THROW_LAST_ERROR_IF(!rootFd);
+
+    p9fs::SetBlockZoneIdentifier(blockZoneIdentifier);
 
     {
         // Create the file system server.
@@ -299,6 +301,11 @@ try
             {
                 Arguments.emplace_back(LX_INIT_PLAN9_LOG_FILE_ARG);
                 Arguments.emplace_back(Config.Plan9LogFile->c_str());
+            }
+
+            if (Config.Plan9BlockZoneIdentifier)
+            {
+                Arguments.emplace_back(LX_INIT_PLAN9_BLOCK_ZONE_IDENTIFIER_ARG);
             }
 
             Arguments.emplace_back(nullptr);

--- a/src/linux/init/plan9.h
+++ b/src/linux/init/plan9.h
@@ -8,6 +8,6 @@
 
 std::pair<unsigned int, wsl::shared::SocketChannel> StartPlan9Server(const char* socketWindowsPath, const wsl::linux::WslDistributionConfig& Config);
 
-void RunPlan9Server(const char* socketPath, const char* logFile, int logLevel, bool truncateLog, int controlSocket, int serverFd, wil::unique_fd& pipeFd);
+void RunPlan9Server(const char* socketPath, const char* logFile, int logLevel, bool truncateLog, int controlSocket, int serverFd, wil::unique_fd& pipeFd, bool blockZoneIdentifier);
 
 bool StopPlan9Server(bool force, wsl::linux::WslDistributionConfig& Config);

--- a/src/linux/plan9/p9file.cpp
+++ b/src/linux/plan9/p9file.cpp
@@ -16,6 +16,7 @@ namespace p9fs {
 constexpr std::string_view c_drvfsFsType = "drvfs"sv;
 constexpr std::string_view c_p9FsType = "9p"sv;
 constexpr std::string_view c_virtioFsType = "virtiofs"sv;
+constexpr std::string_view c_zoneIdentifierSuffix = ":Zone.Identifier"sv;
 
 struct OpenFlagMapping
 {
@@ -41,6 +42,18 @@ const OpenFlagMapping c_openFlagsMapping[] = {
     {OpenFlags::NoAccessTime, O_NOATIME},
     {OpenFlags::CloseOnExec, O_CLOEXEC},
     {OpenFlags::Sync, O_SYNC}};
+
+static bool g_blockZoneIdentifier = false;
+
+void SetBlockZoneIdentifier(bool block)
+{
+    g_blockZoneIdentifier = block;
+}
+
+bool IsBlockedFileName(std::string_view name)
+{
+    return g_blockZoneIdentifier && name.ends_with(c_zoneIdentifierSuffix);
+}
 
 Expected<std::tuple<std::shared_ptr<Fid>, Qid>> CreateFile(std::shared_ptr<const IRoot> root, LX_UID_T uid)
 {
@@ -501,6 +514,11 @@ Expected<Qid> File::Open(OpenFlags flags)
 // Creates a file in a directory, updating this object to point to the new file.
 Expected<Qid> File::Create(std::string_view name, OpenFlags flags, UINT32 mode, UINT32 /* gid */)
 {
+    if (IsBlockedFileName(name))
+    {
+        return LxError{LX_EACCES};
+    }
+
     // Acquire the lock exclusive because the file name will be modified,
     // and to protect against concurrent opens and creates.
     std::lock_guard<std::shared_mutex> lock{m_Lock};
@@ -762,6 +780,11 @@ std::string File::ChildPathWithLockHeld(std::string_view name)
 // Renames a directory entry.
 LX_INT File::RenameAt(std::string_view oldName, Fid& newParent, std::string_view newName)
 {
+    if (IsBlockedFileName(newName))
+    {
+        return LX_EACCES;
+    }
+
     if (!newParent.IsFile() || !newParent.IsOnRoot(m_Root))
     {
         return LX_EINVAL;
@@ -788,6 +811,11 @@ LX_INT File::RenameAt(std::string_view oldName, Fid& newParent, std::string_view
 // Renames the current directory entry.
 LX_INT File::Rename(Fid& newParent, std::string_view newName)
 {
+    if (IsBlockedFileName(newName))
+    {
+        return LX_EACCES;
+    }
+
     if (!newParent.IsFile() || !newParent.IsOnRoot(m_Root))
     {
         return LX_EINVAL;

--- a/src/linux/plan9/p9file.cpp
+++ b/src/linux/plan9/p9file.cpp
@@ -50,7 +50,7 @@ void SetBlockZoneIdentifier(bool block)
     g_blockZoneIdentifier = block;
 }
 
-bool IsBlockedFileName(std::string_view name)
+static bool IsBlockedFileName(std::string_view name)
 {
     return g_blockZoneIdentifier && name.ends_with(c_zoneIdentifierSuffix);
 }
@@ -560,6 +560,11 @@ Expected<Qid> File::Create(std::string_view name, OpenFlags flags, UINT32 mode, 
 // Creates a subdirectory.
 Expected<Qid> File::MkDir(std::string_view name, UINT32 mode, UINT32 /* gid */)
 {
+    if (IsBlockedFileName(name))
+    {
+        return LxError{LX_EACCES};
+    }
+
     const auto newFileName = ChildPath(name);
 
     // The specified gid is currently ignored. Supporting it would be possible, but it would be
@@ -851,6 +856,11 @@ LX_INT File::Rename(Fid& newParent, std::string_view newName)
 // Creates a symbolic link in a directory.
 Expected<Qid> File::SymLink(std::string_view name, std::string_view target, UINT32 /* gid */)
 {
+    if (IsBlockedFileName(name))
+    {
+        return LxError{LX_EACCES};
+    }
+
     if (m_Root->ReadOnly())
     {
         return LxError{LX_EROFS};
@@ -890,6 +900,11 @@ Expected<UINT32> File::ReadLink(gsl::span<char> name)
 // Creates a hard link in a directory to another file.
 LX_INT File::Link(std::string_view newName, Fid& target)
 {
+    if (IsBlockedFileName(newName))
+    {
+        return LX_EACCES;
+    }
+
     if (!target.IsFile() || !target.IsOnRoot(m_Root))
     {
         return LX_EINVAL;
@@ -918,6 +933,11 @@ LX_INT File::Link(std::string_view newName, Fid& target)
 // Creates a device object in a directory.
 Expected<Qid> File::MkNod(std::string_view name, UINT32 mode, UINT32 major, UINT32 minor, UINT32 gid)
 {
+    if (IsBlockedFileName(name))
+    {
+        return LxError{LX_EACCES};
+    }
+
     if (m_Root->ReadOnly())
     {
         return LxError{LX_EROFS};

--- a/src/linux/plan9/p9fs.h
+++ b/src/linux/plan9/p9fs.h
@@ -22,4 +22,6 @@ public:
 
 std::unique_ptr<IPlan9FileSystem> CreateFileSystem(int socket);
 
+void SetBlockZoneIdentifier(bool block);
+
 } // namespace p9fs

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -232,6 +232,7 @@ Abstract:
 #define LX_INIT_PLAN9_LOG_LEVEL_ARG "--log-level"
 #define LX_INIT_PLAN9_PIPE_FD_ARG "--pipe-fd"
 #define LX_INIT_PLAN9_TRUNCATE_LOG_ARG "--log-truncate"
+#define LX_INIT_PLAN9_BLOCK_ZONE_IDENTIFIER_ARG "--block-zone-identifier"
 
 //
 // wsl-capture-crash

--- a/test/windows/Plan9Tests.cpp
+++ b/test/windows/Plan9Tests.cpp
@@ -495,6 +495,43 @@ class Plan9Tests
         VERIFY_ARE_EQUAL(content, L"foo");
     }
 
+    // Tests that the blockZoneIdentifier option prevents creation of Zone.Identifier files.
+    TEST_METHOD(TestBlockZoneIdentifier)
+    {
+        wil::unique_hfile file;
+        IO_STATUS_BLOCK ioStatus;
+
+        // Verify that Zone.Identifier files can be created with the default configuration.
+        CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\default.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        file.reset();
+        VERIFY_ARE_EQUAL(
+            0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/default.txt:Zone.Identifier'"));
+
+        // Clean up the Zone.Identifier file.
+        LxsstuLaunchWsl(L"rm -f '/data/p9_test/default.txt:Zone.Identifier'");
+
+        // Enable blockZoneIdentifier and restart the distro to pick up the new config.
+        LxssWriteWslDistroConfig("[fileServer]\nblockZoneIdentifier=true");
+        TerminateDistribution();
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [] {
+            LxsstuLaunchWsl(L"-u root rm -f /etc/wsl.conf");
+            TerminateDistribution();
+        });
+
+        // Verify that Zone.Identifier file creation is now blocked.
+        CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\blocked.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        file.reset();
+        VERIFY_ARE_EQUAL(
+            1u, LxsstuLaunchWsl(L"test -e '/data/p9_test/blocked.txt:Zone.Identifier'"));
+
+        // Verify that normal file creation still works.
+        CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\normalfile.txt", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        file.reset();
+        VERIFY_ARE_EQUAL(
+            0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/normalfile.txt'"));
+    }
+
     /* Plan9 Test Helper Methods */
 
     static wil::unique_hfile CreateTestFile(std::wstring_view path, DWORD desiredAccess, DWORD disposition = OPEN_EXISTING, DWORD flags = 0)

--- a/test/windows/Plan9Tests.cpp
+++ b/test/windows/Plan9Tests.cpp
@@ -504,8 +504,7 @@ class Plan9Tests
 
         // Use CreateFileNt since xx:xx is not a valid path for standard Windows file APIs
         // Verify that Zone.Identifier files can be created with the default configuration.
-        auto status =
-            CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\default.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        auto status = CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\default.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
         VERIFY_NT_SUCCESS(status);
         file.reset();
         VERIFY_ARE_EQUAL(0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/default.txt:Zone.Identifier'"));
@@ -513,13 +512,7 @@ class Plan9Tests
 
         // Verify that Zone.Identifier directories can be created with the default configuration.
         status = CreateFileNt(
-            &file,
-            LXSST_P9_TEST_DIR L"\\defaultdir:Zone.Identifier",
-            FILE_GENERIC_WRITE,
-            ioStatus,
-            FILE_CREATE,
-            FILE_ATTRIBUTE_DIRECTORY,
-            FILE_DIRECTORY_FILE);
+            &file, LXSST_P9_TEST_DIR L"\\defaultdir:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE, FILE_ATTRIBUTE_DIRECTORY, FILE_DIRECTORY_FILE);
         VERIFY_NT_SUCCESS(status);
         file.reset();
         VERIFY_ARE_EQUAL(0u, LxsstuLaunchWsl(L"test -d '/data/p9_test/defaultdir:Zone.Identifier'"));
@@ -535,21 +528,14 @@ class Plan9Tests
         });
 
         // Verify that Zone.Identifier file creation is now blocked.
-        status =
-            CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\blocked.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        status = CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\blocked.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
         VERIFY_ARE_EQUAL(static_cast<NTSTATUS>(0xC0000022) /* STATUS_ACCESS_DENIED */, status);
         file.reset();
         VERIFY_ARE_EQUAL(1u, LxsstuLaunchWsl(L"test -e '/data/p9_test/blocked.txt:Zone.Identifier'"));
 
         // Verify that Zone.Identifier directory creation is now blocked.
         status = CreateFileNt(
-            &file,
-            LXSST_P9_TEST_DIR L"\\blockeddir:Zone.Identifier",
-            FILE_GENERIC_WRITE,
-            ioStatus,
-            FILE_CREATE,
-            FILE_ATTRIBUTE_DIRECTORY,
-            FILE_DIRECTORY_FILE);
+            &file, LXSST_P9_TEST_DIR L"\\blockeddir:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE, FILE_ATTRIBUTE_DIRECTORY, FILE_DIRECTORY_FILE);
         VERIFY_ARE_EQUAL(static_cast<NTSTATUS>(0xC0000022) /* STATUS_ACCESS_DENIED */, status);
         file.reset();
         VERIFY_ARE_EQUAL(1u, LxsstuLaunchWsl(L"test -d '/data/p9_test/blockeddir:Zone.Identifier'"));

--- a/test/windows/Plan9Tests.cpp
+++ b/test/windows/Plan9Tests.cpp
@@ -495,19 +495,35 @@ class Plan9Tests
         VERIFY_ARE_EQUAL(content, L"foo");
     }
 
-    // Tests that the blockZoneIdentifier option prevents creation of Zone.Identifier files.
+    // N.B. Rename, symlink, and link with ':' cannot be tested — the IO manager intercepts ':'
+    //      as an alternate data stream operation.
     TEST_METHOD(TestBlockZoneIdentifier)
     {
         wil::unique_hfile file;
         IO_STATUS_BLOCK ioStatus;
 
+        // Use CreateFileNt since xx:xx is not a valid path for standard Windows file APIs
         // Verify that Zone.Identifier files can be created with the default configuration.
-        CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\default.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        auto status =
+            CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\default.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        VERIFY_NT_SUCCESS(status);
         file.reset();
         VERIFY_ARE_EQUAL(0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/default.txt:Zone.Identifier'"));
-
-        // Clean up the Zone.Identifier file.
         LxsstuLaunchWsl(L"rm -f '/data/p9_test/default.txt:Zone.Identifier'");
+
+        // Verify that Zone.Identifier directories can be created with the default configuration.
+        status = CreateFileNt(
+            &file,
+            LXSST_P9_TEST_DIR L"\\defaultdir:Zone.Identifier",
+            FILE_GENERIC_WRITE,
+            ioStatus,
+            FILE_CREATE,
+            FILE_ATTRIBUTE_DIRECTORY,
+            FILE_DIRECTORY_FILE);
+        VERIFY_NT_SUCCESS(status);
+        file.reset();
+        VERIFY_ARE_EQUAL(0u, LxsstuLaunchWsl(L"test -d '/data/p9_test/defaultdir:Zone.Identifier'"));
+        LxsstuLaunchWsl(L"rm -rf '/data/p9_test/defaultdir:Zone.Identifier'");
 
         // Enable blockZoneIdentifier and restart the distro to pick up the new config.
         LxssWriteWslDistroConfig("[fileServer]\nblockZoneIdentifier=true");
@@ -519,12 +535,28 @@ class Plan9Tests
         });
 
         // Verify that Zone.Identifier file creation is now blocked.
-        CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\blocked.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        status =
+            CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\blocked.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        VERIFY_ARE_EQUAL(static_cast<NTSTATUS>(0xC0000022) /* STATUS_ACCESS_DENIED */, status);
         file.reset();
         VERIFY_ARE_EQUAL(1u, LxsstuLaunchWsl(L"test -e '/data/p9_test/blocked.txt:Zone.Identifier'"));
 
+        // Verify that Zone.Identifier directory creation is now blocked.
+        status = CreateFileNt(
+            &file,
+            LXSST_P9_TEST_DIR L"\\blockeddir:Zone.Identifier",
+            FILE_GENERIC_WRITE,
+            ioStatus,
+            FILE_CREATE,
+            FILE_ATTRIBUTE_DIRECTORY,
+            FILE_DIRECTORY_FILE);
+        VERIFY_ARE_EQUAL(static_cast<NTSTATUS>(0xC0000022) /* STATUS_ACCESS_DENIED */, status);
+        file.reset();
+        VERIFY_ARE_EQUAL(1u, LxsstuLaunchWsl(L"test -d '/data/p9_test/blockeddir:Zone.Identifier'"));
+
         // Verify that normal file creation still works.
-        CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\normalfile.txt", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        status = CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\normalfile.txt", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
+        VERIFY_NT_SUCCESS(status);
         file.reset();
         VERIFY_ARE_EQUAL(0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/normalfile.txt'"));
     }

--- a/test/windows/Plan9Tests.cpp
+++ b/test/windows/Plan9Tests.cpp
@@ -504,8 +504,7 @@ class Plan9Tests
         // Verify that Zone.Identifier files can be created with the default configuration.
         CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\default.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
         file.reset();
-        VERIFY_ARE_EQUAL(
-            0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/default.txt:Zone.Identifier'"));
+        VERIFY_ARE_EQUAL(0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/default.txt:Zone.Identifier'"));
 
         // Clean up the Zone.Identifier file.
         LxsstuLaunchWsl(L"rm -f '/data/p9_test/default.txt:Zone.Identifier'");
@@ -522,14 +521,12 @@ class Plan9Tests
         // Verify that Zone.Identifier file creation is now blocked.
         CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\blocked.txt:Zone.Identifier", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
         file.reset();
-        VERIFY_ARE_EQUAL(
-            1u, LxsstuLaunchWsl(L"test -e '/data/p9_test/blocked.txt:Zone.Identifier'"));
+        VERIFY_ARE_EQUAL(1u, LxsstuLaunchWsl(L"test -e '/data/p9_test/blocked.txt:Zone.Identifier'"));
 
         // Verify that normal file creation still works.
         CreateFileNt(&file, LXSST_P9_TEST_DIR L"\\normalfile.txt", FILE_GENERIC_WRITE, ioStatus, FILE_CREATE);
         file.reset();
-        VERIFY_ARE_EQUAL(
-            0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/normalfile.txt'"));
+        VERIFY_ARE_EQUAL(0u, LxsstuLaunchWsl(L"test -e '/data/p9_test/normalfile.txt'"));
     }
 
     /* Plan9 Test Helper Methods */


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When copying a file from NTFS with the zone identifier file stream to the p9 share, a `xxx:Zone.Identifier` file will be created in the Linux file system. This has been a problem for WSL users for a long time.
This PR adds a wsl.conf option `fileServer.blockZoneIdentifier` (default false) to block the file creation in the p9 server. So users can opt in to avoid its creation.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/7456 https://github.com/microsoft/WSL/issues/4609
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Add test Plan9Tests::Plan9Tests::TestBlockZoneIdentifier.
* Validated with browser file downloads.