### PR TITLE
Fix garbled UTF-8 progress bars in wslc build output

### DIFF
--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1363,8 +1363,12 @@ void wsl::windows::common::wslutil::SetCrtEncoding(int Mode)
     setMode(stdout, Mode);
     setMode(stderr, Mode);
 
-    // Set the locale to the current environment's default locale.
+    // Set the locale to the current environment's default locale for regional
+    // formatting (numeric, time, collation), then override LC_CTYPE to UTF-8
+    // so that narrow-to-wide conversions (e.g. %hs in wprintf) correctly decode
+    // UTF-8 multi-byte sequences from Linux/container processes.
     WI_VERIFY(_wsetlocale(LC_ALL, L"") != NULL);
+    WI_VERIFY(_wsetlocale(LC_CTYPE, L".UTF-8") != NULL);
 }
 
 void wsl::windows::common::wslutil::SetThreadDescription(LPCWSTR Name)

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1368,7 +1368,10 @@ void wsl::windows::common::wslutil::SetCrtEncoding(int Mode)
     // so that narrow-to-wide conversions (e.g. %hs in wprintf) correctly decode
     // UTF-8 multi-byte sequences from Linux/container processes.
     WI_VERIFY(_wsetlocale(LC_ALL, L"") != NULL);
-    WI_VERIFY(_wsetlocale(LC_CTYPE, L".UTF-8") != NULL);
+    if (Mode == _O_U8TEXT)
+    {
+        WI_VERIFY(_wsetlocale(LC_CTYPE, L".UTF-8") != NULL);
+    }
 }
 
 void wsl::windows::common::wslutil::SetThreadDescription(LPCWSTR Name)


### PR DESCRIPTION
## Problem

When running `wslc build` (e.g. `RUN pwsh playwright.ps1 install --with-deps`), UTF-8 progress bar characters like U+2588 FULL BLOCK are rendered as garbled text.

This happens because `BuildImageCallback::OnProgress` uses `wprintf(L"%hs", status)`, and the `%hs` format specifier uses the CRT locale's `LC_CTYPE` to decode narrow bytes into wide characters. The locale was set to `L""` (system default), which uses the ANSI codepage (e.g. Windows-1252 on English systems) - not UTF-8.

## Fix

After setting the system default locale (preserving regional formatting), override `LC_CTYPE` to UTF-8:

```cpp
WI_VERIFY(_wsetlocale(LC_ALL, L"") != NULL);
WI_VERIFY(_wsetlocale(LC_CTYPE, L".UTF-8") != NULL);
```

This keeps regional settings (numeric, time, collation) from the user's environment while ensuring all narrow-to-wide string conversions use UTF-8.

## Why this is safe

1. **The app already declares itself UTF-8** - `SetCrtEncoding` calls `_setmode(stdout, _O_U8TEXT)` on the same streams.
2. **All narrow strings are UTF-8** - they originate from Linux processes or Docker/container output.
3. **The codebase uses wide strings for Windows paths** - narrow strings through `%hs` are exclusively Linux/container-sourced.
4. **No locale-sensitive CRT functions are used** - no `mbstowcs`, `strtod`, `strcoll`, `strftime` in `src/windows/`.
5. **Only LC_CTYPE is changed** - regional settings (numeric, time, collation) are preserved via `LC_ALL = ""`.
6. **CRT is statically linked (MSVC v143)** - `.UTF-8` locale modifier is fully supported since VS 2017 15.7.

## Repro

`dockerfile
FROM ubuntu:24.04
RUN printf '|\xe2\x96\x88\xe2\x96\x88\xe2\x96\x88| 50%%\n'
`

`wslc build -t test .` - before fix shows garbled output, after fix shows correct block characters.

## Reported by

Scott Hanselman - observed during Playwright browser downloads in Docker builds.
