### PR TITLE
Use overlapped pipes in WSLC session terminate tests

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1113,10 +1113,11 @@ class WSLCTests
         }
 
         // Validate that LoadImage is aborted when the session terminates.
+        // N.B. The read pipe must support overlapped IO so the relay's event-based cancellation works.
+        // CreatePipe creates synchronous pipes where ReadFile blocks the thread, preventing
+        // WaitForMultipleObjects from detecting the session terminating event.
         {
-            wil::unique_handle pipeRead;
-            wil::unique_handle pipeWrite;
-            VERIFY_WIN32_BOOL_SUCCEEDED(CreatePipe(&pipeRead, &pipeWrite, nullptr, 2));
+            auto [pipeRead, pipeWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(2, true, false);
 
             std::promise<HRESULT> terminateResult;
             wil::unique_event testCompleted{wil::EventOptions::ManualReset};
@@ -1218,10 +1219,9 @@ class WSLCTests
         }
 
         // Validate that ImportImage is aborted when the session terminates.
+        // N.B. See the equivalent LoadImage test for why overlapped pipes are required here.
         {
-            wil::unique_handle pipeRead;
-            wil::unique_handle pipeWrite;
-            VERIFY_WIN32_BOOL_SUCCEEDED(CreatePipe(&pipeRead, &pipeWrite, nullptr, 2));
+            auto [pipeRead, pipeWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(2, true, false);
 
             std::promise<HRESULT> terminateResult;
             wil::unique_event testCompleted{wil::EventOptions::ManualReset};


### PR DESCRIPTION
The `LoadImage` and `ImportImage` 'session terminate' sub-tests used `CreatePipe` which creates synchronous pipe handles. When the relay calls `ReadFile` with an `OVERLAPPED` structure on a synchronous handle, the call blocks the thread instead of returning `ERROR_IO_PENDING`. This prevents `WaitForMultipleObjects` from ever checking the session terminating event, causing a deadlock when `Terminate()` is called.

Replace `CreatePipe` with `OpenAnonymousPipe` (`FILE_FLAG_OVERLAPPED`) so `ReadFile` returns `ERROR_IO_PENDING` and the relay's event loop can detect the termination signal.