### PR TITLE
Fix ABBA deadlock between WSLCContainerImpl & COMImplClass

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -415,7 +415,7 @@ unique_com_disconnect::unique_com_disconnect(Microsoft::WRL::ComPtr<WSLCContaine
 {
 }
 
-unique_com_disconnect::~unique_com_disconnect()
+unique_com_disconnect::~unique_com_disconnect() noexcept
 {
     if (m_wrapper)
     {

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -34,6 +34,7 @@ using wsl::windows::service::wslc::ContainerPortMapping;
 using wsl::windows::service::wslc::IWSLCVolume;
 using wsl::windows::service::wslc::RelayedProcessIO;
 using wsl::windows::service::wslc::TypedHandle;
+using wsl::windows::service::wslc::unique_com_disconnect;
 using wsl::windows::service::wslc::VMPortMapping;
 using wsl::windows::service::wslc::WSLCContainer;
 using wsl::windows::service::wslc::WSLCContainerImpl;
@@ -409,6 +410,19 @@ const char* ContainerPortMapping::ProtocolString() const
     }
 }
 
+unique_com_disconnect::unique_com_disconnect(Microsoft::WRL::ComPtr<WSLCContainer>&& wrapper) noexcept :
+    m_wrapper(std::move(wrapper))
+{
+}
+
+unique_com_disconnect::~unique_com_disconnect()
+{
+    if (m_wrapper)
+    {
+        m_wrapper->Disconnect();
+    }
+}
+
 WSLCPortMapping ContainerPortMapping::Serialize() const
 {
     return WSLCPortMapping{
@@ -492,8 +506,14 @@ WSLCContainerImpl::~WSLCContainerImpl()
 
     m_containerEvents.Reset();
 
-    auto lock = m_lock.lock_exclusive();
-    ReleaseResources();
+    // Release resources under m_lock, but extract the COM wrapper so Disconnect()
+    // can be called without holding m_lock. Calling Disconnect() under m_lock can
+    // deadlock if an in-flight COM caller is waiting for m_lock.
+    unique_com_disconnect wrapper;
+    {
+        auto lock = m_lock.lock_exclusive();
+        wrapper = ReleaseResources();
+    }
 }
 
 void WSLCContainerImpl::OnProcessReleased(DockerExecProcessControl* process) noexcept
@@ -680,6 +700,8 @@ void WSLCContainerImpl::Start(WSLCContainerStartFlags Flags, LPCSTR DetachKeys)
 
 void WSLCContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCode, std::uint64_t eventTime)
 {
+    unique_com_disconnect comWrapper;
+
     if (event == ContainerEvent::Stop)
     {
         THROW_HR_IF(E_UNEXPECTED, !exitCode.has_value());
@@ -709,9 +731,14 @@ void WSLCContainerImpl::OnEvent(ContainerEvent event, std::optional<int> exitCod
 
             if (WI_IsFlagSet(m_containerFlags, WSLCContainerFlagsRm))
             {
-                DeleteExclusiveLockHeld(WSLCDeleteFlagsDeleteVolumes);
+                comWrapper = DeleteExclusiveLockHeld(WSLCDeleteFlagsDeleteVolumes);
             }
         }
+
+        // Release m_lock and m_stopLock before the wrapper's destructor calls
+        // Disconnect(), so in-flight COM callers can drain from COMImplClass::m_callers.
+        lock.reset();
+        stopGuard.unlock();
     }
     else if (event == ContainerEvent::Destroy)
     {
@@ -749,6 +776,9 @@ bool WSLCContainerImpl::WaitForEvent(const wil::unique_event& Event, std::chrono
 
 void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
 {
+    // N.B. comWrapper must be destructed after m_lock is released.
+    unique_com_disconnect comWrapper;
+
     std::lock_guard stopGuard{m_stopLock};
     auto lock = m_lock.lock_exclusive();
 
@@ -822,19 +852,20 @@ void WSLCContainerImpl::Stop(WSLCSignal Signal, LONG TimeoutSeconds, bool Kill)
 
     if (WI_IsFlagSet(m_containerFlags, WSLCContainerFlagsRm))
     {
-        DeleteExclusiveLockHeld(WSLCDeleteFlagsForce | WSLCDeleteFlagsDeleteVolumes);
+        comWrapper = DeleteExclusiveLockHeld(WSLCDeleteFlagsForce | WSLCDeleteFlagsDeleteVolumes);
     }
 }
 
 void WSLCContainerImpl::Delete(WSLCDeleteFlags Flags)
 {
-    // Acquire an exclusive lock since this method modifies m_state.
     auto lock = m_lock.lock_exclusive();
+    auto wrapper = DeleteExclusiveLockHeld(Flags);
+    lock.reset();
 
-    DeleteExclusiveLockHeld(Flags);
+    // N.B. wrapper must be destroyed after m_lock is released, since its destructor calls Disconnect().
 }
 
-__requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::DeleteExclusiveLockHeld(WSLCDeleteFlags Flags)
+__requires_exclusive_lock_held(m_lock) unique_com_disconnect WSLCContainerImpl::DeleteExclusiveLockHeld(WSLCDeleteFlags Flags)
 {
     // Validate that the container is not running or already deleted.
     THROW_HR_WITH_USER_ERROR_IF(
@@ -854,7 +885,7 @@ __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::DeleteExclusiveLo
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to delete container '%hs'", m_id.c_str());
 
     Transition(WslcContainerStateDeleted);
-    ReleaseResources();
+    return ReleaseResources();
 }
 
 void WSLCContainerImpl::Export(WSLCHandle OutHandle) const
@@ -1681,7 +1712,7 @@ __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::ReleaseRuntimeRes
     UnmountVolumes(m_mountedVolumes, m_virtualMachine);
 }
 
-__requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::ReleaseResources()
+__requires_exclusive_lock_held(m_lock) unique_com_disconnect WSLCContainerImpl::ReleaseResources()
 {
     WSL_LOG("ReleaseResources", TraceLoggingValue(m_id.c_str(), "ID"));
 
@@ -1693,11 +1724,10 @@ __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::ReleaseResources(
         e.VmMapping.VmPort.reset();
     }
 
-    // Disconnect the COM wrapper so no new RPC calls can reach this container.
-    DisconnectComWrapper();
+    return PrepareDisconnectComWrapper();
 }
 
-__requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::DisconnectComWrapper()
+__requires_exclusive_lock_held(m_lock) unique_com_disconnect WSLCContainerImpl::PrepareDisconnectComWrapper()
 {
     if (m_comWrapper)
     {
@@ -1707,10 +1737,9 @@ __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::DisconnectComWrap
             std::lock_guard processesLock{m_processesLock};
             m_comWrapper->CacheState(m_id, m_name, m_state, m_initProcess);
         }
-
-        m_comWrapper->Disconnect();
-        m_comWrapper.Reset();
     }
+
+    return unique_com_disconnect{std::exchange(m_comWrapper, nullptr)};
 }
 
 __requires_lock_held(m_lock) void WSLCContainerImpl::Transition(WSLCContainerState State, std::optional<std::uint64_t> stateChangedAt) noexcept
@@ -1756,7 +1785,7 @@ HRESULT WSLCContainer::GetState(WSLCContainerState* Result)
         return S_OK;
     }
 
-    // DisconnectComWrapper() populates the cache before setting m_impl to null,
+    // PrepareDisconnectComWrapper() populates the cache before setting m_impl to null,
     // so if CallImpl failed with RPC_E_DISCONNECTED, the cache must be populated.
     if (hr == RPC_E_DISCONNECTED)
     {
@@ -1783,7 +1812,7 @@ HRESULT WSLCContainer::GetInitProcess(IWSLCProcess** Process)
         return S_OK;
     }
 
-    // DisconnectComWrapper() populates the cache before setting m_impl to null,
+    // PrepareDisconnectComWrapper() populates the cache before setting m_impl to null,
     // so if CallImpl failed with RPC_E_DISCONNECTED, the cache must be populated.
     if (hr == RPC_E_DISCONNECTED)
     {
@@ -1861,7 +1890,7 @@ try
 {
     auto cacheLock = m_cacheLock.lock_exclusive();
 
-    // CacheState must only be called once, during DisconnectComWrapper().
+    // CacheState must only be called once, during PrepareDisconnectComWrapper().
     WI_ASSERT(!m_cachedState.has_value());
 
     m_cachedId = id;
@@ -1905,7 +1934,7 @@ try
 
     RETURN_HR_IF(hr, hr != RPC_E_DISCONNECTED);
 
-    // DisconnectComWrapper() populates the cache before setting m_impl to null,
+    // PrepareDisconnectComWrapper() populates the cache before setting m_impl to null,
     // so if LockImpl failed with RPC_E_DISCONNECTED, the cache must be populated.
     auto cacheLock = m_cacheLock.lock_shared();
     if (WI_VERIFY(m_cachedId.has_value()))
@@ -1933,7 +1962,7 @@ try
 
     RETURN_HR_IF(hr, hr != RPC_E_DISCONNECTED);
 
-    // DisconnectComWrapper() populates the cache before setting m_impl to null,
+    // PrepareDisconnectComWrapper() populates the cache before setting m_impl to null,
     // so if LockImpl failed with RPC_E_DISCONNECTED, the cache must be populated.
     auto cacheLock = m_cacheLock.lock_shared();
     if (WI_VERIFY(m_cachedName.has_value()))

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -39,7 +39,7 @@ public:
 
     unique_com_disconnect() = default;
     unique_com_disconnect(Microsoft::WRL::ComPtr<WSLCContainer>&& wrapper) noexcept;
-    ~unique_com_disconnect noexcept();
+    ~unique_com_disconnect() noexcept;
 
 private:
     Microsoft::WRL::ComPtr<WSLCContainer> m_wrapper;

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -31,6 +31,20 @@ namespace wsl::windows::service::wslc {
 class WSLCContainer;
 class WSLCSession;
 
+class unique_com_disconnect
+{
+public:
+    NON_COPYABLE(unique_com_disconnect);
+    DEFAULT_MOVABLE(unique_com_disconnect);
+
+    unique_com_disconnect() = default;
+    unique_com_disconnect(Microsoft::WRL::ComPtr<WSLCContainer>&& wrapper) noexcept;
+    ~unique_com_disconnect();
+
+private:
+    Microsoft::WRL::ComPtr<WSLCContainer> m_wrapper;
+};
+
 struct ContainerPortMapping
 {
     NON_COPYABLE(ContainerPortMapping);
@@ -130,17 +144,17 @@ public:
         IORelay& Relay);
 
 private:
-    __requires_exclusive_lock_held(m_lock) void DeleteExclusiveLockHeld(WSLCDeleteFlags Flags);
+    __requires_exclusive_lock_held(m_lock) unique_com_disconnect DeleteExclusiveLockHeld(WSLCDeleteFlags Flags);
 
     void AllocateBridgedModePorts();
     void OnEvent(ContainerEvent event, std::optional<int> exitCode, std::uint64_t eventTime);
 
     bool WaitForEvent(const wil::unique_event& Event, std::chrono::milliseconds Timeout) const;
 
-    __requires_exclusive_lock_held(m_lock) void ReleaseResources();
+    __requires_exclusive_lock_held(m_lock) unique_com_disconnect ReleaseResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseRuntimeResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseProcesses();
-    __requires_exclusive_lock_held(m_lock) void DisconnectComWrapper();
+    __requires_exclusive_lock_held(m_lock) unique_com_disconnect PrepareDisconnectComWrapper();
 
     std::unique_ptr<RelayedProcessIO> CreateRelayedProcessIO(wil::unique_handle&& stream, WSLCProcessFlags flags);
 
@@ -212,7 +226,7 @@ public:
     IFACEMETHOD(InterfaceSupportsErrorInfo)(REFIID riid);
 
     // Cache read-only properties so they remain accessible after the impl is disconnected.
-    // Called from WSLCContainerImpl::DisconnectComWrapper() while m_lock is held exclusively.
+    // Called from WSLCContainerImpl::PrepareDisconnectComWrapper() while m_lock is held exclusively.
     void CacheState(const std::string& id, const std::string& name, WSLCContainerState state, const Microsoft::WRL::ComPtr<IWSLCProcess>& initProcess) noexcept;
 
 private:

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -39,7 +39,7 @@ public:
 
     unique_com_disconnect() = default;
     unique_com_disconnect(Microsoft::WRL::ComPtr<WSLCContainer>&& wrapper) noexcept;
-    ~unique_com_disconnect();
+    ~unique_com_disconnect noexcept();
 
 private:
     Microsoft::WRL::ComPtr<WSLCContainer> m_wrapper;
@@ -144,17 +144,17 @@ public:
         IORelay& Relay);
 
 private:
-    __requires_exclusive_lock_held(m_lock) unique_com_disconnect DeleteExclusiveLockHeld(WSLCDeleteFlags Flags);
+    __requires_exclusive_lock_held(m_lock) [[nodiscard]] unique_com_disconnect DeleteExclusiveLockHeld(WSLCDeleteFlags Flags);
 
     void AllocateBridgedModePorts();
     void OnEvent(ContainerEvent event, std::optional<int> exitCode, std::uint64_t eventTime);
 
     bool WaitForEvent(const wil::unique_event& Event, std::chrono::milliseconds Timeout) const;
 
-    __requires_exclusive_lock_held(m_lock) unique_com_disconnect ReleaseResources();
+    __requires_exclusive_lock_held(m_lock) [[nodiscard]] unique_com_disconnect ReleaseResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseRuntimeResources();
     __requires_exclusive_lock_held(m_lock) void ReleaseProcesses();
-    __requires_exclusive_lock_held(m_lock) unique_com_disconnect PrepareDisconnectComWrapper();
+    __requires_exclusive_lock_held(m_lock) [[nodiscard]] unique_com_disconnect PrepareDisconnectComWrapper();
 
     std::unique_ptr<RelayedProcessIO> CreateRelayedProcessIO(wil::unique_handle&& stream, WSLCProcessFlags flags);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes an ABBA deadlock between WSLCContainerImpl  and COMImplClass

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Sample stacks: 

Holds `COMImplClass::m_lock`, wants `WSLCContainerImpl::m_lock`
```
02 00000080`00c6d880 00007ff7`48ccc30a     ntdll!RtlAcquireSRWLockShared+0x5c [minkernel\ntos\rtl\srwlock.c @ 2017] 
03 00000080`00c6d8b0 00007ff7`48d09c71     wslcsession!wil::AcquireSRWLockShared+0x1a [C:\Users\piboulay\repos\wsl2\packages\Microsoft.Windows.ImplementationLibrary.1.0.251108.1\include\wil\resource.h @ 3285] 
04 00000080`00c6d8e0 00007ff7`48d1f76c     wslcsession!wil::srwlock::lock_shared+0x21 [C:\Users\piboulay\repos\wsl2\packages\Microsoft.Windows.ImplementationLibrary.1.0.251108.1\include\wil\resource.h @ 3320] 
05 00000080`00c6d910 00007ff7`48d3a694     wslcsession!wsl::windows::service::wslc::WSLCContainerImpl::GetState+0x5c [C:\Users\piboulay\repos\wsl2\src\windows\wslcsession\WSLCContainer.cpp @ 910] 
06 00000080`00c6d970 00007ff7`48d27311     wslcsession!wsl::windows::service::wslc::COMImplClass<wsl::windows::service::wslc::WSLCContainerImpl>::CallImpl<enum _WSLCContainerState *>+0xe4 [C:\Users\piboulay\repos\wsl2\src\windows\common\COMImplClass.h @ 51] 
07 00000080`00c6da60 00007ff8`e70fed73     wslcsession!wsl::windows::service::wslc::WSLCContainer::GetState+0x121 [C:\Users\piboulay\repos\wsl2\src\windows\wslcsession\WSLCContainer.cpp @ 1753] 
```

Holds `WSLCContainerImpl::m_lock`, wants `COMImplClass::m_lock`

```
08 00000080`00d6df50 00007ff7`48d25543     wslcsession!wsl::windows::service::wslc::COMImplClass<wsl::windows::service::wslc::WSLCContainerImpl>::Disconnect+0x8c [C:\Users\piboulay\repos\wsl2\src\windows\common\COMImplClass.h @ 37] 
09 00000080`00d6dfd0 00007ff7`48d25276     wslcsession!wsl::windows::service::wslc::WSLCContainerImpl::DisconnectComWrapper+0x103 [C:\Users\piboulay\repos\wsl2\src\windows\wslcsession\WSLCContainer.cpp @ 1712] 
0a 00000080`00d6e050 00007ff7`48d24afd     wslcsession!wsl::windows::service::wslc::WSLCContainerImpl::ReleaseResources+0xf6 [C:\Users\piboulay\repos\wsl2\src\windows\wslcsession\WSLCContainer.cpp @ 1697] 
0b 00000080`00d6e0c0 00007ff7`48d24d9e     wslcsession!wsl::windows::service::wslc::WSLCContainerImpl::DeleteExclusiveLockHeld+0x46d [C:\Users\piboulay\repos\wsl2\src\windows\wslcsession\WSLCContainer.cpp @ 857] 
0c 00000080`00d6e410 00007ff7`48d61df3     wslcsession!wsl::windows::service::wslc::WSLCContainerImpl::OnEvent+0x26
```

This changes solves the issue by dropping  `WSLCContainerImpl::m_lock` when disconnecting from the COM wrapper

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
