### PR TITLE
Change default MAX VHD size set by SDK from 1GB to 32GB

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -31,7 +31,7 @@ constexpr uint32_t s_DefaultMemoryMB = 2000;
 // Maximum value per use with HVSOCKET_CONNECT_TIMEOUT_MAX
 constexpr ULONG s_DefaultBootTimeout = 300000;
 // Default to 1 GB
-constexpr UINT64 s_DefaultStorageSize = 1000 * 1000 * 1000;
+constexpr UINT64 s_DefaultStorageSize = 1000ULL * 1000 * 1000 * 1000;
 
 #define WSLC_FLAG_VALUE_ASSERT(_wlsc_name_, _wslc_name_) \
     static_assert(_wlsc_name_ == _wslc_name_, "Flag values differ: " #_wlsc_name_ " != " #_wslc_name_);

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -30,8 +30,9 @@ constexpr uint32_t s_DefaultCPUCount = 2;
 constexpr uint32_t s_DefaultMemoryMB = 2000;
 // Maximum value per use with HVSOCKET_CONNECT_TIMEOUT_MAX
 constexpr ULONG s_DefaultBootTimeout = 300000;
-// Default to 1 TB (decimal, 1,000,000,000,000 bytes)
-constexpr UINT64 s_DefaultStorageSize = 1000ULL * 1000 * 1000 * 1000;
+// Default to 32GB
+constexpr UINT64 s_DefaultStorageSize = 32ULL * 1000 * 1000 * 1000;
+
 
 #define WSLC_FLAG_VALUE_ASSERT(_wlsc_name_, _wslc_name_) \
     static_assert(_wlsc_name_ == _wslc_name_, "Flag values differ: " #_wlsc_name_ " != " #_wslc_name_);

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -30,7 +30,7 @@ constexpr uint32_t s_DefaultCPUCount = 2;
 constexpr uint32_t s_DefaultMemoryMB = 2000;
 // Maximum value per use with HVSOCKET_CONNECT_TIMEOUT_MAX
 constexpr ULONG s_DefaultBootTimeout = 300000;
-// Default to 1 GB
+// Default to 1 TB (decimal, 1,000,000,000,000 bytes)
 constexpr UINT64 s_DefaultStorageSize = 1000ULL * 1000 * 1000 * 1000;
 
 #define WSLC_FLAG_VALUE_ASSERT(_wlsc_name_, _wslc_name_) \


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1GB max size is to small for max size. this changes default max size to 1TB to match CLI.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
