### PR TITLE
Revert "Disable shared compilation when building wslsettings"

### DIFF
--- a/src/windows/wslsettings/directory.build.targets.in
+++ b/src/windows/wslsettings/directory.build.targets.in
@@ -1,8 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <!-- Disable the Roslyn shared compiler server (VBCSCompiler) to avoid intermittent CS0016 errors -->
-    <UseSharedCompilation>false</UseSharedCompilation>
-  </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="${WINDOWS_SDK_DOTNET_VERSION}" TargetingPackVersion="${WINDOWS_SDK_DOTNET_VERSION}" />
     <!-- The below can be removed when the OneBranch pipeline container image is updated to use a newer version of the dotnet SDK -->


### PR DESCRIPTION
Reverting this change since the build issue reproed after merging it