### PR TITLE
Update the wslc not to fail if additional images or containers are present

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
@@ -149,9 +149,9 @@ class WSLCE2EContainerListTests
 
         result = RunWslc(L"container list --all --quiet");
         result.Verify({.Stderr = L"", .ExitCode = 0});
-        const auto outputLine = result.GetStdoutOneLine();
 
-        VERIFY_ARE_EQUAL(containerId, outputLine);
+        // Verify the created container ID appears in the quiet output.
+        VERIFY_IS_TRUE(result.StdoutContainsLine(containerId));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_List_InvalidFormatOption)
@@ -175,8 +175,13 @@ class WSLCE2EContainerListTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
         // Parse json and verify we got the expected container information back
         auto containers = wsl::shared::FromJson<std::vector<ContainerInformation>>(result.Stdout.value().c_str());
-        VERIFY_ARE_EQUAL(1U, containers.size());
-        VERIFY_ARE_EQUAL(containerId, wsl::shared::string::MultiByteToWide(containers[0].Id));
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(containers.size(), 1U);
+
+        auto findContainer = [](const std::vector<ContainerInformation>& list, const std::wstring& id) {
+            return std::ranges::any_of(list, [&](const auto& c) { return wsl::shared::string::MultiByteToWide(c.Id) == id; });
+        };
+
+        VERIFY_IS_TRUE(findContainer(containers, containerId));
 
         // Create another container
         result = RunWslc(std::format(L"container create --name {} {}", WslcContainerName2, DebianImage.NameAndTag()));
@@ -189,18 +194,10 @@ class WSLCE2EContainerListTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
         // Parse json and verify we got both containers back
         containers = wsl::shared::FromJson<std::vector<ContainerInformation>>(result.Stdout.value().c_str());
-        VERIFY_ARE_EQUAL(2U, containers.size());
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(containers.size(), 2U);
 
-        // Extract container IDs
-        std::vector<std::wstring> containerIds;
-        for (const auto& container : containers)
-        {
-            containerIds.push_back(wsl::shared::string::MultiByteToWide(container.Id));
-        }
-
-        // Verify both container IDs are in the list
-        VERIFY_IS_TRUE(std::find(containerIds.begin(), containerIds.end(), containerId) != containerIds.end());
-        VERIFY_IS_TRUE(std::find(containerIds.begin(), containerIds.end(), containerId2) != containerIds.end());
+        VERIFY_IS_TRUE(findContainer(containers, containerId));
+        VERIFY_IS_TRUE(findContainer(containers, containerId2));
     }
 
 private:

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -92,7 +92,7 @@ class WSLCE2EImageListTests
 
         const auto images = wsl::shared::FromJson<std::vector<ImageInformation>>(result.Stdout.value().c_str());
 
-        VERIFY_ARE_EQUAL(2u, images.size());
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(images.size(), 2u);
 
         std::vector<std::wstring> imageNames;
         for (const auto& image : images)


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the wslc tests to be resilient to external images & containers being present in the cli session

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
