### PR TITLE
Build NuGet packages in CI/PR pipelines

### DIFF
--- a/.pipelines/package-stage.yml
+++ b/.pipelines/package-stage.yml
@@ -32,7 +32,7 @@ stages:
     dependsOn: [build_x64, build_arm64]
     jobs:
       - job: package
-        displayName: "Create msixbundle & appxupload"
+        displayName: "Package WSL release artifacts"
         timeoutInMinutes: 60
 
         ${{ if eq(parameters.pool, '') }}:

--- a/.pipelines/wsl-build-pr-onebranch.yml
+++ b/.pipelines/wsl-build-pr-onebranch.yml
@@ -46,7 +46,6 @@ extends:
     - template: build-stage.yml@self
       parameters:
         isRelease: false
-        includePackageStage: false
 
     - template: test-stage.yml@self
       parameters:

--- a/.pipelines/wsl-build-pr.yml
+++ b/.pipelines/wsl-build-pr.yml
@@ -8,7 +8,6 @@ stages:
 - template: build-stage.yml@self
   parameters:
     isRelease: false
-    includePackageStage: false
     pool: 'wsl-build'
     vsoOrg: shine-oss
     vsoProject: wsl


### PR DESCRIPTION
Removes `includePackageStage: false` from the PR pipeline templates so the package stage runs on every PR build, producing both `Microsoft.WSL.PluginApi` and `Microsoft.WSL.Containers` nupkgs as pipeline artifacts. This makes it easier to test SDK changes pre-merge.

Tests are unaffected: the test stage still passes `includePackageStage: false`, so it continues to depend only on `build_x64` and downloads `drop_wsl_build` (not the package stage's outputs). The package stage runs in parallel with tests.

NuGet packages are unsigned in PR builds (the ESRP signing step in `package-stage.yml` is gated on `isRelease == true`, which remains `false` for PR builds).