### PR TITLE
Use a scope_exit to cleanup resources in ModuleCleanup

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2135,6 +2135,11 @@ Return Value:
 {
     LogInfo("Exiting UnitTests module");
 
+    auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
+        WslTraceLoggingUninitialize();
+        g_mtaCookie.reset();
+    });
+
     //
     // Release the watchdog timer.
     //
@@ -2189,9 +2194,6 @@ Return Value:
 
         wsl::windows::common::registry::WriteString(userKey.get(), nullptr, L"DefaultDistribution", g_originalDefaultDistro.c_str());
     }
-
-    WslTraceLoggingUninitialize();
-    g_mtaCookie.reset();
 
     return true;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a potential test crash that could happen if ModuleCleanup() returns early, skipping cleanup for two global RAII variables. 


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
