### PR TITLE
Localize ADMX Group Policy strings via Touchdown

### DIFF
--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -104,7 +104,7 @@ stages:
           pool: ${{ parameters.pool }}
 
         steps:
-          - script: python tools/devops/validate-localization.py localization/strings en-US
+          - script: python tools/devops/validate-localization.py
             displayName: Validate localization resources
 
           - script: python tools\devops\validate-copyright-headers.py src

--- a/.pipelines/wsl-build-nightly-localization.yml
+++ b/.pipelines/wsl-build-nightly-localization.yml
@@ -5,6 +5,7 @@ trigger:
   paths:
     include:
     - 'localization/strings/en-US/Resources.resw'
+    - 'intune/en-US/WSL.adml'
 
 # Schedule nightly build
 # Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
@@ -38,6 +39,7 @@ steps:
     resourceFilePath: |
       localization\strings\en-US\Resources.resw;O:localization\strings\
       storebroker\PDPs\en-us\PDP.xml;O:storebroker\PDPs\
+      intune\en-US\WSL.adml;O:intune\
     localizationTarget: true
     pseudoSetting: 'Excluded'
     cultureMappingType: 'None'

--- a/intune/en-US/WSL.adml
+++ b/intune/en-US/WSL.adml
@@ -5,57 +5,83 @@
   <description>Windows Subsystem for Linux</description>
   <resources>
     <stringTable>
+        <!-- {Locked="Windows Subsystem for Linux"} -->
         <string id="WindowsSubsystemForLinux">Windows Subsystem for Linux</string>
 
+        <!-- {Locked="Windows Subsystem for Linux"} -->
         <string id="AllowWSL">Allow the Windows Subsystem for Linux</string>
+        <!-- {Locked="Windows Subsystem for Linux"} -->
         <string id="AllowWSLExplain">When set to disabled, this policy disables access to running Linux distributions in the Windows Subsystem for Linux for all users on the machine.</string>
 
+        <!-- {Locked="Windows Subsystem for Linux"} -->
         <string id="AllowInboxWSL">Allow the Inbox version of the Windows Subsystem for Linux</string>
+        <!-- {Locked="Windows Subsystem for Linux"}{Locked="WSL"} -->
         <string id="AllowInboxWSLExplain">When set to disabled, this policy disables the inbox version (optional component) of the Windows Subsystem for Linux. If this policy is disabled, only the store version of WSL can be used.</string>
 
+        <!-- {Locked="WSL1"} -->
         <string id="AllowWSL1">Allow WSL1</string>
+        <!-- {Locked="WSL1"}{Locked="WSL2"} -->
         <string id="AllowWSL1Explain">When set to disabled, this policy disables WSL1. When disabled, only WSL2 distributions can be used.</string>
 
         <string id="CustomKernelUserSettingConfigurable">Allow custom kernel configuration</string>
+        <!-- {Locked=".wslconfig"}{Locked="wsl2.kernel"}{Locked="Store WSL"} -->
         <string id="CustomKernelExplain">When set to disabled, this policy disables custom kernel configuration via .wslconfig (wsl2.kernel). This policy only applies to Store WSL.</string>
 
         <string id="CustomSystemDistroUserSettingConfigurable">Allow custom system distribution configuration</string>
+        <!-- {Locked=".wslconfig"}{Locked="wsl2.systemDistro"}{Locked="Store WSL"} -->
         <string id="CustomSystemDistroExplain">When set to disabled, this policy disables custom system distribution configuration via .wslconfig (wsl2.systemDistro). This policy only applies to Store WSL.</string>
 
         <string id="CustomKernelCommandLineUserSettingConfigurable">Allow kernel command line configuration</string>
+        <!-- {Locked=".wslconfig"}{Locked="wsl2.kernelCommandLine"}{Locked="Store WSL"} -->
         <string id="CustomKernelCommandLineExplain">When set to disabled, this policy disables kernel command line configuration via .wslconfig (wsl2.kernelCommandLine). This policy only applies to Store WSL.</string>
 
         <string id="AllowDebugShell">Allow the debug shell</string>
+        <!-- {Locked="wsl.exe"}{Locked="debug-shell"}{Locked="Store WSL"} -->
         <string id="AllowDebugShellExplain">When set to disabled, this policy disables the debug shell (wsl.exe --debug-shell). This policy only applies to Store WSL.</string>
 
         <string id="NestedVirtualizationUserSettingConfigurable">Allow nested virtualization</string>
+        <!-- {Locked=".wslconfig"}{Locked="wsl2.nestedVirtualization"}{Locked="Store WSL"} -->
         <string id="NestedVirtualizationExplain">When set to disabled, this policy disables nested virtualization configuration via .wslconfig (wsl2.nestedVirtualization). This policy only applies to Store WSL.</string>
 
         <string id="KernelDebugUserSettingConfigurable">Allow kernel debugging</string>
+        <!-- {Locked=".wslconfig"}{Locked="wsl2.kernelDebugPort"}{Locked="Store WSL"} -->
         <string id="KernelDebugExplain">When set to disabled, this policy disables kernel debugging configuration via .wslconfig (wsl2.kernelDebugPort). This policy only applies to Store WSL.</string>
 
         <string id="CustomNetworkingUserSettingConfigurable">Allow custom networking configuration</string>
-        <string id="CustomNetworkingExplain">When set to disabled, this policy disables custom networking configuration via .wslconfig (wsl2.networkingmode). This policy only applies to Store WSL.</string>
+        <!-- {Locked=".wslconfig"}{Locked="wsl2.networkingMode"}{Locked="Store WSL"} -->
+        <string id="CustomNetworkingExplain">When set to disabled, this policy disables custom networking configuration via .wslconfig (wsl2.networkingMode). This policy only applies to Store WSL.</string>
 
         <string id="FirewallUserSettingConfigurable">Allow user setting firewall configuration</string>
+        <!-- {Locked=".wslconfig"}{Locked="wsl2.firewall"}{Locked="Store WSL"} -->
         <string id="FirewallExplain">When set to disabled, this policy disables firewall configuration via .wslconfig (wsl2.firewall). This policy only applies to Store WSL.</string>
 
         <string id="AllowDiskMount">Allow passthrough disk mount</string>
+        <!-- {Locked="WSL2"}{Locked="wsl.exe"}{Locked="mount"}{Locked="Store WSL"} -->
         <string id="AllowDiskMountExplain">When set to disabled, this policy disables passthrough disk mounting in WSL2 (wsl.exe --mount). This policy only applies to Store WSL.</string>
 
         <string id="DefaultNetworkingMode">Configure default networking mode</string>
+        <!-- {Locked="WSL2"} -->
         <string id="DefaultNetworkingModeExplain">This policy specifies the default networking mode to be used for WSL2.</string>
+        <!-- {Locked="None"} -->
         <string id="NetworkingModeNone">None</string>
+        <!-- {Locked="NAT"} -->
         <string id="NetworkingModeNAT">NAT</string>
+        <!-- {Locked="Mirrored"} -->
         <string id="NetworkingModeMirrored">Mirrored</string>
+        <!-- {Locked="VirtioProxy"} -->
         <string id="NetworkingModeVirtioProxy">VirtioProxy</string>
 
+        <!-- {Locked="WSL"} -->
         <string id="WSLContainer">WSL container</string>
 
+        <!-- {Locked="WSL"} -->
         <string id="AllowWSLContainer">Allow WSL container</string>
+        <!-- {Locked="WSL"}{Locked="Disabled"} -->
         <string id="AllowWSLContainerExplain">This policy controls whether WSL container can be used on this machine. When enabled or not configured, users and Windows applications can run Linux containers via WSL. When set to disabled, WSL container is blocked for all users and Windows apps cannot run Linux containers. Warning: Setting this to 'Disabled' can break Windows apps that depend on Linux containers.</string>
 
+        <!-- {Locked="WSL"} -->
         <string id="WSLContainerRegistryAllowlist">Allowlist for WSL container registries</string>
+        <!-- {Locked="WSL"} -->
         <string id="WSLContainerRegistryAllowlistExplain">When enabled, WSL container will only be allowed to pull images from the registries listed here. This affects both the WSL container CLI and all applications using the WSL container API.</string>
     </stringTable>
     <presentationTable>

--- a/tools/devops/create-change.py
+++ b/tools/devops/create-change.py
@@ -18,7 +18,9 @@ def main(repo_path: str, token: str, committer: str, message: str, branch: str, 
     try:
         repo = Repo(repo_path)
 
-        changed_files = [e.a_path for e in repo.index.diff(None)]
+        modified_files = [e.a_path for e in repo.index.diff(None)]
+        untracked_files = list(repo.untracked_files)
+        changed_files = modified_files + untracked_files
 
         if not changed_files:
             print('No files changed, skipping')
@@ -33,7 +35,9 @@ def main(repo_path: str, token: str, committer: str, message: str, branch: str, 
             config.set_value("user", "email", COMMITTER_EMAIL)
             config.set_value("user", "name", committer)
 
-        repo.git.commit('-a', m=message)
+        # 'git add -A' so newly created files in new directories are staged too.
+        repo.git.add(A=True)
+        repo.git.commit(m=message)
         repo.git.push('origin', branch)
 
         headers = {'Accept': 'application/vnd.github+json', 'Authorization': 'Bearer ' + token}

--- a/tools/devops/validate-localization.py
+++ b/tools/devops/validate-localization.py
@@ -174,7 +174,108 @@ def fix_comments(comments: dict, path: str, strings: dict):
     click.secho(f'Updated file: {path}. {missed} comments need manual changes', fg='green' if missed == 0 else 'yellow', bold=True)
 
 
-def run(resource_folder: str, baseline_language: str, fix: bool):
+ADML_NS = '{http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions}'
+RESOURCE_FOLDER = 'localization/strings'
+BASELINE_LANGUAGE = 'en-US'
+ADML_FOLDER = 'intune'
+ADML_FILENAME = 'WSL.adml'
+
+def get_adml_entries(path: str) -> tuple[dict, set]:
+    """Parse an .adml file.
+
+    Returns ({string_id: (value, [locked_tokens])}, {presentation_id, ...}).
+    Locked tokens are extracted from XML comments of the form
+    `<!-- {Locked="..."}{Locked="..."} -->` placed immediately before a
+    `<string>` element. Non-Locked comments are ignored.
+    """
+    # Parse with a TreeBuilder that preserves comments so we can associate
+    # {Locked="..."} tokens with the <string> element that follows them.
+    parser = xml.etree.ElementTree.XMLParser(
+        target=xml.etree.ElementTree.TreeBuilder(insert_comments=True))
+    root = xml.etree.ElementTree.parse(path, parser=parser).getroot()
+
+    string_table = root.find(f'.//{ADML_NS}stringTable')
+    if string_table is None:
+        raise RuntimeError(f'error: {path} is missing the required <stringTable> element')
+
+    strings = {}
+    pending_tokens = []
+    for child in string_table:
+        if child.tag is xml.etree.ElementTree.Comment:
+            pending_tokens.extend(re.findall(r'\{Locked="([^"]*)"\}', child.text or ''))
+        elif child.tag == f'{ADML_NS}string':
+            sid = child.get('id')
+            if sid is not None:
+                strings[sid] = (child.text or '', pending_tokens)
+            pending_tokens = []
+        else:
+            pending_tokens = []
+
+    presentation_table = root.find(f'.//{ADML_NS}presentationTable')
+    if presentation_table is None:
+        raise RuntimeError(f'error: {path} is missing the required <presentationTable> element')
+
+    presentations = {p.get('id') for p in presentation_table.findall(f'{ADML_NS}presentation') if p.get('id')}
+
+    return strings, presentations
+
+def validate_adml(adml_folder: str, baseline_language: str) -> bool:
+    baseline_path = f'{adml_folder}/{baseline_language}/{ADML_FILENAME}'
+    if not os.path.isfile(baseline_path):
+        print(f'info: ADML baseline not found at {baseline_path}, skipping ADML validation')
+        return True
+
+    print(f'Validating ADML baseline {baseline_path}')
+    baseline, baseline_presentations = get_adml_entries(baseline_path)
+    baseline_ids = set(baseline.keys())
+
+    result = True
+    for sid, (value, tokens) in baseline.items():
+        for tok in tokens:
+            if tok not in value:
+                print(f'error: locked token "{tok}" not found in baseline ADML string {sid}: {value}')
+                result = False
+
+    if not os.path.isdir(adml_folder):
+        return result
+
+    for entry in sorted(os.listdir(adml_folder)):
+        locale_path = f'{adml_folder}/{entry}/{ADML_FILENAME}'
+        if entry == baseline_language or not os.path.isfile(locale_path):
+            continue
+
+        print(f'Validating ADML {locale_path}')
+        translated, translated_presentations = get_adml_entries(locale_path)
+
+        missing = baseline_ids - set(translated.keys())
+        extra = set(translated.keys()) - baseline_ids
+        if missing:
+            print(f'error: ADML {locale_path} is missing string ids: {sorted(missing)}')
+            result = False
+        if extra:
+            print(f'error: ADML {locale_path} has unexpected string ids: {sorted(extra)}')
+            result = False
+
+        missing_p = baseline_presentations - translated_presentations
+        extra_p = translated_presentations - baseline_presentations
+        if missing_p:
+            print(f'error: ADML {locale_path} is missing presentation ids: {sorted(missing_p)}')
+            result = False
+        if extra_p:
+            print(f'error: ADML {locale_path} has unexpected presentation ids: {sorted(extra_p)}')
+            result = False
+
+        for sid in baseline_ids & set(translated.keys()):
+            _, tokens = baseline[sid]
+            tvalue, _ = translated[sid]
+            for tok in tokens:
+                if tok not in tvalue:
+                    print(f'error: locked token "{tok}" not found in {locale_path} string {sid}: {tvalue}')
+                    result = False
+
+    return result
+
+def run(resource_folder: str, baseline_language: str, fix: bool, adml_folder: str):
     baseline_file = f'{resource_folder}/{baseline_language}/Resources.resw'
 
     strings = get_strings_from_file(baseline_file, True)
@@ -186,6 +287,8 @@ def run(resource_folder: str, baseline_language: str, fix: bool):
         print(f'Validating inserts in {path}')
         result &= validate_resource(baseline, path)
 
+    result &= validate_adml(adml_folder, baseline_language)
+
     if fix and comments:
         fix_comments(comments, baseline_file, strings)
 
@@ -193,16 +296,17 @@ def run(resource_folder: str, baseline_language: str, fix: bool):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) == 3: # Hack to work around pip install errors in the build pipeline
-        run(sys.argv[1], sys.argv[2], False)
+    if len(sys.argv) == 1: # Avoid pulling in click for the default (CI) invocation
+        run(RESOURCE_FOLDER, BASELINE_LANGUAGE, False, ADML_FOLDER)
     else:
         import click
 
         @click.command()
-        @click.argument('resource-folder', default='localization/strings')
-        @click.argument('baseline-language', default='en-us')
+        @click.option('--resource-folder', default=RESOURCE_FOLDER, show_default=True)
+        @click.option('--baseline-language', default=BASELINE_LANGUAGE, show_default=True)
+        @click.option('--adml-folder', default=ADML_FOLDER, show_default=True)
         @click.option('--fix', is_flag=True)
-        def main(resource_folder: str, baseline_language: str, fix: bool):
-            run(resource_folder, baseline_language, fix)
-        
+        def main(resource_folder: str, baseline_language: str, adml_folder: str, fix: bool):
+            run(resource_folder, baseline_language, fix, adml_folder)
+
         main()


### PR DESCRIPTION
Adds the WSL ADMX policy strings to the nightly Touchdown localization pipeline so translated `.adml` files are produced for every locale already covered by `Resources.resw`. Translated files land at `intune/<locale>/WSL.adml`, matching the Group Policy on-disk layout (the language-neutral `WSL.admx` stays at `intune/WSL.admx`).

## Changes

- **`intune/en-US/WSL.adml`** — new baseline ADML file. Each translatable string is annotated with `{Locked="..."}` XML comments so translators preserve product names (Windows Subsystem for Linux, WSL, WSL1, WSL2, Store WSL), `.wslconfig` keys (`wsl2.kernel`, `wsl2.systemDistro`, `wsl2.kernelCommandLine`, `wsl2.nestedVirtualization`, `wsl2.kernelDebugPort`, `wsl2.networkingMode`, `wsl2.firewall`), command names (`wsl.exe`, `debug-shell`, `mount`), networking-mode enum values (`None`, `NAT`, `Mirrored`, `VirtioProxy`), and the policy state literal `Disabled`.
- **`.pipelines/wsl-build-nightly-localization.yml`** — adds `intune/en-US/WSL.adml` to the trigger paths and to the `TouchdownBuildTask` `resourceFilePath` block. The combined `;O:intune\` mapping puts translated files at `intune/<locale>/WSL.adml`.
- **`tools/devops/validate-localization.py`** — adds `validate_adml()` enforcing the same locked-token invariant as `.resw` (every `{Locked="X"}` token must appear verbatim in its target string value), id parity for both `<stringTable>` and `<presentationTable>` between baseline and translated files, and a `<!-- ... -->` based comment scan for locked tokens (since ElementTree drops comments). All CLI args are now `--option` form with module-level defaults (`RESOURCE_FOLDER`, `BASELINE_LANGUAGE='en-US'`, `ADML_FOLDER='intune'`); the CI fast path runs zero-arg with no `pip install click` dependency. Local overrides use the click flag form.
- **`.pipelines/build-stage.yml`** — invokes the validator with no args (was `localization/strings en-US`); the script now sources both folders and the baseline language from its module-level defaults.
- **`tools/devops/create-change.py`** — includes untracked files in the `Changed files:` report and stages them with `git add -A` (via `repo.git.add(A=True)`) before commit. Without this, Touchdown's first-time ADML outputs would land as untracked files in newly created `intune/<locale>/` directories and be silently dropped by `git commit -a`, which only stages modifications and deletions of already-tracked files.

## Verification

Manually queued `wsl-github-localization` against this branch (ADO build [`146781281`](https://dev.azure.com/microsoft/Microsoft.WSL/_build/results?buildId=146781281)). Touchdown returned `WSL.adml` translations for 20 locales (cs-CZ, da-DK, de-DE, en-GB, es-ES, fi-FI, fr-FR, hu-HU, it-IT, ja-JP, ko-KR, nb-NO, nl-NL, pl-PL, pt-BR, pt-PT, ru-RU, sv-SE, tr-TR, zh-CN, zh-TW) and saved them to disk at `intune/<locale>/WSL.adml`. A subsequent run with the `create-change.py` fix in this branch will produce a follow-up auto-PR containing those `.adml` files alongside the usual `.resw` updates. Validator was sanity-tested zero-arg under both Windows and WSL Linux (case-sensitive FS): 22 resw locales + ADML baseline pass; injecting bogus locked tokens or removing strings/presentations from a fake locale correctly fails with exit 1.

Note: depends on no other PR. The unrelated nightly-pipeline target-branch fix that surfaced during this debugging is in #40510.