### PR TITLE
Downgrade system IL impersonation token to high

### DIFF
--- a/src/windows/common/WslSecurity.cpp
+++ b/src/windows/common/WslSecurity.cpp
@@ -183,19 +183,12 @@ wil::unique_handle wsl::windows::common::security::GetUserToken(_In_ TOKEN_TYPE 
     // high integrity level and objects created with a higher integrity level token may be inaccessible.
     if (GetUserBasicIntegrityLevel(newToken.get()) == SECURITY_MANDATORY_SYSTEM_RID)
     {
-        union
-        {
-            SID sid;
-            BYTE buffer[SECURITY_SID_SIZE(1)];
-        } sidBuffer;
-        SID_IDENTIFIER_AUTHORITY micSidAuthority = SECURITY_MANDATORY_LABEL_AUTHORITY;
-        THROW_IF_NTSTATUS_FAILED(::RtlInitializeSidEx(&sidBuffer.sid, &micSidAuthority, 1, SECURITY_MANDATORY_HIGH_RID));
-
+        auto [sid, sidBuffer] = wsl::windows::common::security::CreateSid(SECURITY_MANDATORY_LABEL_AUTHORITY, SECURITY_MANDATORY_HIGH_RID);
         TOKEN_MANDATORY_LABEL tokenLabel{};
         tokenLabel.Label.Attributes = SE_GROUP_INTEGRITY;
-        tokenLabel.Label.Sid = &sidBuffer.sid;
+        tokenLabel.Label.Sid = sid;
         THROW_IF_WIN32_BOOL_FALSE(::SetTokenInformation(
-            newToken.get(), TokenIntegrityLevel, &tokenLabel, (sizeof(tokenLabel) + ::GetLengthSid(&sidBuffer.sid))));
+            newToken.get(), TokenIntegrityLevel, &tokenLabel, (sizeof(tokenLabel) + ::GetLengthSid(sid))));
     }
 
     return newToken;

--- a/src/windows/common/WslSecurity.cpp
+++ b/src/windows/common/WslSecurity.cpp
@@ -187,8 +187,8 @@ wil::unique_handle wsl::windows::common::security::GetUserToken(_In_ TOKEN_TYPE 
         TOKEN_MANDATORY_LABEL tokenLabel{};
         tokenLabel.Label.Attributes = SE_GROUP_INTEGRITY;
         tokenLabel.Label.Sid = sid;
-        THROW_IF_WIN32_BOOL_FALSE(::SetTokenInformation(
-            newToken.get(), TokenIntegrityLevel, &tokenLabel, (sizeof(tokenLabel) + ::GetLengthSid(sid))));
+        THROW_IF_WIN32_BOOL_FALSE(
+            ::SetTokenInformation(newToken.get(), TokenIntegrityLevel, &tokenLabel, (sizeof(tokenLabel) + ::GetLengthSid(sid))));
     }
 
     return newToken;

--- a/src/windows/common/WslSecurity.cpp
+++ b/src/windows/common/WslSecurity.cpp
@@ -187,8 +187,7 @@ wil::unique_handle wsl::windows::common::security::GetUserToken(_In_ TOKEN_TYPE 
         TOKEN_MANDATORY_LABEL tokenLabel{};
         tokenLabel.Label.Attributes = SE_GROUP_INTEGRITY;
         tokenLabel.Label.Sid = sid;
-        THROW_IF_WIN32_BOOL_FALSE(
-            ::SetTokenInformation(newToken.get(), TokenIntegrityLevel, &tokenLabel, (sizeof(tokenLabel) + ::GetLengthSid(sid))));
+        THROW_IF_WIN32_BOOL_FALSE(::SetTokenInformation(newToken.get(), TokenIntegrityLevel, &tokenLabel, sizeof(tokenLabel)));
     }
 
     return newToken;

--- a/src/windows/common/WslSecurity.cpp
+++ b/src/windows/common/WslSecurity.cpp
@@ -172,7 +172,31 @@ wil::unique_handle wsl::windows::common::security::GetUserToken(_In_ TOKEN_TYPE 
 
     wil::unique_handle newToken;
     THROW_IF_WIN32_BOOL_FALSE(::DuplicateTokenEx(
-        contextToken.get(), TOKEN_DUPLICATE | TOKEN_IMPERSONATE | TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, nullptr, SecurityImpersonation, tokenType, &newToken));
+        contextToken.get(),
+        TOKEN_DUPLICATE | TOKEN_IMPERSONATE | TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES | TOKEN_ADJUST_DEFAULT,
+        nullptr,
+        SecurityImpersonation,
+        tokenType,
+        &newToken));
+
+    // If the token integrity level is system, reduce it to high integrity level. The VM worker process runs at
+    // high integrity level and objects created with a higher integrity level token may be inaccessible.
+    if (GetUserBasicIntegrityLevel(newToken.get()) == SECURITY_MANDATORY_SYSTEM_RID)
+    {
+        union
+        {
+            SID sid;
+            BYTE buffer[SECURITY_SID_SIZE(1)];
+        } sidBuffer;
+        SID_IDENTIFIER_AUTHORITY micSidAuthority = SECURITY_MANDATORY_LABEL_AUTHORITY;
+        THROW_IF_NTSTATUS_FAILED(::RtlInitializeSidEx(&sidBuffer.sid, &micSidAuthority, 1, SECURITY_MANDATORY_HIGH_RID));
+
+        TOKEN_MANDATORY_LABEL tokenLabel{};
+        tokenLabel.Label.Attributes = SE_GROUP_INTEGRITY;
+        tokenLabel.Label.Sid = &sidBuffer.sid;
+        THROW_IF_WIN32_BOOL_FALSE(::SetTokenInformation(
+            newToken.get(), TokenIntegrityLevel, &tokenLabel, (sizeof(tokenLabel) + ::GetLengthSid(&sidBuffer.sid))));
+    }
 
     return newToken;
 }


### PR DESCRIPTION
## Summary of the Pull Request
Creating objects while impersonating service accounts with an integrity level of 'system' can cause problems because the VM worker process only runs at 'high' IL. Downgrade 'system' to 'high'.

## Validation Steps Performed
Manually ran scenarios under NetworkService account.