### PR TITLE
fedora: Add Fedora 44 and drop Fedora 42

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -199,9 +199,22 @@
         ],
         "Fedora": [
             {
+                "Name": "FedoraLinux-44",
+                "FriendlyName": "Fedora Linux 44",
+                "Default": true,
+                "Amd64Url": {
+                    "Url": "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Container/x86_64/images/Fedora-WSL-Base-44-1.7.x86_64.wsl",
+                    "Sha256": "2e5b153ba4b639952bf546be577fc19b832fe8944caa7de342b32f10da7d319a"
+                },
+                "Arm64Url": {
+                    "Url": "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Container/aarch64/images/Fedora-WSL-Base-44-1.7.aarch64.wsl",
+                    "Sha256": "1a3220262dc918b07d08410278205fb35e92c28a53455382028eea1a980476ee"
+                }
+            },
+            {
                 "Name": "FedoraLinux-43",
                 "FriendlyName": "Fedora Linux 43",
-                "Default": true,
+                "Default": false,
                 "Amd64Url": {
                     "Url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Container/x86_64/images/Fedora-WSL-Base-43-1.6.x86_64.wsl",
                     "Sha256": "220780af9cf225e9645313b4c7b0457a26a38a53285eb203b2ab6188d54d5b82"
@@ -209,19 +222,6 @@
                 "Arm64Url": {
                     "Url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Container/aarch64/images/Fedora-WSL-Base-43-1.6.aarch64.wsl",
                     "Sha256": "7eef7a83260218d8c878b3c7bbdaf11772103145184d0c65df27557f4cd49548"
-                }
-            },
-            {
-                "Name": "FedoraLinux-42",
-                "FriendlyName": "Fedora Linux 42",
-                "Default": false,
-                "Amd64Url": {
-                    "Url": "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Container/x86_64/images/Fedora-WSL-Base-42-1.1.x86_64.tar.xz",
-                    "Sha256": "99fb3d05d78ca17c6815bb03cf528da8ef82ebc6260407f2b09461e0da8a1b8d"
-                },
-                "Arm64Url": {
-                    "Url": "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Container/aarch64/images/Fedora-WSL-Base-42-1.1.aarch64.tar.xz",
-                    "Sha256": "a5a2ceb8ca56b7245b909d021b0fd620427db349f02b8ef3b82b741bcb5611cd"
                 }
             }
         ],


### PR DESCRIPTION
Fedora 44 releases on April 28th; add its images and make it the default. Additionally, Fedora 42 will shortly go EOL so it is removed from the list.