### PR TITLE
Pass tv_sec and tv_nsec to LxtLogError in CheckTime

### DIFF
--- a/test/linux/unit_tests/lxtfs.c
+++ b/test/linux/unit_tests/lxtfs.c
@@ -2231,7 +2231,12 @@ Return Value:
 
     if (LxtFsTimestampDiff(Timestamp1, Timestamp2) <= 0)
     {
-        LxtLogError("Time %lld.%.9ld not greater than time %lld.%.9ld", Timestamp1, Timestamp2);
+        LxtLogError(
+            "Time %lld.%.9ld not greater than time %lld.%.9ld",
+            (long long)Timestamp1->tv_sec,
+            (long)Timestamp1->tv_nsec,
+            (long long)Timestamp2->tv_sec,
+            (long)Timestamp2->tv_nsec);
 
         Result = LXT_RESULT_FAILURE;
         goto ErrorExit;


### PR DESCRIPTION
Split out from #40489.

When `LxtFsTimestampDiff` indicates that `Timestamp1` is not strictly greater than `Timestamp2`, the failure path called `LxtLogError` with a format string expecting four scalars (`sec`, `nsec`, `sec`, `nsec`) but only passed the two `struct timespec*` pointers. The diagnostic therefore printed garbage on test failure, and the call relies on undefined varargs behavior.

### Change
- `test/linux/unit_tests/lxtfs.c`: pass `Timestamp{1,2}->tv_sec` and `->tv_nsec` with `(long long)` / `(long)` casts so the format string matches the arguments.

### Validation
- Diagnostic-only fix: only affects the message printed on a test failure path, not whether the test passes.