### PR TITLE
wslc: add Config (env, cmd, entrypoint, user, workdir) to container inspect output

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -260,8 +260,14 @@ struct ContainerInspectState
 struct ContainerConfig
 {
     std::string Image;
+    std::string User;
+    std::string WorkingDir;
+    std::optional<std::vector<std::string>> Env;
+    std::optional<std::vector<std::string>> Cmd;
+    std::optional<std::vector<std::string>> Entrypoint;
+    std::optional<std::map<std::string, std::string>> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Image);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Image, User, WorkingDir, Env, Cmd, Entrypoint, Labels);
 };
 
 struct InspectMount

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -265,9 +265,8 @@ struct ContainerConfig
     std::optional<std::vector<std::string>> Env;
     std::optional<std::vector<std::string>> Cmd;
     std::optional<std::vector<std::string>> Entrypoint;
-    std::optional<std::map<std::string, std::string>> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Image, User, WorkingDir, Env, Cmd, Entrypoint, Labels);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Image, User, WorkingDir, Env, Cmd, Entrypoint);
 };
 
 struct InspectMount

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -56,6 +56,17 @@ struct InspectHostConfig
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectHostConfig, NetworkMode);
 };
 
+struct InspectContainerConfig
+{
+    std::optional<std::vector<std::string>> Env;
+    std::optional<std::vector<std::string>> Cmd;
+    std::optional<std::vector<std::string>> Entrypoint;
+    std::string User;
+    std::string WorkingDir;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectContainerConfig, Env, Cmd, Entrypoint, User, WorkingDir);
+};
+
 struct InspectContainer
 {
     std::string Id;
@@ -64,11 +75,12 @@ struct InspectContainer
     std::string Image;
     InspectState State;
     InspectHostConfig HostConfig;
+    InspectContainerConfig Config;
     std::map<std::string, std::vector<InspectPortBinding>> Ports;
     std::vector<InspectMount> Mounts;
     std::map<std::string, std::string> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectContainer, Id, Name, Created, Image, State, HostConfig, Ports, Mounts, Labels);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectContainer, Id, Name, Created, Image, State, HostConfig, Config, Ports, Mounts, Labels);
 };
 
 struct ImageConfig

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1109,6 +1109,12 @@ WslcInspectContainer WSLCContainerImpl::BuildInspectContainer(const DockerInspec
 
     wslcInspect.HostConfig.NetworkMode = dockerInspect.HostConfig.NetworkMode;
 
+    wslcInspect.Config.Env = dockerInspect.Config.Env;
+    wslcInspect.Config.Cmd = dockerInspect.Config.Cmd;
+    wslcInspect.Config.Entrypoint = dockerInspect.Config.Entrypoint;
+    wslcInspect.Config.User = dockerInspect.Config.User;
+    wslcInspect.Config.WorkingDir = dockerInspect.Config.WorkingDir;
+
     // Map WSLC port mappings (Windows host ports only). HostIp is not set here and will use
     // the default value ("127.0.0.1") defined in the InspectPortBinding schema.
     for (const auto& e : m_mappedPorts)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5576,6 +5576,7 @@ class WSLCTests
             WSLCContainerLauncher launcher("debian:latest", "test-container-inspect-config", {"99999"}, {envVar});
             launcher.SetEntrypoint({"sleep"});
             launcher.SetWorkingDirectory(std::string{workDir});
+            launcher.SetUser("nobody");
 
             auto container = launcher.Launch(*m_defaultSession);
             auto details = container.Inspect();
@@ -5604,7 +5605,7 @@ class WSLCTests
             VERIFY_ARE_EQUAL(1u, config.Entrypoint->size());
             VERIFY_ARE_EQUAL(config.Entrypoint->at(0), std::string{"sleep"});
 
-            VERIFY_ARE_EQUAL(config.User, std::string{});
+            VERIFY_ARE_EQUAL(config.User, std::string{"nobody"});
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
             VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5567,6 +5567,34 @@ class WSLCTests
 
             VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
         }
+
+        // Test that Config fields are populated in inspect output.
+        {
+            const std::string envVar = "WSLC_TEST_VAR=hello";
+            const std::string workDir = "/tmp";
+
+            WSLCContainerLauncher launcher("debian:latest", "test-container-inspect-config", {"sleep", "99999"}, {envVar});
+            launcher.SetWorkingDirectory(std::string{workDir});
+
+            auto container = launcher.Launch(*m_defaultSession);
+            auto details = container.Inspect();
+
+            VERIFY_IS_TRUE(details.Config.Env.has_value());
+            bool envVarFound = false;
+            for (const auto& env : details.Config.Env.value())
+            {
+                if (env == envVar)
+                {
+                    envVarFound = true;
+                    break;
+                }
+            }
+            VERIFY_IS_TRUE(envVarFound);
+            VERIFY_ARE_EQUAL(details.Config.WorkingDir, workDir);
+
+            VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
+        }
     }
 
     WSLC_TEST_METHOD(Exec)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5584,16 +5584,7 @@ class WSLCTests
             const auto& config = details.Config;
 
             VERIFY_IS_TRUE(config.Env.has_value());
-            bool envVarFound = false;
-            for (const auto& env : *config.Env)
-            {
-                if (env == envVar)
-                {
-                    envVarFound = true;
-                    break;
-                }
-            }
-            VERIFY_IS_TRUE(envVarFound);
+            VERIFY_IS_TRUE(std::ranges::find(*config.Env, envVar) != config.Env->end());
 
             VERIFY_ARE_EQUAL(config.WorkingDir, workDir);
 
@@ -5606,9 +5597,6 @@ class WSLCTests
             VERIFY_ARE_EQUAL(config.Entrypoint->at(0), std::string{"sleep"});
 
             VERIFY_ARE_EQUAL(config.User, std::string{"nobody"});
-
-            VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
-            VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
         }
     }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5573,15 +5573,18 @@ class WSLCTests
             const std::string envVar = "WSLC_TEST_VAR=hello";
             const std::string workDir = "/tmp";
 
-            WSLCContainerLauncher launcher("debian:latest", "test-container-inspect-config", {"sleep", "99999"}, {envVar});
+            WSLCContainerLauncher launcher("debian:latest", "test-container-inspect-config", {"99999"}, {envVar});
+            launcher.SetEntrypoint({"sleep"});
             launcher.SetWorkingDirectory(std::string{workDir});
 
             auto container = launcher.Launch(*m_defaultSession);
             auto details = container.Inspect();
 
-            VERIFY_IS_TRUE(details.Config.Env.has_value());
+            const auto& config = details.Config;
+
+            VERIFY_IS_TRUE(config.Env.has_value());
             bool envVarFound = false;
-            for (const auto& env : details.Config.Env.value())
+            for (const auto& env : *config.Env)
             {
                 if (env == envVar)
                 {
@@ -5590,7 +5593,18 @@ class WSLCTests
                 }
             }
             VERIFY_IS_TRUE(envVarFound);
-            VERIFY_ARE_EQUAL(details.Config.WorkingDir, workDir);
+
+            VERIFY_ARE_EQUAL(config.WorkingDir, workDir);
+
+            VERIFY_IS_TRUE(config.Cmd.has_value());
+            VERIFY_ARE_EQUAL(1u, config.Cmd->size());
+            VERIFY_ARE_EQUAL(config.Cmd->at(0), std::string{"99999"});
+
+            VERIFY_IS_TRUE(config.Entrypoint.has_value());
+            VERIFY_ARE_EQUAL(1u, config.Entrypoint->size());
+            VERIFY_ARE_EQUAL(config.Entrypoint->at(0), std::string{"sleep"});
+
+            VERIFY_ARE_EQUAL(config.User, std::string{});
 
             VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
             VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
wslc inspect was missing the Config block entirely compared to docker inspect. Environment variables, command, entrypoint, user, and working directory were not surfaced in the output. This PR adds a Config section to the inspect output by extending the Docker schema parsing and the WSLC inspect schema.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x ] **Closes:** AB#62097542
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- docker_schema.h: Extended ContainerConfig to parse User, WorkingDir, Env, Cmd and Entrypoint from the Docker daemon's /containers/{id}/json response. NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT is tolerant of missing fields so this is fully backward compatible
- wslc_schema.h: Added a new InspectContainerConfig struct (separate from ImageConfig, they are semantically distinct and may diverge) and added it as the Config field on InspectContainer
- WSLCContainer.cpp: Populated the five Config fields in BuildInspectContainer by copying directly from the Docker inspect response

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
