### PR TITLE
Fix Session 0 support for WSLC SDK callers (e.g. NETWORK SERVICE)

### DIFF
--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -22,6 +22,24 @@ using GetVmWorkerProcessType = decltype(GetVmWorkerProcess(std::declval<Args>().
 
 using namespace wsl::windows::common::hcs;
 
+// Set COM proxy blanket for Session 0 compatibility.
+// In Session 0, cross-process COM callbacks (e.g. from vmwp.exe) fail unless
+// the proxy uses dynamic cloaking with impersonation. Without this, the default
+// COM security context captures the process token at CoInitializeSecurity time,
+// which is insufficient for callbacks from the VM worker process.
+static HRESULT SetProxyBlanketForSession0(IUnknown* proxy)
+{
+    return CoSetProxyBlanket(
+        proxy,
+        RPC_C_AUTHN_DEFAULT,
+        RPC_C_AUTHZ_DEFAULT,
+        COLE_DEFAULT_PRINCIPAL,
+        RPC_C_AUTHN_LEVEL_DEFAULT,
+        RPC_C_IMP_LEVEL_IMPERSONATE,
+        nullptr,
+        EOAC_DYNAMIC_CLOAKING);
+}
+
 DeviceHostProxy::DeviceHostProxy(const std::wstring& VmId, const GUID& RuntimeId) :
     m_systemId{VmId}, m_runtimeId{RuntimeId}, m_system{wsl::windows::common::hcs::OpenComputeSystem(VmId.c_str(), GENERIC_ALL)}, m_shutdown{false}
 {
@@ -151,6 +169,8 @@ try
     static LxssDynamicFunction<decltype(HdvProxyDeviceHost)> proxyDeviceHost{c_hdvModuleName, "HdvProxyDeviceHost"};
     const wil::com_ptr<IVmDeviceHost> remoteHost = DeviceHost;
     const wil::com_ptr<IUnknown> unknown = remoteHost.query<IUnknown>();
+    THROW_IF_FAILED(SetProxyBlanketForSession0(remoteHost.get()));
+    THROW_IF_FAILED(SetProxyBlanketForSession0(unknown.get()));
     THROW_IF_FAILED(proxyDeviceHost(m_system.get(), unknown.get(), ProcessId, IpcSectionHandle));
     return S_OK;
 }
@@ -195,6 +215,7 @@ try
                 c_vmwpctrlModuleName, "GetVmWorkerProcess"};
 
             RETURN_IF_FAILED(getVmWorker(m_runtimeId, __uuidof(*m_deviceAccess), reinterpret_cast<IUnknown**>(&m_deviceAccess)));
+            RETURN_IF_FAILED(SetProxyBlanketForSession0(m_deviceAccess.get()));
         }
 
         RETURN_HR_IF(E_NOINTERFACE, !m_deviceAccess);
@@ -204,6 +225,7 @@ try
         wil::com_ptr<IUnknown> device;
         RETURN_IF_FAILED(m_deviceAccess->GetDevice(FLEXIO_DEVICE_ID, InstanceId, &device));
         knownDevice->second.MemoryNotification = device.query<IVmFiovGuestMemoryFastNotification>();
+        RETURN_IF_FAILED(SetProxyBlanketForSession0(knownDevice->second.MemoryNotification.get()));
     }
 
     const auto result = knownDevice->second.MemoryNotification->RegisterDoorbell(
@@ -261,6 +283,7 @@ try
             static LxssDynamicFunction<GetVmWorkerProcessType<REFGUID, REFIID, IUnknown**>> getVmWorker{
                 c_vmwpctrlModuleName, "GetVmWorkerProcess"};
             THROW_IF_FAILED(getVmWorker(m_runtimeId, __uuidof(*m_deviceAccess), reinterpret_cast<IUnknown**>(&m_deviceAccess)));
+            THROW_IF_FAILED(SetProxyBlanketForSession0(m_deviceAccess.get()));
         }
 
         THROW_HR_IF(E_NOINTERFACE, !m_deviceAccess);
@@ -269,6 +292,7 @@ try
         wil::com_ptr<IUnknown> device;
         THROW_IF_FAILED(m_deviceAccess->GetDevice(FLEXIO_DEVICE_ID, InstanceId, &device));
         knownDevice->second.MemoryMapping = device.query<IVmFiovGuestMmioMappings>();
+        THROW_IF_FAILED(SetProxyBlanketForSession0(knownDevice->second.MemoryMapping.get()));
     }
 
     THROW_IF_FAILED(knownDevice->second.MemoryMapping->CreateSectionBackedMmioRange(

--- a/src/windows/common/Dmesg.cpp
+++ b/src/windows/common/Dmesg.cpp
@@ -67,8 +67,10 @@ std::shared_ptr<DmesgCollector> DmesgCollector::Create(
 std::pair<std::wstring, std::thread> DmesgCollector::StartDmesgThread(InputSource Source)
 {
     std::wstring pipeName = wsl::windows::common::helpers::GetUniquePipeName();
+    auto sd = wsl::windows::common::helpers::CreatePipeSecurityDescriptor();
+    SECURITY_ATTRIBUTES sa = {sizeof(sa), sd.get(), FALSE};
     wil::unique_hfile pipe(CreateNamedPipeW(
-        pipeName.c_str(), (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, nullptr));
+        pipeName.c_str(), (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, &sa));
 
     THROW_LAST_ERROR_IF(!pipe);
 

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -242,6 +242,18 @@ void wsl::windows::common::helpers::ConnectPipe(_In_ HANDLE Pipe, _In_ DWORD Tim
     }
 }
 
+wil::unique_hlocal_security_descriptor wsl::windows::common::helpers::CreatePipeSecurityDescriptor()
+{
+    // Create a security descriptor that grants full access to SYSTEM and Authenticated Users.
+    // This is required for named pipes created in Session 0 — the default DACL of service accounts
+    // (e.g. NETWORK SERVICE) may not allow SYSTEM processes (e.g. vmwp.exe) to connect.
+    wil::unique_hlocal_security_descriptor sd;
+    THROW_IF_WIN32_BOOL_FALSE(
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(L"D:P(A;;GA;;;SY)(A;;GA;;;AU)", SDDL_REVISION_1, &sd, nullptr));
+
+    return sd;
+}
+
 std::wstring_view wsl::windows::common::helpers::ConsumeArgument(_In_ std::wstring_view CommandLine, _In_ std::wstring_view Argument)
 {
     WI_ASSERT((CommandLine.size() >= Argument.size()) && (wcsncmp(CommandLine.data(), Argument.data(), Argument.size()) == 0));
@@ -569,8 +581,10 @@ void wsl::windows::common::helpers::LaunchDebugConsole(
         //     Raw: PIPE_TYPE_BYTE | PIPE_READMODE_BYTE
         //     Blocking: PIPE_WAIT
         WI_SetFlag(flags, LaunchWslRelayFlags::ConnectPipe);
+        auto sd = CreatePipeSecurityDescriptor();
+        SECURITY_ATTRIBUTES sa = {sizeof(sa), sd.get(), FALSE};
         pipe.reset(CreateNamedPipeW(
-            PipeName, (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, nullptr));
+            PipeName, (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, &sa));
     }
 
     THROW_LAST_ERROR_IF(!pipe);
@@ -592,8 +606,10 @@ void wsl::windows::common::helpers::LaunchKdRelay(_In_ LPCWSTR PipeName, _In_ HA
     //     Asynchronous: FILE_FLAG_OVERLAPPED
     //     Raw: PIPE_TYPE_BYTE | PIPE_READMODE_BYTE
     //     Blocking: PIPE_WAIT
+    auto sd = CreatePipeSecurityDescriptor();
+    SECURITY_ATTRIBUTES sa = {sizeof(sa), sd.get(), FALSE};
     const wil::unique_hfile pipe{CreateNamedPipeW(
-        PipeName, (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, nullptr)};
+        PipeName, (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, &sa)};
 
     THROW_LAST_ERROR_IF(!pipe);
 

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -112,6 +112,8 @@ using unique_mta_cookie = wil::unique_any<CO_MTA_USAGE_COOKIE, decltype(::CoDecr
 
 void ConnectPipe(_In_ HANDLE Pipe, _In_ DWORD Timeout = INFINITE, _In_ const std::vector<HANDLE>& ExitEvents = {});
 
+wil::unique_hlocal_security_descriptor CreatePipeSecurityDescriptor();
+
 std::wstring_view ConsumeArgument(_In_ std::wstring_view CommandLine, _In_ std::wstring_view Argument);
 
 void CreateConsole(_In_ LPCWSTR ConsoleTitle = nullptr);

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -299,8 +299,96 @@ wil::com_ptr<TInterface> wsl::windows::common::wslutil::CoGetCallContext()
 
 void wsl::windows::common::wslutil::CoInitializeSecurity()
 {
-    THROW_IF_FAILED(CoInitializeSecurity(
-        nullptr, -1, nullptr, nullptr, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_STATIC_CLOAKING, 0));
+    // Use an explicit security descriptor so that COM callbacks (e.g. from vmwp.exe running as
+    // SYSTEM) succeed even when the process is running in Session 0 (e.g. NETWORK SERVICE).
+    // The default nullptr SD is too restrictive in that environment, causing E_ACCESSDENIED
+    // on incoming COM calls.
+    // The SD grants COM_RIGHTS_EXECUTE (0x1) + COM_RIGHTS_EXECUTE_LOCAL (0x2) +
+    // COM_RIGHTS_ACTIVATE_LOCAL (0x8) = 0xB to SYSTEM and Authenticated Users.
+    //
+    // ConvertStringSecurityDescriptorToSecurityDescriptorW returns a self-relative SD, but
+    // CoInitializeSecurity requires absolute format. Convert via MakeAbsoluteSD.
+    // This follows the same pattern as comservicehelper.h's InitializeSecurity.
+    //
+    // N.B. This function is called before WslTraceLoggingInitialize in some binaries
+    // (e.g. wslrelay.exe), so WSL_LOG must NOT be used here — it would dereference the
+    // uninitialized g_hTraceLoggingProvider (nullptr) and cause an access violation.
+    // Use LOG_IF_FAILED_MSG (WIL-based) instead.
+
+    PSECURITY_DESCRIPTOR pSDRelative = nullptr;
+    auto cleanupRelative = wil::scope_exit([&] {
+        if (pSDRelative)
+            LocalFree(pSDRelative);
+    });
+
+    if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            L"O:BAG:BAD:(A;;0xB;;;SY)(A;;0xB;;;AU)", SDDL_REVISION_1, &pSDRelative, nullptr))
+    {
+        LOG_HR_MSG(HRESULT_FROM_WIN32(GetLastError()), "CoInitializeSecurity: ConvertStringSecurityDescriptorToSecurityDescriptorW failed");
+        goto fallback;
+    }
+
+    {
+        // Query required buffer sizes for MakeAbsoluteSD.
+        DWORD cbSDAbsolute = 0, cbDacl = 0, cbSacl = 0, cbOwner = 0, cbPrimaryGroup = 0;
+        PSECURITY_DESCRIPTOR pSDAbsolute = nullptr;
+        PACL pDacl = nullptr;
+        PACL pSacl = nullptr;
+        PSID pOwner = nullptr;
+        PSID pPrimaryGroup = nullptr;
+
+        auto cleanupAbsolute = wil::scope_exit([&] {
+            if (pSDAbsolute) HeapFree(GetProcessHeap(), 0, pSDAbsolute);
+            if (pDacl) HeapFree(GetProcessHeap(), 0, pDacl);
+            if (pSacl) HeapFree(GetProcessHeap(), 0, pSacl);
+            if (pOwner) HeapFree(GetProcessHeap(), 0, pOwner);
+            if (pPrimaryGroup) HeapFree(GetProcessHeap(), 0, pPrimaryGroup);
+        });
+
+        if (MakeAbsoluteSD(pSDRelative, nullptr, &cbSDAbsolute, nullptr, &cbDacl, nullptr, &cbSacl, nullptr, &cbOwner, nullptr, &cbPrimaryGroup) ||
+            GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+        {
+            LOG_HR_MSG(HRESULT_FROM_WIN32(GetLastError()), "CoInitializeSecurity: MakeAbsoluteSD size query failed");
+            goto fallback;
+        }
+
+        pSDAbsolute = reinterpret_cast<PSECURITY_DESCRIPTOR>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, cbSDAbsolute));
+        pDacl = reinterpret_cast<PACL>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, cbDacl));
+        pSacl = reinterpret_cast<PACL>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, cbSacl));
+        pOwner = reinterpret_cast<PSID>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, cbOwner));
+        pPrimaryGroup = reinterpret_cast<PSID>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, cbPrimaryGroup));
+
+        if (!pSDAbsolute || !pDacl || !pSacl || !pOwner || !pPrimaryGroup)
+        {
+            LOG_HR_MSG(E_OUTOFMEMORY, "CoInitializeSecurity: HeapAlloc failed");
+            goto fallback;
+        }
+
+        if (!MakeAbsoluteSD(pSDRelative, pSDAbsolute, &cbSDAbsolute, pDacl, &cbDacl, pSacl, &cbSacl, pOwner, &cbOwner, pPrimaryGroup, &cbPrimaryGroup))
+        {
+            LOG_HR_MSG(HRESULT_FROM_WIN32(GetLastError()), "CoInitializeSecurity: MakeAbsoluteSD failed");
+            goto fallback;
+        }
+
+        const HRESULT hr = ::CoInitializeSecurity(
+            pSDAbsolute, -1, nullptr, nullptr, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_STATIC_CLOAKING, 0);
+
+        LOG_IF_FAILED_MSG(hr, "CoInitializeSecurity with explicit SD");
+
+        if (SUCCEEDED(hr) || hr == RPC_E_TOO_LATE)
+        {
+            return;
+        }
+    }
+
+fallback:
+    // Fallback: initialize without an explicit SD.
+    const HRESULT hrFallback = ::CoInitializeSecurity(
+        nullptr, -1, nullptr, nullptr, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_STATIC_CLOAKING, 0);
+
+    LOG_IF_FAILED_MSG(hrFallback, "CoInitializeSecurity fallback");
+
+    THROW_IF_FAILED(hrFallback);
 }
 
 void wsl::windows::common::wslutil::ConfigureCrt()

--- a/src/windows/service/exe/GuestTelemetryLogger.cpp
+++ b/src/windows/service/exe/GuestTelemetryLogger.cpp
@@ -46,8 +46,10 @@ void GuestTelemetryLogger::Start(const wil::unique_event& ExitEvent)
     THROW_HR_IF(E_UNEXPECTED, !m_pipeName.empty());
 
     m_pipeName = wsl::windows::common::helpers::GetUniquePipeName();
+    auto sd = wsl::windows::common::helpers::CreatePipeSecurityDescriptor();
+    SECURITY_ATTRIBUTES sa = {sizeof(sa), sd.get(), FALSE};
     wil::unique_hfile pipe(CreateNamedPipeW(
-        m_pipeName.c_str(), (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, nullptr));
+        m_pipeName.c_str(), (PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED), (PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT), 1, LX_RELAY_BUFFER_SIZE, LX_RELAY_BUFFER_SIZE, 0, &sa));
 
     THROW_LAST_ERROR_IF(!pipe);
 

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -351,7 +351,7 @@ try
 }
 CATCH_RETURN()
 
-HRESULT HcsVirtualMachine::ConfigureNetworking(_In_ HANDLE GnsSocket, _In_opt_ HANDLE* DnsSocket)
+HRESULT HcsVirtualMachine::ConfigureNetworking(_In_ ULONG_PTR GnsSocket, _In_opt_ ULONG_PTR* DnsSocket)
 try
 {
     std::lock_guard lock(m_lock);
@@ -362,9 +362,11 @@ try
         return S_OK;
     }
 
-    // Duplicate the socket handles - COM manages the lifetime of the marshalled handles,
-    // so we need our own copies to take ownership.
-    wil::unique_socket gnsSocketHandle{reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(GnsSocket))};
+    // Duplicate the socket handles from the calling process. The handles are passed as
+    // opaque ULONG_PTR values; the server (SYSTEM) pulls them via DuplicateHandleFromCallingProcess
+    // so the client doesn't need PROCESS_DUP_HANDLE access to the server.
+    wil::unique_socket gnsSocketHandle{reinterpret_cast<SOCKET>(
+        wslutil::DuplicateHandleFromCallingProcess(reinterpret_cast<HANDLE>(GnsSocket)))};
     wil::unique_socket dnsSocketHandle;
     if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
     {
@@ -378,7 +380,8 @@ try
         }
         else
         {
-            dnsSocketHandle.reset(reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(*DnsSocket)));
+            dnsSocketHandle.reset(reinterpret_cast<SOCKET>(
+                wslutil::DuplicateHandleFromCallingProcess(reinterpret_cast<HANDLE>(*DnsSocket))));
         }
     }
     else

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -39,7 +39,7 @@ public:
     // IWSLCVirtualMachine implementation
     IFACEMETHOD(GetId)(_Out_ GUID* VmId) override;
     IFACEMETHOD(AcceptConnection)(_Out_ HANDLE* Socket) override;
-    IFACEMETHOD(ConfigureNetworking)(_In_ HANDLE GnsSocket, _In_opt_ HANDLE* DnsSocket) override;
+    IFACEMETHOD(ConfigureNetworking)(_In_ ULONG_PTR GnsSocket, _In_opt_ ULONG_PTR* DnsSocket) override;
     IFACEMETHOD(AttachDisk)(_In_ LPCWSTR Path, _In_ BOOL ReadOnly, _Out_ ULONG* Lun) override;
     IFACEMETHOD(DetachDisk)(_In_ ULONG Lun) override;
     IFACEMETHOD(AddShare)(_In_ LPCWSTR WindowsPath, _In_ BOOL ReadOnly, _Out_ GUID* ShareId) override;

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -418,10 +418,13 @@ interface IWSLCVirtualMachine : IUnknown
 
     // Configures networking engine with sockets from the user process.
     // GnsSocket is required; DnsSocket is optional (NULL if DNS tunneling is disabled).
-    // The service duplicates the socket handles.
+    // Socket handles are passed as opaque ULONG_PTR values (not system_handle) so the
+    // server (SYSTEM) can duplicate them from the client via DuplicateHandleFromCallingProcess.
+    // This avoids requiring the client to OpenProcess(PROCESS_DUP_HANDLE) on the server,
+    // which fails when the client is a non-SYSTEM service account (e.g. NETWORK SERVICE).
     HRESULT ConfigureNetworking(
-        [in, system_handle(sh_socket)] HANDLE GnsSocket,
-        [in, system_handle(sh_socket), unique] HANDLE* DnsSocket);
+        [in] ULONG_PTR GnsSocket,
+        [in, unique] ULONG_PTR* DnsSocket);
 
     // Attaches a VHD or VHDX disk to the VM.
     // GrantVmAccess is called by the service before attaching.

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -390,17 +390,18 @@ void WSLCVirtualMachine::ConfigureNetworking()
     auto process = CreateLinuxProcessImpl("/init", options, fds, nullptr, prepareCommandLine);
 
     // Call back to the service to configure the networking engine.
+    // Pass raw handle values as ULONG_PTR — the service duplicates them server-side.
     auto gnsHandle = process->GetStdHandle(gnsChannelFd);
 
     wil::unique_handle dnsHandle;
-    HANDLE dnsSocketHandle = nullptr;
+    ULONG_PTR dnsSocketValue = 0;
     if (enableDnsTunneling)
     {
         dnsHandle = process->GetStdHandle(dnsChannelFd);
-        dnsSocketHandle = dnsHandle.get();
+        dnsSocketValue = reinterpret_cast<ULONG_PTR>(dnsHandle.get());
     }
 
-    THROW_IF_FAILED(m_vm->ConfigureNetworking(gnsHandle.get(), enableDnsTunneling ? &dnsSocketHandle : nullptr));
+    THROW_IF_FAILED(m_vm->ConfigureNetworking(reinterpret_cast<ULONG_PTR>(gnsHandle.get()), enableDnsTunneling ? &dnsSocketValue : nullptr));
 
     // Launch port relay for port forwarding
     LaunchPortRelay();


### PR DESCRIPTION

## Summary of the Pull Request

Running WslcCreateSession from a Windows service as NETWORK SERVICE in Session 0 exposed five distinct issues across COM security, RPC handle marshaling, named pipe security, and COM proxy authentication. This commit fixes all five.

Scenario: A Windows service (e.g. Microsoft Connected Cache) calling WslcCreateSession via wslcsdk.dll, running as NETWORK SERVICE in Session 0.

== FIXES INCLUDED ==

Issue 1: CoInitializeSecurity - Self-Relative vs Absolute SD
  File: src/windows/common/wslutil.cpp
  ConvertStringSecurityDescriptorToSecurityDescriptorW returns a self-relative SD,
  but CoInitializeSecurity requires absolute format. Added MakeAbsoluteSD conversion
  using HeapAlloc(HEAP_ZERO_MEMORY) pattern matching comservicehelper.h. The SDDL
  O:BAG:BAD:(A;;0xB;;;SY)(A;;0xB;;;AU) grants COM execute/activate rights to SYSTEM
  and Authenticated Users. Falls back to nullptr SD on failure.
  Also replaced WSL_LOG with LOG_IF_FAILED_MSG since this function is called before
  WslTraceLoggingInitialize in some binaries (e.g. wslrelay.exe), where WSL_LOG
  would dereference the uninitialized g_hTraceLoggingProvider and crash.
  Affects: wslcsession.exe, wslrelay.exe, wslhost.exe, wslc.exe, wsl.exe, wslg.exe

Issue 2: ConfigureNetworking IDL - system_handle Marshaling
  Files: src/windows/service/inc/wslc.idl
         src/windows/service/exe/HcsVirtualMachine.cpp
         src/windows/service/exe/HcsVirtualMachine.h
         src/windows/wslcsession/WSLCVirtualMachine.cpp
  [in] system_handle requires the CLIENT to OpenProcess(PROCESS_DUP_HANDLE) on the
  SERVER. NETWORK SERVICE cannot open wslservice.exe (SYSTEM) with that access.
  Changed ConfigureNetworking parameters from system_handle HANDLE to ULONG_PTR.
  The server now uses DuplicateHandleFromCallingProcess() (SYSTEM opening the client)
  instead of the client duplicating to the server.

Issue 3: Named Pipe Security Descriptors
  Files: src/windows/common/helpers.cpp
         src/windows/common/helpers.hpp
         src/windows/common/Dmesg.cpp
         src/windows/service/exe/GuestTelemetryLogger.cpp
  Named pipes for crash dump, telemetry, and debug console were created with nullptr
  security attributes, inheriting the default DACL of the creating process. When
  created by NETWORK SERVICE in Session 0, vmwp.exe (SYSTEM) could not connect.
  Added CreatePipeSecurityDescriptor() returning D:P(A;;GA;;;SY)(A;;GA;;;AU) and
  applied it to all named pipe creation sites.

Issue 4: COM Proxy Blankets for Session 0
  File: src/windows/common/DeviceHostProxy.cpp
  In Session 0, cross-process COM callbacks from vmwp.exe fail without dynamic
  cloaking. Added SetProxyBlanketForSession0() calling CoSetProxyBlanket with
  RPC_C_IMP_LEVEL_IMPERSONATE and EOAC_DYNAMIC_CLOAKING on all cross-process
  COM proxy interfaces: IVmDeviceHost, IUnknown in RegisterDeviceHost,
  m_deviceAccess, IVmFiovGuestMemoryFastNotification, IVmFiovGuestMmioMappings.

== OPEN ITEMS (not addressed in this commit) ==

VirtioProxy / VirtioFs under NETWORK SERVICE:
  CreateComServerAsUser(UserToken) creates wsldevicehost.dll as the calling user.
  When the user is NETWORK SERVICE, HCS device-host APIs (HdvProxyDeviceHost)
  return E_ACCESSDENIED because the caller lacks HCS device-host privileges.
  Interactive users work because they have sufficient HCS permissions.
  Workaround: Use NAT networking mode (avoids VirtioProxy/VirtioFs code paths).
  Long-term: Consider running Plan9FileSystem under SYSTEM for Session 0 callers,
  granting NETWORK SERVICE HCS permissions, or exposing networking mode as an
  SDK parameter.

VHD Volume Permissions for Non-Root Containers:
  WSLCVhdVolume::Create formats VHDs as ext4 with root:root 0755. Containers
  running as non-root UIDs cannot write to the volume root. Consider adding a
  UID/GID parameter to WslcVhdRequirements, defaulting new volume roots to 0777,
  or supporting a --user flag on volume creation.



<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
