### PR TITLE
virtiofs: improve virtiofs performance by negotiating MAX_PAGES

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommunityToolkit.Mvvm" version="8.4.0" />
   <package id="CommunityToolkit.WinUI.Animations" version="8.2.250402" />

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommunityToolkit.Mvvm" version="8.4.0" />
   <package id="CommunityToolkit.WinUI.Animations" version="8.2.250402" />
@@ -19,7 +19,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.23-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.24-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.26.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />


### PR DESCRIPTION
This change updates to a new wsldevicehost.dll that has this change: https://github.com/microsoft/openvmm/pull/3447

The net result is a roughly 20-40% performance improvement for sequential read and write speeds, more details on the above openvmm pr.