### PR TITLE
Don't kill the test process during cleanup

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -70,7 +70,6 @@ std::wstring g_testDistroPath;
 std::wstring g_testDataPath;
 bool g_fastTestRun = false; // True when test.bat was invoked with -f
 static wil::unique_mta_usage_cookie g_mtaCookie;
-static wil::unique_handle g_processJob;
 
 std::pair<wil::unique_handle, wil::unique_handle> CreateSubprocessPipe(bool inheritRead, bool inheritWrite, DWORD bufferSize, _In_opt_ SECURITY_ATTRIBUTES* sa)
 {
@@ -1980,13 +1979,15 @@ Return Value:
     THROW_IF_FAILED(CoIncrementMTAUsage(&g_mtaCookie));
 
     // Assign a job object to the current process to ensure that we don't leak processes on failure.
-    g_processJob.reset(CreateJobObjectW(nullptr, nullptr));
-    THROW_LAST_ERROR_IF(!g_processJob);
+    // N.B. When the job object is closed, all processes associated with the job will be terminated.
+    // Because of that, we're purposefully leaking this job object so we don't kill the test process on cleanup.
+    auto job = CreateJobObjectW(nullptr, nullptr);
+    THROW_LAST_ERROR_IF(!job);
 
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo{};
     jobInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-    THROW_IF_WIN32_BOOL_FALSE(SetInformationJobObject(g_processJob.get(), JobObjectExtendedLimitInformation, &jobInfo, sizeof(jobInfo)));
-    THROW_IF_WIN32_BOOL_FALSE(AssignProcessToJobObject(g_processJob.get(), GetCurrentProcess()));
+    THROW_IF_WIN32_BOOL_FALSE(SetInformationJobObject(job, JobObjectExtendedLimitInformation, &jobInfo, sizeof(jobInfo)));
+    THROW_IF_WIN32_BOOL_FALSE(AssignProcessToJobObject(job, GetCurrentProcess()));
 
 // Don't crash for unknown exceptions (makes debugging testpasses harder)
 #ifndef _DEBUG


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes the following warning when the tests complete: 

```
Warning: TAEF: [HRESULT 0x800706BE] A failure occurred while cleanly shutting down the test host process. (The test host process was unexpectedly terminated with exit code 0x00000000 while preparing to be shut down. (An RPC call failed.))
```

See comment for details 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
