### PR TITLE
Fix shared ptr circular reference leaks

### DIFF
--- a/src/windows/common/Dmesg.cpp
+++ b/src/windows/common/Dmesg.cpp
@@ -72,13 +72,13 @@ std::pair<std::wstring, std::thread> DmesgCollector::StartDmesgThread(InputSourc
 
     THROW_LAST_ERROR_IF(!pipe);
 
-    auto workerThread = std::thread([Self = shared_from_this(), Source, Pipe = std::move(pipe)]() {
+    auto workerThread = std::thread([this, Source, Pipe = std::move(pipe)]() {
         try
         {
             wsl::windows::common::wslutil::SetThreadDescription(L"Dmesg");
 
             // When the pipe connects, start reading data.
-            wsl::windows::common::helpers::ConnectPipe(Pipe.get(), INFINITE, Self->m_exitEvents);
+            wsl::windows::common::helpers::ConnectPipe(Pipe.get(), INFINITE, m_exitEvents);
 
             std::vector<char> buffer(LX_RELAY_BUFFER_SIZE);
             const auto allBuffer = gsl::make_span(buffer);
@@ -89,7 +89,7 @@ std::pair<std::wstring, std::thread> DmesgCollector::StartDmesgThread(InputSourc
             {
                 overlappedEvent.ResetEvent();
                 const auto bytesRead = wsl::windows::common::relay::InterruptableRead(
-                    Pipe.get(), gslhelpers::convert_span<gsl::byte>(allBuffer), Self->m_exitEvents, &overlapped);
+                    Pipe.get(), gslhelpers::convert_span<gsl::byte>(allBuffer), m_exitEvents, &overlapped);
 
                 if (bytesRead == 0)
                 {
@@ -97,7 +97,7 @@ std::pair<std::wstring, std::thread> DmesgCollector::StartDmesgThread(InputSourc
                 }
 
                 auto validBuffer = allBuffer.subspan(0, bytesRead);
-                Self->ProcessInput(Source, validBuffer);
+                ProcessInput(Source, validBuffer);
             }
         }
         catch (...)

--- a/src/windows/common/Dmesg.h
+++ b/src/windows/common/Dmesg.h
@@ -17,7 +17,7 @@ Abstract:
 #include "relay.hpp"
 #include "RingBuffer.h"
 
-class DmesgCollector : public std::enable_shared_from_this<DmesgCollector>
+class DmesgCollector
 {
 public:
     DmesgCollector() = delete;

--- a/src/windows/service/exe/GuestTelemetryLogger.cpp
+++ b/src/windows/service/exe/GuestTelemetryLogger.cpp
@@ -52,13 +52,13 @@ void GuestTelemetryLogger::Start(const wil::unique_event& ExitEvent)
     THROW_LAST_ERROR_IF(!pipe);
 
     wil::unique_handle exitEvent(wsl::windows::common::wslutil::DuplicateHandle(ExitEvent.get()));
-    m_thread = std::thread([Self = shared_from_this(), Pipe = std::move(pipe), ExitEvent = std::move(exitEvent)]() {
+    m_thread = std::thread([this, Pipe = std::move(pipe), ExitEvent = std::move(exitEvent)]() {
         try
         {
             wsl::windows::common::wslutil::SetThreadDescription(L"GuestTelemetryLogger");
 
             // When the pipe connects, start reading data.
-            const std::vector<HANDLE> exitEvents = {Self->m_threadExit.get(), ExitEvent.get()};
+            const std::vector<HANDLE> exitEvents = {m_threadExit.get(), ExitEvent.get()};
             wsl::windows::common::helpers::ConnectPipe(Pipe.get(), INFINITE, exitEvents);
 
             std::vector<gsl::byte> buffer(LX_RELAY_BUFFER_SIZE);
@@ -76,7 +76,7 @@ void GuestTelemetryLogger::Start(const wil::unique_event& ExitEvent)
                     break;
                 }
 
-                Self->ProcessInput(std::string_view{reinterpret_cast<const char*>(buffer.data()), bytesRead});
+                ProcessInput(std::string_view{reinterpret_cast<const char*>(buffer.data()), bytesRead});
             }
         }
         CATCH_LOG()

--- a/src/windows/service/exe/GuestTelemetryLogger.h
+++ b/src/windows/service/exe/GuestTelemetryLogger.h
@@ -17,7 +17,7 @@ Abstract:
 #include "RingBuffer.h"
 #include "relay.hpp"
 
-class GuestTelemetryLogger : public std::enable_shared_from_this<GuestTelemetryLogger>
+class GuestTelemetryLogger
 {
 public:
     GuestTelemetryLogger() = delete;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Both loggers have their member thread holding a shared pointer of themselves. This renders the m_exitEvents logic useless. And could lead to resource leaks.
Since the thread's lifespan is always shorter than the logger's, changing the capture from shared_from_this to this will fix the leak.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/40470
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
