### PR TITLE
Modify CreateRestrictedToken to use better pattern

### DIFF
--- a/src/windows/common/WslSecurity.cpp
+++ b/src/windows/common/WslSecurity.cpp
@@ -81,21 +81,11 @@ wil::unique_handle wsl::windows::common::security::CreateRestrictedToken(_In_ HA
     THROW_IF_WIN32_BOOL_FALSE(::CreateRestrictedToken(newToken.get(), DISABLE_MAX_PRIVILEGE, 0, NULL, 0, NULL, 0, NULL, &restrictedToken));
 
     // Drop the token down to medium integrity level.
-    union
-    {
-        SID sid;
-        BYTE buffer[SECURITY_SID_SIZE(1)];
-    } sidBuffer;
-    SID_IDENTIFIER_AUTHORITY systemSidAuthority = SECURITY_MANDATORY_LABEL_AUTHORITY;
-    THROW_IF_NTSTATUS_FAILED(::RtlInitializeSidEx(&sidBuffer.sid, &systemSidAuthority, 1, SECURITY_MANDATORY_MEDIUM_RID));
-
-    // Set the integrity level to untrusted.
+    auto [sid, sidBuffer] = wsl::windows::common::security::CreateSid(SECURITY_MANDATORY_LABEL_AUTHORITY, SECURITY_MANDATORY_MEDIUM_RID);
     TOKEN_MANDATORY_LABEL tokenLabel{};
     tokenLabel.Label.Attributes = SE_GROUP_INTEGRITY;
-    tokenLabel.Label.Sid = &sidBuffer.sid;
-    THROW_IF_WIN32_BOOL_FALSE(::SetTokenInformation(
-        restrictedToken.get(), TokenIntegrityLevel, &tokenLabel, (sizeof(tokenLabel) + ::GetLengthSid(&sidBuffer.sid))));
-
+    tokenLabel.Label.Sid = sid;
+    THROW_IF_WIN32_BOOL_FALSE(::SetTokenInformation(restrictedToken.get(), TokenIntegrityLevel, &tokenLabel, sizeof(tokenLabel)));
     return restrictedToken;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
Switch CreateRestrictedToken to a newer pattern for consistency.

## Detailed Description of the Pull Request / Additional comments
Use the CreateSid wrapper and only pass the size of the token information class to SetTokenInformation.

## Validation Steps Performed
Manually started WSL