### PR TITLE
Use auto reset event for container stop

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -725,8 +725,7 @@ void WSLCContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
 bool WSLCContainerImpl::WaitForEvent(const wil::unique_event& Event, std::chrono::milliseconds Timeout) const
 {
     const HANDLE waitHandles[] = {Event.get(), m_wslcSession.SessionTerminatingEvent()};
-    const DWORD waitResult =
-        WaitForMultipleObjects(RTL_NUMBER_OF(waitHandles), waitHandles, FALSE, gsl::narrow<DWORD>(Timeout.count()));
+    const DWORD waitResult = WaitForMultipleObjects(RTL_NUMBER_OF(waitHandles), waitHandles, FALSE, gsl::narrow<DWORD>(Timeout.count()));
 
     switch (waitResult)
     {

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -722,6 +722,25 @@ void WSLCContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
         TraceLoggingValue((int)event, "Event"));
 }
 
+bool WSLCContainerImpl::WaitForEvent(const wil::unique_event& Event, std::chrono::milliseconds Timeout) const
+{
+    const HANDLE waitHandles[] = {Event.get(), m_wslcSession.SessionTerminatingEvent()};
+    const DWORD waitResult =
+        WaitForMultipleObjects(RTL_NUMBER_OF(waitHandles), waitHandles, FALSE, gsl::narrow<DWORD>(Timeout.count()));
+
+    switch (waitResult)
+    {
+    case WAIT_OBJECT_0:
+        return true;
+    case WAIT_OBJECT_0 + 1:
+        THROW_HR_MSG(E_ABORT, "Session is terminating");
+    case WAIT_TIMEOUT:
+        return false;
+    default:
+        THROW_LAST_ERROR();
+    }
+}
+
 void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
 {
     // Acquire an exclusive lock since this method modifies m_state.
@@ -785,7 +804,7 @@ void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
     // Wait for the stop event to get the Docker timestamp.
     // OnEvent() signals the event before taking m_lock, so this won't deadlock.
     std::optional<std::uint64_t> stopTimestamp;
-    if (waitForStop && m_stopNotification.Event.wait(60'000))
+    if (waitForStop && WaitForEvent(m_stopNotification.Event, 60s))
     {
         stopTimestamp = m_stopNotification.EventTime.load(std::memory_order_acquire);
     }

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -733,7 +733,6 @@ bool WSLCContainerImpl::WaitForEvent(const wil::unique_event& Event, std::chrono
         return true;
     case WAIT_OBJECT_0 + 1:
         THROW_HR_MSG(E_ABORT, "Session %lu is terminating.", m_wslcSession.Id());
-
     case WAIT_TIMEOUT:
         return false;
     default:

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -662,6 +662,9 @@ void WSLCContainerImpl::Start(WSLCContainerStartFlags Flags, LPCSTR DetachKeys)
     auto portCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [this]() { UnmapPorts(); });
     MapPorts();
 
+    m_stopNotification.Event.ResetEvent();
+    m_stopNotification.EventTime.store(0, std::memory_order_relaxed);
+
     try
     {
         m_dockerClient.StartContainer(m_id, DetachKeys == nullptr ? std::nullopt : std::optional<std::string>(DetachKeys));
@@ -681,17 +684,8 @@ void WSLCContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
     {
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
 
-        // If a Stop() call is in progress, provide the timestamp via the promise
-        // and let Stop() handle the state transition.
-        {
-            std::lock_guard stopLock{m_stopStateLock};
-            if (m_stopState.has_value())
-            {
-                m_stopState->set_value(eventTime);
-                m_stopState.reset();
-                return;
-            }
-        }
+        m_stopNotification.EventTime.store(eventTime, std::memory_order_release);
+        m_stopNotification.Event.SetEvent();
 
         auto lock = m_lock.lock_exclusive();
         auto previousState = m_state;
@@ -757,26 +751,6 @@ void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
     // N.B. If the signal was SIGTERM for instance, we'll receive the stop notification via OnEvent().
     bool waitForStop = !Kill || (SignalArg.value_or(WSLCSignalSIGKILL) == WSLCSignalSIGKILL);
 
-    // Set up a waitable stop state so OnEvent() can pass the Docker timestamp
-    // back to Stop() without needing to take m_lock.
-    std::future<std::uint64_t> stopFuture;
-    if (waitForStop)
-    {
-        std::lock_guard stopLock{m_stopStateLock};
-        m_stopState.emplace();
-        stopFuture = m_stopState->get_future();
-    }
-
-    // Ensure m_stopState is cleared on all exit paths so OnEvent() doesn't
-    // take the promise path after a failed Stop().
-    auto resetStopState = wil::scope_exit([this, waitForStop]() {
-        if (waitForStop)
-        {
-            std::lock_guard stopLock{m_stopStateLock};
-            m_stopState.reset();
-        }
-    });
-
     try
     {
         if (Kill)
@@ -809,11 +783,11 @@ void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
     }
 
     // Wait for the stop event to get the Docker timestamp.
-    // Safe while holding m_lock since OnEvent() uses m_stopStateLock on this path.
+    // OnEvent() signals the event before taking m_lock, so this won't deadlock.
     std::optional<std::uint64_t> stopTimestamp;
-    if (stopFuture.wait_for(60s) == std::future_status::ready)
+    if (waitForStop && m_stopNotification.Event.wait(60'000))
     {
-        stopTimestamp = stopFuture.get();
+        stopTimestamp = m_stopNotification.EventTime.load(std::memory_order_acquire);
     }
 
     Transition(WslcContainerStateExited, stopTimestamp);

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -808,8 +808,11 @@ void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
     }
 
     // Wait for the stop event to get the Docker timestamp.
-    THROW_WIN32_IF(ERROR_TIMEOUT, !WaitForEvent(m_stopNotification.Event, 60s));
-    auto stopTimestamp = m_stopNotification.EventTime.load(std::memory_order_acquire);
+    std::optional<std::uint64_t> stopTimestamp;
+    if (WaitForEvent(m_stopNotification.Event, 60s))
+    {
+        stopTimestamp = m_stopNotification.EventTime.load(std::memory_order_acquire);
+    }
 
     Transition(WslcContainerStateExited, stopTimestamp);
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -684,19 +684,26 @@ void WSLCContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
     {
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
 
+        std::unique_lock stopGuard{m_stopLock, std::try_to_lock};
+
         m_stopNotification.EventTime.store(eventTime, std::memory_order_release);
         m_stopNotification.Event.SetEvent();
 
+        // If Stop() is already in flight, it will wake when the stop event is signaled and take care of cleanup.
+        if (!stopGuard.owns_lock())
+        {
+            return;
+        }
+
         auto lock = m_lock.lock_exclusive();
         auto previousState = m_state;
-
-        ReleaseProcesses();
 
         // Don't run the deletion logic if the container is already in a stopped / deleted state.
         // This can happen if Delete() is called by the user.
         if (previousState == WslcContainerStateRunning)
         {
             Transition(WslcContainerStateExited, eventTime);
+            ReleaseProcesses();
 
             ReleaseRuntimeResources();
 
@@ -742,7 +749,7 @@ bool WSLCContainerImpl::WaitForEvent(const wil::unique_event& Event, std::chrono
 
 void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
 {
-    // Acquire an exclusive lock since this method modifies m_state.
+    std::lock_guard stopGuard{m_stopLock};
     auto lock = m_lock.lock_exclusive();
 
     if (m_state == WslcContainerStateExited && !Kill)
@@ -801,12 +808,8 @@ void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
     }
 
     // Wait for the stop event to get the Docker timestamp.
-    // OnEvent() signals the event before taking m_lock, so this won't deadlock.
-    std::optional<std::uint64_t> stopTimestamp;
-    if (waitForStop && WaitForEvent(m_stopNotification.Event, 60s))
-    {
-        stopTimestamp = m_stopNotification.EventTime.load(std::memory_order_acquire);
-    }
+    THROW_WIN32_IF(ERROR_TIMEOUT, !WaitForEvent(m_stopNotification.Event, 60s));
+    auto stopTimestamp = m_stopNotification.EventTime.load(std::memory_order_acquire);
 
     Transition(WslcContainerStateExited, stopTimestamp);
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -732,7 +732,8 @@ bool WSLCContainerImpl::WaitForEvent(const wil::unique_event& Event, std::chrono
     case WAIT_OBJECT_0:
         return true;
     case WAIT_OBJECT_0 + 1:
-        THROW_HR_MSG(E_ABORT, "Session is terminating");
+        THROW_HR_MSG(E_ABORT, "Session %lu is terminating.", m_wslcSession.Id());
+
     case WAIT_TIMEOUT:
         return false;
     default:

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -158,8 +158,12 @@ private:
     __guarded_by(m_processesLock) Microsoft::WRL::ComPtr<IWSLCProcess> m_initProcess;
     __guarded_by(m_processesLock) DockerContainerProcessControl* m_initProcessControl = nullptr;
 
-    std::mutex m_stopStateLock;
-    std::optional<std::promise<std::uint64_t>> m_stopState;
+    struct StopNotification
+    {
+        std::atomic<std::uint64_t> EventTime{0};
+        wil::slim_event_auto_reset Event;
+    } m_stopNotification;
+    
     DockerHTTPClient& m_dockerClient;
     std::uint64_t m_stateChangedAt{static_cast<std::uint64_t>(std::time(nullptr))};
     std::uint64_t m_createdAt{};

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -134,7 +134,9 @@ private:
 
     void AllocateBridgedModePorts();
     void OnEvent(ContainerEvent event, std::optional<int> exitCode, std::uint64_t eventTime);
-    void WaitForContainerEvent();
+
+    bool WaitForEvent(const wil::unique_event& Event, std::chrono::milliseconds Timeout) const;
+    
     __requires_exclusive_lock_held(m_lock) void ReleaseResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseRuntimeResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseProcesses();
@@ -161,7 +163,7 @@ private:
     struct StopNotification
     {
         std::atomic<std::uint64_t> EventTime{0};
-        wil::slim_event_auto_reset Event;
+        wil::unique_event Event{wil::EventOptions::None};
     } m_stopNotification;
 
     DockerHTTPClient& m_dockerClient;

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -166,6 +166,10 @@ private:
         wil::unique_event Event{wil::EventOptions::None};
     } m_stopNotification;
 
+    // Serializes Stop() callers and signals OnEvent that a Stop is in flight.
+    // Must be acquired before m_lock when both are needed.
+    std::mutex m_stopLock;
+
     DockerHTTPClient& m_dockerClient;
     std::uint64_t m_stateChangedAt{static_cast<std::uint64_t>(std::time(nullptr))};
     std::uint64_t m_createdAt{};

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -163,7 +163,7 @@ private:
         std::atomic<std::uint64_t> EventTime{0};
         wil::slim_event_auto_reset Event;
     } m_stopNotification;
-    
+
     DockerHTTPClient& m_dockerClient;
     std::uint64_t m_stateChangedAt{static_cast<std::uint64_t>(std::time(nullptr))};
     std::uint64_t m_createdAt{};

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -136,7 +136,7 @@ private:
     void OnEvent(ContainerEvent event, std::optional<int> exitCode, std::uint64_t eventTime);
 
     bool WaitForEvent(const wil::unique_event& Event, std::chrono::milliseconds Timeout) const;
-    
+
     __requires_exclusive_lock_held(m_lock) void ReleaseResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseRuntimeResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseProcesses();

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -156,6 +156,11 @@ public:
     UserCOMCallback RegisterUserCOMCallback();
     void UnregisterUserCOMCallback(DWORD ThreadId);
 
+    HANDLE SessionTerminatingEvent() const noexcept
+    {
+        return m_sessionTerminatingEvent.get();
+    }
+
 private:
     ULONG m_id = 0;
 

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -161,6 +161,11 @@ public:
         return m_sessionTerminatingEvent.get();
     }
 
+    ULONG Id() const noexcept
+    {
+        return m_id;
+    }
+
 private:
     ULONG m_id = 0;
 


### PR DESCRIPTION
## Summary of the Pull Request

Refactor the `WSLCContainerImpl` class to utilize an `auto_reset_event` for managing container stop notifications. This change simplifies the signaling mechanism and eliminates the need for a separate promise to handle stop state transitions.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

**Problem.** The previous implementation used a mutex and a lazily-created `std::optional<std::promise<uint64_t>>` to deliver the docker stop-event timestamp from `OnEvent()` to` Stop()`, which exposed a TOCTOU race when the container exited concurrently with a caller invoking `Stop()`: if `OnEvent()` acquired the lock and observed the optional as empty before `Stop()` had a chance to create it, `OnEvent()` would perform the state transition and return without ever fulfilling the promise; `Stop()` would then create the promise, wait on its future, and hang for the full 60-second timeout because the only producer had already run.

**Change.** Introduced a `StopNotification` struct containing an `atomic` timestamp and a `wil::slim_event_auto_reset` for signaling. This change allows `OnEvent` to signal the event directly, simplifying the stop notification process.

## Validation Steps Performed

- Automated tests added or updated to cover the new signaling mechanism.
- Manual validation performed by running container stop scenarios to ensure correct event signaling and state transitions.

