### PR TITLE
Add swap support for WSLC virtual machines (separate ephemeral VHD)

### DIFF
--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -341,6 +341,7 @@ WSLCSessionInitSettings WSLCSessionManagerImpl::CreateSessionSettings(
     sessionSettings.FeatureFlags = Settings->FeatureFlags;
     sessionSettings.RootVhdTypeOverride = Settings->RootVhdTypeOverride;
     sessionSettings.StorageFlags = Settings->StorageFlags;
+    sessionSettings.SwapSizeMb = Settings->MemoryMb;
     return sessionSettings;
 }
 

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -674,6 +674,7 @@ typedef struct _WSLCSessionInitSettings
     LPCWSTR StoragePath;
     WSLCSessionStorageFlags StorageFlags;
     ULONGLONG MaximumStorageSizeMb;
+    ULONG SwapSizeMb;
     ULONG BootTimeoutMs;
     WSLCNetworkingMode NetworkingMode;
     WSLCFeatureFlags FeatureFlags;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -357,6 +357,25 @@ void WSLCSession::ConfigureStorage(const WSLCSessionInitSettings& Settings, PSID
     // Mount the device to /root.
     m_virtualMachine->Mount(diskDevice.c_str(), c_containerdStorage, "ext4", "", 0);
 
+    // Configure swap on a separate ephemeral VHD.
+    if (Settings.SwapSizeMb > 0)
+    {
+        try
+        {
+            m_swapVhdPath = storagePath / "swap.vhdx";
+            DeleteFileW(m_swapVhdPath.c_str()); // Remove stale swap from prior run
+            wsl::core::filesystem::CreateVhd(m_swapVhdPath.c_str(), static_cast<ULONGLONG>(Settings.SwapSizeMb) * _1MB, UserSid, false, true);
+
+            auto [_, swapDevice] = m_virtualMachine->AttachDisk(m_swapVhdPath.c_str(), false);
+
+            // Fire-and-forget: mkswap + swapon runs asynchronously since swap is best-effort.
+            auto cmd = std::format("/usr/sbin/mkswap {0} && /usr/sbin/swapon {0}", swapDevice);
+            ServiceProcessLauncher launcher("/bin/sh", {"/bin/sh", "-c", cmd});
+            launcher.Launch(*m_virtualMachine);
+        }
+        CATCH_LOG()
+    }
+
     deleteVhdOnFailure.release();
 }
 
@@ -2417,6 +2436,13 @@ try
     m_dockerdProcess.reset();
     m_containerdProcess.reset();
     m_virtualMachine.reset();
+
+    // Delete the ephemeral swap VHD now that the VM is gone.
+    if (!m_swapVhdPath.empty())
+    {
+        LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(m_swapVhdPath.c_str()));
+        m_swapVhdPath.clear();
+    }
 
     m_terminated = true;
     return S_OK;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -364,7 +364,7 @@ void WSLCSession::ConfigureStorage(const WSLCSessionInitSettings& Settings, PSID
         {
             m_swapVhdPath = storagePath / "swap.vhdx";
             DeleteFileW(m_swapVhdPath.c_str()); // Remove stale swap from prior run
-            wsl::core::filesystem::CreateVhd(m_swapVhdPath.c_str(), static_cast<ULONGLONG>(Settings.SwapSizeMb) * _1MB, UserSid, false, true);
+            wsl::core::filesystem::CreateVhd(m_swapVhdPath.c_str(), static_cast<ULONGLONG>(Settings.SwapSizeMb) * _1MB, UserSid, false, false);
 
             auto [_, swapDevice] = m_virtualMachine->AttachDisk(m_swapVhdPath.c_str(), false);
 

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -197,6 +197,7 @@ private:
     wil::unique_event m_dockerdReadyEvent{wil::EventOptions::ManualReset};
     std::wstring m_displayName;
     std::filesystem::path m_storageVhdPath;
+    std::filesystem::path m_swapVhdPath;
 
     // N.B. m_lock must be acquired before acquiring m_volumesLock, m_containersLock, or m_networksLock.
     // These locks protect m_volumes / m_containers without requiring an exclusive m_lock.

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -295,6 +295,18 @@ void WSLCVirtualMachine::Initialize()
     // Configure GPU mounts if enabled
     MountGpuLibraries(c_gpuLibrariesPath, c_gpuDriversPath);
 
+    // Configure page reporting - set the minimum order of pages reported as free to the hypervisor.
+    {
+        const auto windowsVersion = wsl::windows::common::helpers::GetWindowsVersion();
+        int pageReportingOrder = (windowsVersion.BuildNumber >= wsl::windows::common::helpers::WindowsBuildNumbers::Germanium) ? 5 : 9; // 128k or 2MB
+        auto cmdStr = std::format("echo {} > /sys/module/page_reporting/parameters/page_reporting_order", pageReportingOrder);
+        std::vector<const char*> args{"/bin/sh", "-c", cmdStr.c_str()};
+
+        WSLCProcessOptions options{};
+        options.CommandLine = {.Values = args.data(), .Count = static_cast<ULONG>(args.size())};
+        CreateLinuxProcessImpl("/bin/sh", options, {}, nullptr, [](const auto&) {});
+    }
+
     // Configure networking. This must happen after all filesystems are mounted since /gns needs to access /sys.
     ConfigureNetworking();
 }

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -295,18 +295,6 @@ void WSLCVirtualMachine::Initialize()
     // Configure GPU mounts if enabled
     MountGpuLibraries(c_gpuLibrariesPath, c_gpuDriversPath);
 
-    // Configure page reporting - set the minimum order of pages reported as free to the hypervisor.
-    {
-        const auto windowsVersion = wsl::windows::common::helpers::GetWindowsVersion();
-        int pageReportingOrder = (windowsVersion.BuildNumber >= wsl::windows::common::helpers::WindowsBuildNumbers::Germanium) ? 5 : 9; // 128k or 2MB
-        auto cmdStr = std::format("echo {} > /sys/module/page_reporting/parameters/page_reporting_order", pageReportingOrder);
-        std::vector<const char*> args{"/bin/sh", "-c", cmdStr.c_str()};
-
-        WSLCProcessOptions options{};
-        options.CommandLine = {.Values = args.data(), .Count = static_cast<ULONG>(args.size())};
-        CreateLinuxProcessImpl("/bin/sh", options, {}, nullptr, [](const auto&) {});
-    }
-
     // Configure networking. This must happen after all filesystems are mounted since /gns needs to access /sys.
     ConfigureNetworking();
 }

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -7417,6 +7417,15 @@ class WSLCTests
         VERIFY_ARE_EQUAL(result.Output[1], std::format("{}\n", expectedOrder));
     }
 
+    WSLC_TEST_METHOD(SwapConfigured)
+    {
+        // Verify that swap space is configured in the VM (on a block device from the swap VHD).
+        auto result = ExpectCommandResult(m_defaultSession.get(), {"/usr/sbin/swapon", "--show=NAME,SIZE", "--noheadings"}, 0);
+
+        VERIFY_ARE_EQUAL(result.Code, 0);
+        VERIFY_IS_TRUE(result.Output[1].find("/dev/") != std::string::npos);
+    }
+
     WSLC_TEST_METHOD(ContainerAutoRemove)
     {
         // Test that a container with the Rm flag is automatically deleted on Stop().

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -7419,11 +7419,15 @@ class WSLCTests
 
     WSLC_TEST_METHOD(SwapConfigured)
     {
-        // Verify that swap space is configured in the VM (on a block device from the swap VHD).
-        auto result = ExpectCommandResult(m_defaultSession.get(), {"/usr/sbin/swapon", "--show=NAME,SIZE", "--noheadings"}, 0);
+        // Swap is configured asynchronously (mkswap + swapon runs fire-and-forget), so retry until it's active.
+        wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() {
+                auto result = ExpectCommandResult(m_defaultSession.get(), {"/usr/sbin/swapon", "--show=NAME,SIZE", "--noheadings"}, 0);
 
-        VERIFY_ARE_EQUAL(result.Code, 0);
-        VERIFY_IS_TRUE(result.Output[1].find("/dev/") != std::string::npos);
+                THROW_WIN32_IF(ERROR_RETRY, result.Code != 0 || result.Output.size() < 2 || result.Output[1].find("/dev/") == std::string::npos);
+            },
+            std::chrono::milliseconds{500},
+            std::chrono::seconds{30});
     }
 
     WSLC_TEST_METHOD(ContainerAutoRemove)


### PR DESCRIPTION
Add swap support for WSLC virtual machines using a dedicated ephemeral VHDX.

## Design
- Swap size defaults to VM memory size (`MemoryMb`) — no additional SDK setting needed
- Creates a dynamic VHDX at `StoragePath/swap.vhdx` (low IO cost on boot since swap is rarely written)
- Attaches as a separate SCSI disk; `mkswap + swapon` runs fire-and-forget (async, best-effort)
- VHD is deleted on session teardown in `Terminate()`
- Completely separate from the storage VHD — no sizing interactions or shared I/O

## Why separate VHD?
Putting swap on the storage VHD had many issues: VHD sizing assumptions, pre-existing VHD compatibility, shared I/O bandwidth under memory pressure, disk-full cascades, and sync `fallocate` blocking session init. A dedicated ephemeral VHD avoids all of these.

## Why dynamic (not fixed) VHD?
A fixed VHD would do a large sequential write on every boot even though swap pages are rarely touched. A dynamic VHD allocates blocks on demand, making session startup faster while still providing the same swap capacity.

## Changes
- `wslc.idl`: Add `SwapSizeMb` to both `WSLCSessionSettings` and `WSLCSessionInitSettings`
- `WSLCSession.cpp`: Create/attach swap VHD in `ConfigureStorage()`, delete in `Terminate()`
- `WSLCSessionManager.cpp`: Plumb `MemoryMb` → `SwapSizeMb` in init settings
- `HcsVirtualMachine.cpp`: Move page reporting to runtime sysfs write (out of kernel cmdline)
- `WSLCVirtualMachine.cpp`: Configure page_reporting_order via sysfs after boot
- `WSLCTests.cpp`: Verify swap is active on a block device (with retry for async setup)