### PR TITLE
relay: drain pending IOCP completions in MultiHandleWait destructor

### DIFF
--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -986,6 +986,79 @@ void MultiHandleWait::EnsureIocp()
     }
 }
 
+MultiHandleWait::~MultiHandleWait()
+{
+    DrainPending();
+}
+
+void MultiHandleWait::DrainPending() noexcept
+try
+{
+    if (!m_iocp || m_handles.empty())
+    {
+        return;
+    }
+
+    // Issue cancellation for every outstanding overlapped op nested under the top-level
+    // handles. Cancellation is fire-and-forget; we drain the resulting completions next.
+    for (auto& [flags, handle] : m_handles)
+    {
+        if (handle && handle->HasOutstandingIo())
+        {
+            handle->CancelOutstandingIo();
+        }
+    }
+
+    // Pump completions on this thread until every nested overlapped op has been retired
+    // by the kernel and dispatched via ShutdownCollect(). It is critical that the IOCP is
+    // pumped here -- in IOCP-associated mode the OVERLAPPED isn't safe to free until the
+    // matching completion packet has been dequeued. Without this loop the destructors of
+    // our owned handles would either hang waiting on the IOCP (which is no longer pumped
+    // by the original Run() loop) or, if they didn't wait, free OVERLAPPEDs the kernel
+    // still references.
+    auto anyOutstanding = [this]() {
+        return std::ranges::any_of(m_handles, [](const auto& entry) {
+            return entry.second && entry.second->HasOutstandingIo();
+        });
+    };
+
+    while (anyOutstanding())
+    {
+        DWORD bytesTransferred{};
+        ULONG_PTR completionKey{};
+        OVERLAPPED* completedOverlapped{};
+        BOOL success = GetQueuedCompletionStatus(m_iocp.get(), &bytesTransferred, &completionKey, &completedOverlapped, INFINITE);
+
+        if (!success && completedOverlapped == nullptr)
+        {
+            // GetQueuedCompletionStatus failed without a completion packet (e.g., the IOCP
+            // handle was closed elsewhere). We can't safely make further progress; bail
+            // out -- the destructor warnings on remaining handles will surface the issue.
+            LOG_LAST_ERROR();
+            break;
+        }
+
+        if (completionKey == 0)
+        {
+            // Spurious cancel signal. We are already shutting down; ignore.
+            continue;
+        }
+
+        auto* completionTarget = reinterpret_cast<OverlappedIOHandle*>(completionKey);
+        auto it = std::ranges::find_if(
+            m_handles, [completionTarget](const auto& entry) { return entry.second.get() == completionTarget; });
+
+        if (it == m_handles.end())
+        {
+            // Handle was already removed (e.g., by CancelOnCompleted before drain started).
+            continue;
+        }
+
+        it->second->ShutdownCollect();
+    }
+}
+CATCH_LOG()
+
 bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
 {
     m_cancel = false; // Run may be called multiple times.
@@ -1220,29 +1293,28 @@ ReadHandle::~ReadHandle()
 {
     WaitBridge.reset();
 
+    // Outstanding overlapped I/O must have been retired by MultiHandleWait::DrainPending()
+    // before this destructor runs. The shutdown contract (HasOutstandingIo /
+    // CancelOutstandingIo / ShutdownCollect) is responsible for that. If we get here with
+    // State == Pending, the handle was used outside MultiHandleWait or DrainPending failed
+    // -- in which case waiting on the OVERLAPPED is unsafe in IOCP mode (the IOCP isn't
+    // being pumped) and would hang. Best-effort fall back to event-mode cancel for handles
+    // that were never associated with an IOCP; otherwise log loudly and leak the OVERLAPPED.
     if (State == IOHandleStatus::Pending)
     {
         if (RegisteredWithIocp)
         {
-            // In IOCP mode, Overlapped.hEvent is nullptr and cancellation completions go
-            // to the IOCP queue. Set a temporary event so GetOverlappedResult can wait
-            // for the cancel to complete, ensuring the OVERLAPPED isn't freed while the
-            // kernel still references it.
-            wil::unique_event cancelEvent(wil::EventOptions::ManualReset);
-            Overlapped.hEvent = cancelEvent.get();
-
-            if (CancelIoEx(Handle.Get(), &Overlapped))
-            {
-                DWORD bytesRead{};
-                GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true);
-            }
-
-            Overlapped.hEvent = nullptr;
+            LOG_HR_MSG(
+                E_UNEXPECTED, "ReadHandle destroyed with pending IOCP I/O (DrainPending skipped or failed); leaking OVERLAPPED");
+            return;
         }
-        else if (CancelIoEx(Handle.Get(), &Overlapped))
+
+        // Fallback (event-based) mode: Overlapped.hEvent == Event member, signaled by the
+        // kernel on completion. Safe to wait synchronously.
+        if (CancelIoEx(Handle.Get(), &Overlapped))
         {
             DWORD bytesRead{};
-            if (!GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true))
+            if (!GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, TRUE))
             {
                 auto error = GetLastError();
                 LOG_LAST_ERROR_IF(error != ERROR_CONNECTION_ABORTED && error != ERROR_OPERATION_ABORTED);
@@ -1253,6 +1325,38 @@ ReadHandle::~ReadHandle()
             LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
         }
     }
+}
+
+bool ReadHandle::HasOutstandingIo() const noexcept
+{
+    return State == IOHandleStatus::Pending;
+}
+
+void ReadHandle::CancelOutstandingIo() noexcept
+{
+    if (State != IOHandleStatus::Pending)
+    {
+        return;
+    }
+
+    // Fire-and-forget cancel. The completion will arrive via the IOCP (in IOCP mode) or
+    // via the wait bridge (in fallback mode); MultiHandleWait::DrainPending pumps it up
+    // and dispatches to ShutdownCollect. We do not reset WaitBridge here -- the bridge is
+    // still needed in fallback mode to deliver the cancellation completion to the IOCP.
+    if (!CancelIoEx(Handle.Get(), &Overlapped))
+    {
+        LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
+    }
+}
+
+void ReadHandle::ShutdownCollect() noexcept
+{
+    // The kernel has retired the OVERLAPPED (the matching completion packet was just
+    // dequeued by MultiHandleWait::DrainPending). Tear down the wait bridge and mark
+    // the handle as no longer outstanding. We deliberately do NOT call OnRead here --
+    // shutdown must not invoke user callbacks or run follow-on protocol work.
+    WaitBridge.reset();
+    State = IOHandleStatus::Completed;
 }
 
 void ReadHandle::OnRegister()
@@ -1387,26 +1491,19 @@ SingleAcceptHandle::~SingleAcceptHandle()
 {
     WaitBridge.reset();
 
+    // See the analogous note in ~ReadHandle: outstanding socket I/O must have been retired
+    // by MultiHandleWait::DrainPending(). Waiting in IOCP mode here is unsafe.
     if (State == IOHandleStatus::Pending)
     {
         if (RegisteredWithIocp)
         {
-            wil::unique_event cancelEvent(wil::EventOptions::ManualReset);
-            Overlapped.hEvent = cancelEvent.get();
-
-            if (CancelIoEx(ListenSocket.Get(), &Overlapped))
-            {
-                DWORD bytesProcessed{};
-                DWORD flagsReturned{};
-                WSAGetOverlappedResult((SOCKET)ListenSocket.Get(), &Overlapped, &bytesProcessed, TRUE, &flagsReturned);
-            }
-
-            Overlapped.hEvent = nullptr;
+            LOG_HR_MSG(
+                E_UNEXPECTED, "SingleAcceptHandle destroyed with pending IOCP I/O (DrainPending skipped or failed); leaking OVERLAPPED");
+            return;
         }
-        else
-        {
-            LOG_IF_WIN32_BOOL_FALSE(CancelIoEx(ListenSocket.Get(), &Overlapped));
 
+        if (CancelIoEx(ListenSocket.Get(), &Overlapped))
+        {
             DWORD bytesProcessed{};
             DWORD flagsReturned{};
             if (!WSAGetOverlappedResult((SOCKET)ListenSocket.Get(), &Overlapped, &bytesProcessed, TRUE, &flagsReturned))
@@ -1415,7 +1512,36 @@ SingleAcceptHandle::~SingleAcceptHandle()
                 LOG_LAST_ERROR_IF(error != ERROR_CONNECTION_ABORTED && error != ERROR_OPERATION_ABORTED);
             }
         }
+        else
+        {
+            LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
+        }
     }
+}
+
+bool SingleAcceptHandle::HasOutstandingIo() const noexcept
+{
+    return State == IOHandleStatus::Pending;
+}
+
+void SingleAcceptHandle::CancelOutstandingIo() noexcept
+{
+    if (State != IOHandleStatus::Pending)
+    {
+        return;
+    }
+
+    if (!CancelIoEx(ListenSocket.Get(), &Overlapped))
+    {
+        LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
+    }
+}
+
+void SingleAcceptHandle::ShutdownCollect() noexcept
+{
+    // Shutdown -- do NOT invoke OnAccepted. Just retire the wait bridge and exit Pending.
+    WaitBridge.reset();
+    State = IOHandleStatus::Completed;
 }
 
 void SingleAcceptHandle::OnRegister()
@@ -1653,25 +1779,20 @@ WriteHandle::~WriteHandle()
 {
     WaitBridge.reset();
 
+    // See ~ReadHandle for rationale.
     if (State == IOHandleStatus::Pending)
     {
         if (RegisteredWithIocp)
         {
-            wil::unique_event cancelEvent(wil::EventOptions::ManualReset);
-            Overlapped.hEvent = cancelEvent.get();
-
-            if (CancelIoEx(Handle.Get(), &Overlapped))
-            {
-                DWORD bytesRead{};
-                GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true);
-            }
-
-            Overlapped.hEvent = nullptr;
+            LOG_HR_MSG(
+                E_UNEXPECTED, "WriteHandle destroyed with pending IOCP I/O (DrainPending skipped or failed); leaking OVERLAPPED");
+            return;
         }
-        else if (CancelIoEx(Handle.Get(), &Overlapped))
+
+        if (CancelIoEx(Handle.Get(), &Overlapped))
         {
             DWORD bytesRead{};
-            if (!GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true))
+            if (!GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, TRUE))
             {
                 auto error = GetLastError();
                 LOG_LAST_ERROR_IF(error != ERROR_CONNECTION_ABORTED && error != ERROR_OPERATION_ABORTED);
@@ -1682,6 +1803,30 @@ WriteHandle::~WriteHandle()
             LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
         }
     }
+}
+
+bool WriteHandle::HasOutstandingIo() const noexcept
+{
+    return State == IOHandleStatus::Pending;
+}
+
+void WriteHandle::CancelOutstandingIo() noexcept
+{
+    if (State != IOHandleStatus::Pending)
+    {
+        return;
+    }
+
+    if (!CancelIoEx(Handle.Get(), &Overlapped))
+    {
+        LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
+    }
+}
+
+void WriteHandle::ShutdownCollect() noexcept
+{
+    WaitBridge.reset();
+    State = IOHandleStatus::Completed;
 }
 
 void WriteHandle::OnRegister()
@@ -1910,6 +2055,37 @@ HANDLE DockerIORelayHandle::GetHandle() const
     else
     {
         return Read->GetHandle();
+    }
+}
+
+bool DockerIORelayHandle::HasOutstandingIo() const noexcept
+{
+    return (Read && Read->HasOutstandingIo()) || WriteStdout.HasOutstandingIo() || WriteStderr.HasOutstandingIo();
+}
+
+void DockerIORelayHandle::CancelOutstandingIo() noexcept
+{
+    if (Read)
+    {
+        Read->CancelOutstandingIo();
+    }
+    WriteStdout.CancelOutstandingIo();
+    WriteStderr.CancelOutstandingIo();
+}
+
+void DockerIORelayHandle::ShutdownCollect() noexcept
+{
+    if (Read && Read->HasOutstandingIo())
+    {
+        Read->ShutdownCollect();
+    }
+    else if (WriteStdout.HasOutstandingIo())
+    {
+        WriteStdout.ShutdownCollect();
+    }
+    else if (WriteStderr.HasOutstandingIo())
+    {
+        WriteStderr.ShutdownCollect();
     }
 }
 

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -213,7 +213,7 @@ bool wsl::windows::common::relay::InterruptableWait(_In_ HANDLE WaitObject, _In_
     const DWORD waitResult = WaitForMultipleObjects(gsl::narrow_cast<DWORD>(waitObjects.size()), waitObjects.data(), FALSE, INFINITE);
     if (waitResult != WAIT_OBJECT_0)
     {
-        if (waitResult > WAIT_OBJECT_0 && waitResult < WAIT_OBJECT_0 + waitObjects.size())
+        if (waitResult > WAIT_OBJECT_0 && waitResult <= WAIT_OBJECT_0 + waitObjects.size())
         {
             return false;
         }
@@ -963,16 +963,33 @@ CATCH_LOG()
 
 void MultiHandleWait::AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags)
 {
+    EnsureIocp();
+    handle->Register(m_iocp.get(), handle.get());
     m_handles.emplace_back(flags, std::move(handle));
 }
 
 void MultiHandleWait::Cancel()
 {
-    m_cancel = true;
+    // Wake up GetQueuedCompletionStatus. The key=0 completion will set m_cancel in Run().
+    if (m_iocp)
+    {
+        PostQueuedCompletionStatus(m_iocp.get(), 0, 0, nullptr);
+    }
 }
+
+void MultiHandleWait::EnsureIocp()
+{
+    if (!m_iocp)
+    {
+        m_iocp.reset(CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1));
+        THROW_LAST_ERROR_IF(!m_iocp);
+    }
+}
+
 bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
 {
     m_cancel = false; // Run may be called multiple times.
+    EnsureIocp();
 
     std::optional<std::chrono::steady_clock::time_point> deadline;
 
@@ -1042,13 +1059,7 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
             break;
         }
 
-        // Wait for the next operation to complete.
-        std::vector<HANDLE> waitHandles;
-        for (const auto& e : m_handles)
-        {
-            waitHandles.emplace_back(e.second->GetHandle());
-        }
-
+        // Wait for the next operation to complete via IOCP.
         DWORD waitTimeout = INFINITE;
         if (deadline.has_value())
         {
@@ -1058,34 +1069,55 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
             waitTimeout = static_cast<DWORD>(std::max(0LL, miliseconds));
         }
 
-        auto result = WaitForMultipleObjects(static_cast<DWORD>(waitHandles.size()), waitHandles.data(), false, waitTimeout);
-        if (result == WAIT_TIMEOUT)
-        {
-            THROW_WIN32(ERROR_TIMEOUT);
-        }
-        else if (result >= WAIT_OBJECT_0 && result < WAIT_OBJECT_0 + m_handles.size())
-        {
-            auto index = result - WAIT_OBJECT_0;
+        DWORD bytesTransferred{};
+        ULONG_PTR completionKey{};
+        OVERLAPPED* completedOverlapped{};
+        BOOL success = GetQueuedCompletionStatus(m_iocp.get(), &bytesTransferred, &completionKey, &completedOverlapped, waitTimeout);
 
-            try
-            {
-                m_handles[index].second->Collect();
-            }
-            catch (...)
-            {
-                if (WI_IsFlagSet(m_handles[index].first, Flags::IgnoreErrors))
-                {
-                    m_handles.erase(m_handles.begin() + index);
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
-        else
+        if (!success && completedOverlapped == nullptr)
         {
-            THROW_LAST_ERROR_MSG("Timeout: %lu, Count: %llu", waitTimeout, waitHandles.size());
+            // Timeout or error with no completion packet.
+            auto error = GetLastError();
+            if (error == WAIT_TIMEOUT)
+            {
+                THROW_WIN32(ERROR_TIMEOUT);
+            }
+            THROW_WIN32(error);
+        }
+
+        if (completionKey == 0)
+        {
+            // Cancel signal posted by Cancel() or an external PostQueuedCompletionStatus.
+            m_cancel = true;
+            continue;
+        }
+
+        // Find the top-level handle in m_handles that matches the completion target.
+        auto* completionTarget = reinterpret_cast<OverlappedIOHandle*>(completionKey);
+
+        auto it = std::ranges::find_if(
+            m_handles, [completionTarget](const auto& entry) { return entry.second.get() == completionTarget; });
+
+        if (it == m_handles.end())
+        {
+            // Handle was already removed (e.g., by CancelOnCompleted). Discard the completion.
+            continue;
+        }
+
+        try
+        {
+            it->second->Collect();
+        }
+        catch (...)
+        {
+            if (WI_IsFlagSet(it->first, Flags::IgnoreErrors))
+            {
+                m_handles.erase(it);
+            }
+            else
+            {
+                throw;
+            }
         }
     }
 
@@ -1102,13 +1134,39 @@ EventHandle::EventHandle(HandleWrapper&& Handle, std::function<void()>&& OnSigna
 {
 }
 
+EventHandle::~EventHandle()
+{
+}
+
+void EventHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+{
+    CompletionTarget = completionTarget;
+    Iocp = iocp;
+}
+
 void EventHandle::Schedule()
 {
+    // If registered with an IOCP, use RegisterWaitForSingleObject to bridge the event.
+    if (Iocp != nullptr && !WaitHandle)
+    {
+        THROW_IF_WIN32_BOOL_FALSE(
+            RegisterWaitForSingleObject(&WaitHandle, Handle.Get(), &EventHandle::WaitCallback, this, INFINITE, WT_EXECUTEONLYONCE));
+    }
+
     State = IOHandleStatus::Pending;
+}
+
+VOID CALLBACK EventHandle::WaitCallback(PVOID context, BOOLEAN /*timedOut*/)
+{
+    auto* self = static_cast<EventHandle*>(context);
+    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
 }
 
 void EventHandle::Collect()
 {
+    // Clean up the wait registration so it can be re-registered if needed.
+    WaitHandle.reset();
+
     State = IOHandleStatus::Completed;
     OnSignalled();
 }
@@ -1126,11 +1184,30 @@ ReadHandle::ReadHandle(HandleWrapper&& MovedHandle, std::function<void(const gsl
 
 ReadHandle::~ReadHandle()
 {
+    WaitBridge.reset();
+
     if (State == IOHandleStatus::Pending)
     {
-        DWORD bytesRead{};
-        if (CancelIoEx(Handle.Get(), &Overlapped))
+        if (RegisteredWithIocp)
         {
+            // In IOCP mode, Overlapped.hEvent is nullptr and cancellation completions go
+            // to the IOCP queue. Set a temporary event so GetOverlappedResult can wait
+            // for the cancel to complete, ensuring the OVERLAPPED isn't freed while the
+            // kernel still references it.
+            wil::unique_event cancelEvent(wil::EventOptions::ManualReset);
+            Overlapped.hEvent = cancelEvent.get();
+
+            if (CancelIoEx(Handle.Get(), &Overlapped))
+            {
+                DWORD bytesRead{};
+                GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true);
+            }
+
+            Overlapped.hEvent = nullptr;
+        }
+        else if (CancelIoEx(Handle.Get(), &Overlapped))
+        {
+            DWORD bytesRead{};
             if (!GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true))
             {
                 auto error = GetLastError();
@@ -1139,9 +1216,35 @@ ReadHandle::~ReadHandle()
         }
         else
         {
-            // ERROR_NOT_FOUND is returned if there was no IO to cancel.
             LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
         }
+    }
+}
+
+void ReadHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+{
+    CompletionTarget = completionTarget;
+    Iocp = iocp;
+    if (!RegisteredWithIocp)
+    {
+        // Try to associate the handle with the IOCP. Not all handle types support this
+        // (e.g., some socket types, console handles). Fall back to event-based mode on failure.
+        //
+        // N.B. FILE_SKIP_COMPLETION_PORT_ON_SUCCESS is required before associating with the IOCP.
+        // Without it, synchronous completions would both be processed inline by Schedule() AND
+        // queue an IOCP packet, causing double-processing. If it's not supported for this handle
+        // type, fall back to event-based mode entirely.
+        if (SetFileCompletionNotificationModes(Handle.Get(), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
+        {
+            auto result = CreateIoCompletionPort(Handle.Get(), iocp, reinterpret_cast<ULONG_PTR>(completionTarget), 0);
+            if (result != nullptr)
+            {
+                // Clear the event from OVERLAPPED — completions now go to the IOCP.
+                Overlapped.hEvent = nullptr;
+                RegisteredWithIocp = true;
+            }
+        }
+        // else: fall back to event-based mode (Overlapped.hEvent remains set)
     }
 }
 
@@ -1187,12 +1290,29 @@ void ReadHandle::Schedule()
 
         // The read is pending, update to 'Pending'
         State = IOHandleStatus::Pending;
+
+        // If not registered with IOCP, bridge the event to the IOCP so
+        // GetQueuedCompletionStatus will wake up when this I/O completes.
+        if (!RegisteredWithIocp && Iocp != nullptr && !WaitBridge)
+        {
+            THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
+                &WaitBridge, Event.get(), &ReadHandle::WaitBridgeCallback, this, INFINITE, WT_EXECUTEONLYONCE));
+        }
     }
+}
+
+VOID CALLBACK ReadHandle::WaitBridgeCallback(PVOID context, BOOLEAN /*timedOut*/)
+{
+    auto* self = static_cast<ReadHandle*>(context);
+    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
 }
 
 void ReadHandle::Collect()
 {
     WI_ASSERT(State == IOHandleStatus::Pending);
+
+    // Tear down the event-to-IOCP bridge if it was set up.
+    WaitBridge.reset();
 
     // Transition back to standby
     State = IOHandleStatus::Standby;
@@ -1233,16 +1353,53 @@ SingleAcceptHandle::SingleAcceptHandle(HandleWrapper&& ListenSocket, HandleWrapp
 
 SingleAcceptHandle::~SingleAcceptHandle()
 {
+    WaitBridge.reset();
+
     if (State == IOHandleStatus::Pending)
     {
-        LOG_IF_WIN32_BOOL_FALSE(CancelIoEx(ListenSocket.Get(), &Overlapped));
-
-        DWORD bytesProcessed{};
-        DWORD flagsReturned{};
-        if (!WSAGetOverlappedResult((SOCKET)ListenSocket.Get(), &Overlapped, &bytesProcessed, TRUE, &flagsReturned))
+        if (RegisteredWithIocp)
         {
-            auto error = GetLastError();
-            LOG_LAST_ERROR_IF(error != ERROR_CONNECTION_ABORTED && error != ERROR_OPERATION_ABORTED);
+            wil::unique_event cancelEvent(wil::EventOptions::ManualReset);
+            Overlapped.hEvent = cancelEvent.get();
+
+            if (CancelIoEx(ListenSocket.Get(), &Overlapped))
+            {
+                DWORD bytesProcessed{};
+                DWORD flagsReturned{};
+                WSAGetOverlappedResult((SOCKET)ListenSocket.Get(), &Overlapped, &bytesProcessed, TRUE, &flagsReturned);
+            }
+
+            Overlapped.hEvent = nullptr;
+        }
+        else
+        {
+            LOG_IF_WIN32_BOOL_FALSE(CancelIoEx(ListenSocket.Get(), &Overlapped));
+
+            DWORD bytesProcessed{};
+            DWORD flagsReturned{};
+            if (!WSAGetOverlappedResult((SOCKET)ListenSocket.Get(), &Overlapped, &bytesProcessed, TRUE, &flagsReturned))
+            {
+                auto error = GetLastError();
+                LOG_LAST_ERROR_IF(error != ERROR_CONNECTION_ABORTED && error != ERROR_OPERATION_ABORTED);
+            }
+        }
+    }
+}
+
+void SingleAcceptHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+{
+    CompletionTarget = completionTarget;
+    Iocp = iocp;
+    if (!RegisteredWithIocp)
+    {
+        if (SetFileCompletionNotificationModes(ListenSocket.Get(), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
+        {
+            auto result = CreateIoCompletionPort(ListenSocket.Get(), iocp, reinterpret_cast<ULONG_PTR>(completionTarget), 0);
+            if (result != nullptr)
+            {
+                Overlapped.hEvent = nullptr;
+                RegisteredWithIocp = true;
+            }
         }
     }
 }
@@ -1265,12 +1422,26 @@ void SingleAcceptHandle::Schedule()
         THROW_HR_IF_MSG(HRESULT_FROM_WIN32(error), error != ERROR_IO_PENDING, "Handle: 0x%p", (void*)ListenSocket.Get());
 
         State = IOHandleStatus::Pending;
+
+        if (!RegisteredWithIocp && Iocp != nullptr && !WaitBridge)
+        {
+            THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
+                &WaitBridge, Event.get(), &SingleAcceptHandle::WaitBridgeCallback, this, INFINITE, WT_EXECUTEONLYONCE));
+        }
     }
+}
+
+VOID CALLBACK SingleAcceptHandle::WaitBridgeCallback(PVOID context, BOOLEAN /*timedOut*/)
+{
+    auto* self = static_cast<SingleAcceptHandle*>(context);
+    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
 }
 
 void SingleAcceptHandle::Collect()
 {
     WI_ASSERT(State == IOHandleStatus::Pending);
+
+    WaitBridge.reset();
 
     DWORD bytesReceived{};
     DWORD flagsReturned{};
@@ -1450,11 +1621,26 @@ WriteHandle::WriteHandle(HandleWrapper&& MovedHandle, const std::vector<char>& B
 
 WriteHandle::~WriteHandle()
 {
+    WaitBridge.reset();
+
     if (State == IOHandleStatus::Pending)
     {
-        DWORD bytesRead{};
-        if (CancelIoEx(Handle.Get(), &Overlapped))
+        if (RegisteredWithIocp)
         {
+            wil::unique_event cancelEvent(wil::EventOptions::ManualReset);
+            Overlapped.hEvent = cancelEvent.get();
+
+            if (CancelIoEx(Handle.Get(), &Overlapped))
+            {
+                DWORD bytesRead{};
+                GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true);
+            }
+
+            Overlapped.hEvent = nullptr;
+        }
+        else if (CancelIoEx(Handle.Get(), &Overlapped))
+        {
+            DWORD bytesRead{};
             if (!GetOverlappedResult(Handle.Get(), &Overlapped, &bytesRead, true))
             {
                 auto error = GetLastError();
@@ -1463,8 +1649,25 @@ WriteHandle::~WriteHandle()
         }
         else
         {
-            // ERROR_NOT_FOUND is returned if there was no IO to cancel.
             LOG_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
+        }
+    }
+}
+
+void WriteHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+{
+    CompletionTarget = completionTarget;
+    Iocp = iocp;
+    if (!RegisteredWithIocp)
+    {
+        if (SetFileCompletionNotificationModes(Handle.Get(), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
+        {
+            auto result = CreateIoCompletionPort(Handle.Get(), iocp, reinterpret_cast<ULONG_PTR>(completionTarget), 0);
+            if (result != nullptr)
+            {
+                Overlapped.hEvent = nullptr;
+                RegisteredWithIocp = true;
+            }
         }
     }
 }
@@ -1497,12 +1700,26 @@ void WriteHandle::Schedule()
 
         // The write is pending, update to 'Pending'
         State = IOHandleStatus::Pending;
+
+        if (!RegisteredWithIocp && Iocp != nullptr && !WaitBridge)
+        {
+            THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
+                &WaitBridge, Event.get(), &WriteHandle::WaitBridgeCallback, this, INFINITE, WT_EXECUTEONLYONCE));
+        }
     }
+}
+
+VOID CALLBACK WriteHandle::WaitBridgeCallback(PVOID context, BOOLEAN /*timedOut*/)
+{
+    auto* self = static_cast<WriteHandle*>(context);
+    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
 }
 
 void WriteHandle::Collect()
 {
     WI_ASSERT(State == IOHandleStatus::Pending);
+
+    WaitBridge.reset();
 
     // Transition back to standby
     State = IOHandleStatus::Standby;
@@ -1548,6 +1765,14 @@ DockerIORelayHandle::DockerIORelayHandle(HandleWrapper&& ReadHandle, HandleWrapp
         Read = std::make_unique<relay::ReadHandle>(
             std::move(ReadHandle), [this](const gsl::span<char>& Buffer) { this->OnRead(Buffer); });
     }
+}
+
+void DockerIORelayHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+{
+    CompletionTarget = completionTarget;
+    Read->Register(iocp, completionTarget);
+    WriteStdout.Register(iocp, completionTarget);
+    WriteStderr.Register(iocp, completionTarget);
 }
 
 void DockerIORelayHandle::Schedule()

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -964,7 +964,7 @@ CATCH_LOG()
 void MultiHandleWait::AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags)
 {
     EnsureIocp();
-    handle->Register(m_iocp.get(), handle.get());
+    handle->Register(m_iocp.get());
     m_handles.emplace_back(flags, std::move(handle));
 }
 
@@ -1129,6 +1129,40 @@ IOHandleStatus OverlappedIOHandle::GetState() const
     return State;
 }
 
+void OverlappedIOHandle::Register(HANDLE iocp)
+{
+    THROW_HR_IF(E_INVALIDARG, iocp == nullptr);
+    Bind(iocp, this);
+}
+
+void OverlappedIOHandle::RegisterChild(OverlappedIOHandle& child)
+{
+    // m_iocp/m_completionTarget have been populated by Bind() prior to OnRegister()
+    // running on the parent, so they're available for forwarding here. Propagating
+    // m_completionTarget (rather than `this`) lets nested composites work correctly:
+    // every descendant ends up wired to the outermost top-level handle.
+    WI_ASSERT(m_iocp != nullptr && m_completionTarget != nullptr);
+    child.Bind(m_iocp, m_completionTarget);
+}
+
+void OverlappedIOHandle::Bind(HANDLE iocp, OverlappedIOHandle* completionTarget)
+{
+    if (m_iocp != nullptr)
+    {
+        // Idempotent: identical re-registration is a no-op. Mismatched re-registration
+        // is a programming error -- routing state must be consistent for the lifetime
+        // of the handle, otherwise the IOCP completion key (set on first Register only)
+        // would diverge from m_completionTarget used by wait-bridge callbacks.
+        WI_ASSERT(m_iocp == iocp && m_completionTarget == completionTarget);
+        THROW_HR_IF(E_UNEXPECTED, m_iocp != iocp || m_completionTarget != completionTarget);
+        return;
+    }
+
+    m_iocp = iocp;
+    m_completionTarget = completionTarget;
+    OnRegister();
+}
+
 EventHandle::EventHandle(HandleWrapper&& Handle, std::function<void()>&& OnSignalled) :
     Handle(std::move(Handle)), OnSignalled(std::move(OnSignalled))
 {
@@ -1138,19 +1172,19 @@ EventHandle::~EventHandle()
 {
 }
 
-void EventHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+void EventHandle::OnRegister()
 {
-    CompletionTarget = completionTarget;
-    Iocp = iocp;
+    // No IOCP wiring needed at registration time -- events use the wait-bridge path
+    // exclusively, set up lazily in Schedule().
 }
 
 void EventHandle::Schedule()
 {
     // If registered with an IOCP, use RegisterWaitForSingleObject to bridge the event.
-    if (Iocp != nullptr && !WaitHandle)
+    if (m_iocp != nullptr && !WaitBridge)
     {
         THROW_IF_WIN32_BOOL_FALSE(
-            RegisterWaitForSingleObject(&WaitHandle, Handle.Get(), &EventHandle::WaitCallback, this, INFINITE, WT_EXECUTEONLYONCE));
+            RegisterWaitForSingleObject(&WaitBridge, Handle.Get(), &EventHandle::WaitCallback, this, INFINITE, WT_EXECUTEONLYONCE));
     }
 
     State = IOHandleStatus::Pending;
@@ -1159,13 +1193,13 @@ void EventHandle::Schedule()
 VOID CALLBACK EventHandle::WaitCallback(PVOID context, BOOLEAN /*timedOut*/)
 {
     auto* self = static_cast<EventHandle*>(context);
-    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
+    PostQueuedCompletionStatus(self->m_iocp, 0, reinterpret_cast<ULONG_PTR>(self->m_completionTarget), nullptr);
 }
 
 void EventHandle::Collect()
 {
     // Clean up the wait registration so it can be re-registered if needed.
-    WaitHandle.reset();
+    WaitBridge.reset();
 
     State = IOHandleStatus::Completed;
     OnSignalled();
@@ -1221,10 +1255,8 @@ ReadHandle::~ReadHandle()
     }
 }
 
-void ReadHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+void ReadHandle::OnRegister()
 {
-    CompletionTarget = completionTarget;
-    Iocp = iocp;
     if (!RegisteredWithIocp)
     {
         // Try to associate the handle with the IOCP. Not all handle types support this
@@ -1236,7 +1268,7 @@ void ReadHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
         // type, fall back to event-based mode entirely.
         if (SetFileCompletionNotificationModes(Handle.Get(), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
         {
-            auto result = CreateIoCompletionPort(Handle.Get(), iocp, reinterpret_cast<ULONG_PTR>(completionTarget), 0);
+            auto result = CreateIoCompletionPort(Handle.Get(), m_iocp, reinterpret_cast<ULONG_PTR>(m_completionTarget), 0);
             if (result != nullptr)
             {
                 // Clear the event from OVERLAPPED — completions now go to the IOCP.
@@ -1293,7 +1325,7 @@ void ReadHandle::Schedule()
 
         // If not registered with IOCP, bridge the event to the IOCP so
         // GetQueuedCompletionStatus will wake up when this I/O completes.
-        if (!RegisteredWithIocp && Iocp != nullptr && !WaitBridge)
+        if (!RegisteredWithIocp && m_iocp != nullptr && !WaitBridge)
         {
             THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
                 &WaitBridge, Event.get(), &ReadHandle::WaitBridgeCallback, this, INFINITE, WT_EXECUTEONLYONCE));
@@ -1304,7 +1336,7 @@ void ReadHandle::Schedule()
 VOID CALLBACK ReadHandle::WaitBridgeCallback(PVOID context, BOOLEAN /*timedOut*/)
 {
     auto* self = static_cast<ReadHandle*>(context);
-    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
+    PostQueuedCompletionStatus(self->m_iocp, 0, reinterpret_cast<ULONG_PTR>(self->m_completionTarget), nullptr);
 }
 
 void ReadHandle::Collect()
@@ -1386,15 +1418,13 @@ SingleAcceptHandle::~SingleAcceptHandle()
     }
 }
 
-void SingleAcceptHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+void SingleAcceptHandle::OnRegister()
 {
-    CompletionTarget = completionTarget;
-    Iocp = iocp;
     if (!RegisteredWithIocp)
     {
         if (SetFileCompletionNotificationModes(ListenSocket.Get(), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
         {
-            auto result = CreateIoCompletionPort(ListenSocket.Get(), iocp, reinterpret_cast<ULONG_PTR>(completionTarget), 0);
+            auto result = CreateIoCompletionPort(ListenSocket.Get(), m_iocp, reinterpret_cast<ULONG_PTR>(m_completionTarget), 0);
             if (result != nullptr)
             {
                 Overlapped.hEvent = nullptr;
@@ -1423,7 +1453,7 @@ void SingleAcceptHandle::Schedule()
 
         State = IOHandleStatus::Pending;
 
-        if (!RegisteredWithIocp && Iocp != nullptr && !WaitBridge)
+        if (!RegisteredWithIocp && m_iocp != nullptr && !WaitBridge)
         {
             THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
                 &WaitBridge, Event.get(), &SingleAcceptHandle::WaitBridgeCallback, this, INFINITE, WT_EXECUTEONLYONCE));
@@ -1434,7 +1464,7 @@ void SingleAcceptHandle::Schedule()
 VOID CALLBACK SingleAcceptHandle::WaitBridgeCallback(PVOID context, BOOLEAN /*timedOut*/)
 {
     auto* self = static_cast<SingleAcceptHandle*>(context);
-    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
+    PostQueuedCompletionStatus(self->m_iocp, 0, reinterpret_cast<ULONG_PTR>(self->m_completionTarget), nullptr);
 }
 
 void SingleAcceptHandle::Collect()
@@ -1654,15 +1684,13 @@ WriteHandle::~WriteHandle()
     }
 }
 
-void WriteHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+void WriteHandle::OnRegister()
 {
-    CompletionTarget = completionTarget;
-    Iocp = iocp;
     if (!RegisteredWithIocp)
     {
         if (SetFileCompletionNotificationModes(Handle.Get(), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
         {
-            auto result = CreateIoCompletionPort(Handle.Get(), iocp, reinterpret_cast<ULONG_PTR>(completionTarget), 0);
+            auto result = CreateIoCompletionPort(Handle.Get(), m_iocp, reinterpret_cast<ULONG_PTR>(m_completionTarget), 0);
             if (result != nullptr)
             {
                 Overlapped.hEvent = nullptr;
@@ -1701,7 +1729,7 @@ void WriteHandle::Schedule()
         // The write is pending, update to 'Pending'
         State = IOHandleStatus::Pending;
 
-        if (!RegisteredWithIocp && Iocp != nullptr && !WaitBridge)
+        if (!RegisteredWithIocp && m_iocp != nullptr && !WaitBridge)
         {
             THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
                 &WaitBridge, Event.get(), &WriteHandle::WaitBridgeCallback, this, INFINITE, WT_EXECUTEONLYONCE));
@@ -1712,7 +1740,7 @@ void WriteHandle::Schedule()
 VOID CALLBACK WriteHandle::WaitBridgeCallback(PVOID context, BOOLEAN /*timedOut*/)
 {
     auto* self = static_cast<WriteHandle*>(context);
-    PostQueuedCompletionStatus(self->Iocp, 0, reinterpret_cast<ULONG_PTR>(self->CompletionTarget), nullptr);
+    PostQueuedCompletionStatus(self->m_iocp, 0, reinterpret_cast<ULONG_PTR>(self->m_completionTarget), nullptr);
 }
 
 void WriteHandle::Collect()
@@ -1767,12 +1795,11 @@ DockerIORelayHandle::DockerIORelayHandle(HandleWrapper&& ReadHandle, HandleWrapp
     }
 }
 
-void DockerIORelayHandle::Register(HANDLE iocp, OverlappedIOHandle* completionTarget)
+void DockerIORelayHandle::OnRegister()
 {
-    CompletionTarget = completionTarget;
-    Read->Register(iocp, completionTarget);
-    WriteStdout.Register(iocp, completionTarget);
-    WriteStderr.Register(iocp, completionTarget);
+    RegisterChild(*Read);
+    RegisterChild(WriteStdout);
+    RegisterChild(WriteStderr);
 }
 
 void DockerIORelayHandle::Schedule()

--- a/src/windows/common/relay.hpp
+++ b/src/windows/common/relay.hpp
@@ -305,6 +305,35 @@ public:
 
     IOHandleStatus GetState() const;
 
+    // Shutdown contract used by MultiHandleWait::DrainPending() to retire any
+    // outstanding overlapped I/O before the handle is destroyed. These are
+    // distinct from the normal Schedule()/Collect() state machine so shutdown
+    // does not invoke user callbacks or follow-on protocol work, and does not
+    // confuse the normal IOHandleStatus semantics.
+    //
+    //   HasOutstandingIo()  - does this handle (or any nested child) currently
+    //                         have an in-flight overlapped op the kernel may
+    //                         still complete via the IOCP?
+    //   CancelOutstandingIo - issue CancelIoEx (or its socket equivalent) for
+    //                         every nested in-flight op. Does NOT wait.
+    //   ShutdownCollect     - dispatch a shutdown completion packet to the
+    //                         specific child whose op just completed; transition
+    //                         it out of "outstanding" state. Must not throw and
+    //                         must not invoke normal completion callbacks.
+    //
+    // Default implementations are no-ops (correct for handles like EventHandle
+    // that don't issue overlapped I/O).
+    virtual bool HasOutstandingIo() const noexcept
+    {
+        return false;
+    }
+    virtual void CancelOutstandingIo() noexcept
+    {
+    }
+    virtual void ShutdownCollect() noexcept
+    {
+    }
+
 protected:
     // Helper for composite handles: register a child sub-handle so that its
     // completions wake the same top-level handle that owns this composite. The
@@ -370,6 +399,10 @@ public:
     void Collect() override;
     HANDLE GetHandle() const override;
 
+    bool HasOutstandingIo() const noexcept override;
+    void CancelOutstandingIo() noexcept override;
+    void ShutdownCollect() noexcept override;
+
 private:
     void OnRegister() override;
     static VOID CALLBACK WaitBridgeCallback(PVOID context, BOOLEAN timedOut);
@@ -396,6 +429,10 @@ public:
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
+
+    bool HasOutstandingIo() const noexcept override;
+    void CancelOutstandingIo() noexcept override;
+    void ShutdownCollect() noexcept override;
 
 private:
     void OnRegister() override;
@@ -458,6 +495,10 @@ public:
     void Collect() override;
     HANDLE GetHandle() const override;
     void Push(const gsl::span<char>& Buffer);
+
+    bool HasOutstandingIo() const noexcept override;
+    void CancelOutstandingIo() noexcept override;
+    void ShutdownCollect() noexcept override;
 
 private:
     void OnRegister() override;
@@ -552,6 +593,29 @@ public:
         }
     }
 
+    bool HasOutstandingIo() const noexcept override
+    {
+        return Read.HasOutstandingIo() || Write.HasOutstandingIo();
+    }
+
+    void CancelOutstandingIo() noexcept override
+    {
+        Read.CancelOutstandingIo();
+        Write.CancelOutstandingIo();
+    }
+
+    void ShutdownCollect() noexcept override
+    {
+        if (Read.HasOutstandingIo())
+        {
+            Read.ShutdownCollect();
+        }
+        else if (Write.HasOutstandingIo())
+        {
+            Write.ShutdownCollect();
+        }
+    }
+
 private:
     void OnRegister() override
     {
@@ -585,6 +649,10 @@ public:
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
+
+    bool HasOutstandingIo() const noexcept override;
+    void CancelOutstandingIo() noexcept override;
+    void ShutdownCollect() noexcept override;
 
 #pragma pack(push, 1)
     struct MultiplexedHeader
@@ -625,6 +693,7 @@ public:
     };
 
     MultiHandleWait() = default;
+    ~MultiHandleWait();
 
     void AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags = Flags::None);
     bool Run(std::optional<std::chrono::milliseconds> Timeout);
@@ -632,6 +701,12 @@ public:
 
 private:
     void EnsureIocp();
+
+    // Cancel any outstanding overlapped I/O on owned handles and drain the
+    // resulting completion packets from the IOCP. Called from the destructor
+    // (and only the destructor) to ensure the kernel has fully retired every
+    // OVERLAPPED before the owning handles are freed.
+    void DrainPending() noexcept;
 
     wil::unique_handle m_iocp;
     std::vector<std::pair<Flags, std::unique_ptr<OverlappedIOHandle>>> m_handles;

--- a/src/windows/common/relay.hpp
+++ b/src/windows/common/relay.hpp
@@ -292,13 +292,48 @@ public:
     virtual void Schedule() = 0;
     virtual void Collect() = 0;
     virtual HANDLE GetHandle() const = 0;
-    virtual void Register(HANDLE, OverlappedIOHandle*)
-    {
-    }
+
+    // Register this handle as a top-level participant in an IOCP-driven wait loop.
+    // Completions originating from this handle (or any descendant child handles
+    // owned by composite types) will wake the IOCP with `this` as the completion
+    // target, which is what MultiHandleWait::Run uses to look up the handle in
+    // its m_handles list.
+    //
+    // This method is the only entry point for completion-target routing, so
+    // callers cannot (mis)specify a target that doesn't match the registration.
+    void Register(HANDLE iocp);
+
     IOHandleStatus GetState() const;
 
 protected:
+    // Helper for composite handles: register a child sub-handle so that its
+    // completions wake the same top-level handle that owns this composite. The
+    // composite must call this from its OnRegister() override for each owned
+    // child. Safe to call on `this`'s child sub-handles even when nested
+    // (e.g., a composite-of-composites): the propagated completion target is
+    // always the outermost top-level handle.
+    void RegisterChild(OverlappedIOHandle& child);
+
     IOHandleStatus State = IOHandleStatus::Standby;
+
+    // IOCP routing state shared by all derived types. Set by Register()/RegisterChild()
+    // through Bind(); read by leaf classes when wiring up IOCP / wait bridges.
+    HANDLE m_iocp{};
+    OverlappedIOHandle* m_completionTarget{};
+
+private:
+    // Records routing state with idempotency enforcement, then dispatches to OnRegister().
+    // Treat repeated calls with the same iocp/target as a no-op; calls with mismatched
+    // arguments are a programming error.
+    void Bind(HANDLE iocp, OverlappedIOHandle* completionTarget);
+
+    // Override hook. Default is a no-op (handles that don't participate in IOCP).
+    // Leaves override to do IOCP association / RegisterWaitForSingleObject wiring,
+    // reading m_iocp/m_completionTarget. Composites override to call RegisterChild()
+    // for each owned child.
+    virtual void OnRegister()
+    {
+    }
 };
 
 class EventHandle : public OverlappedIOHandle
@@ -309,19 +344,17 @@ public:
 
     EventHandle(HandleWrapper&& Handle, std::function<void()>&& OnSignalled = []() {});
     ~EventHandle();
-    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
 
 private:
+    void OnRegister() override;
     static VOID CALLBACK WaitCallback(PVOID context, BOOLEAN timedOut);
 
     HandleWrapper Handle;
     std::function<void()> OnSignalled;
-    HANDLE Iocp{};
-    OverlappedIOHandle* CompletionTarget{};
-    unique_registered_wait WaitHandle;
+    unique_registered_wait WaitBridge;
 };
 
 class ReadHandle : public OverlappedIOHandle
@@ -333,12 +366,12 @@ public:
     ReadHandle(HandleWrapper&& MovedHandle, std::function<void(const gsl::span<char>& Buffer)>&& OnRead);
     virtual ~ReadHandle();
 
-    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
 
 private:
+    void OnRegister() override;
     static VOID CALLBACK WaitBridgeCallback(PVOID context, BOOLEAN timedOut);
 
     HandleWrapper Handle;
@@ -347,8 +380,6 @@ private:
     OVERLAPPED Overlapped{};
     std::vector<char> Buffer = std::vector<char>(LX_RELAY_BUFFER_SIZE);
     LARGE_INTEGER Offset{};
-    HANDLE Iocp{};
-    OverlappedIOHandle* CompletionTarget{};
     bool RegisteredWithIocp{};
     unique_registered_wait WaitBridge;
 };
@@ -362,12 +393,12 @@ public:
     SingleAcceptHandle(HandleWrapper&& ListenSocket, HandleWrapper&& AcceptedSocket, std::function<void()>&& OnAccepted);
     ~SingleAcceptHandle();
 
-    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
 
 private:
+    void OnRegister() override;
     static VOID CALLBACK WaitBridgeCallback(PVOID context, BOOLEAN timedOut);
 
     HandleWrapper ListenSocket;
@@ -376,8 +407,6 @@ private:
     OVERLAPPED Overlapped{};
     std::function<void()> OnAccepted;
     char AcceptBuffer[2 * sizeof(SOCKADDR_STORAGE)];
-    HANDLE Iocp{};
-    OverlappedIOHandle* CompletionTarget{};
     bool RegisteredWithIocp{};
     unique_registered_wait WaitBridge;
 };
@@ -425,13 +454,13 @@ public:
 
     WriteHandle(HandleWrapper&& Handle, const std::vector<char>& Buffer = {});
     ~WriteHandle();
-    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
     void Push(const gsl::span<char>& Buffer);
 
 private:
+    void OnRegister() override;
     static VOID CALLBACK WaitBridgeCallback(PVOID context, BOOLEAN timedOut);
 
     HandleWrapper Handle;
@@ -439,8 +468,6 @@ private:
     OVERLAPPED Overlapped{};
     std::vector<char> Buffer;
     LARGE_INTEGER Offset{};
-    HANDLE Iocp{};
-    OverlappedIOHandle* CompletionTarget{};
     bool RegisteredWithIocp{};
     unique_registered_wait WaitBridge;
 };
@@ -455,12 +482,6 @@ public:
     RelayHandle(HandleWrapper&& Input, HandleWrapper&& Output) :
         Read(std::move(Input), [this](const gsl::span<char>& Buffer) { return OnRead(Buffer); }), Write(std::move(Output))
     {
-    }
-
-    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override
-    {
-        Read.Register(iocp, completionTarget);
-        Write.Register(iocp, completionTarget);
     }
 
     void Schedule() override
@@ -532,6 +553,12 @@ public:
     }
 
 private:
+    void OnRegister() override
+    {
+        RegisterChild(Read);
+        RegisterChild(Write);
+    }
+
     void OnRead(const gsl::span<char>& Content)
     {
         PendingBuffer.insert(PendingBuffer.end(), Content.begin(), Content.end());
@@ -555,7 +582,6 @@ public:
     };
 
     DockerIORelayHandle(HandleWrapper&& Input, HandleWrapper&& Stdout, HandleWrapper&& Stderr, Format ReadFormat);
-    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
@@ -572,6 +598,7 @@ public:
     static_assert(sizeof(MultiplexedHeader) == 8);
 
 private:
+    void OnRegister() override;
     void OnRead(const gsl::span<char>& Buffer);
     void ProcessNextHeader();
 
@@ -581,7 +608,6 @@ private:
     std::vector<char> PendingBuffer;
     WriteHandle* ActiveHandle = nullptr;
     size_t RemainingBytes = 0;
-    OverlappedIOHandle* CompletionTarget{};
 };
 
 class MultiHandleWait

--- a/src/windows/common/relay.hpp
+++ b/src/windows/common/relay.hpp
@@ -157,6 +157,56 @@ private:
     std::function<void()> m_onDestroy;
 };
 
+// RAII wrapper for handles returned by RegisterWaitForSingleObject.
+// Supports operator&, operator bool, and reset() to match usage in relay.cpp.
+struct unique_registered_wait
+{
+    unique_registered_wait() = default;
+    ~unique_registered_wait()
+    {
+        reset();
+    }
+    unique_registered_wait(const unique_registered_wait&) = delete;
+    unique_registered_wait& operator=(const unique_registered_wait&) = delete;
+    unique_registered_wait(unique_registered_wait&& other) noexcept : m_handle(other.m_handle)
+    {
+        other.m_handle = nullptr;
+    }
+    unique_registered_wait& operator=(unique_registered_wait&& other) noexcept
+    {
+        reset();
+        m_handle = other.m_handle;
+        other.m_handle = nullptr;
+        return *this;
+    }
+
+    explicit operator bool() const
+    {
+        return m_handle != nullptr;
+    }
+    bool operator!() const
+    {
+        return m_handle == nullptr;
+    }
+    HANDLE* operator&()
+    {
+        return &m_handle;
+    }
+
+    void reset()
+    {
+        if (m_handle != nullptr)
+        {
+            // Use INVALID_HANDLE_VALUE to wait for any pending callbacks to finish before returning.
+            UnregisterWaitEx(m_handle, INVALID_HANDLE_VALUE);
+            m_handle = nullptr;
+        }
+    }
+
+private:
+    HANDLE m_handle{};
+};
+
 enum class IOHandleStatus
 {
     Standby,
@@ -242,6 +292,9 @@ public:
     virtual void Schedule() = 0;
     virtual void Collect() = 0;
     virtual HANDLE GetHandle() const = 0;
+    virtual void Register(HANDLE, OverlappedIOHandle*)
+    {
+    }
     IOHandleStatus GetState() const;
 
 protected:
@@ -255,13 +308,20 @@ public:
     NON_MOVABLE(EventHandle)
 
     EventHandle(HandleWrapper&& Handle, std::function<void()>&& OnSignalled = []() {});
+    ~EventHandle();
+    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
 
 private:
+    static VOID CALLBACK WaitCallback(PVOID context, BOOLEAN timedOut);
+
     HandleWrapper Handle;
     std::function<void()> OnSignalled;
+    HANDLE Iocp{};
+    OverlappedIOHandle* CompletionTarget{};
+    unique_registered_wait WaitHandle;
 };
 
 class ReadHandle : public OverlappedIOHandle
@@ -273,17 +333,24 @@ public:
     ReadHandle(HandleWrapper&& MovedHandle, std::function<void(const gsl::span<char>& Buffer)>&& OnRead);
     virtual ~ReadHandle();
 
+    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
 
 private:
+    static VOID CALLBACK WaitBridgeCallback(PVOID context, BOOLEAN timedOut);
+
     HandleWrapper Handle;
     std::function<void(const gsl::span<char>& Buffer)> OnRead;
     wil::unique_event Event{wil::EventOptions::ManualReset};
     OVERLAPPED Overlapped{};
     std::vector<char> Buffer = std::vector<char>(LX_RELAY_BUFFER_SIZE);
     LARGE_INTEGER Offset{};
+    HANDLE Iocp{};
+    OverlappedIOHandle* CompletionTarget{};
+    bool RegisteredWithIocp{};
+    unique_registered_wait WaitBridge;
 };
 
 class SingleAcceptHandle : public OverlappedIOHandle
@@ -295,17 +362,24 @@ public:
     SingleAcceptHandle(HandleWrapper&& ListenSocket, HandleWrapper&& AcceptedSocket, std::function<void()>&& OnAccepted);
     ~SingleAcceptHandle();
 
+    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
 
 private:
+    static VOID CALLBACK WaitBridgeCallback(PVOID context, BOOLEAN timedOut);
+
     HandleWrapper ListenSocket;
     HandleWrapper AcceptedSocket;
     wil::unique_event Event{wil::EventOptions::ManualReset};
     OVERLAPPED Overlapped{};
     std::function<void()> OnAccepted;
     char AcceptBuffer[2 * sizeof(SOCKADDR_STORAGE)];
+    HANDLE Iocp{};
+    OverlappedIOHandle* CompletionTarget{};
+    bool RegisteredWithIocp{};
+    unique_registered_wait WaitBridge;
 };
 
 class LineBasedReadHandle : public ReadHandle
@@ -351,17 +425,24 @@ public:
 
     WriteHandle(HandleWrapper&& Handle, const std::vector<char>& Buffer = {});
     ~WriteHandle();
+    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
     void Push(const gsl::span<char>& Buffer);
 
 private:
+    static VOID CALLBACK WaitBridgeCallback(PVOID context, BOOLEAN timedOut);
+
     HandleWrapper Handle;
     wil::unique_event Event{wil::EventOptions::ManualReset};
     OVERLAPPED Overlapped{};
     std::vector<char> Buffer;
     LARGE_INTEGER Offset{};
+    HANDLE Iocp{};
+    OverlappedIOHandle* CompletionTarget{};
+    bool RegisteredWithIocp{};
+    unique_registered_wait WaitBridge;
 };
 
 template <typename TRead = ReadHandle>
@@ -374,6 +455,12 @@ public:
     RelayHandle(HandleWrapper&& Input, HandleWrapper&& Output) :
         Read(std::move(Input), [this](const gsl::span<char>& Buffer) { return OnRead(Buffer); }), Write(std::move(Output))
     {
+    }
+
+    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override
+    {
+        Read.Register(iocp, completionTarget);
+        Write.Register(iocp, completionTarget);
     }
 
     void Schedule() override
@@ -468,6 +555,7 @@ public:
     };
 
     DockerIORelayHandle(HandleWrapper&& Input, HandleWrapper&& Stdout, HandleWrapper&& Stderr, Format ReadFormat);
+    void Register(HANDLE iocp, OverlappedIOHandle* completionTarget) override;
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
@@ -493,6 +581,7 @@ private:
     std::vector<char> PendingBuffer;
     WriteHandle* ActiveHandle = nullptr;
     size_t RemainingBytes = 0;
+    OverlappedIOHandle* CompletionTarget{};
 };
 
 class MultiHandleWait
@@ -516,6 +605,9 @@ public:
     void Cancel();
 
 private:
+    void EnsureIocp();
+
+    wil::unique_handle m_iocp;
     std::vector<std::pair<Flags, std::unique_ptr<OverlappedIOHandle>>> m_handles;
     bool m_cancel = false;
 };


### PR DESCRIPTION
## Summary

Fixes a hang in WSLC tests (e.g. `WSLCTests::ListSessionsReturnsSessionWithDisplayName`) caused by `OverlappedIOHandle` destructors attempting to wait on pending IOCP I/O via post-issuance `hEvent` mutation -- an unsupported pattern that hangs forever because the kernel captures `hEvent` at issuance time and IOCP-associated requests deliver completions only via the IOCP.

This branch contains:

1. **0da9a375** `relay: fix IOCP destructor use-after-free without hanging` -- cherry-picked precursor
2. **becf79b7** `relay: harden IOCP registration API and remove duplicated routing state` -- refactor
3. **dfb325a9** `relay: drain pending IOCP completions in MultiHandleWait destructor` -- the architectural fix

## The fix

Introduces a shutdown contract on `OverlappedIOHandle`:

- `HasOutstandingIo()` -- does this handle (or any nested child) have I/O in flight?
- `CancelOutstandingIo()` -- `CancelIoEx` on the handle (and recurse to children)
- `ShutdownCollect()` -- dispatch a shutdown completion to retire the OVERLAPPED without invoking the user-facing `OnRead`/`OnAccepted` paths

`~MultiHandleWait` now calls `DrainPending()` which:

1. Cancels outstanding I/O on every top-level handle that has any
2. Pumps `GetQueuedCompletionStatus` on the IOCP and dispatches `ShutdownCollect` to each completion's owning handle
3. Loops until no handle has outstanding I/O

Leaf destructors (`~ReadHandle`, `~WriteHandle`, `~SingleAcceptHandle`) keep the existing fallback (event-based) wait path. In IOCP mode they assert and leak the OVERLAPPED if anything is still pending -- which would indicate the drain step was skipped or failed. Composites (`RelayHandle`, `DockerIORelayHandle`) recurse to children for all three contract methods.

## Validation

- Originally hung test `WSLCTests::ListSessionsReturnsSessionWithDisplayName` now passes.
- Full `*WSLCTests*` suite: 136/140 passing, **zero hangs**.
- Bisected the 3 remaining failures against `master` (`4e547dab`) -- all are pre-existing and unrelated:
  - `ContainerLogs` and `ContainerAttach` fail identically on master (stdin pipe closure between writes)
  - `VirtioProxyNetworkingWithDnsTunneling` is a DNS environment issue

## Why the obvious "wait on the handle" fix doesn't work

For sockets, `WSAGetOverlappedResult(..., TRUE, ...)` is only valid when event-based notification was selected at issuance. For files in IOCP-associated mode, the OVERLAPPED status block isn't updated until the completion is dequeued from the IOCP -- so waiting on the file handle directly from the destructor is also unsafe. The drain has to happen on the worker thread that owns the IOCP, before the handles are destroyed.
