### PR TITLE
LifetimeManager: guard s_OnTimeout against unmatched timer fires

### DIFF
--- a/src/windows/service/exe/Lifetime.cpp
+++ b/src/windows/service/exe/Lifetime.cpp
@@ -236,12 +236,16 @@ VOID CALLBACK LifetimeManager::s_OnTimeout(_Inout_ PTP_CALLBACK_INSTANCE, _Inout
                 manager->m_callbackList.erase(client);
             }
 
-            // The destructor has not run because m_callbackList is not empty.
-            // Put the current timer in previousTimerWait to make sure the destructor waits for us if
-            // it runs after we drop manager->m_lock.
-            clientLocal.CancelTimer();
-            previousTimerWait.reset(clientLocal.timer.release());
-            previousTimerWait.swap(manager->m_lastTimerWait);
+            // If we took ownership of the timer (moved into clientLocal), stash it so the
+            // destructor waits for this callback to finish before exiting. Otherwise this
+            // firing is a no-op (e.g., the entry was erased, the timer was replaced, or the
+            // matched entry still has live processes).
+            if (clientLocal.timer)
+            {
+                clientLocal.CancelTimer();
+                previousTimerWait.reset(clientLocal.timer.release());
+                previousTimerWait.swap(manager->m_lastTimerWait);
+            }
         }
 
         // If a callback was found, execute it. If the callback succeeds the


### PR DESCRIPTION
If the timer fires but `find_if` doesn't match (entry erased, or replaced by the retry path), `clientLocal` is default-constructed and the unconditional swap clobbers `m_lastTimerWait` with null - breaking the destructor's wait-for-pending-callbacks guarantee.

Guard the swap so an unmatched fire is a no-op.