### PR TITLE
Fix a potential deadlock between OnEvent() and Delete()

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -913,14 +913,13 @@ void WSLCContainerImpl::Delete(WSLCDeleteFlags Flags)
     {
         auto lock = m_lock.lock_exclusive();
         wrapper = DeleteExclusiveLockHeld(Flags);
+    }
 
-        // Wait for the docker destroy event so anonymous volume cleanup is reflected in tracking by
-        // the time we return. Safe to wait here: OnEvent() signals m_destroyEvent before
-        // taking m_lock. Callers on the docker event-loop thread (OnEvent) must not wait.
-        if (WI_IsFlagSet(Flags, WSLCDeleteFlagsDeleteVolumes))
-        {
-            m_wslcSession.WaitForEventOrSessionTerminating(m_destroyEvent.get(), 60s);
-        }
+    // Wait for the docker destroy event so anonymous volume cleanup is reflected in tracking by
+    // the time we return.
+    if (WI_IsFlagSet(Flags, WSLCDeleteFlagsDeleteVolumes))
+    {
+        m_wslcSession.WaitForEventOrSessionTerminating(m_destroyEvent.get(), 60s);
     }
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a potential deadlock on the container deletion path

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This deadlock happens if `WSLCContainerImpl::Delete()` waits on `m_destroyEvent` while a stop event is being processed. 

The first thread waits for `m_destroyEvent` while holding `m_lock`, but the destroy event is stuck behind the stop event, which is waiting on `m_lock`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
