### PR TITLE
Add a temporary fix to prevent VS project load failures due to 'AnyCpu' targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,10 @@ if (NOT DEFINED WSL_BUILD_WSL_SETTINGS)
     set(WSL_BUILD_WSL_SETTINGS false)
 endif ()
 
+if (NOT DEFINED WSL_BUILD_SDKCS)
+    set(WSL_BUILD_SDKCS false)
+endif ()
+
 find_commit_hash(COMMIT_HASH)
 
 if (NOT PACKAGE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,9 +311,11 @@ if (${TARGET_PLATFORM} STREQUAL "x64")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /CETCOMPAT")
 endif()
 
-set(CMAKE_CSharp_FLAGS "${CMAKE_CSharp_FLAGS} /langversion:latest /debug:full")
-set(CMAKE_DOTNET_SDK "Microsoft.NET.Sdk")
-set(CMAKE_DOTNET_TARGET_FRAMEWORK "net8.0-windows${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+if (WSL_BUILD_SDKCS OR WSL_BUILD_WSL_SETTINGS)
+    set(CMAKE_CSharp_FLAGS "${CMAKE_CSharp_FLAGS} /langversion:latest /debug:full")
+    set(CMAKE_DOTNET_SDK "Microsoft.NET.Sdk")
+    set(CMAKE_DOTNET_TARGET_FRAMEWORK "net8.0-windows${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+endif()
 
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)
@@ -541,7 +543,10 @@ add_subdirectory(src/windows/wslrelay)
 add_subdirectory(src/windows/wslinstall)
 add_subdirectory(src/windows/wslc)
 add_subdirectory(src/windows/WslcSDK)
-add_subdirectory(src/windows/WslcSDK/csharp)
+
+if (WSL_BUILD_SDKCS)
+    add_subdirectory(src/windows/WslcSDK/csharp)
+endif()
 
 if (WSL_BUILD_WSL_SETTINGS)
     add_subdirectory(src/windows/libwsl)

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -36,6 +36,9 @@ endif()
 # # Uncomment to skip building, packaging and installing wslsettings
 # set(WSL_BUILD_WSL_SETTINGS false)
 
+# # Uncomment to skip building the C# WSLC sdk
+# set(WSL_BUILD_SDKCS false)
+
 # # Uncomment to generate a "thin" MSI package which builds and installs faster
 # set(WSL_BUILD_THIN_PACKAGE true)
 

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -33,11 +33,11 @@ if(WSL_DEV_BINARY_PATH)
     endforeach()
 endif()
 
-# # Uncomment to skip building, packaging and installing wslsettings
-# set(WSL_BUILD_WSL_SETTINGS false)
+# # Uncomment to build, package and install wslsettings
+# set(WSL_BUILD_WSL_SETTINGS true)
 
-# # Uncomment to skip building the C# WSLC sdk
-# set(WSL_BUILD_SDKCS false)
+# # Uncomment to build the C# WSLC sdk
+# set(WSL_BUILD_SDKCS true)
 
 # # Uncomment to generate a "thin" MSI package which builds and installs faster
 # set(WSL_BUILD_THIN_PACKAGE true)


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change introduces a temporary opt-out flag to skip the C# version of the SDK, since it breaks loading the project with visual studio: 
<img width="602" height="240" alt="image" src="https://github.com/user-attachments/assets/caa3944c-cb69-4f20-904f-7017fa7b9f2a" />



<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
