### PR TITLE
Fix race condition in VM process tracking logic

### DIFF
--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -645,24 +645,29 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
 
     // Check if this is a tty or not
     const WSLCProcessFd* tty = nullptr;
-    const WSLCProcessFd* ttyControl = nullptr;
     auto [pid, _, childChannel] = Fork(WSLC_FORK::Process);
 
     std::vector<WSLCVirtualMachine::ConnectedSocket> sockets;
+    ConnectedSocket ttyControlhandle;
     for (const auto& e : Fds)
     {
-        if (e.Type == WSLCFdTypeTty)
-        {
-            THROW_HR_IF_MSG(E_INVALIDARG, tty != nullptr, "Multiple terminal fds specified");
-            tty = &e;
-        }
-        else if (e.Type == WSLCFdTypeTtyControl)
-        {
-            THROW_HR_IF_MSG(E_INVALIDARG, ttyControl != nullptr, "Multiple terminal control fds specified");
-            ttyControl = &e;
-        }
 
-        sockets.emplace_back(ConnectSocket(childChannel, static_cast<int32_t>(e.Fd)));
+        if (e.Type == WSLCFdTypeTtyControl)
+        {
+            THROW_HR_IF_MSG(E_INVALIDARG, ttyControlhandle.Fd != -1, "Multiple terminal control fds specified");
+
+            ttyControlhandle = ConnectSocket(childChannel, e.Fd);
+        }
+        else
+        {
+            if (e.Type == WSLCFdTypeTty)
+            {
+                THROW_HR_IF_MSG(E_INVALIDARG, tty != nullptr, "Multiple terminal fds specified");
+                tty = &e;
+            }
+
+            sockets.emplace_back(ConnectSocket(childChannel, e.Fd));
+        }
     }
 
     PrepareCommandLine(sockets);
@@ -674,6 +679,16 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
     Message.WriteStringArray(Message->CommandLineIndex, Options.CommandLine.Values, Options.CommandLine.Count);
     Message.WriteStringArray(Message->EnvironmentIndex, Options.Environment.Values, Options.Environment.Count);
 
+    // N.B. The process control needs to be registered before the actual exec message is sent. Otherwise, if the process exits quickly, we might receive the exit notification before registering it.
+    std::shared_ptr<VMProcessControl> control;
+    auto registerProcess = [&](int processPid) {
+        control = std::make_shared<VMProcessControl>(*this, processPid, std::move(ttyControlhandle.Socket));
+        {
+            std::lock_guard lock{m_trackedProcessesLock};
+            m_trackedProcesses.emplace_back(control);
+        }
+    };
+
     // If this is an interactive tty, we need a relay process
     if (tty != nullptr)
     {
@@ -681,7 +696,7 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
         WSLC_TTY_RELAY relayMessage{};
         relayMessage.TtyMaster = ptyMaster;
         relayMessage.Socket = tty->Fd;
-        relayMessage.TtyControl = ttyControl == nullptr ? -1 : ttyControl->Fd;
+        relayMessage.TtyControl = ttyControlhandle.Fd; // N.B. Fd is set to -1 if unset.
         {
             auto relayTransaction = childChannel.StartTransaction();
             relayTransaction.Send(relayMessage);
@@ -693,6 +708,8 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
             setErrno(result);
             THROW_HR_MSG(E_FAIL, "errno: %i", result);
         }
+
+        registerProcess(grandChildPid);
 
         {
             auto execTransaction = grandChildChannel.StartTransaction();
@@ -710,40 +727,26 @@ Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcessImpl(
     }
     else
     {
+        registerProcess(pid);
+
+        auto execTransaction = childChannel.StartTransaction();
+        execTransaction.Send<WSLC_EXEC>(Message.Span());
+        auto [execResponse, execSpan] = execTransaction.ReceiveOrClosed<RESULT_MESSAGE<int32_t>>();
+        auto result = execResponse != nullptr ? execResponse->Result : 0;
+        if (result != 0)
         {
-            auto execTransaction = childChannel.StartTransaction();
-            execTransaction.Send<WSLC_EXEC>(Message.Span());
-            auto [execResponse, execSpan] = execTransaction.ReceiveOrClosed<RESULT_MESSAGE<int32_t>>();
-            auto result = execResponse != nullptr ? execResponse->Result : 0;
-            if (result != 0)
-            {
-                setErrno(result);
-                THROW_HR_MSG(E_FAIL, "errno: %i", result);
-            }
+            setErrno(result);
+            THROW_HR_MSG(E_FAIL, "errno: %i", result);
         }
     }
-
-    wil::unique_socket ttyControlHandle;
 
     std::map<ULONG, TypedHandle> stdHandles;
     for (auto& [fd, handle] : sockets)
     {
-        if (ttyControl != nullptr && fd == ttyControl->Fd)
-        {
-            ttyControlHandle = std::move(handle);
-            continue;
-        }
-
         stdHandles.emplace(fd, TypedHandle{wil::unique_handle{reinterpret_cast<HANDLE>(handle.release())}, WSLCHandleTypeSocket});
     }
 
     auto io = std::make_unique<VMProcessIO>(std::move(stdHandles));
-    auto control = std::make_shared<VMProcessControl>(*this, pid, std::move(ttyControlHandle));
-
-    {
-        std::lock_guard lock{m_trackedProcessesLock};
-        m_trackedProcesses.emplace_back(control);
-    }
 
     auto process = wil::MakeOrThrow<WSLCProcess>(std::move(control), std::move(io), Options.Flags);
 

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -111,7 +111,7 @@ class WSLCVirtualMachine
 public:
     struct ConnectedSocket
     {
-        int Fd{};
+        int Fd = -1;
         wil::unique_socket Socket;
     };
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the VM process creation logic to start tracking the process before actually exec'ing it, which avoids a potential hang if the process terminates before we add it to `m_trackedProcesses`.

Thanks to @SvenGroot  for reporting this. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
