### PR TITLE
Add SKIP_TEST_SERVER macro and skip BuildImageStuckCallbackCancellation

### DIFF
--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -92,6 +92,15 @@ using namespace std::chrono_literals;
         } \
     }
 
+#define SKIP_TEST_SERVER() \
+    { \
+        if (IsWindowsServer()) \
+        { \
+            LogSkipped("This test is skipped on Windows Server SKUs"); \
+            return; \
+        } \
+    }
+
 #define SKIP_TEST_UNSTABLE() \
     { \
         LogSkipped("This test is skipped because it's unstable"); \

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1030,12 +1030,7 @@ class WSLCTests
 
     WSLC_TEST_METHOD(LoadImage)
     {
-        // This test case is hanging on Windows Server SKUs. Skip the test until the issue is resolved.
-        // TODO: Remove once the fix is available.
-        if (IsWindowsServer())
-        {
-            SKIP_TEST_UNSTABLE();
-        }
+        SKIP_TEST_SERVER();
 
         std::filesystem::path imageTar = GetTestImagePath("hello-world:latest");
         wil::unique_handle imageTarFileHandle{
@@ -1126,12 +1121,7 @@ class WSLCTests
 
     WSLC_TEST_METHOD(ImportImage)
     {
-        // This test case is hanging on Windows Server SKUs. Skip the test until the issue is resolved.
-        // TODO: Remove once the fix is available.
-        if (IsWindowsServer())
-        {
-            SKIP_TEST_UNSTABLE();
-        }
+        SKIP_TEST_SERVER();
 
         auto cleanup =
             wil::scope_exit([&]() { LOG_IF_FAILED(DeleteImageNoThrow("my-hello-world:test", WSLCDeleteImageFlagsNone).first); });
@@ -2756,6 +2746,8 @@ class WSLCTests
 
     WSLC_TEST_METHOD(BuildImageStuckCallbackCancellation)
     {
+        SKIP_TEST_SERVER();
+
         class StuckBuildProgressCallback
             : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IProgressCallback>
         {


### PR DESCRIPTION
Several WSLC tests hang on Windows Server SKUs. Adds a `SKIP_TEST_SERVER()` macro alongside the existing `SKIP_TEST_ARM64` / `SKIP_TEST_UNSTABLE` helpers in `test/windows/Common.h`, and uses it for:

- `LoadImage`
- `ImportImage`
- `BuildImageStuckCallbackCancellation` (newly skipped — was timing out the wslc fe_release CI session at the 2-hour PhaseTimeout, `te.exe` exit 1818)

Investigation of a recent failed `BuildImageStuckCallbackCancellation` session confirms the hang point: the TAEF console log ends mid-test at the `VERIFY_ARE_EQUAL(reachedStatus, std::future_status::ready)` line with no log entry for the immediately following `VERIFY_SUCCEEDED(m_defaultSession->Terminate())`. `Terminate()` is blocking forever — it cannot abort the in-flight `BuildImage` call while the `StuckBuildProgressCallback` is blocked inside `OnProgress`. The underlying `Terminate()` cancellation issue is tracked separately.

The new macro replaces the ad-hoc `IsWindowsServer()` + TODO comment blocks that were starting to be sprinkled across the file.
