### PR TITLE
Update Microsoft.WSL.DeviceHost package to 1.2.20-0

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.14-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.20-0" />
   <package id="Microsoft.WSL.Kernel" version="6.6.114.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />

--- a/test/linux/unit_tests/drvfs.c
+++ b/test/linux/unit_tests/drvfs.c
@@ -3644,15 +3644,8 @@ Return Value:
     LxtCheckMemoryEqual(Mapping, "MZ", 2);
     LxtCheckResult(munmap(Mapping, 2));
 
-    if (g_LxtFsInfo.FsType != LxtFsTypeVirtioFs)
-    {
-        LxtCheckMapErrno(Mapping = mmap(NULL, 2, PROT_READ, MAP_SHARED, Fd, 0));
-        LxtCheckMemoryEqual(Mapping, "MZ", 2);
-    }
-    else
-    {
-        LxtLogInfo("TODO: virtiofs does not support MAP_SHARED");
-    }
+    LxtCheckMapErrno(Mapping = mmap(NULL, 2, PROT_READ, MAP_SHARED, Fd, 0));
+    LxtCheckMemoryEqual(Mapping, "MZ", 2);
 
 ErrorExit:
     if (Mapping != MAP_FAILED)

--- a/test/linux/unit_tests/vfsaccess.c
+++ b/test/linux/unit_tests/vfsaccess.c
@@ -458,10 +458,8 @@ int VfsAccessFileObjectChecks(PLXT_ARGS Args)
     int Result;
     int ResultActual;
     int ResultExpected;
-    bool VirtiofsNoDax;
 
     LxtLogInfo("Fs type %d with dax = %d\n", g_LxtFsInfo.FsType, g_LxtFsInfo.Flags.Dax);
-    VirtiofsNoDax = g_LxtFsInfo.FsType == LxtFsTypeVirtioFs && g_LxtFsInfo.Flags.Dax == 0;
     memset(Files, -1, sizeof(Files));
     LxtCheckResult(VfsAccessFileObjectOpenFiles(Files));
     for (Index = 0; Index < VFS_FILE_OBJECT_COUNT; ++Index)
@@ -531,22 +529,15 @@ int VfsAccessFileObjectChecks(PLXT_ARGS Args)
         // N.B. The Linux 9p client does not allow mapping shared if the file is
         //      opened for write.
         //
-        // N.B. The virtiofs device relies on fuse mapping which only supports
-        //      shared in the presence of DAX.
-        //
 
         ErrnoExpected = EACCES;
         if (Files[Index].Flags == O_PATH)
         {
             ErrnoExpected = EBADF;
         }
-        else if (VirtiofsNoDax && (Files[Index].Flags == O_RDONLY || (Files[Index].Flags & O_ACCMODE) == O_RDWR))
-        {
-            ErrnoExpected = ENODEV;
-        }
 
         ResultExpected = -1;
-        if (!VirtiofsNoDax && (((Files[Index].Flags & O_ACCMODE) == O_RDONLY) || ((Files[Index].Flags & O_ACCMODE) == O_RDWR)) &&
+        if ((((Files[Index].Flags & O_ACCMODE) == O_RDONLY) || ((Files[Index].Flags & O_ACCMODE) == O_RDWR)) &&
             ((Files[Index].Flags & O_PATH) == 0))
         {
 
@@ -619,22 +610,15 @@ int VfsAccessFileObjectChecks(PLXT_ARGS Args)
         //
         // Validate map write shared and private
         //
-        // N.B. The virtiofs device relies on fuse mapping which only supports
-        //      shared in the presence of DAX.
-        //
 
         ErrnoExpected = EACCES;
         if (Files[Index].Flags == O_PATH)
         {
             ErrnoExpected = EBADF;
         }
-        else if (VirtiofsNoDax && (Files[Index].Flags & O_ACCMODE) == O_RDWR)
-        {
-            ErrnoExpected = ENODEV;
-        }
 
         ResultExpected = -1;
-        if (!VirtiofsNoDax && (Files[Index].Flags & O_ACCMODE) == O_RDWR)
+        if ((Files[Index].Flags & O_ACCMODE) == O_RDWR)
         {
             ResultExpected = 1;
         }
@@ -691,10 +675,8 @@ int VfsAccessFileObjectSymlinksChecks(PLXT_ARGS Args)
     int Result;
     int ResultActual;
     int ResultExpected;
-    bool VirtiofsNoDax;
 
     LxtLogInfo("Fs type %d with dax = %d\n", g_LxtFsInfo.FsType, g_LxtFsInfo.Flags.Dax);
-    VirtiofsNoDax = g_LxtFsInfo.FsType == LxtFsTypeVirtioFs && g_LxtFsInfo.Flags.Dax == 0;
 
     memset(Files, -1, sizeof(Files));
     LxtCheckResult(VfsAccessFileObjectOpenSymlinks(Files));
@@ -738,13 +720,9 @@ int VfsAccessFileObjectSymlinksChecks(PLXT_ARGS Args)
         {
             ErrnoExpected = EBADF;
         }
-        else if (VirtiofsNoDax && (Files[Index].Flags == O_RDONLY || (Files[Index].Flags & O_ACCMODE) == O_RDWR))
-        {
-            ErrnoExpected = ENODEV;
-        }
 
         ResultExpected = -1;
-        if (!VirtiofsNoDax && (((Files[Index].Flags & O_ACCMODE) == O_RDONLY) || ((Files[Index].Flags & O_ACCMODE) == O_RDWR)) &&
+        if ((((Files[Index].Flags & O_ACCMODE) == O_RDONLY) || ((Files[Index].Flags & O_ACCMODE) == O_RDWR)) &&
             ((Files[Index].Flags & O_PATH) == 0))
         {
 
@@ -770,13 +748,9 @@ int VfsAccessFileObjectSymlinksChecks(PLXT_ARGS Args)
         {
             ErrnoExpected = EBADF;
         }
-        else if (VirtiofsNoDax && (Files[Index].Flags & O_ACCMODE) == O_RDWR)
-        {
-            ErrnoExpected = ENODEV;
-        }
 
         ResultExpected = -1;
-        if (!VirtiofsNoDax && (Files[Index].Flags & O_ACCMODE) == O_RDWR)
+        if ((Files[Index].Flags & O_ACCMODE) == O_RDWR)
         {
             ResultExpected = 1;
         }
@@ -852,16 +826,11 @@ int VfsAccessRemapReference(PLXT_ARGS Args)
     char Buffer;
     int FdReadOnly = -1;
     int FdReadWrite = -1;
-    int MapFlags;
     void* MapResult;
     void* MapReadOnly = NULL;
     void* MapReadWrite = NULL;
     void* RemappedMemory = NULL;
     int Result;
-    bool VirtiofsNoDax;
-
-    VirtiofsNoDax = g_LxtFsInfo.FsType == LxtFsTypeVirtioFs && g_LxtFsInfo.Flags.Dax == 0;
-    MapFlags = VirtiofsNoDax ? MAP_PRIVATE : MAP_SHARED;
 
     //
     // Open and map a file whose only reference is read only and open second
@@ -869,9 +838,9 @@ int VfsAccessRemapReference(PLXT_ARGS Args)
     //
 
     LxtCheckErrno(FdReadOnly = open(g_VfsFiles[VFS_ACCESS_REMAP_FILE].Name, O_RDONLY, 0));
-    LxtCheckMapErrno(MapReadOnly = mmap(NULL, sizeof(Buffer), PROT_READ, MapFlags, FdReadOnly, 0));
+    LxtCheckMapErrno(MapReadOnly = mmap(NULL, sizeof(Buffer), PROT_READ, MAP_SHARED, FdReadOnly, 0));
     LxtCheckErrno(FdReadWrite = open(g_VfsFiles[VFS_ACCESS_REMAP_FILE].Name, O_RDWR, 0));
-    LxtCheckMapErrno(MapReadWrite = mmap(NULL, sizeof(Buffer), PROT_READ | PROT_WRITE, MapFlags, FdReadWrite, 0));
+    LxtCheckMapErrno(MapReadWrite = mmap(NULL, sizeof(Buffer), PROT_READ | PROT_WRITE, MAP_SHARED, FdReadWrite, 0));
     LxtCheckMapErrno(RemappedMemory = mremap(MapReadWrite, sizeof(Buffer), PAGE_SIZE * 2, MREMAP_MAYMOVE));
 
 ErrorExit:


### PR DESCRIPTION
Updates `Microsoft.WSL.DeviceHost` from `1.2.14-0` to `1.2.20-0`.

The new device host supports `MAP_SHARED` on virtiofs without DAX, so the `VirtiofsNoDax` workarounds in `test/linux/unit_tests/vfsaccess.c` and the virtiofs branch in `test/linux/unit_tests/drvfs.c` are no longer needed and have been removed.