### PR TITLE
Fix two diagnostic bugs in validate-modern.py

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -422,9 +422,9 @@ def read_tar(node, file, elf_magic: str):
 
             unexpected_keys = [e for e in keys if e.casefold() not in valid_keys]
             if unexpected_keys:
-                error(node, f'Found unexpected_keys in "{real_path}": {unexpected_keys}')
+                error(node, f'Found unexpected_keys in "{path}": {unexpected_keys}')
             else:
-                click.secho(f'Found valid keys in "{real_path}": {list(keys.keys())}')
+                click.secho(f'Found valid keys in "{path}": {list(keys.keys())}')
 
             return keys
 

--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -391,7 +391,7 @@ def read_tar(node, file, elf_magic: str):
                 warning(node, f'file: "{path}" has unexpected gid: {info.gid} (expected: {gid})')
 
             if max_size is not None and info.size > max_size:
-                error(node, f'file: "{path}" is too big (info.size), max: {max_size}')
+                error(node, f'file: "{path}" is too big ({info.size}), max: {max_size}')
 
             if magic is not None or parse_method is not None:
                 content = tar.extractfile(real_path)
@@ -409,12 +409,12 @@ def read_tar(node, file, elf_magic: str):
             return True
 
         def validate_config(path: str, valid_keys: list):
-            _, path = get_tar_file(tar, path, follow_symlink=True)
-            if path is None:
-                error(node, f'File "{file}" not found in tar')
+            _, real_path = get_tar_file(tar, path, follow_symlink=True)
+            if real_path is None:
+                error(node, f'File "{path}" not found in tar')
                 return None
 
-            content = tar.extractfile(path)
+            content = tar.extractfile(real_path)
             config = configparser.ConfigParser()
             config.read_string(content.read().decode())
 
@@ -422,9 +422,9 @@ def read_tar(node, file, elf_magic: str):
 
             unexpected_keys = [e for e in keys if e.casefold() not in valid_keys]
             if unexpected_keys:
-                error(node, f'Found unexpected_keys in "{path}": {unexpected_keys}')
+                error(node, f'Found unexpected_keys in "{real_path}": {unexpected_keys}')
             else:
-                click.secho(f'Found valid keys in "{path}": {list(keys.keys())}')
+                click.secho(f'Found valid keys in "{real_path}": {list(keys.keys())}')
 
             return keys
 


### PR DESCRIPTION
Fix two bugs in `distributions/validate-modern.py`.

## Bug 1: missing f-string interpolation

In `read_tar()`, the size-too-big error printed the literal text `(info.size)` instead of the actual byte count:

`error(node, f'file: ""{path}"" is too big (info.size), max: {max_size}')`

Fixed to `({info.size})` so the message reports the offending size.

## Bug 2: variable shadowing in `validate_config()`

The function took `path: str` as input, then immediately did:

`_, path = get_tar_file(tar, path, follow_symlink=True)`

This overwrote the input parameter with the resolved tar path (which can be `None` if the file isn't found). The subsequent `if path is None: error(node, f'File ""{file}"" not found in tar')` couldn't print the original requested path, and downstream messages ("Found unexpected_keys in...", "Found valid keys in...") logged the resolved-symlink path rather than the user-facing config name.

Renamed the inner variable to `real_path` so the original `path` is preserved for diagnostics and `real_path` is used for `tar.extractfile()`.

## Risk

Tooling-only script, no runtime impact. Improves diagnostic output of the distribution validator.
