### PR TITLE
Propagate te.exe exit code from run-tests.ps1

### DIFF
--- a/tools/test/run-tests.ps1
+++ b/tools/test/run-tests.ps1
@@ -12,7 +12,7 @@
 .PARAMETER TestDataPath
     Path to test data folder. Defaults to ".\test_data".
 .PARAMETER Package
-    Path to the wsl.msix package to install. Defaults to ".\wsl.msix".
+    Path to the wsl.msix package to install. Defaults to ".\installer.msix".
 .PARAMETER UnitTestsPath
     Path to the linux/unit_tests directory to copy and install the unit tests.
 .PARAMETER PullRequest
@@ -103,9 +103,9 @@ if ($AttachDebugger)
 else
 {
     te.exe $teArgList
-    if (!$?)
+    if ($LASTEXITCODE -ne 0)
     {
-        exit 1
+        exit $LASTEXITCODE
     }
 }
 


### PR DESCRIPTION
Split out from #40489.

`te.exe` is invoked as a native command in `run-tests.ps1`, so its failure should be detected via `0` rather than `!True` (which can be unreliable for native processes under `Set-StrictMode`). The script also substitutes a hardcoded `1` instead of propagating te.exe's actual exit code, which loses information for CI / wrapper scripts that distinguish between failure modes.

The `-Package` parameter doc lists the default as `.\wsl.msix`, but the actual default in the `param()` block is `.\installer.msix`.

### Changes (`tools/test/run-tests.ps1`)
- Detect te.exe failure with `0 -ne 0` and propagate `0` on exit.
- Update `-Package` parameter doc to match the real default `.\installer.msix`.