### PR TITLE
Skip localization PR creation on file-change CI trigger

### DIFF
--- a/.pipelines/wsl-build-nightly-localization.yml
+++ b/.pipelines/wsl-build-nightly-localization.yml
@@ -43,6 +43,7 @@ steps:
     cultureMappingType: 'None'
 
 - task: PipAuthenticate@1
+  condition: and(succeeded(), in(variables['Build.Reason'], 'Schedule', 'Manual'))
   inputs:
     artifactFeeds: 'wsl'
 

--- a/.pipelines/wsl-build-nightly-localization.yml
+++ b/.pipelines/wsl-build-nightly-localization.yml
@@ -51,6 +51,7 @@ steps:
             python tools/devops/create-change.py . "$env:token" "WSL localization"  "Localization change from build: $env:buildId" "user/localization/$env:buildId" "$env:targetBranch"
 
   displayName: Create pull request
+  condition: and(succeeded(), in(variables['Build.Reason'], 'Schedule', 'Manual'))
   env:
       token: $(GithubPRToken)
       buildId: $(Build.BuildId)


### PR DESCRIPTION
Gate the `Create pull request` step in the nightly localization pipeline on `Build.Reason in (Schedule, Manual)` so it does not run when the pipeline is triggered by a push that modified `localization/strings/en-US/Resources.resw`.

Without this, every change to `Resources.resw` (e.g., #40499) kicks off the pipeline, which then runs Touchdown and opens a follow-up localization PR even though there are no new strings to localize. Those PRs consume build resources without changing any localized strings.

After this change:
- Nightly scheduled runs still create localization PRs as before.
- Manual pipeline runs still create PRs (useful for testing).
- File-change CI runs still execute Touchdown but skip PR creation.