### PR TITLE
Fix a potential hang if synchronous IO is scheduled after CancelUserHandleIO() returns

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2283,30 +2283,47 @@ CATCH_RETURN();
 HRESULT WSLCSession::Terminate()
 try
 {
+    wil::rwlock_release_exclusive_scope_exit sessionLock;
 
+    // Because it's not possible to synchronize CancelIoEx() with ReadFile() calls, keep attempting to acquire the session lock while cancelling IO & callbacks.
+    // This is required because calling CancelIoEx() between two ReadFile() calls does nothing, and therefore could still allow another thread to get stuck doing synchronous IO.
+    while (!sessionLock)
     {
-        std::lock_guard lock(m_userHandlesLock);
+        {
+            std::lock_guard lock(m_userHandlesLock);
 
-        // m_sessionTerminatingEvent is always valid, so it can be signalled without holding m_lock.
-        // This allows a session to be unblocked if a stuck operation is holding m_lock.
-        // N.B. This must happen under m_userHandlesLock to synchronize with potentially running operations.
-        m_sessionTerminatingEvent.SetEvent();
+            // m_sessionTerminatingEvent is always valid, so it can be signalled without holding m_lock.
+            // This allows a session to be unblocked if a stuck operation is holding m_lock.
+            // N.B. This must happen under m_userHandlesLock to synchronize with potentially running operations.
+            if (!m_sessionTerminatingEvent.is_signaled())
+            {
+                m_sessionTerminatingEvent.SetEvent();
+            }
+            else
+            {
+                // If this isn't the first iteration, sleep to present this loop for burning too much CPU.
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
 
-        // Cancel any pending IO on user-provided handles to unblock operations
-        // in case the handles don't support overlapped IO.
-        CancelUserHandleIO();
-    }
+            // Cancel any pending IO on user-provided handles to unblock operations
+            // in case the handles don't support overlapped IO.
+            CancelUserHandleIO();
+        }
 
-    {
-        std::lock_guard comLock(m_userCOMCallbacksLock);
+        {
+            std::lock_guard comLock(m_userCOMCallbacksLock);
 
-        // Cancel any pending outgoing COM callback calls (e.g. IProgressCallback::OnProgress)
-        // to unblock operations waiting for cross-process COM responses.
-        CancelUserCOMCallbacks();
+            // Cancel any pending outgoing COM callback calls (e.g. IProgressCallback::OnProgress)
+            // to unblock operations waiting for cross-process COM responses.
+            CancelUserCOMCallbacks();
+        }
+
+        sessionLock = m_lock.try_lock_exclusive();
     }
 
     // Acquire an exclusive lock to ensure that no operation is running.
-    auto lock = m_lock.lock_exclusive();
+    WI_VERIFY(sessionLock);
+
     std::lock_guard containersLock(m_containersLock);
     std::lock_guard volumesLock(m_volumesLock);
     std::lock_guard networksLock(m_networksLock);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2287,8 +2287,15 @@ try
 
     // Because it's not possible to synchronize CancelIoEx() with ReadFile() calls, keep attempting to acquire the session lock while cancelling IO & callbacks.
     // This is required because calling CancelIoEx() between two ReadFile() calls does nothing, and therefore could still allow another thread to get stuck doing synchronous IO.
+    bool retrying = false;
     while (!sessionLock)
     {
+        // If this isn't the first iteration, sleep to prevent this loop from burning too much CPU.
+        if (retrying)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
         {
             std::lock_guard lock(m_userHandlesLock);
 
@@ -2298,11 +2305,6 @@ try
             if (!m_sessionTerminatingEvent.is_signaled())
             {
                 m_sessionTerminatingEvent.SetEvent();
-            }
-            else
-            {
-                // If this isn't the first iteration, sleep to present this loop for burning too much CPU.
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
 
             // Cancel any pending IO on user-provided handles to unblock operations
@@ -2319,6 +2321,7 @@ try
         }
 
         sessionLock = m_lock.try_lock_exclusive();
+        retrying = true;
     }
 
     // Acquire an exclusive lock to ensure that no operation is running.

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2310,7 +2310,7 @@ try
     {
         return S_OK;
     }
-  
+
     wil::rwlock_release_exclusive_scope_exit sessionLock;
 
     // Because it's not possible to synchronize CancelIoEx() with ReadFile() calls, keep attempting to acquire the session lock while cancelling IO & callbacks.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a potential hang during session termination. See comment for details.

Thanks to @SvenGroot for reporting this.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
