### PR TITLE
wslc: align wslc_schema struct names with docker_schema

### DIFF
--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -38,7 +38,7 @@ struct InspectMount
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectMount, Type, Source, Destination, ReadWrite);
 };
 
-struct InspectState
+struct ContainerInspectState
 {
     std::string Status;
     bool Running{};
@@ -46,7 +46,7 @@ struct InspectState
     std::string StartedAt;
     std::string FinishedAt;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectState, Status, Running, ExitCode, StartedAt, FinishedAt);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerInspectState, Status, Running, ExitCode, StartedAt, FinishedAt);
 };
 
 struct Ulimit
@@ -68,7 +68,7 @@ struct InspectHostConfig
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectHostConfig, NetworkMode, Memory, NanoCpus, Ulimits);
 };
 
-struct InspectContainerConfig
+struct ContainerConfig
 {
     std::optional<std::vector<std::string>> Env;
     std::optional<std::vector<std::string>> Cmd;
@@ -76,7 +76,7 @@ struct InspectContainerConfig
     std::string User;
     std::string WorkingDir;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectContainerConfig, Env, Cmd, Entrypoint, User, WorkingDir);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Env, Cmd, Entrypoint, User, WorkingDir);
 };
 
 struct InspectContainer
@@ -85,9 +85,9 @@ struct InspectContainer
     std::string Name;
     std::string Created;
     std::string Image;
-    InspectState State;
+    ContainerInspectState State;
     InspectHostConfig HostConfig;
-    InspectContainerConfig Config;
+    ContainerConfig Config;
     std::map<std::string, std::vector<InspectPortBinding>> Ports;
     std::vector<InspectMount> Mounts;
     std::map<std::string, std::string> Labels;
@@ -138,33 +138,33 @@ struct InspectVolume
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectVolume, Name, Driver, CreatedAt, DriverOpts, Labels, Status);
 };
 
-struct InspectIPAMConfig
+struct IPAMConfig
 {
     std::string Subnet;
     std::string Gateway;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectIPAMConfig, Subnet, Gateway);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAMConfig, Subnet, Gateway);
 };
 
-struct InspectIPAM
+struct IPAM
 {
     std::string Driver;
-    std::optional<std::vector<InspectIPAMConfig>> Config;
+    std::optional<std::vector<IPAMConfig>> Config;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectIPAM, Driver, Config);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAM, Driver, Config);
 };
 
-struct InspectNetwork
+struct Network
 {
     std::string Id;
     std::string Name;
     std::string Driver;
     std::string Scope;
     bool Internal{};
-    InspectIPAM IPAM;
+    IPAM IPAM;
     std::map<std::string, std::string> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectNetwork, Id, Name, Driver, Scope, Internal, IPAM, Labels);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Network, Id, Name, Driver, Scope, Internal, IPAM, Labels);
 };
 
 } // namespace wsl::windows::common::wslc_schema

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2248,7 +2248,7 @@ try
 
     const auto& entry = it->second;
 
-    wslc_schema::InspectNetwork result;
+    wslc_schema::Network result;
     result.Id = entry.Id;
     result.Name = name;
     result.Driver = entry.Driver;
@@ -2262,7 +2262,7 @@ try
         auto& configs = result.IPAM.Config.emplace();
         for (const auto& cfg : *entry.IPAM.Config)
         {
-            wslc_schema::InspectIPAMConfig inspectCfg;
+            wslc_schema::IPAMConfig inspectCfg;
             inspectCfg.Subnet = cfg.Subnet;
             inspectCfg.Gateway = cfg.Gateway;
             configs.push_back(std::move(inspectCfg));

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4439,7 +4439,7 @@ class WSLCTests
         VERIFY_SUCCEEDED(m_defaultSession->InspectNetwork(networkName.c_str(), &output));
         VERIFY_IS_NOT_NULL(output.get());
 
-        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::InspectNetwork>(output.get());
+        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
         VERIFY_IS_TRUE(inspect.IPAM.Config.has_value());
         VERIFY_ARE_EQUAL(1u, inspect.IPAM.Config->size());
         VERIFY_ARE_EQUAL(std::string("172.31.0.0/16"), inspect.IPAM.Config->at(0).Subnet);
@@ -4539,7 +4539,7 @@ class WSLCTests
         VERIFY_SUCCEEDED(m_defaultSession->InspectNetwork(networkName.c_str(), &output));
         VERIFY_IS_NOT_NULL(output.get());
 
-        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::InspectNetwork>(output.get());
+        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
         VERIFY_ARE_EQUAL(inspect.Name, networkName);
         VERIFY_ARE_EQUAL(inspect.Driver, std::string("bridge"));
         VERIFY_IS_FALSE(inspect.Id.empty());
@@ -4567,7 +4567,7 @@ class WSLCTests
         VERIFY_SUCCEEDED(m_defaultSession->InspectNetwork(networkName.c_str(), &output));
         VERIFY_IS_NOT_NULL(output.get());
 
-        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::InspectNetwork>(output.get());
+        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
         VERIFY_ARE_EQUAL(inspect.Name, networkName);
         VERIFY_ARE_EQUAL(inspect.Driver, std::string("bridge"));
         VERIFY_IS_TRUE(inspect.IPAM.Config.has_value());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Renames structs in wslc_schema.h to match the corresponding type names in docker_schema.h, making it easier to compare the two schemas side by side.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Renames the following structs in wslc_schema.h to match docker_schema.h:
InspectState → ContainerInspectState
InspectContainerConfig → ContainerConfig
InspectIPAMConfig → IPAMConfig
InspectIPAM → IPAM
InspectNetwork → Network

Not renamed:
InspectHostConfig - WSLC only exposes a few fields, Docker's HostConfig has 10+. Sharing the name would be misleading.
InspectMount - already matches docker_schema::InspectMount.
InspectPortBinding - no direct equivalent in docker_schema.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
All existing tests pass - no behavior change, only internal type names