### PR TITLE
Bump GitPython to 3.1.50 to address CVE-2026-42215 bypass

### DIFF
--- a/distributions/requirements.txt
+++ b/distributions/requirements.txt
@@ -1,5 +1,5 @@
 python-magic==0.4.27
 click==8.1.3
-GitPython==3.1.49
+GitPython==3.1.50
 PyGithub==2.5.0
 json-cfg==0.4.2

--- a/tools/devops/requirements.txt
+++ b/tools/devops/requirements.txt
@@ -1,4 +1,4 @@
 azure-devops==7.1.0b4
 click==8.1.3
-gitpython==3.1.49
+gitpython==3.1.50
 backoff==2.2.1


### PR DESCRIPTION
Fixes Dependabot alerts [#22](https://github.com/microsoft/WSL/security/dependabot/22) and [#23](https://github.com/microsoft/WSL/security/dependabot/23).

GitPython <= 3.1.49 has a newline injection vulnerability in `config_writer()` section parameter that bypasses the CVE-2026-42215 patch and enables RCE via `core.hooksPath`. Bumps the pin in both `distributions/requirements.txt` and `tools/devops/requirements.txt` to `3.1.50`.