### PR TITLE
WSLC: sanitize HostingProcessNameSuffix to keep vmmem process name well-formed

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -14,6 +14,8 @@ Abstract:
 
 #include "HcsVirtualMachine.h"
 #include <format>
+#include <string>
+#include <string_view>
 #include "hcs_schema.h"
 #include "VirtioNetworking.h"
 #include "NatNetworking.h"
@@ -29,6 +31,28 @@ using wsl::windows::service::wslc::HcsVirtualMachine;
 constexpr auto MAX_VM_CRASH_FILES = 3;
 constexpr auto SAVED_STATE_FILE_EXTENSION = L".vmrs";
 constexpr auto SAVED_STATE_FILE_PREFIX = L"saved-state-";
+
+namespace {
+
+// Replace any character outside the conservative ASCII allowlist with '_' so the
+// result is safe to use as the HCS HostingProcessNameSuffix (which becomes the
+// vmmem-XXX process name visible in Task Manager and parsed by various tooling).
+std::wstring SanitizeHostingProcessNameSuffix(std::wstring_view name)
+{
+    constexpr std::wstring_view c_allowed = L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.";
+    std::wstring sanitized{name};
+    for (auto& c : sanitized)
+    {
+        if (c_allowed.find(c) == std::wstring_view::npos)
+        {
+            c = L'_';
+        }
+    }
+
+    return sanitized;
+}
+
+} // namespace
 
 HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 {
@@ -95,7 +119,10 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
     if (helpers::IsVmemmSuffixSupported() && Settings->DisplayName)
     {
-        vmSettings.ComputeTopology.Memory.HostingProcessNameSuffix = Settings->DisplayName;
+        // The vmmem-XXX process name shown in Task Manager (and parsed by tooling)
+        // can't tolerate spaces / unicode / etc., so sanitize before use. Note that
+        // Settings->DisplayName itself (e.g. the HCS Owner) is left untouched.
+        vmSettings.ComputeTopology.Memory.HostingProcessNameSuffix = SanitizeHostingProcessNameSuffix(Settings->DisplayName);
     }
 
 #ifdef _AMD64_


### PR DESCRIPTION
## Problem

The HCS `HostingProcessNameSuffix` becomes the `vmmem-XXX` process name visible in Task Manager and parsed by various tooling. `HcsVirtualMachine` was passing the caller's `Settings->DisplayName` straight through, but for default WSLC sessions that string is built from the caller's username via `LookupAccountSidW` (added in #40144 / cd05f5c7). Usernames can easily contain spaces, unicode, or other characters that produce a malformed vmmem process name.

## Fix

Sanitize the value when it's written to `HostingProcessNameSuffix`: replace any character outside the conservative ASCII allowlist `[A-Za-z0-9._-]` with `_`.

`Settings->DisplayName` itself is **not** modified — it still flows verbatim into the HCS `Owner` field, session lookup, telemetry, etc. Only the vmmem suffix gets the scrub.

## Scope

Intentionally minimal. This PR does **not**:
- Change how default session names are resolved (username suffix retained)
- Add caller-side validation of `DisplayName`
- Change reserved-name semantics or per-user lookup behavior
- Touch the existing WSL (non-WSLC) path in `WslCoreVm.cpp`, which already uses the literal `c_vmOwner = L"WSL"` for its suffix and so doesn't need sanitizing

If we later want to drop the username from the HCS `Owner` field too, that's a separate change.

## Files

- `src/windows/service/exe/HcsVirtualMachine.cpp` — file-local `SanitizeHostingProcessNameSuffix` helper applied at the single `HostingProcessNameSuffix` assignment site.

## Build/test status

IntelliSense-checked only. No new tests — the sanitization is a one-line string transform on a path that has no observable behavior other than the vmmem process name.
