### PR TITLE
Pipeline: fix loc/notice PR base branch for non-master runs

### DIFF
--- a/.pipelines/wsl-build-nightly-localization.yml
+++ b/.pipelines/wsl-build-nightly-localization.yml
@@ -17,8 +17,13 @@ schedules:
     - "master"
   always: true
 
+# Build.SourceBranchName is only the leaf segment of the ref (e.g.
+# 'loc-pipeline-debug' for refs/heads/user/benhill/loc-pipeline-debug), which
+# fails GitHub's pulls API with a 422 'base invalid' when the branch name
+# contains slashes. Strip 'refs/heads/' from the full ref instead so the PR
+# targets the actual branch the pipeline ran against.
 variables:
-  targetBranch: ${{ variables['Build.SourceBranchName'] }}
+  targetBranch: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 pool:
   vmImage: 'windows-latest'

--- a/.pipelines/wsl-build-notice.yml
+++ b/.pipelines/wsl-build-notice.yml
@@ -4,7 +4,7 @@ trigger:
     - master
 
 variables:
-  targetBranch: ${{ variables['Build.SourceBranchName'] }}
+  targetBranch: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 pool:
     vmImage: 'windows-latest'


### PR DESCRIPTION
The nightly localization and notice pipelines derived the PR target branch from `Build.SourceBranchName`, which Azure DevOps documents as the leaf segment after the last `/` in the source ref. For `refs/heads/master` that round-trips (`master`), so scheduled runs work — but a manual queue against any branch with slashes (e.g. `user/benhill/loc-pipeline-debug`) sends only the leaf as the PR base, which GitHub rejects with:

```
422 Validation Failed
{"resource":"PullRequest","field":"base","code":"invalid"}
```

This was surfaced by manually queueing `wsl-build-nightly-localization` against `user/benhill/loc-pipeline-debug` with diagnostic instrumentation in `create-change.py` (separate branch). The pipeline POSTed `"base": "loc-pipeline-debug"` instead of `"base": "user/benhill/loc-pipeline-debug"`.

Same bug exists in `wsl-build-notice.yml` (the line was copy-pasted in #14492 when the target branch was first parameterized) — the truncation case had simply never been exercised because the schedule only runs on master.

Fix: derive `targetBranch` from `Build.SourceBranch` and strip the `refs/heads/` prefix at runtime so the full branch name is preserved. master nightlies are unaffected (`refs/heads/master` -> `master`).