### PR TITLE
Fix typos in user-facing strings: 'chose' -> 'choose'

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -169,7 +169,7 @@ Install using 'wsl.exe {} &lt;Distro&gt;'.
     <value>The supplied install location is already in use.</value>
   </data>
   <data name="MessageDistroNameAlreadyExists" xml:space="preserve">
-    <value>A distribution with the supplied name already exists. Use --name to chose a different name.</value>
+    <value>A distribution with the supplied name already exists. Use --name to choose a different name.</value>
     <comment>{Locked="--name "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageDistroNotFound" xml:space="preserve">
@@ -805,7 +805,7 @@ For more information on Admin Protection, please visit https://aka.ms/apdevguide
     <value>Open EventViewer</value>
   </data>
   <data name="MessageDistributionNameNeeded" xml:space="preserve">
-    <value>This distribution doesn't contain a default name. Use --name to chose the distribution name.</value>
+    <value>This distribution doesn't contain a default name. Use --name to choose the distribution name.</value>
     <comment>{Locked="--name "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageArgumentsNotValidTogether" xml:space="preserve">

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -4397,7 +4397,7 @@ VERSION_ID="Invalid|Format"
             // Import should fail without --name
             constexpr auto expectedOutput =
                 L"Installing: distro-no-default-name.tar\r\n\
-This distribution doesn't contain a default name. Use --name to chose the distribution name.\r\n\
+This distribution doesn't contain a default name. Use --name to choose the distribution name.\r\n\
 Error code: Wsl/Service/RegisterDistro/WSL_E_DISTRIBUTION_NAME_NEEDED\r\n";
 
             InstallFromTar(L"distro-no-default-name.tar", L"", -1, expectedOutput);
@@ -4656,7 +4656,7 @@ Error code: Wsl/Service/RegisterDistro/WSL_E_DISTRIBUTION_NAME_NEEDED\r\n";
 
             constexpr auto expectedOutput =
                 L"Installing: conflict.tar\r\n\
-A distribution with the supplied name already exists. Use --name to chose a different name.\r\n\
+A distribution with the supplied name already exists. Use --name to choose a different name.\r\n\
 Error code: Wsl/Service/RegisterDistro/ERROR_ALREADY_EXISTS\r\n";
 
             InstallFromTar(L"conflict.tar", L"", -1, expectedOutput);


### PR DESCRIPTION
Fix two user-facing typos: `chose` → `choose`.

Both strings in `localization/strings/en-US/Resources.resw` used the past tense `chose` where the imperative `choose` was intended:

- `MessageDistroNameAlreadyExists` — *""Use --name to chose a different name.""*
- `MessageDistributionNameNeeded` — *""Use --name to chose the distribution name.""*

These are shipped to users in error output. `{Locked=""--name ""}` annotations preserved.
