### PR TITLE
Fix int-to-bool truncation in InstallPrerequisites

### DIFF
--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -634,7 +634,7 @@ bool InstallPrerequisites(_In_ bool installWslOptionalComponent)
         const auto exitCode = LaunchElevated(elevatedCommand.c_str());
         if (exitCode != 0)
         {
-            return exitCode;
+            THROW_HR(HRESULT_FROM_WIN32(exitCode));
         }
     }
     else

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -634,7 +634,9 @@ bool InstallPrerequisites(_In_ bool installWslOptionalComponent)
         const auto exitCode = LaunchElevated(elevatedCommand.c_str());
         if (exitCode != 0)
         {
-            THROW_HR(HRESULT_FROM_WIN32(exitCode));
+            THROW_HR_WITH_USER_ERROR(
+                WSL_E_INSTALL_COMPONENT_FAILED,
+                Localization::MessageOptionalComponentInstallFailed(wsl::shared::string::Join(missingComponents, L','), exitCode));
         }
     }
     else


### PR DESCRIPTION
Fix int-to-bool truncation in `InstallPrerequisites`.

## Problem

`InstallPrerequisites()` in `src/windows/common/WslClient.cpp` returns `bool` (meaning ""reboot required""), but on the elevated-install failure path it returned the `int` exit code directly:

` cpp
const auto exitCode = LaunchElevated(elevatedCommand.c_str());
if (exitCode != 0)
{
    return exitCode;  // int -> bool: any non-zero becomes true
}
`

Implicit `int → bool` conversion meant any non-zero exit code (e.g. exit code 2 from a failed install) was misinterpreted as `true` = ""reboot required"". The user saw a ""please reboot"" message instead of the actual error.

## Fix

Throw `HRESULT_FROM_WIN32(exitCode)` instead so the failure surfaces as a proper error.

## Caller analysis

Only caller is `WslClient.cpp:544` (top of the `wsl.exe --install` flow). The top-level `catch (...)` at line 1897 already catches exceptions from this code path and converts them to a non-zero process exit code with an appropriate user message - the standard wsl.exe error-handling pattern.

## Behavior change

- Before: any failure silently misinterpreted as ""reboot required""; install proceeds incorrectly or the user gets misleading messaging.
- After: failure surfaces as a proper error message with the actual `HRESULT`.
