### PR TITLE
Add caller file name to WSLCCreateSession event

### DIFF
--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -189,11 +189,26 @@ void WSLCSessionManagerImpl::CreateSession(const WSLCSessionSettings* Settings, 
         Settings = &defaultSettings->Settings;
     }
 
+    std::wstring callerFileName;
+
     HRESULT creationResult = wil::ResultFromException([&]() {
         // Get caller info.
         const auto callerProcess = wslutil::OpenCallingProcess(PROCESS_QUERY_LIMITED_INFORMATION);
         const ULONG sessionId = m_nextSessionId++;
         const DWORD creatorPid = GetProcessId(callerProcess.get());
+
+        // Query the full image path of the calling process and extract just the file name.
+        // Failure is non-fatal: callerFileName remains empty if the process has already exited.
+        if (callerProcess)
+        {
+            WCHAR imagePath[MAX_PATH];
+            DWORD imagePathLen = ARRAYSIZE(imagePath);
+            if (QueryFullProcessImageNameW(callerProcess.get(), 0, imagePath, &imagePathLen))
+            {
+                callerFileName = std::filesystem::path(imagePath).filename().wstring();
+            }
+        }
+
         const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);
 
         // Create the VM in the SYSTEM service (privileged).
@@ -232,6 +247,7 @@ void WSLCSessionManagerImpl::CreateSession(const WSLCSessionSettings* Settings, 
         TraceLoggingValue(creationResult, "Result"),
         TraceLoggingValue(tokenInfo.Elevated, "Elevated"),
         TraceLoggingValue(static_cast<uint32_t>(Flags), "Flags"),
+        TraceLoggingValue(callerFileName.c_str(), "CallerFileName"),
         TraceLoggingLevel(WINEVENT_LEVEL_INFO));
 
     THROW_IF_FAILED_MSG(creationResult, "Failed to create session: %ls", resolvedDisplayName.c_str());

--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -198,15 +198,10 @@ void WSLCSessionManagerImpl::CreateSession(const WSLCSessionSettings* Settings, 
         const DWORD creatorPid = GetProcessId(callerProcess.get());
 
         // Query the full image path of the calling process and extract just the file name.
-        // Failure is non-fatal: callerFileName remains empty if the process has already exited.
-        if (callerProcess)
+        std::wstring callerFilePath;
+        if (SUCCEEDED_LOG(wil::QueryFullProcessImageNameW<std::wstring>(callerProcess.get(), 0, callerFilePath)))
         {
-            WCHAR imagePath[MAX_PATH];
-            DWORD imagePathLen = ARRAYSIZE(imagePath);
-            if (QueryFullProcessImageNameW(callerProcess.get(), 0, imagePath, &imagePathLen))
-            {
-                callerFileName = std::filesystem::path(imagePath).filename().wstring();
-            }
+            callerFileName = std::filesystem::path(callerFilePath).filename().wstring();
         }
 
         const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add caller file name to `WSLCCreateSession` event.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Uses `QueryFullProcessImageNameW` to get the calling process file name for the `WSLCCreateSession` event.  This will allow for a better bucketization of usage statistics.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually confirmed presence of correct value in realtime event stream.