### PR TITLE
Bump GitPython to 3.1.49 to fix Dependabot alerts

### DIFF
--- a/distributions/requirements.txt
+++ b/distributions/requirements.txt
@@ -1,5 +1,5 @@
 python-magic==0.4.27
 click==8.1.3
-GitPython==3.1.47
+GitPython==3.1.49
 PyGithub==2.5.0
 json-cfg==0.4.2

--- a/tools/devops/requirements.txt
+++ b/tools/devops/requirements.txt
@@ -1,4 +1,4 @@
 azure-devops==7.1.0b4
 click==8.1.3
-gitpython==3.1.47
+gitpython==3.1.49
 backoff==2.2.1


### PR DESCRIPTION
Bumps GitPython from 3.1.47 to 3.1.49 in 	ools/devops/requirements.txt and distributions/requirements.txt to address open Dependabot alerts.

## Vulnerabilities fixed

- **GHSA path traversal** in GitPython reference APIs allowing arbitrary file write/delete outside the repository (patched in 3.1.48). Alerts #18, #19.
- **Newline injection in config_writer().set_value()** enabling RCE via core.hooksPath (patched in 3.1.49). Alerts #20, #21.

See https://github.com/microsoft/WSL/security/dependabot.
