### PR TITLE
Make the tests actually terminate on ctrl-c

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -58,6 +58,7 @@ static HANDLE g_OriginalStderr;
 static BOOL g_RelogEverything = TRUE;
 static bool g_LogDmesgAfterEachTest = false;
 static PTP_TIMER g_WatchdogTimer;
+
 static BOOL g_VmMode;
 static std::wstring g_originalConfig;
 static std::wstring g_originalDefaultDistro;
@@ -69,6 +70,7 @@ std::wstring g_testDistroPath;
 std::wstring g_testDataPath;
 bool g_fastTestRun = false; // True when test.bat was invoked with -f
 static wil::unique_mta_usage_cookie g_mtaCookie;
+static wil::unique_handle g_processJob;
 
 std::pair<wil::unique_handle, wil::unique_handle> CreateSubprocessPipe(bool inheritRead, bool inheritWrite, DWORD bufferSize, _In_opt_ SECURITY_ATTRIBUTES* sa)
 {
@@ -1976,6 +1978,15 @@ Return Value:
     wsl::windows::common::wslutil::InitializeWil();
 
     THROW_IF_FAILED(CoIncrementMTAUsage(&g_mtaCookie));
+
+    // Assign a job object to the current process to ensure that we don't leak processes on failure.
+    g_processJob.reset(CreateJobObjectW(nullptr, nullptr));
+    THROW_LAST_ERROR_IF(!g_processJob);
+
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo{};
+    jobInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    THROW_IF_WIN32_BOOL_FALSE(SetInformationJobObject(g_processJob.get(), JobObjectExtendedLimitInformation, &jobInfo, sizeof(jobInfo)));
+    THROW_IF_WIN32_BOOL_FALSE(AssignProcessToJobObject(g_processJob.get(), GetCurrentProcess()));
 
 // Don't crash for unknown exceptions (makes debugging testpasses harder)
 #ifndef _DEBUG

--- a/tools/test/run-tests.ps1
+++ b/tools/test/run-tests.ps1
@@ -89,14 +89,20 @@ if (-not $HasUserSelection)
     $teArgList += "/select:`"@WSLVersion='$Version' or not(@WSLVersion='*')`""
 }
 
-$teProcess = Start-Process -FilePath "te.exe" -ArgumentList $teArgList -PassThru -NoNewWindow
-
 if ($AttachDebugger)
 {
+    $teProcess = Start-Process -FilePath "te.exe" -ArgumentList $teArgList -PassThru -NoNewWindow
+
     # /inproc is always added above, so attach directly to TE.exe.
     Write-Host "Launching WinDbgX attached to TE.exe (PID: $($teProcess.Id))..."
     Start-Process "WinDbgX.exe" -ArgumentList "-p $($teProcess.Id)"
+
+    $teProcess | Wait-Process
+    exit $teProcess.ExitCode
+}
+else
+{
+    te.exe $teArgList
+    exit $?
 }
 
-$teProcess | Wait-Process
-exit $teProcess.ExitCode

--- a/tools/test/run-tests.ps1
+++ b/tools/test/run-tests.ps1
@@ -103,6 +103,9 @@ if ($AttachDebugger)
 else
 {
     te.exe $teArgList
-    exit $?
+    if (!$?)
+    {
+        exit 1
+    }
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves two issues when running the tests locally: 

1) Child processes are sometimes leaked 
   Fixed via a job object

2) Ctrl-c doesn't actually terminate the tests
    This is because powershell's eats the ctrl-C since we're using Start-Process. Fixed by only using it when a debugger is requested.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
