### PR TITLE
Comment typos and minor cleanups in wslcsession and lxtfs

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -978,7 +978,7 @@ void WSLCContainerImpl::Export(WSLCHandle OutHandle) const
     }
 
     // Release the lock so the container can still be interacted with while the export is in progress.
-    // Passed this point, no member variables can be accessed.
+    // Past this point, no member variables can be accessed.
     lock.reset();
 
     io.Run({});
@@ -1795,7 +1795,7 @@ void WSLCContainerImpl::MapPorts()
         if (!e.VmMapping.VmPort)
         {
             // Reuse existing vm port allocation when possible.
-            // This is required because the same container can be bind the port number for different families or protocols.
+            // This is required because the same container can bind the port number for different families or protocols.
             auto existing = allocatedPorts.find(e.ContainerPort);
             if (existing != allocatedPorts.end())
             {

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -29,6 +29,7 @@ using wsl::windows::service::wslc::WSLCVirtualMachine;
 
 constexpr auto c_containerdStorage = "/var/lib/docker";
 constexpr auto c_containerdSocket = "/run/containerd/containerd.sock";
+constexpr auto c_dockerdReadyLogLine = "API listen on /var/run/docker.sock";
 constexpr DWORD c_processTerminateTimeoutMs = 30 * 1000;
 constexpr DWORD c_processKillTimeoutMs = 10 * 1000;
 
@@ -422,8 +423,6 @@ try
     {
         return;
     }
-
-    constexpr auto c_dockerdReadyLogLine = "API listen on /var/run/docker.sock";
 
     std::string entry = {Buffer.begin(), Buffer.end()};
     WSL_LOG(
@@ -1223,7 +1222,7 @@ try
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to list images");
 
     // Compute the number of entries - one entry per tag, or one per image if no tags
-    auto entries = std::accumulate<decltype(images.begin()), size_t>(images.begin(), images.end(), 0, [](auto sum, const auto& e) {
+    auto entries = std::accumulate(images.begin(), images.end(), size_t{0}, [](auto sum, const auto& e) {
         return sum + (e.RepoTags.empty() ? 1 : e.RepoTags.size());
     });
 

--- a/test/linux/unit_tests/lxtfs.c
+++ b/test/linux/unit_tests/lxtfs.c
@@ -149,7 +149,7 @@ void LxtFsUtimeRoundToNt(struct timespec* Timespec);
 
 //
 // All real timestamps are offset from the year 2000 because FAT can only
-// accept timestamps afer 1980.
+// accept timestamps after 1980.
 
 BASIC_TEST_CASE BasicTestCases[] = {
     {{{FS_UNIX_TIME_2000 + 1111111, 2222222}, {FS_UNIX_TIME_2000 + 3333333, 4444444}},
@@ -2056,7 +2056,7 @@ Arguments:
     DrvFsDir - Supplies the DrvFs directory to use for testing. This must
         start with a slash, and be relative from the root of the DrvFs mount.
 
-    UseDrvFs - Supplies a pa value indicating whether DrvFs is being used.
+    UseDrvFs - Supplies a value indicating whether DrvFs is being used.
 
 Return Value:
 


### PR DESCRIPTION
Split out from #40489. Cleanup-only changes (no functional effect) bundled together for ease of review.

### Comment typos
- `src/windows/wslcsession/WSLCContainer.cpp`:
  - "Passed this point" -> "Past this point"
  - "can be bind" -> "can bind"
- `test/linux/unit_tests/lxtfs.c`:
  - "afer 1980" -> "after 1980"
  - "Supplies a pa value" -> "Supplies a value"

### WSLCSession.cpp minor cleanups
- Move the dockerd-ready log marker (`c_dockerdReadyLogLine`) to a file-scope `constexpr auto` alongside the other socket/path constants, instead of redeclaring it inside `OnProcessLog` (called once per log line).
- Drop redundant explicit template arguments from `std::accumulate` in `ListImages` and switch the init value to `size_t{0}` so the accumulator type is explicit and matches the consumer.

### Notes / changes from the original bundled PR
Two changes from #40489 were intentionally **dropped**:
- The `IndentLines` rewrite (index loop -> iterators with `std::next`) — the original index loop is at least as readable.
- The `waitForStop` rename in `WSLCContainerImpl::Stop` — the original one-liner is already clear, the introduced `isKillSignal` / `shouldWaitWhenKill` pair adds noise without changing meaning.
- The `c_logId` change from `static constexpr char[]` to `constexpr auto` was also dropped because it changes the variable's type from `const char (&)[N]` to `const char *` rather than being purely cosmetic.