### PR TITLE
Set page_reporting_order via kernel command line

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -290,7 +290,7 @@ try
     // and memory reclaim. This ensures that the maximum number of pages can be discarded to the host.
     //
 
-    std::thread([Mode = Mode]() mutable {
+    std::thread([Mode]() mutable {
         try
         {
             //

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -122,7 +122,7 @@ std::optional<bool> g_EnableSocketLogging;
 
 int Chroot(const char* Target);
 
-void ConfigureMemoryReduction(int PageReportingOrder, LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode);
+void ConfigureMemoryReduction(LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode);
 
 void CreateSwap(unsigned int Lun);
 
@@ -265,19 +265,15 @@ Return Value:
     return 0;
 }
 
-void ConfigureMemoryReduction(int PageReportingOrder, LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode)
+void ConfigureMemoryReduction(LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode)
 
 /*++
 
 Routine Description:
 
-    This routine sets the page reporting order.
+    This routine configures memory reduction behavior including memory reclaim and compaction.
 
 Arguments:
-
-    PageReportingOrder - Supplies the page reporting order. This value determines the size of cold discard hints
-        by using the equation: 2^PageReportingOrder * PAGE_SIZE
-        Example: 2^9 * 4096 = 2MB
 
     Mode - Supplies the memory reclaim mode.
 
@@ -290,32 +286,11 @@ Return Value:
 try
 {
     //
-    // Ensure the value falls within a reasonable range (single page to 2MB).
+    // Create a worker thread to periodically check if the VM is idle and performs memory compaction
+    // and memory reclaim. This ensures that the maximum number of pages can be discarded to the host.
     //
 
-    if (PageReportingOrder < 0 || PageReportingOrder > 9)
-    {
-        LOG_WARNING("Invalid page_reporting_order {}", PageReportingOrder);
-        PageReportingOrder = 0;
-    }
-    else
-    {
-        WriteToFile("/sys/module/page_reporting/parameters/page_reporting_order", std::to_string(PageReportingOrder).c_str());
-    }
-
-    //
-    // Create a worker thread to periodically check if the VM is idle and performs memory compaction.
-    // This ensures that the maximum number of pages can be discarded to the host.
-    //
-    // N.B. Compaction is not needed if page reporting order is set to single page mode.
-    //
-
-    if (PageReportingOrder == 0 && Mode == LxMiniInitMemoryReclaimModeDisabled)
-    {
-        return;
-    }
-
-    std::thread([PageReportingOrder = PageReportingOrder, Mode = Mode]() mutable {
+    std::thread([Mode = Mode]() mutable {
         try
         {
             //
@@ -422,11 +397,10 @@ try
 
                 //
                 // Perform memory compaction if the VM is idle.
-                //
-                // N.B. Memory compaction is not needed if the page reporting order is set to single page (0).
+                // This coalesces free pages into larger blocks for more efficient page reporting.
                 //
 
-                if (PageReportingOrder != 0 && (Start - Stop) > IdleThreshold)
+                if ((Start - Stop) > IdleThreshold)
                 {
                     std::this_thread::sleep_for(std::chrono::seconds(1));
                     Stop = GetUserCpuTime();
@@ -3294,10 +3268,10 @@ try
         }
 
         //
-        // Configure page reporting and memory reclamation.
+        // Configure memory reclamation.
         //
 
-        ConfigureMemoryReduction(EarlyConfig->PageReportingOrder, EarlyConfig->MemoryReclaimMode);
+        ConfigureMemoryReduction(EarlyConfig->MemoryReclaimMode);
 
         //
         // Initialize system distro if supported.

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1251,7 +1251,6 @@ typedef struct _LX_MINI_INIT_EARLY_CONFIG_MESSAGE
     unsigned int SwapLun;
     LX_MINI_INIT_MOUNT_DEVICE_TYPE SystemDistroDeviceType;
     unsigned int SystemDistroDeviceId;
-    int PageReportingOrder;
     LX_MINI_INIT_MEMORY_RECLAIM_MODE MemoryReclaimMode;
     // IPv4 address stored in network byte order
     uint32_t DnsTunnelingIpAddress = 0;
@@ -1269,7 +1268,6 @@ typedef struct _LX_MINI_INIT_EARLY_CONFIG_MESSAGE
         FIELD(SwapLun),
         FIELD(SystemDistroDeviceType),
         FIELD(SystemDistroDeviceId),
-        FIELD(PageReportingOrder),
         FIELD(MemoryReclaimMode),
         FIELD(DnsTunnelingIpAddress),
         FIELD(EnableDebugShell),

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -76,15 +76,21 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     vmSettings.ComputeTopology.Memory.EnableColdDiscardHint = true;
     vmSettings.ComputeTopology.Processor.Count = Settings->CpuCount;
 
-    // Configure backing page size, fault cluster shift size, and cold discard hint size to favor density (lower vmmem usage).
+    // Configure backing page size, fault cluster shift size, and page reporting order to favor density (lower vmmem usage).
     //
-    // N.B. Cold discard hint size should be a multiple of the fault cluster shift size.
+    // N.B. Page reporting order must be >= fault cluster size shift.
     const auto windowsVersion = wsl::windows::common::helpers::GetWindowsVersion();
+    int pageReportingOrder;
     if (windowsVersion.BuildNumber >= WindowsBuildNumbers::Germanium)
     {
         vmSettings.ComputeTopology.Memory.BackingPageSize = hcs::MemoryBackingPageSize::Small;
         vmSettings.ComputeTopology.Memory.FaultClusterSizeShift = 4;
         vmSettings.ComputeTopology.Memory.DirectMapFaultClusterSizeShift = 4;
+        pageReportingOrder = 5; // 128k
+    }
+    else
+    {
+        pageReportingOrder = 9; // 2MB
     }
 
     if (helpers::IsVmemmSuffixSupported() && Settings->DisplayName)
@@ -109,7 +115,6 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
 
     // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
-    int pageReportingOrder = (windowsVersion.BuildNumber >= WindowsBuildNumbers::Germanium) ? 5 : 9;
     kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", pageReportingOrder);
 
     // Setup dmesg collector with optional DmesgOutput handle.

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -108,6 +108,10 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     // Enable timesync workaround to sync on resume from sleep in modern standby.
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
 
+    // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
+    int pageReportingOrder = (windowsVersion.BuildNumber >= WindowsBuildNumbers::Germanium) ? 5 : 9;
+    kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", pageReportingOrder);
+
     // Setup dmesg collector with optional DmesgOutput handle.
     // TODO: move dmesg collector to user session process.
     // N.B. 'DmesgOutput' needs to be duplicated since COM will close it when this call completes.

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1380,9 +1380,9 @@ std::wstring WslCoreVm::GenerateConfigJson()
     vmSettings.ComputeTopology.Memory.EnableDeferredCommit = true;
     vmSettings.ComputeTopology.Memory.EnableColdDiscardHint = true;
 
-    // Configure backing page size, fault cluster shift size, and cold discard hint size to favor density (lower vmmem usage).
+    // Configure backing page size, fault cluster shift size, and page reporting order to favor density (lower vmmem usage).
     //
-    // N.B. Cold discard hint size should be a multiple of the fault cluster shift size.
+    // N.B. Page reporting order must be >= fault cluster size shift.
     //
     // N.B. This is only done on builds that have the fix for the VID deadlock on partition teardown.
     if ((m_windowsVersion.BuildNumber >= WindowsBuildNumbers::Germanium) ||
@@ -1393,11 +1393,11 @@ std::wstring WslCoreVm::GenerateConfigJson()
         vmSettings.ComputeTopology.Memory.BackingPageSize = hcs::MemoryBackingPageSize::Small;
         vmSettings.ComputeTopology.Memory.FaultClusterSizeShift = 4;          // 64k
         vmSettings.ComputeTopology.Memory.DirectMapFaultClusterSizeShift = 4; // 64k
-        m_coldDiscardShiftSize = 5;                                           // 128k
+        m_pageReportingOrder = 5;                                             // 128k
     }
     else
     {
-        m_coldDiscardShiftSize = 9; // 2MB
+        m_pageReportingOrder = 9; // 2MB
     }
 
     // May need more MMIO than the default 16GB. WSL uses a vpci device per Plan9 share, WSLg adds a GPU device,
@@ -1527,7 +1527,7 @@ std::wstring WslCoreVm::GenerateConfigJson()
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
 
     // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
-    kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", m_coldDiscardShiftSize);
+    kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", m_pageReportingOrder);
 
     // If using virtio features, enable SWIOTLB as a perf optimization (will cause VM to consume 64MB more memory).
     if (m_vmConfig.EnableVirtio9p || m_vmConfig.EnableVirtioFs || m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -509,7 +509,6 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     message->SwapLun = swapLun;
     message->SystemDistroDeviceType = m_systemDistroDeviceType;
     message->SystemDistroDeviceId = m_systemDistroDeviceId;
-    message->PageReportingOrder = m_coldDiscardShiftSize;
     message->MemoryReclaimMode = static_cast<LX_MINI_INIT_MEMORY_RECLAIM_MODE>(m_vmConfig.MemoryReclaim);
     message->EnableDebugShell = m_vmConfig.EnableDebugShell;
     message->EnableSafeMode = m_vmConfig.EnableSafeMode;
@@ -1526,6 +1525,9 @@ std::wstring WslCoreVm::GenerateConfigJson()
 
     // Enable timesync workaround to sync on resume from sleep in modern standby.
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
+
+    // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
+    kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", m_coldDiscardShiftSize);
 
     // If using virtio features, enable SWIOTLB as a perf optimization (will cause VM to consume 64MB more memory).
     if (m_vmConfig.EnableVirtio9p || m_vmConfig.EnableVirtioFs || m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -277,7 +277,7 @@ private:
     wsl::core::Config m_vmConfig;
     std::wstring m_comPipe0;
     std::wstring m_comPipe1;
-    int m_coldDiscardShiftSize;
+    int m_pageReportingOrder;
     WslTraceLoggingClient m_traceClient;
     std::filesystem::path m_rootFsPath;
     std::filesystem::path m_tempPath;

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -295,19 +295,6 @@ void WSLCVirtualMachine::Initialize()
     // Configure GPU mounts if enabled
     MountGpuLibraries("/usr/lib/wsl/lib", "/usr/lib/wsl/drivers");
 
-    // Configure cold discard hint size for page reporting.
-    // This sets the minimum order of pages that will be reported as free to the hypervisor.
-    {
-        const auto windowsVersion = wsl::windows::common::helpers::GetWindowsVersion();
-        int pageReportingOrder = (windowsVersion.BuildNumber >= wsl::windows::common::helpers::WindowsBuildNumbers::Germanium) ? 5 : 9; // 128k or 2MB
-        auto cmdStr = std::format("echo {} > /sys/module/page_reporting/parameters/page_reporting_order", pageReportingOrder);
-        std::vector<const char*> args{"/bin/sh", "-c", cmdStr.c_str()};
-
-        WSLCProcessOptions options{};
-        options.CommandLine = {.Values = args.data(), .Count = static_cast<ULONG>(args.size())};
-        CreateLinuxProcessImpl("/bin/sh", options, {}, nullptr, [](const auto&) {});
-    }
-
     // Configure networking. This must happen after all filesystems are mounted since /gns needs to access /sys.
     ConfigureNetworking();
 }


### PR DESCRIPTION
Move page reporting configuration from post-boot process launches and init messages to the kernel command line parameter (`page_reporting.page_reporting_order=N`). This ensures the correct order is set at boot time for both WSLC and WSL2.

- Remove `PageReportingOrder` from the early config message struct
- Simplify the memory reduction thread in init to always perform compaction when idle, removing the `PageReportingOrder` gate which was effectively dead code (the value was always non-zero in practice)
- Remove the post-boot echo process from WSLC
- Rename `m_coldDiscardShiftSize` to `m_pageReportingOrder` for clarity
- Align HcsVirtualMachine page reporting logic with WslCoreVm (derive order from the same version-gated block that sets BackingPageSize/FaultClusterSizeShift)

Verified via ETL trace that the parameter takes effect at boot (`hv_balloon: Cold memory discard hint enabled with order 5`).