### PR TITLE
Use session display name as WSLC VM owner

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -49,7 +49,7 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
     // Build HCS settings
     hcs::ComputeSystem systemSettings{};
-    systemSettings.Owner = L"WSL";
+    systemSettings.Owner = Settings->DisplayName ? Settings->DisplayName : L"WSLC";
     systemSettings.ShouldTerminateOnLastHandleClosed = true;
 
     // Determine which schema version to use based on the Windows version. Windows 10 does not support

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include "WSLCProcessLauncher.h"
 #include "WSLCContainerLauncher.h"
 #include "WslCoreFilesystem.h"
+#include <nlohmann/json.hpp>
 
 using namespace std::literals::chrono_literals;
 using namespace wsl::windows::common::registry;
@@ -434,6 +435,50 @@ class WSLCTests
             settings.StorageFlags = static_cast<WSLCSessionStorageFlags>(0x2);
             wil::com_ptr<IWSLCSession> session;
             VERIFY_ARE_EQUAL(sessionManager->CreateSession(&settings, WSLCSessionFlagsNone, &session), E_INVALIDARG);
+        }
+    }
+
+    // Returns the set of VM owner names currently reported by hcsdiag.
+    static std::vector<std::wstring> ListVmOwners()
+    {
+        std::wstring commandLine = L"hcsdiag list -raw";
+        wsl::windows::common::SubProcess process(nullptr, commandLine.c_str());
+        auto output = process.RunAndCaptureOutput(10000);
+
+        std::vector<std::wstring> owners;
+        auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(output.Stdout), nullptr, false);
+        if (!json.is_array())
+        {
+            return owners;
+        }
+
+        for (const auto& entry : json)
+        {
+            if (entry.contains("Owner") && entry["Owner"].is_string())
+            {
+                owners.push_back(wsl::shared::string::MultiByteToWide(entry["Owner"].get<std::string>()));
+            }
+        }
+
+        return owners;
+    }
+
+    WSLC_TEST_METHOD(VmOwnerMatchesSessionDisplayName)
+    {
+        // The default session (c_testSessionName) is already running from class setup.
+        // Verify its display name appears as a VM owner in hcsdiag output.
+        auto owners = ListVmOwners();
+
+        auto found = std::ranges::find(owners, c_testSessionName);
+        if (found == owners.end())
+        {
+            LogError("Expected VM owner '%ws' not found. Owners:", c_testSessionName);
+            for (const auto& owner : owners)
+            {
+                LogError("  '%ws'", owner.c_str());
+            }
+
+            VERIFY_FAIL();
         }
     }
 


### PR DESCRIPTION
Use the session display name as the HCS VM owner field so that `hcsdiag list` output shows which session owns each VM (e.g. `wslc-cli-admin-benhillis`). This aids debugging and allows tests to reliably identify their VM.

Falls back to `WSLC` if DisplayName is null (defensive, should not happen in practice).

### Changes
- `HcsVirtualMachine.cpp`: Set owner to `Settings->DisplayName` instead of `L"WSL"`
- `WSLCTests.cpp`: Add `VmOwnerMatchesSessionDisplayName` test with `ListVmOwners()` helper that parses `hcsdiag list` output