### PR TITLE
Add Uid/Gid/Fixed driver options to WSLC VHD volumes and expose via SDK

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2179,6 +2179,10 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>Missing required option: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name = "MessageWslcInvalidVolumeOption" xml:space = "preserve" >
+    <value>Invalid value for option '{}': '{}'</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name = "MessageWslcInvalidVolumeType" xml:space = "preserve" >
     <value>Unsupported volume type: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2183,6 +2183,10 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>Invalid value for option '{}': '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name = "MessageWslcUnknownVolumeOption" xml:space = "preserve" >
+    <value>Unknown option: '{}'</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name = "MessageWslcInvalidVolumeType" xml:space = "preserve" >
     <value>Unsupported volume type: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/WslcSDK/winrt/VhdRequirements.cpp
+++ b/src/windows/WslcSDK/winrt/VhdRequirements.cpp
@@ -40,6 +40,19 @@ winrt::Microsoft::WSL::Containers::VhdType VhdRequirements::Type()
     return static_cast<winrt::Microsoft::WSL::Containers::VhdType>(m_vhdRequirements.type);
 }
 
+void VhdRequirements::SetOwner(uint32_t uid, uint32_t gid)
+{
+    m_vhdRequirements.uid = uid;
+    m_vhdRequirements.gid = gid;
+    m_vhdRequirements.flags = m_vhdRequirements.flags | WSLC_VHD_REQ_FLAG_OWNER;
+}
+
+void VhdRequirements::SetMode(uint32_t mode)
+{
+    m_vhdRequirements.mode = mode;
+    m_vhdRequirements.flags = m_vhdRequirements.flags | WSLC_VHD_REQ_FLAG_MODE;
+}
+
 WslcVhdRequirements* VhdRequirements::ToStructPointer()
 {
     return &m_vhdRequirements;

--- a/src/windows/WslcSDK/winrt/VhdRequirements.cpp
+++ b/src/windows/WslcSDK/winrt/VhdRequirements.cpp
@@ -49,13 +49,8 @@ void VhdRequirements::SetOwner(uint32_t uid, uint32_t gid)
 
 void VhdRequirements::SetMode(uint32_t mode)
 {
-    // Match the documented contract on the IDL surface: chmod 0000 makes the
-    // volume root inaccessible (defeating the point of explicit mode bits) and
-    // POSIX file modes are bounded by setuid/setgid/sticky + rwx triplet at
-    // 07777. Rejecting at the setter gives WinRT callers immediate feedback
-    // instead of an opaque E_INVALIDARG hours later from CreateVolume.
-    constexpr uint32_t c_maxModeBits = 07777;
-    if (mode == 0 || mode > c_maxModeBits)
+    // Match the IDL contract: chmod 0 makes the root inaccessible and POSIX modes are bounded by 07777.
+    if (mode == 0 || mode > 07777)
     {
         throw winrt::hresult_invalid_argument(L"mode must be non-zero and <= 07777");
     }

--- a/src/windows/WslcSDK/winrt/VhdRequirements.cpp
+++ b/src/windows/WslcSDK/winrt/VhdRequirements.cpp
@@ -49,6 +49,17 @@ void VhdRequirements::SetOwner(uint32_t uid, uint32_t gid)
 
 void VhdRequirements::SetMode(uint32_t mode)
 {
+    // Match the documented contract on the IDL surface: chmod 0000 makes the
+    // volume root inaccessible (defeating the point of explicit mode bits) and
+    // POSIX file modes are bounded by setuid/setgid/sticky + rwx triplet at
+    // 07777. Rejecting at the setter gives WinRT callers immediate feedback
+    // instead of an opaque E_INVALIDARG hours later from CreateVolume.
+    constexpr uint32_t c_maxModeBits = 07777;
+    if (mode == 0 || mode > c_maxModeBits)
+    {
+        throw winrt::hresult_invalid_argument(L"mode must be non-zero and <= 07777");
+    }
+
     m_vhdRequirements.mode = mode;
     m_vhdRequirements.flags = m_vhdRequirements.flags | WSLC_VHD_REQ_FLAG_MODE;
 }

--- a/src/windows/WslcSDK/winrt/VhdRequirements.cpp
+++ b/src/windows/WslcSDK/winrt/VhdRequirements.cpp
@@ -47,18 +47,6 @@ void VhdRequirements::SetOwner(uint32_t uid, uint32_t gid)
     m_vhdRequirements.flags = m_vhdRequirements.flags | WSLC_VHD_REQ_FLAG_OWNER;
 }
 
-void VhdRequirements::SetMode(uint32_t mode)
-{
-    // Match the IDL contract: chmod 0 makes the root inaccessible and POSIX modes are bounded by 07777.
-    if (mode == 0 || mode > 07777)
-    {
-        throw winrt::hresult_invalid_argument(L"mode must be non-zero and <= 07777");
-    }
-
-    m_vhdRequirements.mode = mode;
-    m_vhdRequirements.flags = m_vhdRequirements.flags | WSLC_VHD_REQ_FLAG_MODE;
-}
-
 WslcVhdRequirements* VhdRequirements::ToStructPointer()
 {
     return &m_vhdRequirements;

--- a/src/windows/WslcSDK/winrt/VhdRequirements.h
+++ b/src/windows/WslcSDK/winrt/VhdRequirements.h
@@ -27,7 +27,6 @@ struct VhdRequirements : VhdRequirementsT<VhdRequirements>
     winrt::Microsoft::WSL::Containers::VhdType Type();
 
     void SetOwner(uint32_t uid, uint32_t gid);
-    void SetMode(uint32_t mode);
 
     WslcVhdRequirements* ToStructPointer();
 

--- a/src/windows/WslcSDK/winrt/VhdRequirements.h
+++ b/src/windows/WslcSDK/winrt/VhdRequirements.h
@@ -26,6 +26,9 @@ struct VhdRequirements : VhdRequirementsT<VhdRequirements>
     uint64_t SizeInBytes();
     winrt::Microsoft::WSL::Containers::VhdType Type();
 
+    void SetOwner(uint32_t uid, uint32_t gid);
+    void SetMode(uint32_t mode);
+
     WslcVhdRequirements* ToStructPointer();
 
 private:

--- a/src/windows/WslcSDK/winrt/wslcsdk.idl
+++ b/src/windows/WslcSDK/winrt/wslcsdk.idl
@@ -58,13 +58,17 @@ namespace Microsoft.WSL.Containers
 
         // Sets the POSIX owner uid and gid that the volume root will be chowned to
         // after creation. Both values are set together to avoid half-configured ownership.
-        // Has no effect when called on a VhdRequirements used with the session rootfs VHD.
+        // Owner/mode are only supported on named volumes created via Session.Create's
+        // VHD volume API; if the resulting VhdRequirements is assigned to
+        // SessionSettings.VhdRequirements (the session rootfs VHD), Session creation
+        // will fail with E_INVALIDARG.
         void SetOwner(UInt32 uid, UInt32 gid);
 
         // Sets the POSIX mode bits (e.g. 0o750) that the volume root will be chmoded to
-        // after creation. Maximum legal value is 07777 (decimal 4095); larger values are
-        // rejected by the service. Has no effect when called on a VhdRequirements used
-        // with the session rootfs VHD.
+        // after creation. Must be non-zero and <= 07777; out-of-range or zero values
+        // are rejected. Owner/mode are only supported on named volumes; if the
+        // resulting VhdRequirements is assigned to SessionSettings.VhdRequirements
+        // (the session rootfs VHD), Session creation will fail with E_INVALIDARG.
         void SetMode(UInt32 mode);
     };
 }

--- a/src/windows/WslcSDK/winrt/wslcsdk.idl
+++ b/src/windows/WslcSDK/winrt/wslcsdk.idl
@@ -55,5 +55,16 @@ namespace Microsoft.WSL.Containers
         String Name { get; };
         UInt64 SizeInBytes { get; };
         VhdType Type { get; };
+
+        // Sets the POSIX owner uid and gid that the volume root will be chowned to
+        // after creation. Both values are set together to avoid half-configured ownership.
+        // Has no effect when called on a VhdRequirements used with the session rootfs VHD.
+        void SetOwner(UInt32 uid, UInt32 gid);
+
+        // Sets the POSIX mode bits (e.g. 0o750) that the volume root will be chmoded to
+        // after creation. Maximum legal value is 07777 (decimal 4095); larger values are
+        // rejected by the service. Has no effect when called on a VhdRequirements used
+        // with the session rootfs VHD.
+        void SetMode(UInt32 mode);
     };
 }

--- a/src/windows/WslcSDK/winrt/wslcsdk.idl
+++ b/src/windows/WslcSDK/winrt/wslcsdk.idl
@@ -58,7 +58,8 @@ namespace Microsoft.WSL.Containers
 
         // Sets POSIX owner uid/gid on the volume root inode (baked in at mkfs
         // time via -E root_owner). Only supported on named volumes — assigning
-        // to the session rootfs VHD will fail Session creation with E_INVALIDARG.
+        // a VhdRequirements with owner set to SessionSettings.VhdRequirements
+        // will fail at property-set time with E_INVALIDARG.
         void SetOwner(UInt32 uid, UInt32 gid);
     };
 }

--- a/src/windows/WslcSDK/winrt/wslcsdk.idl
+++ b/src/windows/WslcSDK/winrt/wslcsdk.idl
@@ -56,14 +56,9 @@ namespace Microsoft.WSL.Containers
         UInt64 SizeInBytes { get; };
         VhdType Type { get; };
 
-        // Sets POSIX owner uid/gid (chowned to the volume root). Owner/mode
-        // are only supported on named volumes — assigning to the session
-        // rootfs VHD will fail Session creation with E_INVALIDARG.
+        // Sets POSIX owner uid/gid on the volume root inode (baked in at mkfs
+        // time via -E root_owner). Only supported on named volumes — assigning
+        // to the session rootfs VHD will fail Session creation with E_INVALIDARG.
         void SetOwner(UInt32 uid, UInt32 gid);
-
-        // Sets POSIX mode bits (e.g. 0o750). Must be non-zero and <= 07777
-        // (rejected at the setter with E_INVALIDARG). Owner/mode are only
-        // supported on named volumes.
-        void SetMode(UInt32 mode);
     };
 }

--- a/src/windows/WslcSDK/winrt/wslcsdk.idl
+++ b/src/windows/WslcSDK/winrt/wslcsdk.idl
@@ -56,20 +56,14 @@ namespace Microsoft.WSL.Containers
         UInt64 SizeInBytes { get; };
         VhdType Type { get; };
 
-        // Sets the POSIX owner uid and gid that the volume root will be chowned to
-        // after creation. Both values are set together to avoid half-configured ownership.
-        // Owner/mode are only supported on named volumes created via Session.Create's
-        // VHD volume API; if the resulting VhdRequirements is assigned to
-        // SessionSettings.VhdRequirements (the session rootfs VHD), Session creation
-        // will fail with E_INVALIDARG.
+        // Sets POSIX owner uid/gid (chowned to the volume root). Owner/mode
+        // are only supported on named volumes — assigning to the session
+        // rootfs VHD will fail Session creation with E_INVALIDARG.
         void SetOwner(UInt32 uid, UInt32 gid);
 
-        // Sets the POSIX mode bits (e.g. 0o750) that the volume root will be chmoded to
-        // after creation. Must be non-zero and <= 07777; out-of-range or zero values
-        // are rejected immediately by the setter with E_INVALIDARG. Owner/mode are only
-        // supported on named volumes; if the resulting VhdRequirements is assigned to
-        // SessionSettings.VhdRequirements (the session rootfs VHD), Session creation
-        // will fail with E_INVALIDARG.
+        // Sets POSIX mode bits (e.g. 0o750). Must be non-zero and <= 07777
+        // (rejected at the setter with E_INVALIDARG). Owner/mode are only
+        // supported on named volumes.
         void SetMode(UInt32 mode);
     };
 }

--- a/src/windows/WslcSDK/winrt/wslcsdk.idl
+++ b/src/windows/WslcSDK/winrt/wslcsdk.idl
@@ -56,10 +56,9 @@ namespace Microsoft.WSL.Containers
         UInt64 SizeInBytes { get; };
         VhdType Type { get; };
 
-        // Sets POSIX owner uid/gid on the volume root inode (baked in at mkfs
-        // time via -E root_owner). Only supported on named volumes — assigning
-        // a VhdRequirements with owner set to SessionSettings.VhdRequirements
-        // will fail at property-set time with E_INVALIDARG.
+        // Sets owner uid/gid on the volume root inode at mkfs time. Only
+        // supported on named volumes; setting this on a SessionSettings
+        // VhdRequirements fails at property-set time with E_INVALIDARG.
         void SetOwner(UInt32 uid, UInt32 gid);
     };
 }

--- a/src/windows/WslcSDK/winrt/wslcsdk.idl
+++ b/src/windows/WslcSDK/winrt/wslcsdk.idl
@@ -66,9 +66,10 @@ namespace Microsoft.WSL.Containers
 
         // Sets the POSIX mode bits (e.g. 0o750) that the volume root will be chmoded to
         // after creation. Must be non-zero and <= 07777; out-of-range or zero values
-        // are rejected. Owner/mode are only supported on named volumes; if the
-        // resulting VhdRequirements is assigned to SessionSettings.VhdRequirements
-        // (the session rootfs VHD), Session creation will fail with E_INVALIDARG.
+        // are rejected immediately by the setter with E_INVALIDARG. Owner/mode are only
+        // supported on named volumes; if the resulting VhdRequirements is assigned to
+        // SessionSettings.VhdRequirements (the session rootfs VHD), Session creation
+        // will fail with E_INVALIDARG.
         void SetMode(UInt32 mode);
     };
 }

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -493,16 +493,56 @@ try
 
     RETURN_HR_IF_NULL(E_INVALIDARG, options->name);
     RETURN_HR_IF(E_INVALIDARG, options->sizeBytes == 0);
-    RETURN_HR_IF(E_NOTIMPL, options->type != WSLC_VHD_TYPE_DYNAMIC);
+
+    // Reject unknown flag bits up-front so future flag additions cannot be
+    // silently ignored by older SDK versions.
+    constexpr WslcVhdRequirementsFlags c_knownFlags = WSLC_VHD_REQ_FLAG_OWNER | WSLC_VHD_REQ_FLAG_MODE;
+    RETURN_HR_IF(E_INVALIDARG, (options->flags & ~c_knownFlags) != WSLC_VHD_REQ_FLAG_NONE);
+
+    // chmod 0 makes the volume root inaccessible to the container's non-root
+    // user (the entire reason MODE exists). Treat it as caller error rather
+    // than honoring it silently.
+    if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_MODE))
+    {
+        RETURN_HR_IF(E_INVALIDARG, options->mode == 0);
+    }
+
+    // Build the driver-options vector dynamically. Strings referenced by
+    // WSLCDriverOption are LPCSTR, so the std::string holders below must
+    // outlive the WSLCDriverOption[] passed to CreateVolume.
+    const auto sizeStr = std::to_string(options->sizeBytes);
+    const auto uidStr = std::to_string(options->uid);
+    const auto gidStr = std::to_string(options->gid);
+    const auto modeStr = std::format("{:o}", options->mode); // forwarded as octal so the service parses base-8
+
+    std::vector<WSLCDriverOption> driverOpts;
+    driverOpts.push_back({"SizeBytes", sizeStr.c_str()});
+
+    if (options->type == WSLC_VHD_TYPE_FIXED)
+    {
+        driverOpts.push_back({"Fixed", "true"});
+    }
+    else
+    {
+        RETURN_HR_IF(E_INVALIDARG, options->type != WSLC_VHD_TYPE_DYNAMIC);
+    }
+
+    if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_OWNER))
+    {
+        driverOpts.push_back({"Uid", uidStr.c_str()});
+        driverOpts.push_back({"Gid", gidStr.c_str()});
+    }
+
+    if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_MODE))
+    {
+        driverOpts.push_back({"Mode", modeStr.c_str()});
+    }
 
     WSLCVolumeOptions volumeOptions{};
     volumeOptions.Name = options->name;
     volumeOptions.Driver = "vhd";
-
-    auto sizeStr = std::to_string(options->sizeBytes);
-    WSLCDriverOption driverOpts[] = {{"SizeBytes", sizeStr.c_str()}};
-    volumeOptions.DriverOpts = driverOpts;
-    volumeOptions.DriverOptsCount = ARRAYSIZE(driverOpts);
+    volumeOptions.DriverOpts = driverOpts.data();
+    volumeOptions.DriverOptsCount = static_cast<ULONG>(driverOpts.size());
 
     WSLCVolumeInformation volumeInfo{};
     return errorInfoWrapper.CaptureResult(internalType->session->CreateVolume(&volumeOptions, &volumeInfo));
@@ -531,6 +571,11 @@ try
     {
         RETURN_HR_IF(E_INVALIDARG, vhdRequirements->sizeBytes == 0);
         RETURN_HR_IF(E_NOTIMPL, vhdRequirements->type != WSLC_VHD_TYPE_DYNAMIC);
+
+        // Owner / mode driver options are only honored on named volumes
+        // (WslcCreateSessionVhdVolume). Reject them here so callers don't
+        // mistakenly believe they applied to the session rootfs VHD.
+        RETURN_HR_IF(E_INVALIDARG, vhdRequirements->flags != WSLC_VHD_REQ_FLAG_NONE);
 
         internalType->vhdRequirements = *vhdRequirements;
     }

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -495,22 +495,16 @@ try
     RETURN_HR_IF(E_INVALIDARG, options->sizeBytes == 0);
 
     // Reject unknown flag bits so future additions can't be silently ignored.
-    constexpr WslcVhdRequirementsFlags c_knownFlags = WSLC_VHD_REQ_FLAG_OWNER | WSLC_VHD_REQ_FLAG_MODE;
+    constexpr WslcVhdRequirementsFlags c_knownFlags = WSLC_VHD_REQ_FLAG_OWNER;
     RETURN_HR_IF(E_INVALIDARG, (options->flags & ~c_knownFlags) != WSLC_VHD_REQ_FLAG_NONE);
 
-    if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_MODE))
-    {
-        // chmod 0 makes the volume root inaccessible; > 07777 isn't a valid POSIX mode.
-        RETURN_HR_IF(E_INVALIDARG, options->mode == 0 || options->mode > 07777);
-    }
-
-    // uid/gid/mode are documented as "honored iff their flag is set", so materialize
-    // their strings only inside the flag-guarded blocks below. Holders live at function
-    // scope so the c_str() pointers stored in driverOpts stay valid through CreateVolume.
+    // uid/gid are documented as "honored iff their flag is set", so materialize
+    // their strings only inside the flag-guarded block below. Holders live at
+    // function scope so the c_str() pointers stored in driverOpts stay valid
+    // through CreateVolume.
     const auto sizeStr = std::to_string(options->sizeBytes);
     std::string uidStr;
     std::string gidStr;
-    std::string modeStr;
 
     std::vector<WSLCDriverOption> driverOpts;
     driverOpts.push_back({"SizeBytes", sizeStr.c_str()});
@@ -530,12 +524,6 @@ try
         gidStr = std::to_string(options->gid);
         driverOpts.push_back({"Uid", uidStr.c_str()});
         driverOpts.push_back({"Gid", gidStr.c_str()});
-    }
-
-    if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_MODE))
-    {
-        modeStr = std::format("{:o}", options->mode);
-        driverOpts.push_back({"Mode", modeStr.c_str()});
     }
 
     WSLCVolumeOptions volumeOptions{};

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -494,25 +494,19 @@ try
     RETURN_HR_IF_NULL(E_INVALIDARG, options->name);
     RETURN_HR_IF(E_INVALIDARG, options->sizeBytes == 0);
 
-    // Reject unknown flag bits up-front so future flag additions cannot be
-    // silently ignored by older SDK versions.
+    // Reject unknown flag bits so future additions can't be silently ignored.
     constexpr WslcVhdRequirementsFlags c_knownFlags = WSLC_VHD_REQ_FLAG_OWNER | WSLC_VHD_REQ_FLAG_MODE;
     RETURN_HR_IF(E_INVALIDARG, (options->flags & ~c_knownFlags) != WSLC_VHD_REQ_FLAG_NONE);
 
-    // chmod 0 makes the volume root inaccessible to the container's non-root
-    // user (the entire reason MODE exists). Treat it as caller error rather
-    // than honoring it silently.
     if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_MODE))
     {
-        RETURN_HR_IF(E_INVALIDARG, options->mode == 0);
+        // chmod 0 makes the volume root inaccessible; > 07777 isn't a valid POSIX mode.
+        RETURN_HR_IF(E_INVALIDARG, options->mode == 0 || options->mode > 07777);
     }
 
-    // Build the driver-options vector dynamically. Strings referenced by
-    // WSLCDriverOption are LPCSTR, so the std::string holders below must
-    // outlive the WSLCDriverOption[] passed to CreateVolume. Format
-    // uid/gid/mode only when their flag is set — the underlying fields are
-    // documented as "honored iff the flag is set" and a defensive caller may
-    // leave them uninitialized.
+    // uid/gid/mode are documented as "honored iff their flag is set", so materialize
+    // their strings only inside the flag-guarded blocks below. Holders live at function
+    // scope so the c_str() pointers stored in driverOpts stay valid through CreateVolume.
     const auto sizeStr = std::to_string(options->sizeBytes);
     std::string uidStr;
     std::string gidStr;
@@ -540,7 +534,7 @@ try
 
     if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_MODE))
     {
-        modeStr = std::format("{:o}", options->mode); // forwarded as octal so the service parses base-8
+        modeStr = std::format("{:o}", options->mode);
         driverOpts.push_back({"Mode", modeStr.c_str()});
     }
 

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -560,7 +560,7 @@ try
         RETURN_HR_IF(E_INVALIDARG, vhdRequirements->sizeBytes == 0);
         RETURN_HR_IF(E_NOTIMPL, vhdRequirements->type != WSLC_VHD_TYPE_DYNAMIC);
 
-        // Owner / mode driver options are only honored on named volumes
+        // Owner driver options are only honored on named volumes
         // (WslcCreateSessionVhdVolume). Reject them here so callers don't
         // mistakenly believe they applied to the session rootfs VHD.
         RETURN_HR_IF(E_INVALIDARG, vhdRequirements->flags != WSLC_VHD_REQ_FLAG_NONE);

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -498,10 +498,8 @@ try
     constexpr WslcVhdRequirementsFlags c_knownFlags = WSLC_VHD_REQ_FLAG_OWNER;
     RETURN_HR_IF(E_INVALIDARG, (options->flags & ~c_knownFlags) != WSLC_VHD_REQ_FLAG_NONE);
 
-    // uid/gid are documented as "honored iff their flag is set", so materialize
-    // their strings only inside the flag-guarded block below. Holders live at
-    // function scope so the c_str() pointers stored in driverOpts stay valid
-    // through CreateVolume.
+    // Hold uid/gid strings at function scope so the c_str() pointers stored
+    // in driverOpts stay valid through CreateVolume.
     const auto sizeStr = std::to_string(options->sizeBytes);
     std::string uidStr;
     std::string gidStr;
@@ -560,9 +558,8 @@ try
         RETURN_HR_IF(E_INVALIDARG, vhdRequirements->sizeBytes == 0);
         RETURN_HR_IF(E_NOTIMPL, vhdRequirements->type != WSLC_VHD_TYPE_DYNAMIC);
 
-        // Owner driver options are only honored on named volumes
-        // (WslcCreateSessionVhdVolume). Reject them here so callers don't
-        // mistakenly believe they applied to the session rootfs VHD.
+        // Owner is only honored on named volumes; reject here so callers can't
+        // mistakenly believe it applied to the session rootfs VHD.
         RETURN_HR_IF(E_INVALIDARG, vhdRequirements->flags != WSLC_VHD_REQ_FLAG_NONE);
 
         internalType->vhdRequirements = *vhdRequirements;

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -509,11 +509,14 @@ try
 
     // Build the driver-options vector dynamically. Strings referenced by
     // WSLCDriverOption are LPCSTR, so the std::string holders below must
-    // outlive the WSLCDriverOption[] passed to CreateVolume.
+    // outlive the WSLCDriverOption[] passed to CreateVolume. Format
+    // uid/gid/mode only when their flag is set — the underlying fields are
+    // documented as "honored iff the flag is set" and a defensive caller may
+    // leave them uninitialized.
     const auto sizeStr = std::to_string(options->sizeBytes);
-    const auto uidStr = std::to_string(options->uid);
-    const auto gidStr = std::to_string(options->gid);
-    const auto modeStr = std::format("{:o}", options->mode); // forwarded as octal so the service parses base-8
+    std::string uidStr;
+    std::string gidStr;
+    std::string modeStr;
 
     std::vector<WSLCDriverOption> driverOpts;
     driverOpts.push_back({"SizeBytes", sizeStr.c_str()});
@@ -529,12 +532,15 @@ try
 
     if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_OWNER))
     {
+        uidStr = std::to_string(options->uid);
+        gidStr = std::to_string(options->gid);
         driverOpts.push_back({"Uid", uidStr.c_str()});
         driverOpts.push_back({"Gid", gidStr.c_str()});
     }
 
     if (WI_IsFlagSet(options->flags, WSLC_VHD_REQ_FLAG_MODE))
     {
+        modeStr = std::format("{:o}", options->mode); // forwarded as octal so the service parses base-8
         driverOpts.push_back({"Mode", modeStr.c_str()});
     }
 

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -40,7 +40,7 @@ EXTERN_C_START
 #define WSLC_E_SDK_UPDATE_NEEDED MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, WSLC_E_BASE + 11)         /* 0x8004060B */
 
 // Session values
-#define WSLC_SESSION_OPTIONS_SIZE 80
+#define WSLC_SESSION_OPTIONS_SIZE 96
 #define WSLC_SESSION_OPTIONS_ALIGNMENT 8
 
 typedef struct WslcSessionSettings
@@ -80,8 +80,21 @@ typedef enum WslcContainerNetworkingMode
 typedef enum WslcVhdType
 {
     WSLC_VHD_TYPE_DYNAMIC = 0, // Expanding VHDX (default)
-    WSLC_VHD_TYPE_FIXED = 1
+    WSLC_VHD_TYPE_FIXED = 1    // Fixed-allocation VHDX (only honored by WslcCreateSessionVhdVolume)
 } WslcVhdType;
+
+typedef enum WslcVhdRequirementsFlags
+{
+    WSLC_VHD_REQ_FLAG_NONE = 0x00000000,
+    // When set, WslcVhdRequirements::uid and gid are honored. When clear,
+    // those fields are ignored and the volume is left owned by root:root.
+    WSLC_VHD_REQ_FLAG_OWNER = 0x00000001,
+    // When set, WslcVhdRequirements::mode is honored. When clear, the field
+    // is ignored and the volume keeps the default mkfs.ext4 mode (0755).
+    WSLC_VHD_REQ_FLAG_MODE = 0x00000002,
+} WslcVhdRequirementsFlags;
+
+DEFINE_ENUM_FLAG_OPERATORS(WslcVhdRequirementsFlags);
 
 typedef struct WslcVhdRequirements
 {
@@ -89,6 +102,15 @@ typedef struct WslcVhdRequirements
     _In_z_ PCSTR name;
     _In_ uint64_t sizeBytes; // Desired size (for create/expand)
     _In_ WslcVhdType type;
+    // The remaining fields are only honored by WslcCreateSessionVhdVolume.
+    // WslcSetSessionSettingsVhd manages the session's root VHD where
+    // ownership/mode have no meaning, and rejects any non-NONE flags with
+    // E_INVALIDARG so callers do not silently miss the limitation.
+    _In_ WslcVhdRequirementsFlags flags;
+    _In_ uint32_t uid;  // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
+    _In_ uint32_t gid;  // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
+    _In_ uint32_t mode; // octal file mode (e.g. 0750), honored iff (flags & WSLC_VHD_REQ_FLAG_MODE).
+                        // Must be non-zero and <= 07777 when WSLC_VHD_REQ_FLAG_MODE is set.
 } WslcVhdRequirements;
 
 typedef enum WslcSessionFeatureFlags

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -103,14 +103,12 @@ typedef struct WslcVhdRequirements
     _In_ uint64_t sizeBytes; // Desired size (for create/expand)
     _In_ WslcVhdType type;
     // The remaining fields are only honored by WslcCreateSessionVhdVolume.
-    // WslcSetSessionSettingsVhd manages the session's root VHD where
-    // ownership/mode have no meaning, and rejects any non-NONE flags with
-    // E_INVALIDARG so callers do not silently miss the limitation.
+    // WslcSetSessionSettingsVhd rejects non-NONE flags with E_INVALIDARG.
     _In_ WslcVhdRequirementsFlags flags;
     _In_ uint32_t uid;  // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
     _In_ uint32_t gid;  // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
-    _In_ uint32_t mode; // octal file mode (e.g. 0750), honored iff (flags & WSLC_VHD_REQ_FLAG_MODE).
-                        // Must be non-zero and <= 07777 when WSLC_VHD_REQ_FLAG_MODE is set.
+    _In_ uint32_t mode; // octal mode (e.g. 0750), non-zero and <= 07777,
+                        // honored iff (flags & WSLC_VHD_REQ_FLAG_MODE)
 } WslcVhdRequirements;
 
 typedef enum WslcSessionFeatureFlags

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -40,7 +40,7 @@ EXTERN_C_START
 #define WSLC_E_SDK_UPDATE_NEEDED MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, WSLC_E_BASE + 11)         /* 0x8004060B */
 
 // Session values
-#define WSLC_SESSION_OPTIONS_SIZE 96
+#define WSLC_SESSION_OPTIONS_SIZE 88
 #define WSLC_SESSION_OPTIONS_ALIGNMENT 8
 
 typedef struct WslcSessionSettings
@@ -89,9 +89,6 @@ typedef enum WslcVhdRequirementsFlags
     // When set, WslcVhdRequirements::uid and gid are honored. When clear,
     // those fields are ignored and the volume is left owned by root:root.
     WSLC_VHD_REQ_FLAG_OWNER = 0x00000001,
-    // When set, WslcVhdRequirements::mode is honored. When clear, the field
-    // is ignored and the volume keeps the default mkfs.ext4 mode (0755).
-    WSLC_VHD_REQ_FLAG_MODE = 0x00000002,
 } WslcVhdRequirementsFlags;
 
 DEFINE_ENUM_FLAG_OPERATORS(WslcVhdRequirementsFlags);
@@ -105,10 +102,8 @@ typedef struct WslcVhdRequirements
     // The remaining fields are only honored by WslcCreateSessionVhdVolume.
     // WslcSetSessionSettingsVhd rejects non-NONE flags with E_INVALIDARG.
     _In_ WslcVhdRequirementsFlags flags;
-    _In_ uint32_t uid;  // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
-    _In_ uint32_t gid;  // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
-    _In_ uint32_t mode; // octal mode (e.g. 0750), non-zero and <= 07777,
-                        // honored iff (flags & WSLC_VHD_REQ_FLAG_MODE)
+    _In_ uint32_t uid; // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
+    _In_ uint32_t gid; // honored iff (flags & WSLC_VHD_REQ_FLAG_OWNER)
 } WslcVhdRequirements;
 
 typedef enum WslcSessionFeatureFlags

--- a/src/windows/wslcsession/CMakeLists.txt
+++ b/src/windows/wslcsession/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     DockerEventTracker.cpp
     DockerHTTPClient.cpp
     IORelay.cpp
+    OptionParser.cpp
     ServiceProcessLauncher.cpp
     )
 
@@ -33,6 +34,7 @@ set(HEADERS
     DockerEventTracker.h
     DockerHTTPClient.h
     IORelay.h
+    OptionParser.h
     ServiceProcessLauncher.h
     WSLCContainer.h
     WSLCContainerMetadata.h

--- a/src/windows/wslcsession/OptionParser.cpp
+++ b/src/windows/wslcsession/OptionParser.cpp
@@ -59,7 +59,7 @@ void OptionParser::RejectUnknown()
     {
         if (m_consumed.find(key) == m_consumed.end())
         {
-            ThrowInvalid(key, value);
+            ThrowUnknown(key);
         }
     }
 }
@@ -72,6 +72,11 @@ void OptionParser::ThrowInvalid(std::string_view Key, const std::string& Value)
 void OptionParser::ThrowMissing(std::string_view Key)
 {
     THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcMissingVolumeOption(std::string(Key)));
+}
+
+void OptionParser::ThrowUnknown(std::string_view Key)
+{
+    THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcUnknownVolumeOption(std::string(Key)));
 }
 
 } // namespace wsl::windows::service::wslc

--- a/src/windows/wslcsession/OptionParser.cpp
+++ b/src/windows/wslcsession/OptionParser.cpp
@@ -1,0 +1,77 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    OptionParser.cpp
+
+Abstract:
+
+    Implementation of OptionParser. Handles the non-template error/lookup
+    primitives that the templated accessors in OptionParser.h call into.
+
+--*/
+
+#include "precomp.h"
+#include "OptionParser.h"
+
+using wsl::shared::Localization;
+
+namespace wsl::windows::service::wslc {
+
+OptionParser::OptionParser(const std::map<std::string, std::string>& Options) noexcept : m_options(Options)
+{
+}
+
+const std::string* OptionParser::Find(std::string_view Key)
+{
+    const auto it = m_options.find(std::string(Key));
+    if (it == m_options.end())
+    {
+        return nullptr;
+    }
+
+    m_consumed.insert(it->first);
+    return &it->second;
+}
+
+std::optional<bool> OptionParser::OptionalBool(std::string_view Key)
+{
+    const auto* value = Find(Key);
+    if (value == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    const auto parsed = wsl::shared::string::ParseBool(value->c_str());
+    if (!parsed.has_value())
+    {
+        ThrowInvalid(Key, *value);
+    }
+
+    return parsed;
+}
+
+void OptionParser::RejectUnknown()
+{
+    for (const auto& [key, value] : m_options)
+    {
+        if (m_consumed.find(key) == m_consumed.end())
+        {
+            ThrowInvalid(key, value);
+        }
+    }
+}
+
+void OptionParser::ThrowInvalid(std::string_view Key, const std::string& Value)
+{
+    THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(std::string(Key), Value));
+}
+
+void OptionParser::ThrowMissing(std::string_view Key)
+{
+    THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcMissingVolumeOption(std::string(Key)));
+}
+
+} // namespace wsl::windows::service::wslc

--- a/src/windows/wslcsession/OptionParser.h
+++ b/src/windows/wslcsession/OptionParser.h
@@ -42,14 +42,13 @@ public:
     // Parses a required unsigned integer value. Throws E_INVALIDARG with
     // MessageWslcMissingVolumeOption if Key is absent, or
     // MessageWslcInvalidVolumeOption if the value is empty, has a leading
-    // sign, contains non-digit (for the given Base) characters, overflows, or
-    // exceeds Max.
+    // sign, contains non-digit characters, overflows, or exceeds Max.
     template <typename T>
-    T Required(std::string_view Key, T Max = (std::numeric_limits<T>::max)(), int Base = 10);
+    T Required(std::string_view Key, T Max = (std::numeric_limits<T>::max)());
 
     // Same validation as Required, but returns nullopt when the key is absent.
     template <typename T>
-    std::optional<T> Optional(std::string_view Key, T Max = (std::numeric_limits<T>::max)(), int Base = 10);
+    std::optional<T> Optional(std::string_view Key, T Max = (std::numeric_limits<T>::max)());
 
     // Parses an optional boolean using wsl::shared::string::ParseBool semantics
     // (accepts "0"/"1"/"true"/"false", case-insensitive). Throws on unknown
@@ -69,14 +68,14 @@ private:
     [[noreturn]] static void ThrowMissing(std::string_view Key);
 
     template <typename T>
-    static T ParseUnsignedValue(std::string_view Key, const std::string& Value, T Max, int Base);
+    static T ParseUnsignedValue(std::string_view Key, const std::string& Value, T Max);
 
     const std::map<std::string, std::string>& m_options;
     std::set<std::string, std::less<>> m_consumed;
 };
 
 template <typename T>
-inline T OptionParser::Required(std::string_view Key, T Max, int Base)
+inline T OptionParser::Required(std::string_view Key, T Max)
 {
     const auto* value = Find(Key);
     if (value == nullptr)
@@ -84,11 +83,11 @@ inline T OptionParser::Required(std::string_view Key, T Max, int Base)
         ThrowMissing(Key);
     }
 
-    return ParseUnsignedValue<T>(Key, *value, Max, Base);
+    return ParseUnsignedValue<T>(Key, *value, Max);
 }
 
 template <typename T>
-inline std::optional<T> OptionParser::Optional(std::string_view Key, T Max, int Base)
+inline std::optional<T> OptionParser::Optional(std::string_view Key, T Max)
 {
     const auto* value = Find(Key);
     if (value == nullptr)
@@ -96,11 +95,11 @@ inline std::optional<T> OptionParser::Optional(std::string_view Key, T Max, int 
         return std::nullopt;
     }
 
-    return ParseUnsignedValue<T>(Key, *value, Max, Base);
+    return ParseUnsignedValue<T>(Key, *value, Max);
 }
 
 template <typename T>
-inline T OptionParser::ParseUnsignedValue(std::string_view Key, const std::string& Value, T Max, int Base)
+inline T OptionParser::ParseUnsignedValue(std::string_view Key, const std::string& Value, T Max)
 {
     static_assert(std::is_unsigned_v<T>, "OptionParser numeric accessors only support unsigned integer types");
 
@@ -116,7 +115,7 @@ inline T OptionParser::ParseUnsignedValue(std::string_view Key, const std::strin
 
     errno = 0;
     char* end = nullptr;
-    const auto parsed = wsl::shared::string::ToUInt64(Value.c_str(), &end, Base);
+    const auto parsed = wsl::shared::string::ToUInt64(Value.c_str(), &end, 10);
     // Capture errno immediately so any subsequent call (debug allocators,
     // logging hooks, etc.) cannot stomp on it before we inspect it.
     const int parseErrno = errno;

--- a/src/windows/wslcsession/OptionParser.h
+++ b/src/windows/wslcsession/OptionParser.h
@@ -34,13 +34,9 @@ class OptionParser
 public:
     NON_COPYABLE(OptionParser);
 
-    // The supplied options map must outlive this OptionParser instance.
-    // The parser stores a non-owning reference to the map. Only Find()
-    // returns a pointer into the map's backing storage (used internally);
-    // Required/Optional/OptionalBool return parsed values *by value*, so
-    // callers do not need to keep the map alive past the accessor call.
-    // Typical use is a function-local parser that lives only for the
-    // duration of one Parse() call.
+    // The supplied options map must outlive this OptionParser. Required/Optional/
+    // OptionalBool return parsed values by value; only Find() (used internally)
+    // returns a pointer into the map.
     explicit OptionParser(const std::map<std::string, std::string>& Options) noexcept;
 
     // Parses a required unsigned integer value. Throws E_INVALIDARG with

--- a/src/windows/wslcsession/OptionParser.h
+++ b/src/windows/wslcsession/OptionParser.h
@@ -19,6 +19,7 @@ Abstract:
 
 #pragma once
 
+#include <cerrno>
 #include <limits>
 #include <map>
 #include <optional>
@@ -59,6 +60,7 @@ private:
 
     [[noreturn]] static void ThrowInvalid(std::string_view Key, const std::string& Value);
     [[noreturn]] static void ThrowMissing(std::string_view Key);
+    [[noreturn]] static void ThrowUnknown(std::string_view Key);
 
     template <typename T>
     static T ParseUnsignedValue(std::string_view Key, const std::string& Value, T Max);

--- a/src/windows/wslcsession/OptionParser.h
+++ b/src/windows/wslcsession/OptionParser.h
@@ -34,34 +34,27 @@ class OptionParser
 public:
     NON_COPYABLE(OptionParser);
 
-    // The supplied options map must outlive this OptionParser. Required/Optional/
-    // OptionalBool return parsed values by value; only Find() (used internally)
-    // returns a pointer into the map.
+    // Options map must outlive this OptionParser.
     explicit OptionParser(const std::map<std::string, std::string>& Options) noexcept;
 
-    // Parses a required unsigned integer value. Throws E_INVALIDARG with
-    // MessageWslcMissingVolumeOption if Key is absent, or
-    // MessageWslcInvalidVolumeOption if the value is empty, has a leading
-    // sign, contains non-digit characters, overflows, or exceeds Max.
+    // Required unsigned integer. Throws E_INVALIDARG if missing, empty,
+    // signed, non-decimal, overflows, or > Max.
     template <typename T>
     T Required(std::string_view Key, T Max = (std::numeric_limits<T>::max)());
 
-    // Same validation as Required, but returns nullopt when the key is absent.
+    // As Required, but returns nullopt when the key is absent.
     template <typename T>
     std::optional<T> Optional(std::string_view Key, T Max = (std::numeric_limits<T>::max)());
 
-    // Parses an optional boolean using wsl::shared::string::ParseBool semantics
-    // (accepts "0"/"1"/"true"/"false", case-insensitive). Throws on unknown
-    // values; returns nullopt when the key is absent.
+    // Parses an optional boolean via wsl::shared::string::ParseBool
+    // ("0"/"1"/"true"/"false", case-insensitive). Throws on unknown values.
     std::optional<bool> OptionalBool(std::string_view Key);
 
-    // Throws E_INVALIDARG with MessageWslcInvalidVolumeOption on the first
-    // option that was supplied but never consumed by Required/Optional/etc.
+    // Throws E_INVALIDARG on the first option that was supplied but never consumed.
     void RejectUnknown();
 
 private:
-    // Returns a pointer to the value for Key (or nullptr if absent) and marks
-    // the key as consumed.
+    // Returns the value for Key (nullptr if absent) and marks it consumed.
     const std::string* Find(std::string_view Key);
 
     [[noreturn]] static void ThrowInvalid(std::string_view Key, const std::string& Value);
@@ -103,11 +96,8 @@ inline T OptionParser::ParseUnsignedValue(std::string_view Key, const std::strin
 {
     static_assert(std::is_unsigned_v<T>, "OptionParser numeric accessors only support unsigned integer types");
 
-    // ToUInt64 (which wraps strtoull) interprets a leading '-' as wraparound
-    // (e.g. "-1" parses to ULLONG_MAX) and silently accepts a leading '+'.
-    // Reject either explicit sign and empty input up-front so signed/empty
-    // options are reported as user errors instead of producing surprising
-    // unsigned values.
+    // strtoull treats a leading '-' as unsigned wraparound and accepts '+';
+    // reject both (and empty input) up-front.
     if (Value.empty() || Value.front() == '-' || Value.front() == '+')
     {
         ThrowInvalid(Key, Value);
@@ -116,8 +106,7 @@ inline T OptionParser::ParseUnsignedValue(std::string_view Key, const std::strin
     errno = 0;
     char* end = nullptr;
     const auto parsed = wsl::shared::string::ToUInt64(Value.c_str(), &end, 10);
-    // Capture errno immediately so any subsequent call (debug allocators,
-    // logging hooks, etc.) cannot stomp on it before we inspect it.
+    // Capture errno immediately so debug allocators/logging hooks can't stomp it.
     const int parseErrno = errno;
     if (parseErrno != 0 || end == nullptr || *end != '\0' || parsed > static_cast<uint64_t>(Max))
     {

--- a/src/windows/wslcsession/OptionParser.h
+++ b/src/windows/wslcsession/OptionParser.h
@@ -1,0 +1,131 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    OptionParser.h
+
+Abstract:
+
+    Helper for parsing string-keyed driver options (e.g. WSLC volume driver
+    options) into typed values with consistent error reporting.
+
+    Each accessor records the keys it consumed so RejectUnknown() can flag
+    options the caller passed but the driver does not support. All errors are
+    surfaced through the WSLC localized message strings.
+
+--*/
+
+#pragma once
+
+#include <limits>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace wsl::windows::service::wslc {
+
+class OptionParser
+{
+public:
+    NON_COPYABLE(OptionParser);
+
+    // The supplied options map must outlive this OptionParser instance —
+    // accessors return references into it. Typical use is a function-local
+    // parser that lives only for the duration of one Parse() call.
+    explicit OptionParser(const std::map<std::string, std::string>& Options) noexcept;
+
+    // Parses a required unsigned integer value. Throws E_INVALIDARG with
+    // MessageWslcMissingVolumeOption if Key is absent, or
+    // MessageWslcInvalidVolumeOption if the value is empty, has a leading
+    // sign, contains non-digit (for the given Base) characters, overflows, or
+    // exceeds Max.
+    template <typename T>
+    T Required(std::string_view Key, T Max = (std::numeric_limits<T>::max)(), int Base = 10);
+
+    // Same validation as Required, but returns nullopt when the key is absent.
+    template <typename T>
+    std::optional<T> Optional(std::string_view Key, T Max = (std::numeric_limits<T>::max)(), int Base = 10);
+
+    // Parses an optional boolean using wsl::shared::string::ParseBool semantics
+    // (accepts "0"/"1"/"true"/"false", case-insensitive). Throws on unknown
+    // values; returns nullopt when the key is absent.
+    std::optional<bool> OptionalBool(std::string_view Key);
+
+    // Throws E_INVALIDARG with MessageWslcInvalidVolumeOption on the first
+    // option that was supplied but never consumed by Required/Optional/etc.
+    void RejectUnknown();
+
+private:
+    // Returns a pointer to the value for Key (or nullptr if absent) and marks
+    // the key as consumed.
+    const std::string* Find(std::string_view Key);
+
+    [[noreturn]] static void ThrowInvalid(std::string_view Key, const std::string& Value);
+    [[noreturn]] static void ThrowMissing(std::string_view Key);
+
+    template <typename T>
+    static T ParseUnsignedValue(std::string_view Key, const std::string& Value, T Max, int Base);
+
+    const std::map<std::string, std::string>& m_options;
+    std::set<std::string, std::less<>> m_consumed;
+};
+
+template <typename T>
+inline T OptionParser::Required(std::string_view Key, T Max, int Base)
+{
+    const auto* value = Find(Key);
+    if (value == nullptr)
+    {
+        ThrowMissing(Key);
+    }
+
+    return ParseUnsignedValue<T>(Key, *value, Max, Base);
+}
+
+template <typename T>
+inline std::optional<T> OptionParser::Optional(std::string_view Key, T Max, int Base)
+{
+    const auto* value = Find(Key);
+    if (value == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    return ParseUnsignedValue<T>(Key, *value, Max, Base);
+}
+
+template <typename T>
+inline T OptionParser::ParseUnsignedValue(std::string_view Key, const std::string& Value, T Max, int Base)
+{
+    static_assert(std::is_unsigned_v<T>, "OptionParser numeric accessors only support unsigned integer types");
+
+    // ToUInt64 (which wraps strtoull) interprets a leading '-' as wraparound
+    // (e.g. "-1" parses to ULLONG_MAX) and silently accepts a leading '+'.
+    // Reject either explicit sign and empty input up-front so signed/empty
+    // options are reported as user errors instead of producing surprising
+    // unsigned values.
+    if (Value.empty() || Value.front() == '-' || Value.front() == '+')
+    {
+        ThrowInvalid(Key, Value);
+    }
+
+    errno = 0;
+    char* end = nullptr;
+    const auto parsed = wsl::shared::string::ToUInt64(Value.c_str(), &end, Base);
+    // Capture errno immediately so any subsequent call (debug allocators,
+    // logging hooks, etc.) cannot stomp on it before we inspect it.
+    const int parseErrno = errno;
+    if (parseErrno != 0 || end == nullptr || *end != '\0' || parsed > static_cast<uint64_t>(Max))
+    {
+        ThrowInvalid(Key, Value);
+    }
+
+    return static_cast<T>(parsed);
+}
+
+} // namespace wsl::windows::service::wslc

--- a/src/windows/wslcsession/OptionParser.h
+++ b/src/windows/wslcsession/OptionParser.h
@@ -34,9 +34,13 @@ class OptionParser
 public:
     NON_COPYABLE(OptionParser);
 
-    // The supplied options map must outlive this OptionParser instance —
-    // accessors return references into it. Typical use is a function-local
-    // parser that lives only for the duration of one Parse() call.
+    // The supplied options map must outlive this OptionParser instance.
+    // The parser stores a non-owning reference to the map. Only Find()
+    // returns a pointer into the map's backing storage (used internally);
+    // Required/Optional/OptionalBool return parsed values *by value*, so
+    // callers do not need to keep the map alive past the accessor call.
+    // Typical use is a function-local parser that lives only for the
+    // duration of one Parse() call.
     explicit OptionParser(const std::map<std::string, std::string>& Options) noexcept;
 
     // Parses a required unsigned integer value. Throws E_INVALIDARG with

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -55,7 +55,7 @@ namespace {
 
             opts.SizeBytes = parser.Required<ULONGLONG>(c_sizeBytesOpt);
             THROW_HR_WITH_USER_ERROR_IF(
-                E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_sizeBytesOpt, std::string("0")), opts.SizeBytes == 0);
+                E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_sizeBytesOpt, DriverOpts.at(c_sizeBytesOpt)), opts.SizeBytes == 0);
 
             opts.Fixed = parser.OptionalBool(c_fixedOpt).value_or(false);
 
@@ -80,7 +80,7 @@ namespace {
             opts.Mode = parser.Optional<uint32_t>(c_modeOpt, c_maxModeBits, 8);
             if (opts.Mode.has_value() && *opts.Mode == 0)
             {
-                THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_modeOpt, std::string("0")));
+                THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_modeOpt, DriverOpts.at(c_modeOpt)));
             }
 
             // Anything else is unrecognized and a user error.

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -136,11 +136,8 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
     auto [lun, device] = VirtualMachine.AttachDisk(hostPath.c_str(), false);
     auto attachCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.DetachDisk(lun); });
 
-    // Owner is baked into the ext4 root inode at format time via -E root_owner
-    // so a non-root container user can write to the volume without any
-    // post-mount chown step. For a fresh filesystem the root inode is the
-    // only user-visible inode, so this is sufficient: anything the container
-    // later creates inherits its own uid/gid.
+    // Ownership is baked into the ext4 root inode at format time so the
+    // container user can write without a post-mount chown.
     VirtualMachine.Ext4Format(device, opts.Uid, opts.Gid);
 
     auto virtualMachinePath = std::format("/mnt/wslc-volumes/{}", name);

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -72,8 +72,16 @@ namespace {
 
             // Mode (optional). Parsed as octal so we can range-check against
             // c_maxModeBits and reject non-octal characters via the shared
-            // OptionParser validation.
+            // OptionParser validation. Mode==0 makes the volume root
+            // inaccessible to the container's non-root user (defeating the
+            // entire point of MODE), so reject it here for parity with the
+            // SDK-side check — direct COM callers and persisted metadata
+            // both flow through Parse.
             opts.Mode = parser.Optional<uint32_t>(c_modeOpt, c_maxModeBits, 8);
+            if (opts.Mode.has_value() && *opts.Mode == 0)
+            {
+                THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_modeOpt, std::string("0")));
+            }
 
             // Anything else is unrecognized and a user error.
             parser.RejectUnknown();

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -37,16 +37,13 @@ namespace {
     // Maximum valid file mode bits: setuid | setgid | sticky | rwxrwxrwx == 07777.
     constexpr uint32_t c_maxModeBits = 07777;
 
-    // Parsed and validated VHD-driver-specific options. All option semantics
-    // (defaults, validation, cross-field constraints) live in Parse() so the
-    // create / open paths can simply consume the result.
     struct VhdVolumeOptions
     {
         ULONGLONG SizeBytes{};
         bool Fixed{false};
         std::optional<uint32_t> Uid;
         std::optional<uint32_t> Gid;
-        std::optional<uint32_t> Mode; // octal mode bits, 0..c_maxModeBits
+        std::optional<uint32_t> Mode;
 
         static VhdVolumeOptions Parse(const std::map<std::string, std::string>& DriverOpts)
         {
@@ -59,9 +56,8 @@ namespace {
 
             opts.Fixed = parser.OptionalBool(c_fixedOpt).value_or(false);
 
-            // Uid / Gid (optional uint32). Must be supplied together — chown
-            // semantics would otherwise leak the mkfs default (root) into one
-            // half, which is a confusing footgun.
+            // Uid and Gid must be supplied together — leaving one as the
+            // mkfs default (root) is a confusing footgun.
             opts.Uid = parser.Optional<uint32_t>(c_uidOpt);
             opts.Gid = parser.Optional<uint32_t>(c_gidOpt);
             if (opts.Uid.has_value() != opts.Gid.has_value())
@@ -70,20 +66,13 @@ namespace {
                 THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcMissingVolumeOption(missing));
             }
 
-            // Mode (optional). Parsed as octal so we can range-check against
-            // c_maxModeBits and reject non-octal characters via the shared
-            // OptionParser validation. Mode==0 makes the volume root
-            // inaccessible to the container's non-root user (defeating the
-            // entire point of MODE), so reject it here for parity with the
-            // SDK-side check — direct COM callers and persisted metadata
-            // both flow through Parse.
+            // chmod 0 makes the volume root inaccessible to the container's non-root user.
             opts.Mode = parser.Optional<uint32_t>(c_modeOpt, c_maxModeBits, 8);
             if (opts.Mode.has_value() && *opts.Mode == 0)
             {
                 THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_modeOpt, DriverOpts.at(c_modeOpt)));
             }
 
-            // Anything else is unrecognized and a user error.
             parser.RejectUnknown();
 
             return opts;

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -15,7 +15,6 @@ Abstract:
 #include "precomp.h"
 #include "DockerHTTPClient.h"
 #include "OptionParser.h"
-#include "ServiceProcessLauncher.h"
 #include "WSLCVhdVolume.h"
 #include "WSLCVirtualMachine.h"
 #include "WSLCVolumeMetadata.h"
@@ -32,10 +31,6 @@ namespace {
     constexpr auto c_fixedOpt = "Fixed";
     constexpr auto c_uidOpt = "Uid";
     constexpr auto c_gidOpt = "Gid";
-    constexpr auto c_modeOpt = "Mode";
-
-    // Maximum valid file mode bits: setuid | setgid | sticky | rwxrwxrwx == 07777.
-    constexpr uint32_t c_maxModeBits = 07777;
 
     struct VhdVolumeOptions
     {
@@ -43,7 +38,6 @@ namespace {
         bool Fixed{false};
         std::optional<uint32_t> Uid;
         std::optional<uint32_t> Gid;
-        std::optional<uint32_t> Mode;
 
         static VhdVolumeOptions Parse(const std::map<std::string, std::string>& DriverOpts)
         {
@@ -64,13 +58,6 @@ namespace {
             {
                 const auto* missing = opts.Uid.has_value() ? c_gidOpt : c_uidOpt;
                 THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcMissingVolumeOption(missing));
-            }
-
-            // chmod 0 makes the volume root inaccessible to the container's non-root user.
-            opts.Mode = parser.Optional<uint32_t>(c_modeOpt, c_maxModeBits, 8);
-            if (opts.Mode.has_value() && *opts.Mode == 0)
-            {
-                THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_modeOpt, DriverOpts.at(c_modeOpt)));
             }
 
             parser.RejectUnknown();
@@ -95,13 +82,6 @@ namespace {
         }
 
         return name;
-    }
-
-    void RunVmCommand(WSLCVirtualMachine& VirtualMachine, const std::string& Executable, const std::vector<std::string>& Arguments, const char* FailureContext)
-    {
-        ServiceProcessLauncher launcher(Executable, Arguments);
-        auto result = launcher.Launch(VirtualMachine).WaitAndCaptureOutput();
-        THROW_HR_IF_MSG(E_FAIL, result.Code != 0, "%hs: %hs", FailureContext, launcher.FormatResult(result).c_str());
     }
 
 } // namespace
@@ -156,29 +136,17 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
     auto [lun, device] = VirtualMachine.AttachDisk(hostPath.c_str(), false);
     auto attachCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.DetachDisk(lun); });
 
-    VirtualMachine.Ext4Format(device);
+    // Owner is baked into the ext4 root inode at format time via -E root_owner
+    // so a non-root container user can write to the volume without any
+    // post-mount chown step. For a fresh filesystem the root inode is the
+    // only user-visible inode, so this is sufficient: anything the container
+    // later creates inherits its own uid/gid.
+    VirtualMachine.Ext4Format(device, opts.Uid, opts.Gid);
 
     auto virtualMachinePath = std::format("/mnt/wslc-volumes/{}", name);
     VirtualMachine.Mount(device.c_str(), virtualMachinePath.c_str(), "ext4", "", 0);
 
     auto mountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.Unmount(virtualMachinePath.c_str()); });
-
-    // Apply ownership and mode to the volume root if requested. These are
-    // persisted on disk in the ext4 root inode and survive remount/recovery,
-    // so they are only applied at create time. Parse() guarantees Uid and Gid
-    // are either both present or both absent.
-    if (opts.Uid.has_value())
-    {
-        const auto owner = std::format("{}:{}", *opts.Uid, *opts.Gid);
-        RunVmCommand(VirtualMachine, "/bin/chown", {"/bin/chown", owner, virtualMachinePath}, "Failed to set volume ownership");
-    }
-
-    if (opts.Mode.has_value())
-    {
-        const auto modeStr = std::format("{:04o}", *opts.Mode);
-        RunVmCommand(
-            VirtualMachine, "/bin/chmod", {"/bin/chmod", modeStr, virtualMachinePath}, "Failed to set volume permissions");
-    }
 
     WSLCVolumeMetadata metadata;
     metadata.Driver = WSLCVhdVolumeDriver;

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -14,6 +14,8 @@ Abstract:
 
 #include "precomp.h"
 #include "DockerHTTPClient.h"
+#include "OptionParser.h"
+#include "ServiceProcessLauncher.h"
 #include "WSLCVhdVolume.h"
 #include "WSLCVirtualMachine.h"
 #include "WSLCVolumeMetadata.h"
@@ -26,6 +28,60 @@ using wsl::shared::Localization;
 namespace wsl::windows::service::wslc {
 
 namespace {
+    constexpr auto c_sizeBytesOpt = "SizeBytes";
+    constexpr auto c_fixedOpt = "Fixed";
+    constexpr auto c_uidOpt = "Uid";
+    constexpr auto c_gidOpt = "Gid";
+    constexpr auto c_modeOpt = "Mode";
+
+    // Maximum valid file mode bits: setuid | setgid | sticky | rwxrwxrwx == 07777.
+    constexpr uint32_t c_maxModeBits = 07777;
+
+    // Parsed and validated VHD-driver-specific options. All option semantics
+    // (defaults, validation, cross-field constraints) live in Parse() so the
+    // create / open paths can simply consume the result.
+    struct VhdVolumeOptions
+    {
+        ULONGLONG SizeBytes{};
+        bool Fixed{false};
+        std::optional<uint32_t> Uid;
+        std::optional<uint32_t> Gid;
+        std::optional<uint32_t> Mode; // octal mode bits, 0..c_maxModeBits
+
+        static VhdVolumeOptions Parse(const std::map<std::string, std::string>& DriverOpts)
+        {
+            OptionParser parser(DriverOpts);
+            VhdVolumeOptions opts{};
+
+            opts.SizeBytes = parser.Required<ULONGLONG>(c_sizeBytesOpt);
+            THROW_HR_WITH_USER_ERROR_IF(
+                E_INVALIDARG, Localization::MessageWslcInvalidVolumeOption(c_sizeBytesOpt, std::string("0")), opts.SizeBytes == 0);
+
+            opts.Fixed = parser.OptionalBool(c_fixedOpt).value_or(false);
+
+            // Uid / Gid (optional uint32). Must be supplied together — chown
+            // semantics would otherwise leak the mkfs default (root) into one
+            // half, which is a confusing footgun.
+            opts.Uid = parser.Optional<uint32_t>(c_uidOpt);
+            opts.Gid = parser.Optional<uint32_t>(c_gidOpt);
+            if (opts.Uid.has_value() != opts.Gid.has_value())
+            {
+                const auto* missing = opts.Uid.has_value() ? c_gidOpt : c_uidOpt;
+                THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcMissingVolumeOption(missing));
+            }
+
+            // Mode (optional). Parsed as octal so we can range-check against
+            // c_maxModeBits and reject non-octal characters via the shared
+            // OptionParser validation.
+            opts.Mode = parser.Optional<uint32_t>(c_modeOpt, c_maxModeBits, 8);
+
+            // Anything else is unrecognized and a user error.
+            parser.RejectUnknown();
+
+            return opts;
+        }
+    };
+
     std::string GenerateName()
     {
         std::random_device rd;
@@ -44,20 +100,11 @@ namespace {
         return name;
     }
 
-    ULONGLONG ParseSizeBytes(std::map<std::string, std::string>& DriverOpts)
+    void RunVmCommand(WSLCVirtualMachine& VirtualMachine, const std::string& Executable, const std::vector<std::string>& Arguments, const char* FailureContext)
     {
-        const auto it = DriverOpts.find("SizeBytes");
-        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcMissingVolumeOption("SizeBytes"), it == DriverOpts.end());
-
-        auto& value = it->second;
-        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageInvalidSize(value), value.empty() || value[0] == '-');
-
-        errno = 0;
-        char* end = nullptr;
-        auto sizeBytes = wsl::shared::string::ToUInt64(value.c_str(), &end);
-        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageInvalidSize(value), errno != 0 || *end != '\0' || sizeBytes == 0);
-
-        return sizeBytes;
+        ServiceProcessLauncher launcher(Executable, Arguments);
+        auto result = launcher.Launch(VirtualMachine).WaitAndCaptureOutput();
+        THROW_HR_IF_MSG(E_FAIL, result.Code != 0, "%hs: %hs", FailureContext, launcher.FormatResult(result).c_str());
     }
 
 } // namespace
@@ -98,7 +145,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
     DockerHTTPClient& DockerClient)
 {
     std::string name = (Name != nullptr && Name[0] != '\0') ? std::string(Name) : GenerateName();
-    auto sizeBytes = ParseSizeBytes(DriverOpts);
+    const auto opts = VhdVolumeOptions::Parse(DriverOpts);
     auto hostPath = StoragePath / "volumes" / (name + ".vhdx");
 
     auto createVhdCleanup =
@@ -107,7 +154,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
     std::filesystem::create_directories(hostPath.parent_path());
 
     const auto tokenInfo = wil::get_token_information<TOKEN_USER>(GetCurrentProcessToken());
-    wsl::core::filesystem::CreateVhd(hostPath.c_str(), sizeBytes, tokenInfo->User.Sid, false, false);
+    wsl::core::filesystem::CreateVhd(hostPath.c_str(), opts.SizeBytes, tokenInfo->User.Sid, false, opts.Fixed);
 
     auto [lun, device] = VirtualMachine.AttachDisk(hostPath.c_str(), false);
     auto attachCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.DetachDisk(lun); });
@@ -118,6 +165,23 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
     VirtualMachine.Mount(device.c_str(), virtualMachinePath.c_str(), "ext4", "", 0);
 
     auto mountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.Unmount(virtualMachinePath.c_str()); });
+
+    // Apply ownership and mode to the volume root if requested. These are
+    // persisted on disk in the ext4 root inode and survive remount/recovery,
+    // so they are only applied at create time. Parse() guarantees Uid and Gid
+    // are either both present or both absent.
+    if (opts.Uid.has_value())
+    {
+        const auto owner = std::format("{}:{}", *opts.Uid, *opts.Gid);
+        RunVmCommand(VirtualMachine, "/bin/chown", {"/bin/chown", owner, virtualMachinePath}, "Failed to set volume ownership");
+    }
+
+    if (opts.Mode.has_value())
+    {
+        const auto modeStr = std::format("{:04o}", *opts.Mode);
+        RunVmCommand(
+            VirtualMachine, "/bin/chmod", {"/bin/chmod", modeStr, virtualMachinePath}, "Failed to set volume permissions");
+    }
 
     WSLCVolumeMetadata metadata;
     metadata.Driver = WSLCVhdVolumeDriver;
@@ -147,7 +211,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
         auto createdVolume = DockerClient.CreateVolume(request);
 
         auto volume = std::make_unique<WSLCVhdVolumeImpl>(
-            std::move(name), std::move(hostPath), sizeBytes, lun, std::move(virtualMachinePath), std::move(DriverOpts), std::move(Labels), VirtualMachine, DockerClient);
+            std::move(name), std::move(hostPath), opts.SizeBytes, lun, std::move(virtualMachinePath), std::move(DriverOpts), std::move(Labels), VirtualMachine, DockerClient);
         volume->m_createdAt = createdVolume.CreatedAt;
 
         mountCleanup.release();
@@ -176,7 +240,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Open(
 
     auto hostPath = std::filesystem::path(hostPathIt->second);
     auto driverOpts = metadata.DriverOpts;
-    auto sizeBytes = ParseSizeBytes(driverOpts);
+    const auto opts = VhdVolumeOptions::Parse(driverOpts);
 
     THROW_HR_IF(E_INVALIDARG, !Volume.Options.has_value());
     auto deviceIt = Volume.Options->find("device");
@@ -201,7 +265,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Open(
     auto mountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.Unmount(virtualMachinePath.c_str()); });
 
     auto volume = std::make_unique<WSLCVhdVolumeImpl>(
-        std::string{Volume.Name}, std::move(hostPath), sizeBytes, lun, std::move(virtualMachinePath), std::move(driverOpts), std::move(userLabels), VirtualMachine, DockerClient);
+        std::string{Volume.Name}, std::move(hostPath), opts.SizeBytes, lun, std::move(virtualMachinePath), std::move(driverOpts), std::move(userLabels), VirtualMachine, DockerClient);
     volume->m_createdAt = Volume.CreatedAt;
 
     mountCleanup.release();

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -481,13 +481,8 @@ void WSLCVirtualMachine::Ext4Format(const std::string& Device, std::optional<uin
 {
     constexpr auto mkfsPath = "/usr/sbin/mkfs.ext4";
 
-    // -E root_owner=UID:GID sets the ownership of the root inode at format
-    // time, so a non-root container can write to the volume without us having
-    // to spawn a separate chown helper after mount. ext4 has no uid/gid mount
-    // option, so on-disk inode ownership is the only persistent knob.
-    // Uid and Gid must be supplied together; callers in the named-volume
-    // driver enforce this at parse time, this assert catches future callers
-    // that bypass that path.
+    // Uid/Gid must be paired; the named-volume parser enforces this for user
+    // input — this catches future internal callers that bypass it.
     WI_ASSERT(Uid.has_value() == Gid.has_value());
 
     std::vector<std::string> args = {mkfsPath};

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -482,8 +482,8 @@ void WSLCVirtualMachine::Ext4Format(const std::string& Device, std::optional<uin
     constexpr auto mkfsPath = "/usr/sbin/mkfs.ext4";
 
     // Uid/Gid must be paired; the named-volume parser enforces this for user
-    // input — this catches future internal callers that bypass it.
-    WI_ASSERT(Uid.has_value() == Gid.has_value());
+    // input — this guards future internal callers that bypass it.
+    THROW_HR_IF(E_UNEXPECTED, Uid.has_value() != Gid.has_value());
 
     std::vector<std::string> args = {mkfsPath};
     std::string rootOwner;

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -477,10 +477,25 @@ std::pair<ULONG, std::string> WSLCVirtualMachine::AttachDisk(_In_ PCWSTR Path, _
     return {Lun, Device};
 }
 
-void WSLCVirtualMachine::Ext4Format(const std::string& Device)
+void WSLCVirtualMachine::Ext4Format(const std::string& Device, std::optional<uint32_t> Uid, std::optional<uint32_t> Gid)
 {
     constexpr auto mkfsPath = "/usr/sbin/mkfs.ext4";
-    ServiceProcessLauncher launcher(mkfsPath, {mkfsPath, Device});
+
+    // -E root_owner=UID:GID sets the ownership of the root inode at format
+    // time, so a non-root container can write to the volume without us having
+    // to spawn a separate chown helper after mount. ext4 has no uid/gid mount
+    // option, so on-disk inode ownership is the only persistent knob.
+    std::vector<std::string> args = {mkfsPath};
+    std::string rootOwner;
+    if (Uid.has_value() && Gid.has_value())
+    {
+        rootOwner = std::format("root_owner={}:{}", *Uid, *Gid);
+        args.push_back("-E");
+        args.push_back(rootOwner);
+    }
+    args.push_back(Device);
+
+    ServiceProcessLauncher launcher(mkfsPath, std::move(args));
     auto result = launcher.Launch(*this).WaitAndCaptureOutput();
 
     THROW_HR_IF_MSG(E_FAIL, result.Code != 0, "%hs", launcher.FormatResult(result).c_str());

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -500,7 +500,7 @@ void WSLCVirtualMachine::Ext4Format(const std::string& Device, std::optional<uin
     }
     args.push_back(Device);
 
-    ServiceProcessLauncher launcher(mkfsPath, std::move(args));
+    ServiceProcessLauncher launcher(mkfsPath, args);
     auto result = launcher.Launch(*this).WaitAndCaptureOutput();
 
     THROW_HR_IF_MSG(E_FAIL, result.Code != 0, "%hs", launcher.FormatResult(result).c_str());

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -485,6 +485,11 @@ void WSLCVirtualMachine::Ext4Format(const std::string& Device, std::optional<uin
     // time, so a non-root container can write to the volume without us having
     // to spawn a separate chown helper after mount. ext4 has no uid/gid mount
     // option, so on-disk inode ownership is the only persistent knob.
+    // Uid and Gid must be supplied together; callers in the named-volume
+    // driver enforce this at parse time, this assert catches future callers
+    // that bypass that path.
+    WI_ASSERT(Uid.has_value() == Gid.has_value());
+
     std::vector<std::string> args = {mkfsPath};
     std::string rootOwner;
     if (Uid.has_value() && Gid.has_value())

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -22,6 +22,7 @@ Abstract:
 #include "WSLCContainerMetadata.h"
 #include <thread>
 #include <filesystem>
+#include <optional>
 
 namespace wsl::windows::service::wslc {
 
@@ -147,7 +148,7 @@ public:
 
     std::pair<ULONG, std::string> AttachDisk(_In_ PCWSTR Path, _In_ BOOL ReadOnly);
     void DetachDisk(_In_ ULONG Lun);
-    void Ext4Format(_In_ const std::string& Device);
+    void Ext4Format(_In_ const std::string& Device, _In_ std::optional<uint32_t> Uid = std::nullopt, _In_ std::optional<uint32_t> Gid = std::nullopt);
     void Mount(_In_ LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags);
 
     wil::unique_socket ConnectUnixSocket(_In_ const char* Path);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4092,26 +4092,166 @@ class WSLCTests
 
         // Invalid SizeBytes values.
         WSLCDriverOption emptySize[] = {{"SizeBytes", ""}};
-        validateInvalidOptionsFailure(emptySize, ARRAYSIZE(emptySize), E_INVALIDARG, L"Invalid size: ");
+        validateInvalidOptionsFailure(emptySize, ARRAYSIZE(emptySize), E_INVALIDARG, L"Invalid value for option 'SizeBytes': ''");
 
         WSLCDriverOption zeroSize[] = {{"SizeBytes", "0"}};
-        validateInvalidOptionsFailure(zeroSize, ARRAYSIZE(zeroSize), E_INVALIDARG, L"Invalid size: 0");
+        validateInvalidOptionsFailure(zeroSize, ARRAYSIZE(zeroSize), E_INVALIDARG, L"Invalid value for option 'SizeBytes': '0'");
 
         WSLCDriverOption invalidSizeAbc[] = {{"SizeBytes", "abc"}};
-        validateInvalidOptionsFailure(invalidSizeAbc, ARRAYSIZE(invalidSizeAbc), E_INVALIDARG, L"Invalid size: abc");
+        validateInvalidOptionsFailure(
+            invalidSizeAbc, ARRAYSIZE(invalidSizeAbc), E_INVALIDARG, L"Invalid value for option 'SizeBytes': 'abc'");
 
         WSLCDriverOption invalidSizeMixed[] = {{"SizeBytes", "123abc"}};
-        validateInvalidOptionsFailure(invalidSizeMixed, ARRAYSIZE(invalidSizeMixed), E_INVALIDARG, L"Invalid size: 123abc");
+        validateInvalidOptionsFailure(
+            invalidSizeMixed, ARRAYSIZE(invalidSizeMixed), E_INVALIDARG, L"Invalid value for option 'SizeBytes': '123abc'");
 
         WSLCDriverOption invalidSizeSign[] = {{"SizeBytes", "+-1"}};
-        validateInvalidOptionsFailure(invalidSizeSign, ARRAYSIZE(invalidSizeSign), E_INVALIDARG, L"Invalid size: +-1");
+        validateInvalidOptionsFailure(
+            invalidSizeSign, ARRAYSIZE(invalidSizeSign), E_INVALIDARG, L"Invalid value for option 'SizeBytes': '+-1'");
 
         WSLCDriverOption invalidSizeOverflow[] = {{"SizeBytes", "18446744073709551616"}};
         validateInvalidOptionsFailure(
-            invalidSizeOverflow, ARRAYSIZE(invalidSizeOverflow), E_INVALIDARG, L"Invalid size: 18446744073709551616");
+            invalidSizeOverflow,
+            ARRAYSIZE(invalidSizeOverflow),
+            E_INVALIDARG,
+            L"Invalid value for option 'SizeBytes': '18446744073709551616'");
 
         WSLCDriverOption invalidSizeNeg[] = {{"SizeBytes", "-1"}};
-        validateInvalidOptionsFailure(invalidSizeNeg, ARRAYSIZE(invalidSizeNeg), E_INVALIDARG, L"Invalid size: -1");
+        validateInvalidOptionsFailure(
+            invalidSizeNeg, ARRAYSIZE(invalidSizeNeg), E_INVALIDARG, L"Invalid value for option 'SizeBytes': '-1'");
+
+        // Invalid Fixed values.
+        WSLCDriverOption invalidFixed[] = {{"SizeBytes", "1073741824"}, {"Fixed", "yes"}};
+        validateInvalidOptionsFailure(
+            invalidFixed, ARRAYSIZE(invalidFixed), E_INVALIDARG, L"Invalid value for option 'Fixed': 'yes'");
+
+        WSLCDriverOption emptyFixed[] = {{"SizeBytes", "1073741824"}, {"Fixed", ""}};
+        validateInvalidOptionsFailure(emptyFixed, ARRAYSIZE(emptyFixed), E_INVALIDARG, L"Invalid value for option 'Fixed': ''");
+
+        // Invalid Uid values. Tests pair Uid with a valid Gid because Parse
+        // requires both to be present together.
+        WSLCDriverOption negUid[] = {{"SizeBytes", "1073741824"}, {"Uid", "-1"}, {"Gid", "0"}};
+        validateInvalidOptionsFailure(negUid, ARRAYSIZE(negUid), E_INVALIDARG, L"Invalid value for option 'Uid': '-1'");
+
+        WSLCDriverOption abcUid[] = {{"SizeBytes", "1073741824"}, {"Uid", "abc"}, {"Gid", "0"}};
+        validateInvalidOptionsFailure(abcUid, ARRAYSIZE(abcUid), E_INVALIDARG, L"Invalid value for option 'Uid': 'abc'");
+
+        WSLCDriverOption hugeUid[] = {{"SizeBytes", "1073741824"}, {"Uid", "4294967296"}, {"Gid", "0"}}; // 2^32, exceeds uint32_t max
+        validateInvalidOptionsFailure(hugeUid, ARRAYSIZE(hugeUid), E_INVALIDARG, L"Invalid value for option 'Uid': '4294967296'");
+
+        // Invalid Gid values.
+        WSLCDriverOption negGid[] = {{"SizeBytes", "1073741824"}, {"Uid", "0"}, {"Gid", "-1"}};
+        validateInvalidOptionsFailure(negGid, ARRAYSIZE(negGid), E_INVALIDARG, L"Invalid value for option 'Gid': '-1'");
+
+        // Uid without Gid (or vice versa) is rejected: chown semantics for
+        // 'foo' vs ':foo' differ and silently leaving one side as the mkfs
+        // default (root) is a footgun.
+        WSLCDriverOption uidOnly[] = {{"SizeBytes", "1073741824"}, {"Uid", "1000"}};
+        validateInvalidOptionsFailure(uidOnly, ARRAYSIZE(uidOnly), E_INVALIDARG, L"Missing required option: 'Gid'");
+
+        WSLCDriverOption gidOnly[] = {{"SizeBytes", "1073741824"}, {"Gid", "1000"}};
+        validateInvalidOptionsFailure(gidOnly, ARRAYSIZE(gidOnly), E_INVALIDARG, L"Missing required option: 'Uid'");
+
+        // Invalid Mode values.
+        WSLCDriverOption invalidMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "0888"}}; // 8 is not octal
+        validateInvalidOptionsFailure(
+            invalidMode, ARRAYSIZE(invalidMode), E_INVALIDARG, L"Invalid value for option 'Mode': '0888'");
+
+        WSLCDriverOption nonOctalMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "0x755"}};
+        validateInvalidOptionsFailure(
+            nonOctalMode, ARRAYSIZE(nonOctalMode), E_INVALIDARG, L"Invalid value for option 'Mode': '0x755'");
+
+        WSLCDriverOption tooLargeMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "10000"}}; // > 07777
+        validateInvalidOptionsFailure(
+            tooLargeMode, ARRAYSIZE(tooLargeMode), E_INVALIDARG, L"Invalid value for option 'Mode': '10000'");
+
+        WSLCDriverOption signedMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "+755"}};
+        validateInvalidOptionsFailure(signedMode, ARRAYSIZE(signedMode), E_INVALIDARG, L"Invalid value for option 'Mode': '+755'");
+
+        WSLCDriverOption emptyMode[] = {{"SizeBytes", "1073741824"}, {"Mode", ""}};
+        validateInvalidOptionsFailure(emptyMode, ARRAYSIZE(emptyMode), E_INVALIDARG, L"Invalid value for option 'Mode': ''");
+
+        // Unknown options are rejected (catches typos and unsupported keys).
+        WSLCDriverOption unknownOpt[] = {{"SizeBytes", "1073741824"}, {"Bogus", "value"}};
+        validateInvalidOptionsFailure(
+            unknownOpt, ARRAYSIZE(unknownOpt), E_INVALIDARG, L"Invalid value for option 'Bogus': 'value'");
+    }
+
+    WSLC_TEST_METHOD(NamedVolumesVhdOwnership)
+    {
+        // Verify that Uid/Gid/Mode driver options are applied to the VHD volume
+        // root, allowing a non-root container user to read/write the volume.
+        const std::string volumeName = "wslc-test-vhd-ownership";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteVolume(volumeName.c_str()));
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteVolume(volumeName.c_str())); });
+
+        // nobody/nogroup are typically uid=65534 / gid=65534 on Debian.
+        WSLCDriverOption driverOpts[] = {{"SizeBytes", "1073741824"}, {"Uid", "65534"}, {"Gid", "65534"}, {"Mode", "0750"}};
+
+        WSLCVolumeOptions volumeOptions{};
+        volumeOptions.Name = volumeName.c_str();
+        volumeOptions.Driver = "vhd";
+        volumeOptions.DriverOpts = driverOpts;
+        volumeOptions.DriverOptsCount = ARRAYSIZE(driverOpts);
+
+        WSLCVolumeInformation volInfo{};
+        VERIFY_SUCCEEDED(m_defaultSession->CreateVolume(&volumeOptions, &volInfo));
+
+        // A container running as 'nobody' should be able to write to the volume.
+        {
+            WSLCContainerLauncher writer(
+                "debian:latest", "vhd-ownership-writer", {"/bin/sh", "-c", "echo non-root >/data/marker.txt"});
+            writer.AddNamedVolume(volumeName, "/data", false);
+            writer.SetUser("nobody:nogroup");
+
+            auto writerContainer = writer.Launch(*m_defaultSession);
+            auto writerProcess = writerContainer.GetInitProcess();
+            ValidateProcessOutput(writerProcess, {});
+        }
+
+        // Verify the file is owned by the same uid/gid and the directory has mode 0750.
+        {
+            WSLCContainerLauncher checker(
+                "debian:latest", "vhd-ownership-checker", {"/bin/sh", "-c", "stat -c '%u %g %a' /data && cat /data/marker.txt"});
+            checker.AddNamedVolume(volumeName, "/data", true);
+
+            auto checkerContainer = checker.Launch(*m_defaultSession);
+            auto checkerProcess = checkerContainer.GetInitProcess();
+            ValidateProcessOutput(checkerProcess, {{1, "65534 65534 750\nnon-root\n"}});
+        }
+    }
+
+    WSLC_TEST_METHOD(NamedVolumesVhdFixed)
+    {
+        // Verify that Fixed=true creates a fixed-allocation VHD: the .vhdx file
+        // size on disk should be at least the requested SizeBytes (it includes a
+        // small metadata header beyond the raw payload).
+        const std::string volumeName = "wslc-test-vhd-fixed";
+        const std::filesystem::path volumeVhdPath = m_storagePath / "volumes" / (volumeName + ".vhdx");
+        constexpr ULONGLONG c_sizeBytes = 64 * _1MB;
+
+        LOG_IF_FAILED(m_defaultSession->DeleteVolume(volumeName.c_str()));
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteVolume(volumeName.c_str())); });
+
+        const auto sizeBytesStr = std::to_string(c_sizeBytes);
+        WSLCDriverOption driverOpts[] = {{"SizeBytes", sizeBytesStr.c_str()}, {"Fixed", "true"}};
+
+        WSLCVolumeOptions volumeOptions{};
+        volumeOptions.Name = volumeName.c_str();
+        volumeOptions.Driver = "vhd";
+        volumeOptions.DriverOpts = driverOpts;
+        volumeOptions.DriverOptsCount = ARRAYSIZE(driverOpts);
+
+        WSLCVolumeInformation volInfo{};
+        VERIFY_SUCCEEDED(m_defaultSession->CreateVolume(&volumeOptions, &volInfo));
+
+        VERIFY_IS_TRUE(std::filesystem::exists(volumeVhdPath));
+        const auto fileSize = std::filesystem::file_size(volumeVhdPath);
+
+        // A dynamic VHD for a 64MB volume is typically a few MB; a fixed VHD
+        // pre-allocates the full payload (>= SizeBytes).
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(fileSize, c_sizeBytes);
     }
 
     WSLC_TEST_METHOD(ListAndInspectNamedVolumesTest)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4171,10 +4171,7 @@ class WSLCTests
         WSLCDriverOption emptyMode[] = {{"SizeBytes", "1073741824"}, {"Mode", ""}};
         validateInvalidOptionsFailure(emptyMode, ARRAYSIZE(emptyMode), E_INVALIDARG, L"Invalid value for option 'Mode': ''");
 
-        // Mode=0 is the documented invalid value (spec is 1..07777). chmod 0000
-        // would make the volume root inaccessible, so it is rejected by Parse()
-        // for parity with the SDK-side check and to keep direct COM callers
-        // and persisted-metadata reload aligned with the public contract.
+        // Mode=0 (chmod 0 = inaccessible root) is rejected by Parse().
         WSLCDriverOption zeroMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "0"}};
         validateInvalidOptionsFailure(zeroMode, ARRAYSIZE(zeroMode), E_INVALIDARG, L"Invalid value for option 'Mode': '0'");
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4152,8 +4152,7 @@ class WSLCTests
 
         // Unknown options are rejected (catches typos and unsupported keys).
         WSLCDriverOption unknownOpt[] = {{"SizeBytes", "1073741824"}, {"Bogus", "value"}};
-        validateInvalidOptionsFailure(
-            unknownOpt, ARRAYSIZE(unknownOpt), E_INVALIDARG, L"Invalid value for option 'Bogus': 'value'");
+        validateInvalidOptionsFailure(unknownOpt, ARRAYSIZE(unknownOpt), E_INVALIDARG, L"Unknown option: 'Bogus'");
     }
 
     WSLC_TEST_METHOD(NamedVolumesVhdOwnership)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4171,6 +4171,13 @@ class WSLCTests
         WSLCDriverOption emptyMode[] = {{"SizeBytes", "1073741824"}, {"Mode", ""}};
         validateInvalidOptionsFailure(emptyMode, ARRAYSIZE(emptyMode), E_INVALIDARG, L"Invalid value for option 'Mode': ''");
 
+        // Mode=0 is the documented invalid value (spec is 1..07777). chmod 0000
+        // would make the volume root inaccessible, so it is rejected by Parse()
+        // for parity with the SDK-side check and to keep direct COM callers
+        // and persisted-metadata reload aligned with the public contract.
+        WSLCDriverOption zeroMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "0"}};
+        validateInvalidOptionsFailure(zeroMode, ARRAYSIZE(zeroMode), E_INVALIDARG, L"Invalid value for option 'Mode': '0'");
+
         // Unknown options are rejected (catches typos and unsupported keys).
         WSLCDriverOption unknownOpt[] = {{"SizeBytes", "1073741824"}, {"Bogus", "value"}};
         validateInvalidOptionsFailure(

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4152,29 +4152,6 @@ class WSLCTests
         WSLCDriverOption gidOnly[] = {{"SizeBytes", "1073741824"}, {"Gid", "1000"}};
         validateInvalidOptionsFailure(gidOnly, ARRAYSIZE(gidOnly), E_INVALIDARG, L"Missing required option: 'Uid'");
 
-        // Invalid Mode values.
-        WSLCDriverOption invalidMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "0888"}}; // 8 is not octal
-        validateInvalidOptionsFailure(
-            invalidMode, ARRAYSIZE(invalidMode), E_INVALIDARG, L"Invalid value for option 'Mode': '0888'");
-
-        WSLCDriverOption nonOctalMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "0x755"}};
-        validateInvalidOptionsFailure(
-            nonOctalMode, ARRAYSIZE(nonOctalMode), E_INVALIDARG, L"Invalid value for option 'Mode': '0x755'");
-
-        WSLCDriverOption tooLargeMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "10000"}}; // > 07777
-        validateInvalidOptionsFailure(
-            tooLargeMode, ARRAYSIZE(tooLargeMode), E_INVALIDARG, L"Invalid value for option 'Mode': '10000'");
-
-        WSLCDriverOption signedMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "+755"}};
-        validateInvalidOptionsFailure(signedMode, ARRAYSIZE(signedMode), E_INVALIDARG, L"Invalid value for option 'Mode': '+755'");
-
-        WSLCDriverOption emptyMode[] = {{"SizeBytes", "1073741824"}, {"Mode", ""}};
-        validateInvalidOptionsFailure(emptyMode, ARRAYSIZE(emptyMode), E_INVALIDARG, L"Invalid value for option 'Mode': ''");
-
-        // Mode=0 (chmod 0 = inaccessible root) is rejected by Parse().
-        WSLCDriverOption zeroMode[] = {{"SizeBytes", "1073741824"}, {"Mode", "0"}};
-        validateInvalidOptionsFailure(zeroMode, ARRAYSIZE(zeroMode), E_INVALIDARG, L"Invalid value for option 'Mode': '0'");
-
         // Unknown options are rejected (catches typos and unsupported keys).
         WSLCDriverOption unknownOpt[] = {{"SizeBytes", "1073741824"}, {"Bogus", "value"}};
         validateInvalidOptionsFailure(
@@ -4183,15 +4160,15 @@ class WSLCTests
 
     WSLC_TEST_METHOD(NamedVolumesVhdOwnership)
     {
-        // Verify that Uid/Gid/Mode driver options are applied to the VHD volume
-        // root, allowing a non-root container user to read/write the volume.
+        // Verify that Uid/Gid driver options are baked into the volume root inode
+        // at mkfs time, allowing a non-root container user to read/write the volume.
         const std::string volumeName = "wslc-test-vhd-ownership";
 
         LOG_IF_FAILED(m_defaultSession->DeleteVolume(volumeName.c_str()));
         auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteVolume(volumeName.c_str())); });
 
         // nobody/nogroup are typically uid=65534 / gid=65534 on Debian.
-        WSLCDriverOption driverOpts[] = {{"SizeBytes", "1073741824"}, {"Uid", "65534"}, {"Gid", "65534"}, {"Mode", "0750"}};
+        WSLCDriverOption driverOpts[] = {{"SizeBytes", "1073741824"}, {"Uid", "65534"}, {"Gid", "65534"}};
 
         WSLCVolumeOptions volumeOptions{};
         volumeOptions.Name = volumeName.c_str();
@@ -4214,15 +4191,15 @@ class WSLCTests
             ValidateProcessOutput(writerProcess, {});
         }
 
-        // Verify the file is owned by the same uid/gid and the directory has mode 0750.
+        // Verify the file is owned by the same uid/gid as the volume root.
         {
             WSLCContainerLauncher checker(
-                "debian:latest", "vhd-ownership-checker", {"/bin/sh", "-c", "stat -c '%u %g %a' /data && cat /data/marker.txt"});
+                "debian:latest", "vhd-ownership-checker", {"/bin/sh", "-c", "stat -c '%u %g' /data && cat /data/marker.txt"});
             checker.AddNamedVolume(volumeName, "/data", true);
 
             auto checkerContainer = checker.Launch(*m_defaultSession);
             auto checkerProcess = checkerContainer.GetInitProcess();
-            ValidateProcessOutput(checkerProcess, {{1, "65534 65534 750\nnon-root\n"}});
+            ValidateProcessOutput(checkerProcess, {{1, "65534 65534\nnon-root\n"}});
         }
     }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -4143,9 +4143,7 @@ class WSLCTests
         WSLCDriverOption negGid[] = {{"SizeBytes", "1073741824"}, {"Uid", "0"}, {"Gid", "-1"}};
         validateInvalidOptionsFailure(negGid, ARRAYSIZE(negGid), E_INVALIDARG, L"Invalid value for option 'Gid': '-1'");
 
-        // Uid without Gid (or vice versa) is rejected: chown semantics for
-        // 'foo' vs ':foo' differ and silently leaving one side as the mkfs
-        // default (root) is a footgun.
+        // Uid without Gid (or vice versa) is rejected.
         WSLCDriverOption uidOnly[] = {{"SizeBytes", "1073741824"}, {"Uid", "1000"}};
         validateInvalidOptionsFailure(uidOnly, ARRAYSIZE(uidOnly), E_INVALIDARG, L"Missing required option: 'Gid'");
 
@@ -4160,8 +4158,8 @@ class WSLCTests
 
     WSLC_TEST_METHOD(NamedVolumesVhdOwnership)
     {
-        // Verify that Uid/Gid driver options are baked into the volume root inode
-        // at mkfs time, allowing a non-root container user to read/write the volume.
+        // Verify Uid/Gid are baked into the root inode at mkfs time so a
+        // non-root container user can write to the volume.
         const std::string volumeName = "wslc-test-vhd-ownership";
 
         LOG_IF_FAILED(m_defaultSession->DeleteVolume(volumeName.c_str()));
@@ -4205,9 +4203,7 @@ class WSLCTests
 
     WSLC_TEST_METHOD(NamedVolumesVhdFixed)
     {
-        // Verify that Fixed=true creates a fixed-allocation VHD: the .vhdx file
-        // size on disk should be at least the requested SizeBytes (it includes a
-        // small metadata header beyond the raw payload).
+        // Fixed=true produces a .vhdx whose on-disk size is at least SizeBytes.
         const std::string volumeName = "wslc-test-vhd-fixed";
         const std::filesystem::path volumeVhdPath = m_storagePath / "volumes" / (volumeName + ".vhdx");
         constexpr ULONGLONG c_sizeBytes = 64 * _1MB;

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2022,8 +2022,10 @@ class WslcSdkTests
             VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_fixedVolumeName, &deleteErr));
         }
 
-        // Positive: owner + mode flags must be honored — a non-root container
-        // user can write the volume root.
+        // Positive: owner + mode flags must be honored — chown/chmod are
+        // applied to the volume root so a non-root container user can read
+        // and write it. Verify by stat-ing the mount inside a container
+        // (rather than just trusting the SDK-side option emission).
         {
             constexpr auto c_ownedVolumeName = "wslc-sdk-vhd-owned";
             WslcVhdRequirements vhd{};
@@ -2037,8 +2039,29 @@ class WslcSdkTests
             wil::unique_cotaskmem_string errorMsg;
             VERIFY_SUCCEEDED(WslcCreateSessionVhdVolume(session.get(), &vhd, &errorMsg));
 
-            wil::unique_cotaskmem_string deleteErr;
-            VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_ownedVolumeName, &deleteErr));
+            auto deleteVolume =
+                wil::scope_exit([&]() { LOG_IF_FAILED(WslcDeleteSessionVhdVolume(session.get(), c_ownedVolumeName, nullptr)); });
+
+            // Mount the volume into a container and stat it. Expect uid=65534,
+            // gid=65534, mode=750 (octal). The trailing newline from `stat` is
+            // included in the comparison.
+            WslcProcessSettings procSettings;
+            VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+            const char* argv[] = {"/usr/bin/stat", "-c", "%u %g %a", "/data"};
+            VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
+
+            WslcContainerSettings containerSettings;
+            VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+            VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &procSettings));
+
+            WslcContainerNamedVolume namedVol{};
+            namedVol.name = c_ownedVolumeName;
+            namedVol.containerPath = "/data";
+            namedVol.readOnly = FALSE;
+            VERIFY_SUCCEEDED(WslcSetContainerSettingsNamedVolumes(&containerSettings, &namedVol, 1));
+
+            auto output = RunContainerAndCapture(session.get(), containerSettings);
+            VERIFY_ARE_EQUAL(output.stdoutOutput, "65534 65534 750\n");
         }
 
         // Negative: out-of-range mode (> 07777) must be rejected.

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2022,10 +2022,8 @@ class WslcSdkTests
             VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_fixedVolumeName, &deleteErr));
         }
 
-        // Positive: owner + mode flags must be honored — chown/chmod are
-        // applied to the volume root so a non-root container user can read
-        // and write it. Verify by stat-ing the mount inside a container
-        // (rather than just trusting the SDK-side option emission).
+        // Positive: owner + mode flags are honored — chown/chmod applied to
+        // the volume root. Verify by stat-ing the mount inside a container.
         {
             constexpr auto c_ownedVolumeName = "wslc-sdk-vhd-owned";
             WslcVhdRequirements vhd{};
@@ -2042,9 +2040,6 @@ class WslcSdkTests
             auto deleteVolume =
                 wil::scope_exit([&]() { LOG_IF_FAILED(WslcDeleteSessionVhdVolume(session.get(), c_ownedVolumeName, nullptr)); });
 
-            // Mount the volume into a container and stat it. Expect uid=65534,
-            // gid=65534, mode=750 (octal). The trailing newline from `stat` is
-            // included in the comparison.
             WslcProcessSettings procSettings;
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
             const char* argv[] = {"/usr/bin/stat", "-c", "%u %g %a", "/data"};
@@ -2064,20 +2059,18 @@ class WslcSdkTests
             VERIFY_ARE_EQUAL(output.stdoutOutput, "65534 65534 750\n");
         }
 
-        // Negative: out-of-range mode (> 07777) must be rejected.
+        // Negative: out-of-range mode (> 07777) is rejected.
         {
             WslcVhdRequirements vhd{};
             vhd.name = c_volumeName;
             vhd.sizeBytes = c_vhdSizeBytes;
             vhd.type = WSLC_VHD_TYPE_DYNAMIC;
             vhd.flags = WSLC_VHD_REQ_FLAG_MODE;
-            vhd.mode = 0x10000; // out of range
+            vhd.mode = 0x10000;
             VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
         }
 
-        // Negative: mode=0 with FLAG_MODE set is a foot-gun (chmod 0 makes
-        // the volume root inaccessible to the container's non-root user) and
-        // must be rejected client-side.
+        // Negative: mode=0 (chmod 0 = inaccessible root) is rejected.
         {
             WslcVhdRequirements vhd{};
             vhd.name = c_volumeName;
@@ -2088,19 +2081,17 @@ class WslcSdkTests
             VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
         }
 
-        // Negative: unknown flag bits are rejected so future flag additions
-        // can never be silently ignored by older SDK versions.
+        // Negative: unknown flag bits are rejected.
         {
             WslcVhdRequirements vhd{};
             vhd.name = c_volumeName;
             vhd.sizeBytes = c_vhdSizeBytes;
             vhd.type = WSLC_VHD_TYPE_DYNAMIC;
-            vhd.flags = static_cast<WslcVhdRequirementsFlags>(0x80000000); // unassigned bit
+            vhd.flags = static_cast<WslcVhdRequirementsFlags>(0x80000000);
             VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
         }
 
-        // Positive: flags=NONE with non-zero uid/gid must silently ignore
-        // those fields (no chown is emitted, defaults to root:root).
+        // Positive: flags=NONE silently ignores uid/gid/mode (volume defaults to root:root).
         {
             constexpr auto c_unflaggedVolumeName = "wslc-sdk-vhd-unflagged";
             WslcVhdRequirements vhd{};

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2001,9 +2001,7 @@ class WslcSdkTests
             VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
         }
 
-        // Positive: fixed-allocation VHD must produce a .vhdx whose on-disk size
-        // is at least the requested SizeBytes (dynamic VHDs are typically much
-        // smaller until populated).
+        // Positive: fixed-allocation VHD; on-disk file size must be >= SizeBytes.
         {
             constexpr auto c_fixedVolumeName = "wslc-sdk-vhd-fixed";
             constexpr auto c_fixedSizeBytes = 64ull * _1MB;

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2022,18 +2022,17 @@ class WslcSdkTests
             VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_fixedVolumeName, &deleteErr));
         }
 
-        // Positive: owner + mode flags are honored — chown/chmod applied to
-        // the volume root. Verify by stat-ing the mount inside a container.
+        // Positive: owner flags are honored — uid/gid baked into the volume root
+        // inode at mkfs time. Verify by stat-ing the mount inside a container.
         {
             constexpr auto c_ownedVolumeName = "wslc-sdk-vhd-owned";
             WslcVhdRequirements vhd{};
             vhd.name = c_ownedVolumeName;
             vhd.sizeBytes = c_vhdSizeBytes;
             vhd.type = WSLC_VHD_TYPE_DYNAMIC;
-            vhd.flags = WSLC_VHD_REQ_FLAG_OWNER | WSLC_VHD_REQ_FLAG_MODE;
+            vhd.flags = WSLC_VHD_REQ_FLAG_OWNER;
             vhd.uid = 65534; // nobody
             vhd.gid = 65534; // nogroup
-            vhd.mode = 0750;
             wil::unique_cotaskmem_string errorMsg;
             VERIFY_SUCCEEDED(WslcCreateSessionVhdVolume(session.get(), &vhd, &errorMsg));
 
@@ -2042,7 +2041,7 @@ class WslcSdkTests
 
             WslcProcessSettings procSettings;
             VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
-            const char* argv[] = {"/usr/bin/stat", "-c", "%u %g %a", "/data"};
+            const char* argv[] = {"/usr/bin/stat", "-c", "%u %g", "/data"};
             VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
 
             WslcContainerSettings containerSettings;
@@ -2056,29 +2055,7 @@ class WslcSdkTests
             VERIFY_SUCCEEDED(WslcSetContainerSettingsNamedVolumes(&containerSettings, &namedVol, 1));
 
             auto output = RunContainerAndCapture(session.get(), containerSettings);
-            VERIFY_ARE_EQUAL(output.stdoutOutput, "65534 65534 750\n");
-        }
-
-        // Negative: out-of-range mode (> 07777) is rejected.
-        {
-            WslcVhdRequirements vhd{};
-            vhd.name = c_volumeName;
-            vhd.sizeBytes = c_vhdSizeBytes;
-            vhd.type = WSLC_VHD_TYPE_DYNAMIC;
-            vhd.flags = WSLC_VHD_REQ_FLAG_MODE;
-            vhd.mode = 0x10000;
-            VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
-        }
-
-        // Negative: mode=0 (chmod 0 = inaccessible root) is rejected.
-        {
-            WslcVhdRequirements vhd{};
-            vhd.name = c_volumeName;
-            vhd.sizeBytes = c_vhdSizeBytes;
-            vhd.type = WSLC_VHD_TYPE_DYNAMIC;
-            vhd.flags = WSLC_VHD_REQ_FLAG_MODE;
-            vhd.mode = 0;
-            VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
+            VERIFY_ARE_EQUAL(output.stdoutOutput, "65534 65534\n");
         }
 
         // Negative: unknown flag bits are rejected.
@@ -2091,7 +2068,7 @@ class WslcSdkTests
             VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
         }
 
-        // Positive: flags=NONE silently ignores uid/gid/mode (volume defaults to root:root).
+        // Positive: flags=NONE silently ignores uid/gid (volume defaults to root:root).
         {
             constexpr auto c_unflaggedVolumeName = "wslc-sdk-vhd-unflagged";
             WslcVhdRequirements vhd{};
@@ -2101,7 +2078,6 @@ class WslcSdkTests
             vhd.flags = WSLC_VHD_REQ_FLAG_NONE;
             vhd.uid = 1000;
             vhd.gid = 1000;
-            vhd.mode = 0750;
             wil::unique_cotaskmem_string errorMsg;
             VERIFY_SUCCEEDED(WslcCreateSessionVhdVolume(session.get(), &vhd, &errorMsg));
 

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2012,12 +2012,12 @@ class WslcSdkTests
             wil::unique_cotaskmem_string errorMsg;
             VERIFY_SUCCEEDED(WslcCreateSessionVhdVolume(session.get(), &vhd, &errorMsg));
 
+            auto deleteVolume =
+                wil::scope_exit([&]() { LOG_IF_FAILED(WslcDeleteSessionVhdVolume(session.get(), c_fixedVolumeName, nullptr)); });
+
             std::filesystem::path expectedVhdPath = vhdSessionStorage / "volumes" / (std::string(c_fixedVolumeName) + ".vhdx");
             VERIFY_IS_TRUE(std::filesystem::exists(expectedVhdPath));
             VERIFY_IS_GREATER_THAN_OR_EQUAL(std::filesystem::file_size(expectedVhdPath), c_fixedSizeBytes);
-
-            wil::unique_cotaskmem_string deleteErr;
-            VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_fixedVolumeName, &deleteErr));
         }
 
         // Positive: owner flags are honored — uid/gid baked into the volume root

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1992,13 +1992,107 @@ class WslcSdkTests
             VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
         }
 
-        // Negative: fixed VHD type is not yet supported.
+        // Negative: invalid VHD type must fail.
         {
             WslcVhdRequirements vhd{};
             vhd.name = c_volumeName;
             vhd.sizeBytes = c_vhdSizeBytes;
+            vhd.type = static_cast<WslcVhdType>(42);
+            VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
+        }
+
+        // Positive: fixed-allocation VHD must produce a .vhdx whose on-disk size
+        // is at least the requested SizeBytes (dynamic VHDs are typically much
+        // smaller until populated).
+        {
+            constexpr auto c_fixedVolumeName = "wslc-sdk-vhd-fixed";
+            constexpr auto c_fixedSizeBytes = 64ull * _1MB;
+            WslcVhdRequirements vhd{};
+            vhd.name = c_fixedVolumeName;
+            vhd.sizeBytes = c_fixedSizeBytes;
             vhd.type = WSLC_VHD_TYPE_FIXED;
-            VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_NOTIMPL);
+            wil::unique_cotaskmem_string errorMsg;
+            VERIFY_SUCCEEDED(WslcCreateSessionVhdVolume(session.get(), &vhd, &errorMsg));
+
+            std::filesystem::path expectedVhdPath = vhdSessionStorage / "volumes" / (std::string(c_fixedVolumeName) + ".vhdx");
+            VERIFY_IS_TRUE(std::filesystem::exists(expectedVhdPath));
+            VERIFY_IS_GREATER_THAN_OR_EQUAL(std::filesystem::file_size(expectedVhdPath), c_fixedSizeBytes);
+
+            wil::unique_cotaskmem_string deleteErr;
+            VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_fixedVolumeName, &deleteErr));
+        }
+
+        // Positive: owner + mode flags must be honored — a non-root container
+        // user can write the volume root.
+        {
+            constexpr auto c_ownedVolumeName = "wslc-sdk-vhd-owned";
+            WslcVhdRequirements vhd{};
+            vhd.name = c_ownedVolumeName;
+            vhd.sizeBytes = c_vhdSizeBytes;
+            vhd.type = WSLC_VHD_TYPE_DYNAMIC;
+            vhd.flags = WSLC_VHD_REQ_FLAG_OWNER | WSLC_VHD_REQ_FLAG_MODE;
+            vhd.uid = 65534; // nobody
+            vhd.gid = 65534; // nogroup
+            vhd.mode = 0750;
+            wil::unique_cotaskmem_string errorMsg;
+            VERIFY_SUCCEEDED(WslcCreateSessionVhdVolume(session.get(), &vhd, &errorMsg));
+
+            wil::unique_cotaskmem_string deleteErr;
+            VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_ownedVolumeName, &deleteErr));
+        }
+
+        // Negative: out-of-range mode (> 07777) must be rejected.
+        {
+            WslcVhdRequirements vhd{};
+            vhd.name = c_volumeName;
+            vhd.sizeBytes = c_vhdSizeBytes;
+            vhd.type = WSLC_VHD_TYPE_DYNAMIC;
+            vhd.flags = WSLC_VHD_REQ_FLAG_MODE;
+            vhd.mode = 0x10000; // out of range
+            VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
+        }
+
+        // Negative: mode=0 with FLAG_MODE set is a foot-gun (chmod 0 makes
+        // the volume root inaccessible to the container's non-root user) and
+        // must be rejected client-side.
+        {
+            WslcVhdRequirements vhd{};
+            vhd.name = c_volumeName;
+            vhd.sizeBytes = c_vhdSizeBytes;
+            vhd.type = WSLC_VHD_TYPE_DYNAMIC;
+            vhd.flags = WSLC_VHD_REQ_FLAG_MODE;
+            vhd.mode = 0;
+            VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
+        }
+
+        // Negative: unknown flag bits are rejected so future flag additions
+        // can never be silently ignored by older SDK versions.
+        {
+            WslcVhdRequirements vhd{};
+            vhd.name = c_volumeName;
+            vhd.sizeBytes = c_vhdSizeBytes;
+            vhd.type = WSLC_VHD_TYPE_DYNAMIC;
+            vhd.flags = static_cast<WslcVhdRequirementsFlags>(0x80000000); // unassigned bit
+            VERIFY_ARE_EQUAL(WslcCreateSessionVhdVolume(session.get(), &vhd, nullptr), E_INVALIDARG);
+        }
+
+        // Positive: flags=NONE with non-zero uid/gid must silently ignore
+        // those fields (no chown is emitted, defaults to root:root).
+        {
+            constexpr auto c_unflaggedVolumeName = "wslc-sdk-vhd-unflagged";
+            WslcVhdRequirements vhd{};
+            vhd.name = c_unflaggedVolumeName;
+            vhd.sizeBytes = c_vhdSizeBytes;
+            vhd.type = WSLC_VHD_TYPE_DYNAMIC;
+            vhd.flags = WSLC_VHD_REQ_FLAG_NONE;
+            vhd.uid = 1000;
+            vhd.gid = 1000;
+            vhd.mode = 0750;
+            wil::unique_cotaskmem_string errorMsg;
+            VERIFY_SUCCEEDED(WslcCreateSessionVhdVolume(session.get(), &vhd, &errorMsg));
+
+            wil::unique_cotaskmem_string deleteErr;
+            VERIFY_SUCCEEDED(WslcDeleteSessionVhdVolume(session.get(), c_unflaggedVolumeName, &deleteErr));
         }
     }
 


### PR DESCRIPTION
## Summary

Adds POSIX `Uid`/`Gid` and pre-allocated `Fixed` driver options to the WSLC named-volume `vhd` driver, and plumbs them through the public C SDK and the WinRT projection.

Today, containers running as a non-root user cannot write to their own persistent volumes — `mkfs.ext4` leaves the root inode owned by `root:root`, and the `vhd` driver only accepted `SizeBytes`. The new options let the SDK consumer create a volume that is immediately usable by the in-container user.

`Fixed` lets workloads that need predictable I/O pre-allocate the VHD instead of growing it dynamically.

## Driver options (named volumes)

| Option | Type | Notes |
|---|---|---|
| `SizeBytes` | uint64 (decimal) | required; >0 |
| `Fixed` | bool (`true`/`false`/`1`/`0`) | optional; defaults to `false` |
| `Uid` | uint32 (decimal) | optional; **must be paired with `Gid`** |
| `Gid` | uint32 (decimal) | optional; **must be paired with `Uid`** |

Ownership is baked into the ext4 root inode at format time via `mkfs.ext4 -E root_owner=UID:GID`, not via a post-mount `chown`. The container user owns the root inode from the first mount and can `chmod` it with its own umask if it needs different permissions.

All option parsing goes through a shared `OptionParser` helper (`Required<T>`/`Optional<T>`/`OptionalBool`/`RejectUnknown`) with errno-capture, end-pointer validation, leading-sign rejection, and consumed-key tracking. The `Open` path uses the same parser so persisted metadata is validated identically on reload.

## C SDK (`wslcsdk.h` / `wslcsdk.dll`)

```c
typedef enum WslcVhdRequirementsFlags {
    WSLC_VHD_REQ_FLAG_NONE  = 0,
    WSLC_VHD_REQ_FLAG_OWNER = 1,
} WslcVhdRequirementsFlags;

typedef struct WslcVhdRequirements {
    PCSTR    name;
    uint64_t sizeBytes;
    WslcVhdType type;
    WslcVhdRequirementsFlags flags;
    uint32_t uid;
    uint32_t gid;
} WslcVhdRequirements;
```

`WslcCreateSessionVhdVolume`:
* honors `WSLC_VHD_TYPE_FIXED` (was previously `E_NOTIMPL`)
* dynamically builds the underlying `WSLCDriverOption[]` based on the flag bits
* rejects unknown `type` values and unknown flag bits with `E_INVALIDARG` so future additions cannot silently fail-open

`WslcSetSessionSettingsVhd` does not plumb owner/fixed through the session rootfs VHD path and rejects `flags != NONE` with `E_INVALIDARG` instead of silently ignoring those fields.

> [!IMPORTANT]
> **ABI break:** `WSLC_SESSION_OPTIONS_SIZE` bumps `80 → 88` to match the wider embedded `WslcVhdRequirements`. Callers of `wslcsdk.lib`/`wslcsdk.dll` must recompile against the new header.

### Caller usage

```c
WslcVhdRequirements vhd = {0};
vhd.name      = "data";
vhd.sizeBytes = 64ULL << 20;
vhd.type      = WSLC_VHD_TYPE_FIXED;
vhd.flags     = WSLC_VHD_REQ_FLAG_OWNER;
vhd.uid       = 65534;
vhd.gid       = 65534;
WslcCreateSessionVhdVolume(session, &vhd, &errorMsg);
```

## WinRT projection (`Microsoft.WSL.Containers`)

```idl
runtimeclass VhdRequirements {
    VhdRequirements(String name, UInt64 sizeInBytes, VhdType type);
    String  Name        { get; };
    UInt64  SizeInBytes { get; };
    VhdType Type        { get; };

    void SetOwner(UInt32 uid, UInt32 gid);
}
```

Pair-based `SetOwner` avoids the half-set foot-gun that per-property setters would create. Default-constructed `VhdRequirements` (or any path that does not call the new setter) gets `flags = NONE` = old behavior.

```csharp
var req = new VhdRequirements("data", 64UL << 20, VhdType.Fixed);
req.SetOwner(65534, 65534);
```

The WinRT projection has no test infrastructure in the repo (the existing `Name`/`SizeInBytes`/`Type` projection has never had tests either). Behavior is fully covered at the C SDK layer that the projection delegates to.

## Tests

* `WSLCTests.cpp`
  * `NamedVolumeVhdOptionsParseTest` — SizeBytes presence/range, unknown-key rejection (`Bogus=...`), sign rejection
  * `NamedVolumesVhdOwnership` — `mkfs -E root_owner` end-to-end (`stat -c "%u %g"` on mount root)
  * `NamedVolumesVhdFixed` — asserts on-disk `file_size >= requested`
* `WslcSdkTests.cpp`
  * Invalid type → `E_INVALIDARG`
  * `Fixed` positive (size verification on disk)
  * `OWNER` positive (uid=65534, gid=65534)
  * Unknown flag bit → `E_INVALIDARG`
  * `flags=NONE` with non-zero uid/gid silently ignored

## Validation status

* [x] `cmake --build` clean (`wslservice`, `wslcsession`, `wslcsdk`, `wslcsdkwinrt`, `wsltests`)
* [x] `FormatSource.ps1 -ModifiedOnly $true` — clang-format reports no changes
