### PR TITLE
Fix WSLCTests::ListVms parser for older Windows hcsdiag

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -18,6 +18,8 @@ Abstract:
 #include "WSLCProcessLauncher.h"
 #include "WSLCContainerLauncher.h"
 #include "WslCoreFilesystem.h"
+#include "hcs.hpp"
+#include <nlohmann/json.hpp>
 
 using namespace std::literals::chrono_literals;
 using namespace wsl::windows::common::registry;
@@ -443,61 +445,37 @@ class WSLCTests
         std::wstring Owner;
     };
 
-    // Returns VM info (Id + Owner) for all running VMs via hcsdiag.
+    // Returns VM info (Id + Owner) for all running compute systems via the HCS API.
     //
-    // Parses the default `hcsdiag list` text output rather than `-raw` because
-    // the JSON option is not available on older Windows builds (e.g. Win10 22H2).
-    // The text format is consistently:
-    //
-    //   <id>
-    //       <Type>, <State>, <Id>, <Owner>
-    //
-    // where the indented line is a comma-separated list (with arbitrary
-    // whitespace padding) common to every supported Windows version.
+    // We call HcsEnumerateComputeSystems directly rather than shelling out to
+    // hcsdiag.exe because hcsdiag's `-raw` (JSON) flag is not supported on
+    // older in-box hcsdiag (e.g. Win10 22H2), and parsing its plain-text output
+    // is brittle (the comma-separated layout breaks if Owner contains commas).
     static std::vector<VmInfo> ListVms()
     {
-        wsl::windows::common::SubProcess process(nullptr, L"hcsdiag list");
-        const auto output = process.RunAndCaptureOutput(10000);
+        auto operation = wsl::windows::common::hcs::CreateOperation();
+        THROW_IF_FAILED(::HcsEnumerateComputeSystems(L"{}", operation.get()));
 
-        LogInfo("hcsdiag list exit=%lu stdout='%ws' stderr='%ws'", output.ExitCode, output.Stdout.c_str(), output.Stderr.c_str());
+        wil::unique_cotaskmem_string resultDocument;
+        const auto result = ::HcsWaitForOperationResult(operation.get(), 10000, &resultDocument);
+        THROW_IF_FAILED_MSG(result, "HcsEnumerateComputeSystems failed (error: %ls)", resultDocument.get());
 
-        VERIFY_ARE_EQUAL(output.ExitCode, 0u);
-
-        const auto trim = [](std::wstring_view text) {
-            constexpr auto whitespace = L" \t\r\n";
-            const auto first = text.find_first_not_of(whitespace);
-            if (first == std::wstring_view::npos)
-            {
-                return std::wstring{};
-            }
-
-            const auto last = text.find_last_not_of(whitespace);
-            return std::wstring{text.substr(first, last - first + 1)};
-        };
+        LogInfo("HcsEnumerateComputeSystems result='%ws'", resultDocument.get());
 
         std::vector<VmInfo> vms;
-        std::wistringstream stream(output.Stdout);
-        std::wstring line;
-        while (std::getline(stream, line))
+        const auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(resultDocument.get()), nullptr, false);
+        if (!json.is_array())
         {
-            // Only the indented detail line carries the comma-separated fields.
-            if (line.empty() || !std::iswspace(static_cast<wint_t>(line.front())))
-            {
-                continue;
-            }
+            return vms;
+        }
 
-            std::vector<std::wstring> fields;
-            std::wistringstream lineStream(line);
-            std::wstring field;
-            while (std::getline(lineStream, field, L','))
+        for (const auto& entry : json)
+        {
+            if (entry.contains("Owner") && entry["Owner"].is_string() && entry.contains("Id") && entry["Id"].is_string())
             {
-                fields.push_back(trim(field));
-            }
-
-            // Expected layout: {Type, State, Id, Owner}.
-            if (fields.size() >= 4 && !fields[2].empty())
-            {
-                vms.push_back({std::move(fields[2]), std::move(fields[3])});
+                vms.push_back(
+                    {wsl::shared::string::MultiByteToWide(entry["Id"].get<std::string>()),
+                     wsl::shared::string::MultiByteToWide(entry["Owner"].get<std::string>())});
             }
         }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -461,6 +461,8 @@ class WSLCTests
 
         LogInfo("hcsdiag list exit=%lu stdout='%ws' stderr='%ws'", output.ExitCode, output.Stdout.c_str(), output.Stderr.c_str());
 
+        VERIFY_ARE_EQUAL(output.ExitCode, 0u);
+
         const auto trim = [](std::wstring_view text) {
             constexpr auto whitespace = L" \t\r\n";
             const auto first = text.find_first_not_of(whitespace);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -445,7 +445,7 @@ class WSLCTests
         std::wstring Owner;
     };
 
-    // Returns VM info (Id + Owner) for all running compute systems via the HCS API.
+    // Returns VM info (Id + Owner) for all compute systems via the HCS API.
     static std::vector<VmInfo> ListVms()
     {
         const wsl::windows::common::ExecutionContext context(wsl::windows::common::Context::HCS);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -18,7 +18,6 @@ Abstract:
 #include "WSLCProcessLauncher.h"
 #include "WSLCContainerLauncher.h"
 #include "WslCoreFilesystem.h"
-#include <nlohmann/json.hpp>
 
 using namespace std::literals::chrono_literals;
 using namespace wsl::windows::common::registry;
@@ -445,25 +444,58 @@ class WSLCTests
     };
 
     // Returns VM info (Id + Owner) for all running VMs via hcsdiag.
+    //
+    // Parses the default `hcsdiag list` text output rather than `-raw` because
+    // the JSON option is not available on older Windows builds (e.g. Win10 22H2).
+    // The text format is consistently:
+    //
+    //   <id>
+    //       <Type>, <State>, <Id>, <Owner>
+    //
+    // where the indented line is a comma-separated list (with arbitrary
+    // whitespace padding) common to every supported Windows version.
     static std::vector<VmInfo> ListVms()
     {
-        wsl::windows::common::SubProcess process(nullptr, L"hcsdiag list -raw");
-        auto output = process.RunAndCaptureOutput(10000);
+        wsl::windows::common::SubProcess process(nullptr, L"hcsdiag list");
+        const auto output = process.RunAndCaptureOutput(10000);
+
+        LogInfo("hcsdiag list exit=%lu stdout='%ws' stderr='%ws'", output.ExitCode, output.Stdout.c_str(), output.Stderr.c_str());
+
+        const auto trim = [](std::wstring_view text) {
+            constexpr auto whitespace = L" \t\r\n";
+            const auto first = text.find_first_not_of(whitespace);
+            if (first == std::wstring_view::npos)
+            {
+                return std::wstring{};
+            }
+
+            const auto last = text.find_last_not_of(whitespace);
+            return std::wstring{text.substr(first, last - first + 1)};
+        };
 
         std::vector<VmInfo> vms;
-        auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(output.Stdout), nullptr, false);
-        if (!json.is_array())
+        std::wistringstream stream(output.Stdout);
+        std::wstring line;
+        while (std::getline(stream, line))
         {
-            return vms;
-        }
-
-        for (const auto& entry : json)
-        {
-            if (entry.contains("Owner") && entry["Owner"].is_string() && entry.contains("Id") && entry["Id"].is_string())
+            // Only the indented detail line carries the comma-separated fields.
+            if (line.empty() || !std::iswspace(static_cast<wint_t>(line.front())))
             {
-                vms.push_back(
-                    {wsl::shared::string::MultiByteToWide(entry["Id"].get<std::string>()),
-                     wsl::shared::string::MultiByteToWide(entry["Owner"].get<std::string>())});
+                continue;
+            }
+
+            std::vector<std::wstring> fields;
+            std::wistringstream lineStream(line);
+            std::wstring field;
+            while (std::getline(lineStream, field, L','))
+            {
+                fields.push_back(trim(field));
+            }
+
+            // Expected layout: {Type, State, Id, Owner}.
+            if (fields.size() >= 4 && !fields[2].empty())
+            {
+                vms.push_back({std::move(fields[2]), std::move(fields[3])});
             }
         }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -446,13 +446,10 @@ class WSLCTests
     };
 
     // Returns VM info (Id + Owner) for all running compute systems via the HCS API.
-    //
-    // We call HcsEnumerateComputeSystems directly rather than shelling out to
-    // hcsdiag.exe because hcsdiag's `-raw` (JSON) flag is not supported on
-    // older in-box hcsdiag (e.g. Win10 22H2), and parsing its plain-text output
-    // is brittle (the comma-separated layout breaks if Owner contains commas).
     static std::vector<VmInfo> ListVms()
     {
+        const wsl::windows::common::ExecutionContext context(wsl::windows::common::Context::HCS);
+
         auto operation = wsl::windows::common::hcs::CreateOperation();
         THROW_IF_FAILED(::HcsEnumerateComputeSystems(L"{}", operation.get()));
 
@@ -463,7 +460,7 @@ class WSLCTests
         LogInfo("HcsEnumerateComputeSystems result='%ws'", resultDocument.get());
 
         std::vector<VmInfo> vms;
-        const auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(resultDocument.get()), nullptr, false);
+        const auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(resultDocument.get()));
         if (!json.is_array())
         {
             return vms;


### PR DESCRIPTION
`WSLCTests::ListVms()` originally called `hcsdiag list -raw` and parsed the JSON output. That fails on older Windows builds (e.g. Win10 22H2 / build 19041), where the in-box `hcsdiag` doesn't recognize `-raw` and just prints its help text — so the JSON parse silently produced a discarded value, `ListVms()` returned an empty vector, and three tests failed in the `vb_release` lab image with `VM with owner 'X' not found`:

- `WSLCTests::VmOwnerMatchesSessionDisplayName`
- `WSLCTests::VmKillTerminatesSession`
- `WSLCTests::VmKillFailsInFlightOperations`

Per review feedback from @OneBlue, replace the `hcsdiag.exe` shellout with a direct call to `HcsEnumerateComputeSystems` (which is what `hcsdiag` does internally anyway). This avoids the older-Windows compatibility problem entirely, gives us a guaranteed JSON contract from the HCS API, drops a process launch, and matches the existing `wsl::windows::common::hcs` helper conventions (`CreateOperation` + `HcsWaitForOperationResult` + `ExecutionContext(Context::HCS)`). Also adds a `LogInfo` of the HCS result document so future failures have the raw enumeration captured next to the assertion.