### PR TITLE
Avoid std::terminate in FsUserContext destructor (Plan9)

### DIFF
--- a/src/linux/plan9/p9util.cpp
+++ b/src/linux/plan9/p9util.cpp
@@ -242,17 +242,21 @@ FsUserContext::FsUserContext(uid_t uid, gid_t gid, const std::vector<gid_t>& gro
 // Restores the effective uid and gid to root.
 FsUserContext::~FsUserContext()
 {
-    if (m_Restore)
+    try
     {
-        // Use the syscall directly since the wrappers change the value on all threads.
-        LOG_LAST_ERROR_IF(sys_setresuid(-1, 0, -1) < 0);
-        LOG_LAST_ERROR_IF(sys_setresgid(c_InvalidGid, 0, c_InvalidGid) < 0);
-    }
+        if (m_Restore)
+        {
+            // Use the syscall directly since the wrappers change the value on all threads.
+            THROW_LAST_ERROR_IF(sys_setresuid(-1, 0, -1) < 0);
+            THROW_LAST_ERROR_IF(sys_setresgid(c_InvalidGid, 0, c_InvalidGid) < 0);
+        }
 
-    if (m_restoreGroups)
-    {
-        LOG_LAST_ERROR_IF(sys_setgroups(0, nullptr) < 0);
+        if (m_restoreGroups)
+        {
+            THROW_LAST_ERROR_IF(sys_setgroups(0, nullptr) < 0);
+        }
     }
+    CATCH_LOG()
 }
 
 } // namespace p9fs::util

--- a/src/linux/plan9/p9util.cpp
+++ b/src/linux/plan9/p9util.cpp
@@ -245,13 +245,13 @@ FsUserContext::~FsUserContext()
     if (m_Restore)
     {
         // Use the syscall directly since the wrappers change the value on all threads.
-        THROW_LAST_ERROR_IF(sys_setresuid(-1, 0, -1) < 0);
-        THROW_LAST_ERROR_IF(sys_setresgid(c_InvalidGid, 0, c_InvalidGid) < 0);
+        LOG_LAST_ERROR_IF(sys_setresuid(-1, 0, -1) < 0);
+        LOG_LAST_ERROR_IF(sys_setresgid(c_InvalidGid, 0, c_InvalidGid) < 0);
     }
 
     if (m_restoreGroups)
     {
-        THROW_LAST_ERROR_IF(sys_setgroups(0, nullptr) < 0);
+        LOG_LAST_ERROR_IF(sys_setgroups(0, nullptr) < 0);
     }
 }
 


### PR DESCRIPTION
Avoid potential `std::terminate` from throwing in `FsUserContext` destructor.

## Problem

`FsUserContext::~FsUserContext()` in `src/linux/plan9/p9util.cpp` used `THROW_LAST_ERROR_IF()` to validate that `sys_setresuid`, `sys_setresgid`, and `sys_setgroups` succeeded when restoring root. If this destructor runs during stack unwinding from another in-flight exception, the second exception triggers `std::terminate()` and aborts the process.

## Fix

Replace `THROW_LAST_ERROR_IF` with `LOG_LAST_ERROR_IF` for the three syscalls. Standard pattern for destructors.

## Notes

- The constructor at lines 228, 237-238 still uses `THROW_LAST_ERROR_IF` correctly - failures during setup should propagate.
- These restore-to-root syscalls running in a privileged daemon thread virtually never fail.
- A silent restore failure would leave the thread with the wrong uid/gid, but throwing was strictly worse: process termination is non-recoverable and destroys any in-flight exception context.
