### PR TITLE
Fix inconsistent early return in GetWslConfigSetting for SwapSizeBytes

### DIFF
--- a/src/windows/libwsl/WslCoreConfigInterface.cpp
+++ b/src/windows/libwsl/WslCoreConfigInterface.cpp
@@ -94,7 +94,7 @@ WslConfigSetting GetWslConfigSetting(WslConfig_t wslConfig, WslConfigEntry wslCo
     case SwapSizeBytes:
         static_assert(std::is_same<decltype(wslConfigSetting.UInt64Value), decltype(wslConfig->Config.SwapSizeBytes)>::value);
         wslConfigSetting.UInt64Value = wslConfig->Config.SwapSizeBytes;
-        return wslConfigSetting;
+        break;
     case SwapFilePath:
         static_assert(std::is_same<decltype(wslConfigSetting.StringValue), decltype(wslConfig->Config.SwapFilePath.c_str())>::value);
         wslConfigSetting.StringValue = wslConfig->Config.SwapFilePath.c_str();


### PR DESCRIPTION
Make `SwapSizeBytes` consistent with the rest of the switch in `GetWslConfigSetting`.

## Problem

In `src/windows/libwsl/WslCoreConfigInterface.cpp`, every case in the 25-case switch in `GetWslConfigSetting` ends with `break;` and falls through to the single `return wslConfigSetting;` after the switch - except `SwapSizeBytes`, which uses `return wslConfigSetting;` directly.

Functionally identical today, but a copy-paste inconsistency that could mask bugs if any common post-switch logic is added later (logging, ConfigEntry tagging, etc.).

## Fix

Replace `return wslConfigSetting;` with `break;` in the `SwapSizeBytes` case.

## Risk

None - pure cleanup. Independent of #40414 (no textual overlap).
