### PR TITLE
Verify WinGet config exists before invoking winget configure

### DIFF
--- a/tools/setup-dev-env.ps1
+++ b/tools/setup-dev-env.ps1
@@ -55,6 +55,12 @@ else
 }
 
 $configPath = Join-Path $configDir $configFile
+if (-not (Test-Path -LiteralPath $configPath -PathType Leaf))
+{
+    Write-Host "Configuration file not found: $configPath" -ForegroundColor Red
+    Write-Host "Ensure the repository is fully checked out and the .config folder contains $configFile." -ForegroundColor Yellow
+    exit 1
+}
 
 # ── Run WinGet Configuration ────────────────────────────────────────
 Write-Host ""
@@ -72,7 +78,7 @@ if ($LASTEXITCODE -ne 0)
 winget configure -f "$configPath" --accept-configuration-agreements
 if ($LASTEXITCODE -ne 0)
 {
-    Write-Host "Failed to apply WinGet configuration file: $configFile" -ForegroundColor Red
+    Write-Host "Failed to apply WinGet configuration file: $configPath" -ForegroundColor Red
     exit 1
 }
 


### PR DESCRIPTION
Split out from #40489.

If the resolved `` does not exist (e.g. the repo wasn't fully checked out, or the .config folder is missing the file), `winget configure` fails with a cryptic error instead of pointing at the missing file. The existing error message after a failed `winget configure` also prints just `` (the bare name), not the full path actually passed to winget.

### Changes (`tools/setup-dev-env.ps1`)
- Add a `Test-Path` guard on `` after it's resolved, exiting with a clear message if the file is missing.
- Update the post-`winget configure` failure message to print `` instead of ``.