### PR TITLE
Use uint64_t instead of size_t in LX_INIT_START_SOCKET_RELAY wire struct

### DIFF
--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1115,7 +1115,7 @@ typedef struct _LX_INIT_START_SOCKET_RELAY
     MESSAGE_HEADER Header;
     unsigned short Family;
     unsigned short Port;
-    size_t BufferSize;
+    uint64_t BufferSize;
 
     PRETTY_PRINT(FIELD(Header), FIELD(Family), FIELD(Port), FIELD(BufferSize));
 } LX_INIT_START_SOCKET_RELAY, *PLX_INIT_START_SOCKET_RELAY;


### PR DESCRIPTION
Use a fixed-width type for `LX_INIT_START_SOCKET_RELAY::BufferSize`.

## Problem

`LX_INIT_START_SOCKET_RELAY` in `src/shared/inc/lxinitshared.h` is a wire-protocol struct serialized cross-process between the Windows host (`wslrelay`, `wslcsession`) and the Linux init guest (parsed via `try_get_struct` in `src/linux/init/localhost.cpp`). All other fields use fixed-width types (`unsigned short`, `MESSAGE_HEADER`), but `BufferSize` was declared `size_t`, which is implementation-defined.

Both sides are currently 64-bit so the on-the-wire layout happens to be stable today, but using `size_t` in a serialized cross-boundary struct violates the wire-protocol convention used by every other message in this header and would silently break if either side ever ran in a 32-bit context.

## Fix

`diff
-    size_t BufferSize;
+    uint64_t BufferSize;
`

## Compatibility

- All producers assign small integer constants (`LOCALHOST_RELAY_BUFFER_SIZE`, `0x20000`) — no narrowing/widening risk.
- Both sides recompile from the same shared header; on-the-wire layout is unchanged on current 64-bit builds.
