### PR TITLE
Fix NTSTATUS/Win32 error code mismatch in registry::GetKeyPath()

### DIFF
--- a/src/windows/common/registry.cpp
+++ b/src/windows/common/registry.cpp
@@ -51,7 +51,7 @@ std::wstring GetKeyPath(_In_ HKEY Key)
     std::vector<char> buffer(requiredSize, 0);
 
     status = ZwQueryKey(Key, KeyNameInformation, buffer.data(), static_cast<ULONG>(buffer.size()), &requiredSize);
-    THROW_IF_WIN32_ERROR(status);
+    THROW_IF_NTSTATUS_FAILED(status);
 
     const auto* info = reinterpret_cast<KEY_NAME_INFORMATION*>(buffer.data());
 


### PR DESCRIPTION
Fix NTSTATUS/Win32 error code mismatch in `registry::GetKeyPath()`.

## Problem

In `src/windows/common/registry.cpp`, `GetKeyPath()` makes two consecutive `ZwQueryKey()` calls. `ZwQueryKey` returns `NTSTATUS`. The first call (line 48) correctly uses `THROW_NTSTATUS`, but the second call (line 54) used `THROW_IF_WIN32_ERROR()`, which expects an `LSTATUS`/Win32 error code domain.

When the second `ZwQueryKey()` failed, the `NTSTATUS` value was reinterpreted as a Win32 error code, producing the wrong `HRESULT` (or in some cases silently treating an NTSTATUS failure as success when its bit pattern happened to look like `ERROR_SUCCESS`-adjacent values).

## Fix

One-line change: `THROW_IF_WIN32_ERROR(status)` → `THROW_IF_NTSTATUS_FAILED(status)`.

## Why it's safe

- Same function, same `NTSTATUS` variable returned from `ZwQueryKey`.
- The other `ZwQueryKey` call site in this file already uses `THROW_IF_NTSTATUS_FAILED`.
- Only behavior change is that previously misclassified failures now throw the correct `HRESULT`.
