### PR TITLE
Move definition of TFM for NuGet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,6 @@ endif()
 set(CMAKE_CSharp_FLAGS "${CMAKE_CSharp_FLAGS} /langversion:latest /debug:full")
 set(CMAKE_DOTNET_SDK "Microsoft.NET.Sdk")
 set(CMAKE_DOTNET_TARGET_FRAMEWORK "net8.0-windows${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
-set(WSL_NUGET_TARGET_FRAMEWORK "net8.0-windows10.0.19041.0")
 
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)

--- a/nuget/CMakeLists.txt
+++ b/nuget/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(NUGET_PACKAGES Microsoft.WSL.PluginApi.nuspec Microsoft.WSL.Containers.nuspec)
+set(WSL_NUGET_TARGET_FRAMEWORK "net8.0-windows10.0.19041.0")
 
 # generate vars with native paths since nuget won't accept unix path separators
 cmake_path(NATIVE_PATH CMAKE_SOURCE_DIR CMAKE_SOURCE_DIR_NATIVE)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes a build error when creating the NuGet packages.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The WSLC SDK NuGet package uses a CMake variable to set its Target Framework. This variable is usually set later in the configure process, but when only doing the "bundle" target, most of the usual configuration is skipped. As a result, when using the "bundle" target to configure the .nuspec, this value was missing. Fixed by moving this variable to within the nuget folder.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
