### PR TITLE
Check WSLCHandle discriminant before accessing union member

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -118,7 +118,8 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     // TODO: move dmesg collector to user session process.
     // N.B. 'DmesgOutput' needs to be duplicated since COM will close it when this call completes.
     wil::unique_handle dmesgOutputHandle;
-    if (Settings->DmesgOutput.Handle.File != nullptr && Settings->DmesgOutput.Handle.File != INVALID_HANDLE_VALUE)
+    if (Settings->DmesgOutput.Type == WSLCHandleTypeFile && Settings->DmesgOutput.Handle.File != nullptr &&
+        Settings->DmesgOutput.Handle.File != INVALID_HANDLE_VALUE)
     {
         dmesgOutputHandle.reset(wslutil::DuplicateHandle(wslutil::FromCOMInputHandle(Settings->DmesgOutput), GENERIC_WRITE | SYNCHRONIZE));
     }


### PR DESCRIPTION
Check `WSLCHandle` discriminant before accessing union member.

## Problem

In `HcsVirtualMachine::HcsVirtualMachine()` (around line 121), the dmesg output handle setup reads `Settings->DmesgOutput.Handle.File` without first checking `Settings->DmesgOutput.Type`.

`WSLCHandle` is a discriminated union (see `src/windows/service/inc/wslc.idl:329-348`):

`cpp
typedef struct _WSLCHandle {
    WSLCHandleType Type;  // File | Pipe | Socket | Unknown
    [switch_type(WSLCHandleType), switch_is(Type)]
    union {
        [case(WSLCHandleTypeFile)]   FILE_HANDLE  File;
        [case(WSLCHandleTypePipe)]   PIPE_HANDLE  Pipe;
        [case(WSLCHandleTypeSocket)] SOCKET_HANDLE Socket;
    } Handle;
} WSLCHandle;
`

Reading `.Handle.File` when the active union member is `.Pipe` or `.Socket` is undefined behavior under C++ object-lifetime rules.

## Fix

Add `Settings->DmesgOutput.Type == WSLCHandleTypeFile` as a precondition to the existing `!= nullptr && != INVALID_HANDLE_VALUE` checks, so the union member is only accessed via the active discriminant.

## Risk

Tightens an undefined-behavior path. If callers were relying on the implicit reinterpret of a non-File handle as `FILE_HANDLE`, the dmesg-output capture would now be skipped for that handle type instead of producing UB. The existing `DuplicateHandle` path on the next line is documented to require a file handle anyway, so this is consistent with the intended contract.
