### PR TITLE
Bump GitPython to 3.1.47 to fix command injection vulnerabilities

### DIFF
--- a/distributions/requirements.txt
+++ b/distributions/requirements.txt
@@ -1,5 +1,5 @@
 python-magic==0.4.27
 click==8.1.3
-GitPython==3.1.41
+GitPython==3.1.47
 PyGithub==2.5.0
 json-cfg==0.4.2

--- a/tools/devops/requirements.txt
+++ b/tools/devops/requirements.txt
@@ -1,4 +1,4 @@
 azure-devops==7.1.0b4
 click==8.1.3
-gitpython==3.1.41
+gitpython==3.1.47
 backoff==2.2.1


### PR DESCRIPTION
Bumps GitPython from 3.1.41 to 3.1.47 in both 	ools/devops/requirements.txt and distributions/requirements.txt.

Fixes all 4 open Dependabot alerts (CVE-2024-22190, GHSA-2mqj-m65w-jghx).