### PR TITLE
Validate NUL-termination of flexible-array Buffer in interop messages

### DIFF
--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -670,8 +670,7 @@ void HandleMessageImpl(
     Transaction.SendResultMessage(result < 0 ? errno : 0);
 }
 
-void HandleMessageImpl(
-    wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const WSLC_UNMOUNT& Message, const gsl::span<gsl::byte>& Buffer)
+void HandleMessageImpl(wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const WSLC_UNMOUNT&, const gsl::span<gsl::byte>& Buffer)
 {
     auto* path = wsl::shared::string::FromMessageBuffer<WSLC_UNMOUNT>(Buffer);
     auto result = umount(path) < 0 ? errno : 0;

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -673,10 +673,11 @@ void HandleMessageImpl(
 void HandleMessageImpl(
     wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const WSLC_UNMOUNT& Message, const gsl::span<gsl::byte>& Buffer)
 {
-    auto result = umount(Message.Buffer) < 0 ? errno : 0;
+    auto* path = wsl::shared::string::FromMessageBuffer<WSLC_UNMOUNT>(Buffer);
+    auto result = umount(path) < 0 ? errno : 0;
     if (result == 0)
     {
-        result = rmdir(Message.Buffer) < 0 ? errno : 0;
+        result = rmdir(path) < 0 ? errno : 0;
     }
 
     Transaction.SendResultMessage<int32_t>(result);

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -394,7 +394,7 @@ try
             return;
         }
 
-        auto Value = UtilGetEnvironmentVariable(Query->Buffer);
+        auto Value = UtilGetEnvironmentVariable(wsl::shared::string::FromMessageBuffer<LX_INIT_QUERY_ENVIRONMENT_VARIABLE>(Message));
         wsl::shared::MessageWriter<LX_INIT_QUERY_ENVIRONMENT_VARIABLE> Response(LxInitMessageQueryEnvironmentVariable);
         Response.WriteString(Value);
         Transaction.Send<LX_INIT_QUERY_ENVIRONMENT_VARIABLE>(Response.Span());
@@ -427,7 +427,8 @@ try
         }
         else
         {
-            success = CreateLoginSession(Config, CreateSession->Buffer, CreateSession->Uid);
+            success = CreateLoginSession(
+                Config, wsl::shared::string::FromMessageBuffer<LX_INIT_CREATE_LOGIN_SESSION>(Message), CreateSession->Uid);
         }
 
         break;

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -2925,7 +2925,7 @@ Return Value:
                     return;
                 }
 
-                Target = GetMountTarget(Message->Buffer);
+                Target = GetMountTarget(wsl::shared::string::FromMessageBuffer<LX_MINI_INIT_UNMOUNT_MESSAGE>(Buffer));
 
                 Step = LxMiniInitMountStepUnmount;
                 Result = umount(Target.c_str());


### PR DESCRIPTION
Use `string::FromMessageBuffer<T>()` instead of directly accessing the `Buffer[]` flexible-array member in interop message structs. `FromMessageBuffer` validates that a NUL terminator exists within the span bounds, preventing out-of-bounds reads when a malformed message contains no Buffer data or lacks NUL termination.

**Affected message handlers:**
- `LxInitMessageQueryEnvironmentVariable` (config.cpp)
- `LxInitMessageCreateLoginSession` (config.cpp)
- `LxMiniInitMessageUnmount` (main.cpp)
- `WSLC_UNMOUNT` (WSLCInit.cpp)