### PR TITLE
Don't run the VM owner tests since custom VM owners are only support on Windows >= 11

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -472,6 +472,8 @@ class WSLCTests
 
     WSLC_TEST_METHOD(VmOwnerMatchesSessionDisplayName)
     {
+        WINDOWS_11_TEST_ONLY();
+
         // The default session (c_testSessionName) is already running from class setup.
         // Verify its display name appears as a VM owner in hcsdiag output.
         auto vms = ListVms();
@@ -8477,6 +8479,8 @@ class WSLCTests
 
     WSLC_TEST_METHOD(VmKillTerminatesSession)
     {
+        WINDOWS_11_TEST_ONLY();
+
         constexpr auto c_sessionName = L"wslc-vm-kill-test";
         auto settings = GetDefaultSessionSettings(c_sessionName);
         auto session = CreateSession(settings);
@@ -8489,6 +8493,8 @@ class WSLCTests
 
     WSLC_TEST_METHOD(VmKillFailsInFlightOperations)
     {
+        WINDOWS_11_TEST_ONLY();
+
         constexpr auto c_sessionName = L"wslc-vm-kill-inflight-test";
         auto settings = GetDefaultSessionSettings(c_sessionName);
         auto session = CreateSession(settings);


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change skips the VM owner tests since they fail on vb and fe because that feature isn't supported there.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
