### PR TITLE
Write explicit null terminator in CopyToSpan

### DIFF
--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -47,6 +47,7 @@ using MacAddress = std::array<std::uint8_t, 6>;
 inline unsigned int CopyToSpan(const std::string_view String, const gsl::span<gsl::byte> Span, size_t& Offset)
 {
     gsl::copy(as_bytes(gsl::make_span(String.data(), String.size())), Span.subspan(Offset));
+    Span[Offset + String.size()] = gsl::byte{0};
     const auto PreviousOffset = gsl::narrow_cast<unsigned int>(Offset);
     Offset += String.size() + 1;
     return PreviousOffset;


### PR DESCRIPTION
Make `CopyToSpan` self-contained by explicitly writing the trailing NUL.

## Problem

`CopyToSpan` in `src/shared/inc/stringshared.h` copies `String.size()` bytes and advances `Offset` by `String.size() + 1` (reserving room for a NUL terminator), but never actually writes that NUL byte. Correctness relied on every caller pre-zeroing the destination buffer.

## Fix

Add an explicit `Span[Offset + String.size()] = gsl::byte{0};` after the copy.

## Safety

The existing `Offset += String.size() + 1` already implied callers must allocate at least `String.size() + 1` bytes per call - otherwise prior calls into the same buffer would already be buggy. The new write therefore stays in-bounds wherever the existing API contract was satisfied. `gsl::span::operator[]` bounds-checks in debug builds, so any contract violation surfaces as an assertion rather than silent UB.

All callers verified:
- `src/linux/init/binfmt.cpp` (3 calls)
- `src/windows/common/GnsChannel.cpp` (1 call)
- `src/windows/service/exe/LxssCreateProcess.cpp` (8 calls)
