### PR TITLE
Fix snprintf buffer size for ExpectedCombinedOptions in lxtfs

### DIFF
--- a/test/linux/unit_tests/lxtfs.c
+++ b/test/linux/unit_tests/lxtfs.c
@@ -231,7 +231,7 @@ Return Value:
         }
 
         snprintf(ExpectedOptions, sizeof(ExpectedOptions), "rw,%s", Options);
-        snprintf(ExpectedCombinedOptions, sizeof(ExpectedOptions), "rw,noatime,%s", Options);
+        snprintf(ExpectedCombinedOptions, sizeof(ExpectedCombinedOptions), "rw,noatime,%s", Options);
 
         LxtCheckResult(MountCheckIsMount(Target, ParentId, Source, "drvfs", MountRoot, "rw,noatime", ExpectedOptions, ExpectedCombinedOptions, 0));
     }


### PR DESCRIPTION
Split out from #40489.

The second snprintf in `MountCheckIsMountWithOptions` used `sizeof(ExpectedOptions)` (the wrong buffer) when writing into `ExpectedCombinedOptions`. This is a buffer-size bug regardless of whether the two arrays happen to be the same size today; it should reference its own destination buffer.

### Change
- `test/linux/unit_tests/lxtfs.c`: pass `sizeof(ExpectedCombinedOptions)` to the matching `snprintf`.

### Validation
- Mechanical, single-line fix; no behavior change when buffers happen to be the same size.