### PR TITLE
Fix CodeSign validation for wslcsdkcs.dll in SDK output

### DIFF
--- a/.pipelines/build-job.yml
+++ b/.pipelines/build-job.yml
@@ -212,8 +212,13 @@ jobs:
               if (Test-Path "generated\dev-cert.pfx") { Copy-Item "generated\dev-cert.pfx" "$(ob_outputDirectory)\installer\dev-cert.pfx" }
               New-Item -ItemType Directory -Path "$(ob_outputDirectory)\sdk\${{ parameters.platform }}" -Force
               Copy-Item -Path "bin\${{ parameters.platform }}\release\wslcsdk.lib" -Destination "$(ob_outputDirectory)\sdk\${{ parameters.platform }}\wslcsdk.lib"
-              Copy-Item -Path "bin\${{ parameters.platform }}\release\wslcsdk.dll" -Destination "$(ob_outputDirectory)\sdk\${{ parameters.platform }}\wslcsdk.dll"
-              Copy-Item -Path "bin\${{ parameters.platform }}\release\wslcsdkcs.dll" -Destination "$(ob_outputDirectory)\sdk\${{ parameters.platform }}\wslcsdkcs.dll"
+              if ('${{ parameters.isRelease }}' -eq 'True') {
+                  Copy-Item -Path "$(packageStagingDir)\${{ parameters.platform }}\wslcsdk.dll" -Destination "$(ob_outputDirectory)\sdk\${{ parameters.platform }}\wslcsdk.dll"
+                  Copy-Item -Path "$(packageStagingDir)\${{ parameters.platform }}\wslcsdkcs.dll" -Destination "$(ob_outputDirectory)\sdk\${{ parameters.platform }}\wslcsdkcs.dll"
+              } else {
+                  Copy-Item -Path "bin\${{ parameters.platform }}\release\wslcsdk.dll" -Destination "$(ob_outputDirectory)\sdk\${{ parameters.platform }}\wslcsdk.dll"
+                  Copy-Item -Path "bin\${{ parameters.platform }}\release\wslcsdkcs.dll" -Destination "$(ob_outputDirectory)\sdk\${{ parameters.platform }}\wslcsdkcs.dll"
+              }
 
       - task: PowerShell@2
         displayName: "Create CAB from ${{ parameters.platform }} installer msi"

--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -32,12 +32,12 @@ parameters:
   - name: targets
     type: object
     default:
-      - target: "wsl;libwsl;wslg;wslservice;wslhost;wslrelay;wslinstaller;wslinstall;initramfs;wslserviceproxystub;wslsettings;wslinstallerproxystub;testplugin;wslcsession;wslc;wsltests;wslcsdk;wslcsdkcs"
-        pattern: "wsl.exe,libwsl.dll,wslg.exe,wslservice.exe,wslhost.exe,wslrelay.exe,wslinstaller.exe,wslinstall.dll,wslserviceproxystub.dll,wslsettings/wslsettings.dll,wslsettings/wslsettings.exe,wslinstallerproxystub.dll,WSLDVCPlugin.dll,testplugin.dll,wsldeps.dll,wslcsession.exe,wslc.exe,wslcsdk.dll,wslcsdkcs.dll"
+      - target: "wsl;libwsl;wslg;wslservice;wslhost;wslrelay;wslinstaller;wslinstall;initramfs;wslserviceproxystub;wslsettings;wslinstallerproxystub;testplugin;wslcsession;wslc;wsltests;wslcsdk"
+        pattern: "wsl.exe,libwsl.dll,wslg.exe,wslservice.exe,wslhost.exe,wslrelay.exe,wslinstaller.exe,wslinstall.dll,wslserviceproxystub.dll,wslsettings/wslsettings.dll,wslsettings/wslsettings.exe,wslinstallerproxystub.dll,WSLDVCPlugin.dll,testplugin.dll,wsldeps.dll,wslcsession.exe,wslc.exe,wslcsdk.dll"
       - target: "msixgluepackage"
         pattern: "gluepackage.msix"
-      - target: "msipackage"
-        pattern: "wsl.msi"
+      - target: "msipackage;wslcsdkcs"
+        pattern: "wsl.msi,wslcsdkcs.dll"
 
   - name: pool
     type: string


### PR DESCRIPTION
**Problem:** Guardian CodeSign validation fails for \sdk/arm64/wslcsdkcs.dll\ with \CodeSign.MissingSigningCert\.

**Root cause:** \wslcsdkcs\ was in the first target group alongside \wslcsdk\. After that group is built and signed, the \Build remaining targets\ step (\cmake --build . --config Release\) rebuilds \wslcsdkcs.dll\ because MSBuild detects its dependency (\wslcsdk.dll\) was modified by signing. The unsigned rebuild overwrites the signed version in \in/\.

**Fix:** Move \wslcsdkcs\ to the \msipackage\ target stage. Since this stage runs after the first group is signed, \wslcsdkcs\ gets built against the already-signed \wslcsdk.dll\. When \Build remaining targets\ runs later, nothing has changed for \wslcsdkcs\ so it won't be rebuilt — the signed version stays intact.

Same class of issue as the wslsettings signing fix.