### PR TITLE
Fix std::format type mismatch in container bind source path

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1353,7 +1353,9 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         volumes.push_back(WSLCVolumeMount{hostPath, parentVMPath, volume.ContainerPath, static_cast<bool>(volume.ReadOnly), sourceFilename});
 
         auto options = volume.ReadOnly ? "ro" : "rw";
-        auto bindSource = sourceFilename.empty() ? parentVMPath : std::format("{}/{}", parentVMPath, sourceFilename);
+        auto bindSource = sourceFilename.empty()
+                              ? parentVMPath
+                              : std::format("{}/{}", parentVMPath, wsl::shared::string::WideToMultiByte(sourceFilename));
         auto bind = std::format("{}:{}:{}", bindSource, volume.ContainerPath, options);
 
         binds.push_back(std::move(bind));


### PR DESCRIPTION
Fix `std::format` type mismatch mixing `std::wstring` and `std::string`.

## Problem

In `WSLCContainer::Create()` (around line 1356), the bind source path for file-mounts is constructed via:

`cpp
auto parentVMPath  = std::format("/mnt/{}", wsl::shared::string::GuidToString<char>(volumeId)); // std::string
std::wstring sourceFilename;                                                                    // line 1323
...
auto bindSource = sourceFilename.empty()
    ? parentVMPath
    : std::format("{}/{}", parentVMPath, sourceFilename);   // <-- mixes wide+narrow
`

The format string is narrow (`const char*`), so passing `sourceFilename` (`std::wstring`) as an argument is ill-formed in C++20 `std::format`. MSVC may accept it as a non-standard extension and emit a garbled byte sequence at runtime (the wide chars reinterpreted as narrow bytes), producing a malformed Linux bind path that `docker` will reject or, worse, silently misroute.

This branch is hit whenever `volume.HostPath` resolves to a regular file (vs. a directory).

## Fix

Convert `sourceFilename` to a narrow string via `wsl::shared::string::WideToMultiByte` before formatting, so all arguments to the narrow `std::format` are narrow.

## Risk

Behavior change is exactly what was always intended: produce a well-formed UTF-8 bind path. Filenames with non-ASCII characters that previously produced garbage will now produce correct bytes.
