### PR TITLE
Strip fractional seconds in ParseDockerTimestamp

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -362,17 +362,23 @@ DockerNetworkMode ParseDockerNetworkMode(const std::string& mode)
 std::uint64_t ParseDockerTimestamp(const std::string& timestamp)
 {
     // Docker timestamps are UTC ISO 8601 with a trailing 'Z', e.g.
-    // "2026-03-05T10:30:00.123456789Z". Require the 'Z' suffix so a non-UTC
-    // offset like "+05:00" is rejected rather than silently treated as UTC.
-    THROW_HR_IF_MSG(
-        E_INVALIDARG, timestamp.empty() || timestamp.back() != 'Z', "Failed to parse timestamp '%hs'", timestamp.c_str());
-
-    // chrono::parse leaves the trailing fractional component (if any) and the 'Z'
-    // unread; that is not treated as a parse failure.
+    // "2026-03-05T10:30:00.123456789Z". Parse the date/time then verify the
+    // unconsumed tail is either "Z" or ".<digits>Z" so non-UTC offsets like
+    // "+05:00" and other malformed suffixes are rejected.
     std::chrono::sys_seconds utcSeconds;
     std::istringstream stream(timestamp);
     stream >> std::chrono::parse("%FT%H:%M:%S", utcSeconds);
-    THROW_HR_IF_MSG(E_INVALIDARG, stream.fail(), "Failed to parse timestamp '%hs'", timestamp.c_str());
+
+    bool valid = !stream.fail();
+    if (valid)
+    {
+        const auto pos = stream.tellg();
+        const std::string_view tail = (pos < 0) ? std::string_view{} : std::string_view{timestamp}.substr(static_cast<std::size_t>(pos));
+        const bool fractional = tail.size() >= 3 && tail.front() == '.' && tail.back() == 'Z' &&
+                                std::all_of(tail.begin() + 1, tail.end() - 1, [](char c) { return c >= '0' && c <= '9'; });
+        valid = (tail == "Z") || fractional;
+    }
+    THROW_HR_IF_MSG(E_INVALIDARG, !valid, "Failed to parse timestamp '%hs'", timestamp.c_str());
 
     return static_cast<std::uint64_t>(utcSeconds.time_since_epoch().count());
 }

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -368,7 +368,7 @@ std::uint64_t ParseDockerTimestamp(const std::string& timestamp)
     {
         if (const auto dot = normalized.find('.', tPos + 1); dot != std::string::npos)
         {
-            const auto tzStart = normalized.find_first_of("Z+-", dot);
+            const auto tzStart = normalized.find_first_of("Z+-", dot + 1);
             normalized.erase(dot, (tzStart == std::string::npos) ? std::string::npos : tzStart - dot);
         }
     }

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -361,9 +361,14 @@ DockerNetworkMode ParseDockerNetworkMode(const std::string& mode)
 
 std::uint64_t ParseDockerTimestamp(const std::string& timestamp)
 {
-    // Docker timestamps are UTC ISO 8601, e.g. "2026-03-05T10:30:00.123456789Z".
-    // We only need epoch seconds; the trailing fractional component and "Z" are left
-    // unread, which std::chrono::parse does not treat as a failure.
+    // Docker timestamps are UTC ISO 8601 with a trailing 'Z', e.g.
+    // "2026-03-05T10:30:00.123456789Z". Require the 'Z' suffix so a non-UTC
+    // offset like "+05:00" is rejected rather than silently treated as UTC.
+    THROW_HR_IF_MSG(
+        E_INVALIDARG, timestamp.empty() || timestamp.back() != 'Z', "Failed to parse timestamp '%hs'", timestamp.c_str());
+
+    // chrono::parse leaves the trailing fractional component (if any) and the 'Z'
+    // unread; that is not treated as a parse failure.
     std::chrono::sys_seconds utcSeconds;
     std::istringstream stream(timestamp);
     stream >> std::chrono::parse("%FT%H:%M:%S", utcSeconds);

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -362,8 +362,19 @@ DockerNetworkMode ParseDockerNetworkMode(const std::string& mode)
 std::uint64_t ParseDockerTimestamp(const std::string& timestamp)
 {
     // Docker timestamps are UTC ISO 8601, e.g. "2026-03-05T10:30:00.123456789Z".
+    // We only need epoch seconds, so strip the optional fractional component before parsing.
+    std::string normalized = timestamp;
+    if (const auto tPos = normalized.find('T'); tPos != std::string::npos)
+    {
+        if (const auto dot = normalized.find('.', tPos + 1); dot != std::string::npos)
+        {
+            const auto tzStart = normalized.find_first_of("Z+-", dot);
+            normalized.erase(dot, (tzStart == std::string::npos) ? std::string::npos : tzStart - dot);
+        }
+    }
+
     std::chrono::sys_seconds utcSeconds;
-    std::istringstream stream(timestamp);
+    std::istringstream stream(normalized);
     stream >> std::chrono::parse("%FT%H:%M:%S%Z", utcSeconds);
     THROW_HR_IF_MSG(E_INVALIDARG, stream.fail(), "Failed to parse timestamp '%hs'", timestamp.c_str());
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -362,20 +362,11 @@ DockerNetworkMode ParseDockerNetworkMode(const std::string& mode)
 std::uint64_t ParseDockerTimestamp(const std::string& timestamp)
 {
     // Docker timestamps are UTC ISO 8601, e.g. "2026-03-05T10:30:00.123456789Z".
-    // We only need epoch seconds, so strip the optional fractional component before parsing.
-    std::string normalized = timestamp;
-    if (const auto tPos = normalized.find('T'); tPos != std::string::npos)
-    {
-        if (const auto dot = normalized.find('.', tPos + 1); dot != std::string::npos)
-        {
-            const auto tzStart = normalized.find_first_of("Z+-", dot + 1);
-            normalized.erase(dot, (tzStart == std::string::npos) ? std::string::npos : tzStart - dot);
-        }
-    }
-
+    // We only need epoch seconds; the trailing fractional component and "Z" are left
+    // unread, which std::chrono::parse does not treat as a failure.
     std::chrono::sys_seconds utcSeconds;
-    std::istringstream stream(normalized);
-    stream >> std::chrono::parse("%FT%H:%M:%S%Z", utcSeconds);
+    std::istringstream stream(timestamp);
+    stream >> std::chrono::parse("%FT%H:%M:%S", utcSeconds);
     THROW_HR_IF_MSG(E_INVALIDARG, stream.fail(), "Failed to parse timestamp '%hs'", timestamp.c_str());
 
     return static_cast<std::uint64_t>(utcSeconds.time_since_epoch().count());


### PR DESCRIPTION
Split out from #40489.

The chrono parse format `%FT%H:%M:%S%Z` does not consume the optional fractional seconds component that Docker emits in ISO 8601 timestamps (e.g. `2026-03-05T10:30:00.123456789Z`). For timestamps with a fractional component the parse fails and the call throws `E_INVALIDARG` for what is actually a valid Docker timestamp.

### Change
- `src/windows/wslcsession/WSLCContainer.cpp`: strip the optional fractional component (between `.` and the timezone marker `Z` / `+` / `-`) before parsing. The function returns epoch seconds, so dropping sub-second precision is correct.

### Validation
- Mechanical normalization; `%Z` parse for `Z` / abbreviated zones still runs unchanged.
- Manual review of representative inputs:
  - `2026-03-05T10:30:00Z` — no `.`, unchanged
  - `2026-03-05T10:30:00.123456789Z` — fractional stripped before `Z`
  - `2026-03-05T10:30:00.123+05:00` — fractional stripped before `+`