### PR TITLE
Move printk.devkmsg and page_reporting_order to kernel command line

### DIFF
--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -948,15 +948,6 @@ int WSLCEntryPoint(int Argc, char* Argv[])
     }
 
     //
-    // Disable rate limiting of user writes to dmesg.
-    //
-
-    if (WriteToFile("/proc/sys/kernel/printk_devkmsg", "on\n") < 0)
-    {
-        return -1;
-    }
-
-    //
     // Set the ephemeral port range
     //
 

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1481,15 +1481,6 @@ Return Value:
     }
 
     //
-    // Disable rate limiting of user writes to dmesg.
-    //
-
-    if (WriteToFile("/proc/sys/kernel/printk_devkmsg", "on\n") < 0)
-    {
-        return -1;
-    }
-
-    //
     // Set the hostname.
     //
 

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -730,3 +730,15 @@ try
     wsl::windows::common::registry::WriteString(dcatKey.get(), nullptr, L"Version", registeredVersion.c_str());
 }
 CATCH_LOG()
+
+void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder)
+{
+    // Enable timesync workaround to sync on resume from sleep in modern standby.
+    kernelCmdLine += L" hv_utils.timesync_implicit=1";
+
+    // Disable rate limiting of user writes to dmesg.
+    kernelCmdLine += L" printk.devkmsg=on";
+
+    // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
+    kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", pageReportingOrder);
+}

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -201,4 +201,6 @@ bool TryAttachConsole();
 
 void RegisterWithDcat(_In_ bool IncludeVersionNumber = true);
 
+void AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder);
+
 } // namespace wsl::windows::common::helpers

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -111,11 +111,8 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     std::wstring kernelCmdLine = L"initrd=\\" LXSS_VM_MODE_INITRD_NAME L" " TEXT(WSLC_ROOT_INIT_ENV) L"=1 panic=-1";
     kernelCmdLine += std::format(L" nr_cpus={}", Settings->CpuCount);
 
-    // Enable timesync workaround to sync on resume from sleep in modern standby.
-    kernelCmdLine += L" hv_utils.timesync_implicit=1";
-
-    // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
-    kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", pageReportingOrder);
+    // Append common kernel parameters shared between WSL2 and WSLC.
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder);
 
     // Setup dmesg collector with optional DmesgOutput handle.
     // TODO: move dmesg collector to user session process.

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1523,11 +1523,8 @@ std::wstring WslCoreVm::GenerateConfigJson()
     // Set number of processors.
     kernelCmdLine += std::format(L" nr_cpus={}", m_vmConfig.ProcessorCount);
 
-    // Enable timesync workaround to sync on resume from sleep in modern standby.
-    kernelCmdLine += L" hv_utils.timesync_implicit=1";
-
-    // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
-    kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", m_pageReportingOrder);
+    // Append common kernel parameters shared between WSL2 and WSLC.
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder);
 
     // If using virtio features, enable SWIOTLB as a perf optimization (will cause VM to consume 64MB more memory).
     if (m_vmConfig.EnableVirtio9p || m_vmConfig.EnableVirtioFs || m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)


### PR DESCRIPTION
Move `printk.devkmsg=on` from post-boot runtime writes in init to the kernel command line, ensuring it is applied at boot for both WSL2 and WSLC VMs.

Also adds `AppendCommonKernelCommandLine()` helper in `helpers.hpp`/`helpers.cpp` to share common kernel parameters (`hv_utils.timesync_implicit=1`, `printk.devkmsg=on`, and `page_reporting.page_reporting_order`) between WslCoreVm and HcsVirtualMachine.

Verified via `/proc/cmdline` and `/proc/sys/kernel/printk_devkmsg` that the parameter takes effect at boot.