### PR TITLE
Add serviceTreeId to TouchdownBuildTask

### DIFF
--- a/.pipelines/wsl-build-nightly-localization.yml
+++ b/.pipelines/wsl-build-nightly-localization.yml
@@ -37,6 +37,7 @@ steps:
   inputs:
     environment: 'PRODEXT'
     teamId: '38646'
+    serviceTreeId: 'd8846bef-e9b5-4542-bcfc-98ebabac8a7b'
     authType: 'FederatedIdentity'
     FederatedIdentityServiceConnection: 'Azure-Connection'
     isPreview: false


### PR DESCRIPTION
The Touchdown build task currently emits this warning on every nightly localization run:

> Warning: No 'serviceTreeId' is specified for this team. This field is currently optional but will become mandatory within FY26. See https://aka.ms/tdbuild/adotask for details/instructions.

Add the WSL service's Service Tree GUID to `TouchdownBuildTask@5` in `.pipelines/wsl-build-nightly-localization.yml` so the warning is silenced and the pipeline keeps working once the field is enforced.