### PR TITLE
Simplify the clang-format hook logic to generate pre-commit.in with the correct clang-format.exe path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,9 +410,6 @@ set(WSL_PRE_COMMIT_MODE "warn" CACHE STRING "Pre-commit hook behavior: warn, err
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tools/hooks)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/tools/hooks/pre-commit.in ${CMAKE_BINARY_DIR}/tools/hooks/pre-commit @ONLY)
 
-file(CREATE_LINK ${LLVM_INSTALL_DIR}/clang-format.exe ${CMAKE_CURRENT_LIST_DIR}/tools/clang-format.exe COPY_ON_ERROR)
-file(COPY_FILE ${CMAKE_CURRENT_LIST_DIR}/tools/hooks/pre-commit ${CMAKE_CURRENT_LIST_DIR}/tools/hooks/pre-commit ONLY_IF_DIFFERENT)
-
 set(LINUXSDK_PATH ${LINUXSDK_SOURCE_DIR}/${LLVM_ARCH})
 set(LLVM_TARGET "${LLVM_ARCH}-unknown-linux-musl")
 set(LINUX_CC ${LLVM_INSTALL_DIR}/clang.exe)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,11 +410,8 @@ set(WSL_PRE_COMMIT_MODE "warn" CACHE STRING "Pre-commit hook behavior: warn, err
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tools/hooks)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/tools/hooks/pre-commit.in ${CMAKE_BINARY_DIR}/tools/hooks/pre-commit @ONLY)
 
-cmake_path(COMPARE "${wsl_SOURCE_DIR}" EQUAL "${wsl_BINARY_DIR}" BUILD_IN_SOURCE)
-if (NOT ${BUILD_IN_SOURCE}) # Testing on 3.26 project_type_DIR paths appear canonicalized
-    file(CREATE_LINK ${LLVM_INSTALL_DIR}/clang-format.exe ${wsl_SOURCE_DIR}/tools/clang-format.exe COPY_ON_ERROR)
-    file(COPY_FILE ${CMAKE_BINARY_DIR}/tools/hooks/pre-commit ${wsl_SOURCE_DIR}/tools/hooks/pre-commit ONLY_IF_DIFFERENT)
-endif()
+file(CREATE_LINK ${LLVM_INSTALL_DIR}/clang-format.exe ${CMAKE_CURRENT_LIST_DIR}/tools/clang-format.exe COPY_ON_ERROR)
+file(COPY_FILE ${CMAKE_CURRENT_LIST_DIR}/tools/hooks/pre-commit ${CMAKE_CURRENT_LIST_DIR}/tools/hooks/pre-commit ONLY_IF_DIFFERENT)
 
 set(LINUXSDK_PATH ${LINUXSDK_SOURCE_DIR}/${LLVM_ARCH})
 set(LLVM_TARGET "${LLVM_ARCH}-unknown-linux-musl")

--- a/tools/hooks/pre-commit.in
+++ b/tools/hooks/pre-commit.in
@@ -13,7 +13,7 @@
 
 MODE="@WSL_PRE_COMMIT_MODE@"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-CLANG_FORMAT="$REPO_ROOT/tools/clang-format.exe"
+CLANG_FORMAT="@LLVM_INSTALL_DIR@/clang-format.exe"
 
 # --- Collect staged C/C++ source files ---
 STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|cpp|cxx|h|hpp|hxx)$')


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This fixed the clang-format hook for my setup.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
