### PR TITLE
Fix issue with VS project load caused by AnyCPU targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,12 +315,6 @@ if (${TARGET_PLATFORM} STREQUAL "x64")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /CETCOMPAT")
 endif()
 
-if (WSL_BUILD_SDKCS OR WSL_BUILD_WSL_SETTINGS)
-    set(CMAKE_CSharp_FLAGS "${CMAKE_CSharp_FLAGS} /langversion:latest /debug:full")
-    set(CMAKE_DOTNET_SDK "Microsoft.NET.Sdk")
-    set(CMAKE_DOTNET_TARGET_FRAMEWORK "net8.0-windows${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
-endif()
-
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)
 set(COMMON_LINK_LIBRARIES

--- a/cmake/FindCSharp.cmake
+++ b/cmake/FindCSharp.cmake
@@ -1,6 +1,11 @@
 function(configure_csharp_target TARGET)
     set(TARGET_PLATFORM_MIN_VERSION "10.0.19041.0")
 
+    target_compile_options(
+        ${TARGET}
+        PRIVATE "/langversion:latest"
+        PRIVATE "/debug:full")
+
     set_target_properties(
         ${TARGET} PROPERTIES
         VS_GLOBAL_TargetPlatformVersion "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
@@ -9,5 +14,7 @@ function(configure_csharp_target TARGET)
         VS_GLOBAL_AppendRuntimeIdentifierToOutputPath false
         VS_GLOBAL_GenerateAssemblyInfo false
         VS_GLOBAL_TargetLatestRuntimePatch false
+        DOTNET_SDK "Microsoft.NET.Sdk"
+        DOTNET_TARGET_FRAMEWORK "net8.0-windows${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
     )
 endfunction()

--- a/cmake/FindCSharp.cmake
+++ b/cmake/FindCSharp.cmake
@@ -3,8 +3,9 @@ function(configure_csharp_target TARGET)
 
     target_compile_options(
         ${TARGET}
-        PRIVATE "/langversion:latest"
-        PRIVATE "/debug:full")
+        PRIVATE
+            "/langversion:latest"
+            "/debug:full")
 
     set_target_properties(
         ${TARGET} PROPERTIES


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Removes the .NET variables being set at the top-level CMakeLists.txt and sets them only for C# projects.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Builds on top of #40348.

When `CMAKE_DOTNET_SDK` is set, one of the platform variables is automatically set to `AnyCPU`. Doing it at the top level meant that every target would get it, and when generating the solution file, CMake would select that as the current platform for all targets instead of using the same x64 or arm64 as it did for the `.vcxproj`. Moving this to only be set for the C# targets means that those are the only ones that get `AnyCPU`, even when the overall solution is x64/arm64.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
