### PR TITLE
Remove DnsTunnelingSocket flag from VirtioNetworking

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -442,6 +442,7 @@ try
     }
     runtimeSettings.FeatureFlags = ConvertFlags(internalType->featureFlags);
     WI_SetFlag(runtimeSettings.FeatureFlags, WslcFeatureFlagsVirtioFs);
+    WI_SetFlag(runtimeSettings.FeatureFlags, WslcFeatureFlagsDnsTunneling);
 
     if (SUCCEEDED(errorInfoWrapper.CaptureResult(sessionManager->CreateSession(&runtimeSettings, WSLCSessionFlagsNone, &result->session))))
     {

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -15,11 +15,7 @@ static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
 VirtioNetworking::VirtioNetworking(
-    GnsChannel&& gnsChannel,
-    VirtioNetworkingFlags flags,
-    LPCWSTR dnsOptions,
-    std::shared_ptr<GuestDeviceManager> guestDeviceManager,
-    wil::shared_handle userToken) :
+    GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
     m_guestDeviceManager(std::move(guestDeviceManager)),
     m_userToken(std::move(userToken)),
     m_gnsChannel(std::move(gnsChannel)),

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -15,7 +15,11 @@ static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
 VirtioNetworking::VirtioNetworking(
-    GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
+    GnsChannel&& gnsChannel,
+    VirtioNetworkingFlags flags,
+    LPCWSTR dnsOptions,
+    std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+    wil::shared_handle userToken) :
     m_guestDeviceManager(std::move(guestDeviceManager)),
     m_userToken(std::move(userToken)),
     m_gnsChannel(std::move(gnsChannel)),

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -15,29 +15,13 @@ static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
 VirtioNetworking::VirtioNetworking(
-    GnsChannel&& gnsChannel,
-    VirtioNetworkingFlags flags,
-    LPCWSTR dnsOptions,
-    std::shared_ptr<GuestDeviceManager> guestDeviceManager,
-    wil::shared_handle userToken,
-    wil::unique_socket&& dnsHvsocket) :
+    GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
     m_guestDeviceManager(std::move(guestDeviceManager)),
     m_userToken(std::move(userToken)),
     m_gnsChannel(std::move(gnsChannel)),
     m_flags(flags),
     m_dnsOptions(dnsOptions)
 {
-    THROW_HR_IF_MSG(
-        E_INVALIDARG,
-        ((!!dnsHvsocket != WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunnelingSocket)) ||
-         (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunnelingSocket) && WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))),
-        "Incompatible DNS settings");
-
-    if (dnsHvsocket)
-    {
-        networking::DnsResolverFlags resolverFlags{};
-        m_dnsTunnelingResolver.emplace(std::move(dnsHvsocket), resolverFlags);
-    }
 }
 
 VirtioNetworking::~VirtioNetworking()
@@ -212,10 +196,6 @@ void VirtioNetworking::RefreshGuestConnection()
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))
     {
         currentDns = networking::HostDnsInfo::GetDnsTunnelingSettings(default_route);
-    }
-    else if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunnelingSocket))
-    {
-        currentDns = networking::HostDnsInfo::GetDnsTunnelingSettings(TEXT(LX_INIT_DNS_TUNNELING_IP_ADDRESS));
     }
     else
     {

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -4,7 +4,6 @@
 
 #include "INetworkingEngine.h"
 #include "GnsChannel.h"
-#include "DnsResolver.h"
 #include "WslCoreHostDnsInfo.h"
 #include "GnsPortTrackerChannel.h"
 #include "GuestDeviceManager.h"
@@ -17,20 +16,13 @@ enum class VirtioNetworkingFlags
     LocalhostRelay = 0x1,
     DnsTunneling = 0x2,
     Ipv6 = 0x4,
-    DnsTunnelingSocket = 0x8,
 };
 DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
 
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(
-        GnsChannel&& gnsChannel,
-        VirtioNetworkingFlags flags,
-        LPCWSTR dnsOptions,
-        std::shared_ptr<GuestDeviceManager> guestDeviceManager,
-        wil::shared_handle userToken,
-        wil::unique_socket&& dnsHvsocket = {});
+    VirtioNetworking(GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
 
     ~VirtioNetworking();
 
@@ -70,7 +62,6 @@ private:
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
     VirtioNetworkingFlags m_flags = VirtioNetworkingFlags::None;
     LPCWSTR m_dnsOptions = nullptr;
-    std::optional<networking::DnsResolver> m_dnsTunnelingResolver;
     std::optional<GUID> m_localhostAdapterId;
     std::optional<GUID> m_adapterId;
 

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -22,7 +22,12 @@ DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
+    VirtioNetworking(
+        GnsChannel&& gnsChannel,
+        VirtioNetworkingFlags flags,
+        LPCWSTR dnsOptions,
+        std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+        wil::shared_handle userToken);
 
     ~VirtioNetworking();
 

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -22,12 +22,7 @@ DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(
-        GnsChannel&& gnsChannel,
-        VirtioNetworkingFlags flags,
-        LPCWSTR dnsOptions,
-        std::shared_ptr<GuestDeviceManager> guestDeviceManager,
-        wil::shared_handle userToken);
+    VirtioNetworking(GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
 
     ~VirtioNetworking();
 

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -372,24 +372,26 @@ try
     // so we need our own copies to take ownership.
     wil::unique_socket gnsSocketHandle{reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(GnsSocket))};
     wil::unique_socket dnsSocketHandle;
+
+    // Run the DnsResolver support check first so it can clear the feature flag before the validation below.
+    // The check still applies to virtio proxy because the host virtio proxy uses the same Windows DNS APIs.
     if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
     {
-        THROW_HR_IF(E_INVALIDARG, DnsSocket == nullptr);
-
         const auto result = wsl::core::networking::DnsResolver::LoadDnsResolverMethods();
         if (FAILED(result))
         {
             LOG_HR_MSG(result, "Failed to load DNS resolver methods, DNS tunneling will be disabled");
             WI_ClearFlag(m_featureFlags, WslcFeatureFlagsDnsTunneling);
         }
-        else
-        {
-            dnsSocketHandle.reset(reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(*DnsSocket)));
-        }
     }
-    else
+
+    // The DNS hvsocket is only allocated for NAT mode.
+    const bool expectDnsSocket = FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode == WSLCNetworkingModeNAT;
+    THROW_HR_IF(E_INVALIDARG, expectDnsSocket != (DnsSocket != nullptr));
+
+    if (DnsSocket != nullptr)
     {
-        THROW_HR_IF(E_INVALIDARG, DnsSocket != nullptr);
+        dnsSocketHandle.reset(reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(*DnsSocket)));
     }
 
     if (m_networkingMode == WSLCNetworkingModeNAT)
@@ -425,11 +427,11 @@ try
         wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::Ipv6;
         if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
         {
-            WI_SetFlag(flags, wsl::core::VirtioNetworkingFlags::DnsTunnelingSocket);
+            WI_SetFlag(flags, wsl::core::VirtioNetworkingFlags::DnsTunneling);
         }
 
         m_networkEngine = std::make_unique<wsl::core::VirtioNetworking>(
-            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken, std::move(dnsSocketHandle));
+            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken);
     }
     else
     {

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -373,7 +373,9 @@ try
     wil::unique_socket gnsSocketHandle{reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(GnsSocket))};
     wil::unique_socket dnsSocketHandle;
 
-    // Run the DnsResolver support check first so it can clear the feature flag before the validation below.
+    // The DNS hvsocket is only allocated for NAT mode.
+    THROW_HR_IF(E_INVALIDARG, (FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode == WSLCNetworkingModeNAT) != (DnsSocket != nullptr));
+
     // The check still applies to virtio proxy because the host virtio proxy uses the same Windows DNS APIs.
     if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
     {
@@ -385,11 +387,7 @@ try
         }
     }
 
-    // The DNS hvsocket is only allocated for NAT mode.
-    const bool expectDnsSocket = FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode == WSLCNetworkingModeNAT;
-    THROW_HR_IF(E_INVALIDARG, expectDnsSocket != (DnsSocket != nullptr));
-
-    if (DnsSocket != nullptr)
+    if (DnsSocket != nullptr && FeatureEnabled(WslcFeatureFlagsDnsTunneling))
     {
         dnsSocketHandle.reset(reinterpret_cast<SOCKET>(wslutil::DuplicateHandle(*DnsSocket)));
     }

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -512,7 +512,8 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     message->MemoryReclaimMode = static_cast<LX_MINI_INIT_MEMORY_RECLAIM_MODE>(m_vmConfig.MemoryReclaim);
     message->EnableDebugShell = m_vmConfig.EnableDebugShell;
     message->EnableSafeMode = m_vmConfig.EnableSafeMode;
-    message->EnableDnsTunneling = m_vmConfig.EnableDnsTunneling;
+    // Virtio proxy forwards DNS via the host proxy, so the dedicated DNS hvsocket is only used by NAT and Mirrored modes.
+    message->EnableDnsTunneling = m_vmConfig.EnableDnsTunneling && m_vmConfig.NetworkingMode != NetworkingMode::VirtioProxy;
     message->DefaultKernel = m_defaultKernel;
     message->KernelModulesDeviceId = m_kernelModulesDeviceId;
     message.WriteString(message->HostnameOffset, wsl::windows::common::filesystem::GetLinuxHostName());
@@ -571,9 +572,11 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             {
                 wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::Ipv6;
                 WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::LocalhostRelay, m_vmConfig.EnableLocalhostRelay);
-                WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::DnsTunnelingSocket, m_vmConfig.EnableDnsTunneling);
+                WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::DnsTunneling, m_vmConfig.EnableDnsTunneling);
+                // NAT may have fallen back to virtio proxy after the early-config message; drop the unused DNS hvsocket.
+                dnsTunnelingSocket.reset();
                 m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
-                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken, std::move(dnsTunnelingSocket));
+                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::Bridged)
             {
@@ -1904,7 +1907,9 @@ bool WslCoreVm::InitializeDrvFsLockHeld(_In_ HANDLE UserToken)
 
 bool WslCoreVm::IsDnsTunnelingSupported() const
 {
-    WI_ASSERT(m_vmConfig.NetworkingMode == NetworkingMode::Nat || m_vmConfig.NetworkingMode == NetworkingMode::Mirrored);
+    WI_ASSERT(
+        m_vmConfig.NetworkingMode == NetworkingMode::Nat || m_vmConfig.NetworkingMode == NetworkingMode::Mirrored ||
+        m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy);
 
     return SUCCEEDED_LOG(wsl::core::networking::DnsResolver::LoadDnsResolverMethods());
 }
@@ -2853,7 +2858,7 @@ void WslCoreVm::ValidateNetworkingMode()
         EMIT_USER_WARNING(Localization::MessageLocalhostForwardingNotSupportedMirroredMode());
     }
 
-    // If DNS tunneling was requested, ensure it is supported by Windows.
+    // The DnsResolver support check still applies to virtio proxy because the host virtio proxy uses the same Windows DNS APIs.
     if (m_vmConfig.EnableDnsTunneling && !IsDnsTunnelingSupported())
     {
         // Since DNS tunneling is enabled by default, only show the warning if the user explicitly asked for it.

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -341,7 +341,8 @@ void WSLCVirtualMachine::ConfigureNetworking()
     std::vector<WSLCProcessFd> fds;
     fds.emplace_back(WSLCProcessFd{.Fd = -1, .Type = WSLCFdType::WSLCFdTypeDefault});
 
-    bool enableDnsTunneling = FeatureEnabled(WslcFeatureFlagsDnsTunneling);
+    // Virtio proxy forwards DNS via the host proxy, so the DNS channel and /gns args are only needed for NAT mode.
+    const bool enableDnsTunneling = FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode != WSLCNetworkingModeVirtioProxy;
     if (enableDnsTunneling)
     {
         fds.emplace_back(WSLCProcessFd{.Fd = -1, .Type = WSLCFdType::WSLCFdTypeDefault});

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -5083,5 +5083,22 @@ class VirtioProxyTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
+
+    // Verifies that virtio proxy + dnsTunneling points resolv.conf at the gateway, not the hvsocket listener IP.
+    WSL2_TEST_METHOD(DnsTunnelingResolvConfUsesGateway)
+    {
+        VIRTIOPROXY_TEST_ONLY();
+        DNS_TUNNELING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+
+        const auto state = NetworkTests::GetInterfaceState(L"eth0");
+        VERIFY_IS_TRUE(state.Gateway.has_value());
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"cat /etc/resolv.conf | grep nameserver | grep -F " + state.Gateway.value()), static_cast<DWORD>(0));
+
+        VERIFY_ARE_NOT_EQUAL(
+            LxsstuLaunchWsl(L"cat /etc/resolv.conf | grep nameserver | grep -F " + c_dnsTunnelingDefaultIp), static_cast<DWORD>(0));
+    }
 };
 } // namespace NetworkTests

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2884,7 +2884,22 @@ class WSLCTests
         {
             auto result = ExpectCommandResult(session.get(), {"/bin/grep", "-iF", "nameserver ", "/etc/resolv.conf"}, 0);
 
-            VERIFY_ARE_EQUAL(result.Output[1], std::format("nameserver {}\n", LX_INIT_DNS_TUNNELING_IP_ADDRESS));
+            if (mode == WSLCNetworkingModeVirtioProxy)
+            {
+                // Virtio proxy points resolv.conf at the eth0 gateway.
+                ExpectCommandResult(
+                    session.get(),
+                    {"/bin/sh",
+                     "-c",
+                     "ns=$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf); "
+                     "gw=$(ip route show default | awk '{print $3; exit}'); "
+                     "[ -n \"$ns\" ] && [ -n \"$gw\" ] && [ \"$ns\" = \"$gw\" ]"},
+                    0);
+            }
+            else
+            {
+                VERIFY_ARE_EQUAL(result.Output[1], std::format("nameserver {}\n", LX_INIT_DNS_TUNNELING_IP_ADDRESS));
+            }
         }
 
         // Verify DNS resolution.


### PR DESCRIPTION
Drops the `DnsTunnelingSocket` virtio networking flag (and the dedicated DNS hvsocket plumbing it carried) in favor of the in-built `DnsTunneling` path. In virtio proxy mode, DNS queries are now always forwarded by the host virtio proxy itself: Linux's `/etc/resolv.conf` points at the eth0 gateway IP rather than the listener IP, no DNS hvsocket is opened, and the Linux init does not start a `DnsTunnelingManager`.

Changes:
- `VirtioNetworking`: remove `DnsTunnelingSocket` enum value, `dnsHvsocket` constructor parameter, `m_dnsTunnelingResolver` field, and the `DnsResolver.h` include. `RefreshGuestConnection` now uses only the in-built `DnsTunneling` path.
- `WslCoreVm`: virtio proxy branch unconditionally sets the `DnsTunneling` flag when DNS tunneling is enabled. `message->EnableDnsTunneling` is suppressed for virtio proxy mode so Linux init won't open the DNS hvsocket. The pre-accepted `dnsTunnelingSocket` is dropped on the NAT->VirtioProxy fallback path.
- `HcsVirtualMachine`: WSLC virtio proxy branch likewise switches to the `DnsTunneling` flag and discards the unused `dnsSocketHandle`.
- Tests: add `VirtioProxyTests::DnsTunnelingResolvConfUsesGateway` which asserts `resolv.conf` contains the gateway IP and not the legacy listener IP, confirming the in-built path is in use.