### PR TITLE
Improve VirtioFs performance with swiotlb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,20 @@ find_nuget_package(Microsoft.RemoteDesktop.Client.MSRDC.SessionHost MSRDC /build
 find_nuget_package(Microsoft.Taef TAEF /)
 find_nuget_package(Microsoft.Windows.ImplementationLibrary WIL /)
 find_nuget_package(Microsoft.WSL.DeviceHost WSL_DEVICE_HOST /build/native)
+
+# Allow developers to swap in a locally-built wsldevicehost.dll without producing a new NuGet.
+# Usage: cmake . -DWSL_DEVICE_HOST_DLL=C:/path/to/wsldevicehost.dll
+set(WSL_DEVICE_HOST_DLL "" CACHE FILEPATH "Optional path to a wsldevicehost.dll that overrides the copy from the Microsoft.WSL.DeviceHost NuGet package.")
+if (WSL_DEVICE_HOST_DLL)
+    if (NOT EXISTS "${WSL_DEVICE_HOST_DLL}")
+        message(FATAL_ERROR "WSL_DEVICE_HOST_DLL='${WSL_DEVICE_HOST_DLL}' does not exist.")
+    endif()
+    message(STATUS "Overriding wsldevicehost.dll with ${WSL_DEVICE_HOST_DLL}")
+    set(WSL_DEVICE_HOST_DLL_PATH "${WSL_DEVICE_HOST_DLL}")
+else()
+    set(WSL_DEVICE_HOST_DLL_PATH "${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.dll")
+endif()
+
 find_nuget_package(Microsoft.WSL.Kernel KERNEL /build/native)
 find_nuget_package(Microsoft.WSL.bsdtar BSDTARD /build/native/bin)
 find_nuget_package(Microsoft.WSL.LinuxSdk LINUXSDK /)

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -56,3 +56,9 @@ endif()
 # #   error - block the commit when formatting issues are found
 # #   fix   - automatically fix formatting and re-stage files
 # set(WSL_PRE_COMMIT_MODE "warn")
+
+# # Uncomment to replace the wsldevicehost.dll from the Microsoft.WSL.DeviceHost NuGet
+# # package with a locally-built copy. The MSI build will pick up changes to the file
+# # automatically, so you can iterate by rebuilding the dll and then running:
+# #   cmake --build . --target msipackage
+# set(WSL_DEVICE_HOST_DLL "C:/path/to/wsldevicehost.dll")

--- a/doc/docs/dev-loop.md
+++ b/doc/docs/dev-loop.md
@@ -137,6 +137,7 @@ Also see:
 
 - `WSL_BUILD_THIN_PACKAGE` to build an even smaller package
 - `WSL_POST_BUILD_COMMAND` to automatically deploy the package during build
+- `WSL_DEVICE_HOST_DLL` to swap in a locally-built `wsldevicehost.dll` instead of the one from the `Microsoft.WSL.DeviceHost` NuGet package
 
 **Code formatting**
 

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -802,6 +802,10 @@ For more information on Admin Protection, please visit https://aka.ms/apdevguide
     <value>Invalid IP value '{}' for key '{}' in {}:{}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageConfigInvalidSwiotlb" xml:space="preserve">
+    <value>Invalid SWIOTLB value '{}' for key '{}' in {}:{}. Expected format: '0x&lt;hex&gt;,&lt;size&gt;K|M'</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="MessageConfigInvalidBoolean" xml:space="preserve">
     <value>Invalid boolean value '{}' for key '{}' in {}:{}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
@@ -1125,6 +1129,14 @@ Attempting web download...</value>
   </data>
   <data name="MessageConfigVirtio9pDisabled" xml:space="preserve">
     <value>wsl2.virtio9p is disabled, falling back to 9p with vsock transport.</value>
+  </data>
+  <data name="MessageVirtioProxyRequiresVirtio" xml:space="preserve">
+    <value>VirtioProxy networking is not supported when wsl2.virtio is disabled; falling back to networkingMode {}.</value>
+    <comment>{Locked="wsl2.virtio"}{Locked="VirtioProxy"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageSwiotlbKernelUnsupported" xml:space="preserve">
+    <value>The running kernel is missing a patch that significantly improves virtio device performance. Update to a more recent WSL kernel to enable this optimization.</value>
+    <comment>{Locked="virtio"}</comment>
   </data>
   <data name="MessageInstallationCorrupted" xml:space="preserve">
     <value>WSL installation appears to be corrupted (Error code: {}).

--- a/msipackage/CMakeLists.txt
+++ b/msipackage/CMakeLists.txt
@@ -32,6 +32,10 @@ foreach(binary ${LINUX_BINARIES})
     list(APPEND BINARIES_DEPENDENCIES "${BIN}/${binary}")
 endforeach()
 
+# Track wsldevicehost.dll (either from the NuGet package or from a -DWSL_DEVICE_HOST_DLL override)
+# so editing it triggers an MSI rebuild.
+list(APPEND BINARIES_DEPENDENCIES "${WSL_DEVICE_HOST_DLL_PATH}")
+
 if (${WSL_BUILD_THIN_PACKAGE})
     set(COMPRESS_PACKAGE "no")
 else()

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -240,7 +240,7 @@
                      which would fail the install. -->
                 <ServiceControl Id="StopService" Stop="both" Remove="uninstall" Name="WSLService" Wait="yes" />
 
-                <File Id="wsldevicehost.dll" Source="${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.dll" />
+                <File Id="wsldevicehost.dll" Source="${WSL_DEVICE_HOST_DLL_PATH}" />
 
                 <!-- WSLC COM app - activated through WSLService -->
                 <RegistryKey Root="HKCR" Key="AppID\{E9B79997-57E3-4201-AECC-6A464E530DD2}">

--- a/packages.config
+++ b/packages.config
@@ -19,8 +19,8 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.23-0" />
-  <package id="Microsoft.WSL.Kernel" version="6.18.26.1-1" targetFramework="native" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.29-0" />
+  <package id="Microsoft.WSL.Kernel" version="6.18.26.2-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -118,6 +118,7 @@ struct VmConfiguration
 int g_LogFd = STDERR_FILENO;
 int g_TelemetryFd = -1;
 std::optional<bool> g_EnableSocketLogging;
+bool g_KernelSupportsHvPciSwiotlb = false;
 
 int Chroot(const char* Target);
 
@@ -3399,6 +3400,7 @@ try
 
     uint32_t SeccompFlag = SECCOMP_RET_USER_NOTIF;
     Message->SeccompAvailable = syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 0, &SeccompFlag) == 0;
+    Message->KernelSupportsHvPciSwiotlb = g_KernelSupportsHvPciSwiotlb;
 
     Channel.SendMessage<LX_INIT_GUEST_CAPABILITIES>(Message.Span());
     return 0;
@@ -3690,6 +3692,15 @@ int main(int Argc, char* Argv[])
     }
 
     if (unsetenv(WSL_ROOT_INIT_ENV))
+    {
+        LOG_ERROR("unsetenv failed {}", errno);
+    }
+
+    // Linux passes unrecognized key=value cmdline parameters to init as env vars,
+    // so seeing hv_pci_swiotlb= in the environment means the kernel didn't consume
+    // it (no WSL swiotlb patch).
+    g_KernelSupportsHvPciSwiotlb = (getenv("hv_pci_swiotlb") == nullptr);
+    if (!g_KernelSupportsHvPciSwiotlb && unsetenv("hv_pci_swiotlb"))
     {
         LOG_ERROR("unsetenv failed {}", errno);
     }

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1430,9 +1430,10 @@ typedef struct _LX_INIT_GUEST_CAPABILITIES
 
     MESSAGE_HEADER Header;
     bool SeccompAvailable;
+    bool KernelSupportsHvPciSwiotlb;
     char Buffer[]; // Contains the kernel version string
 
-    PRETTY_PRINT(FIELD(Header), FIELD(SeccompAvailable), BUFFER_FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(SeccompAvailable), FIELD(KernelSupportsHvPciSwiotlb), BUFFER_FIELD(Buffer));
 } LX_INIT_GUEST_CAPABILITIES, *PLX_INIT_GUEST_CAPABILITIES;
 
 typedef struct _LX_MINI_INIT_WAIT_FOR_PMEM_DEVICE_MESSAGE

--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -133,6 +133,20 @@ void DeviceHostProxy::Shutdown()
 {
     {
         auto lock = m_lock.lock_exclusive();
+
+        for (auto& entry : m_fileSystems)
+        {
+            try
+            {
+                wil::com_ptr<IPlan9FileSystem> instance;
+                THROW_IF_FAILED(
+                    m_git->GetInterfaceFromGlobal(entry.Cookie, __uuidof(IPlan9FileSystem), reinterpret_cast<void**>(instance.put())));
+
+                LOG_IF_FAILED(instance->Teardown());
+            }
+            CATCH_LOG()
+        }
+
         m_fileSystems.clear();
         m_shutdown = true;
     }

--- a/src/windows/common/GuestDeviceManager.cpp
+++ b/src/windows/common/GuestDeviceManager.cpp
@@ -5,7 +5,9 @@
 #include "DeviceHostProxy.h"
 
 GuestDeviceManager::GuestDeviceManager(_In_ const std::wstring& machineId, _In_ const GUID& runtimeId) :
-    m_machineId(machineId), m_deviceHostSupport(wil::MakeOrThrow<DeviceHostProxy>(machineId, runtimeId))
+    m_machineId(machineId),
+    m_vmIdOption(std::format(L";vm_id={}", machineId)),
+    m_deviceHostSupport(wil::MakeOrThrow<DeviceHostProxy>(machineId, runtimeId))
 {
 }
 
@@ -35,12 +37,15 @@ GUID GuestDeviceManager::AddHdvShareWithOptions(
     // Options are appended to the name with a semi-colon separator.
     //  "name;key1=value1;key2=value2"
     // The AddSharePath implementation is responsible for separating them out and interpreting them.
+    // N.B. A ";vm_id=<guid>" option is always appended so the device host can identify the owning VM.
     std::wstring nameWithOptions{AccessName};
-    if (ARGUMENT_PRESENT(Options))
+    if (ARGUMENT_PRESENT(Options) && Options[0] != L'\0')
     {
         nameWithOptions += L";";
         nameWithOptions += Options;
     }
+
+    nameWithOptions += m_vmIdOption;
 
     {
         auto revert = wil::impersonate_token(UserToken);

--- a/src/windows/common/GuestDeviceManager.h
+++ b/src/windows/common/GuestDeviceManager.h
@@ -75,6 +75,7 @@ private:
 
     wil::srwlock m_lock;
     std::wstring m_machineId;
+    std::wstring m_vmIdOption;
     wil::com_ptr<DeviceHostProxy> m_deviceHostSupport;
     _Guarded_by_(m_lock) std::vector<DirectoryObjectLifetime> m_objectDirectories;
 };

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -15,12 +15,18 @@ static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
 VirtioNetworking::VirtioNetworking(
-    GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
+    GnsChannel&& gnsChannel,
+    VirtioNetworkingFlags flags,
+    LPCWSTR dnsOptions,
+    std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+    wil::shared_handle userToken,
+    std::wstring swiotlbConfig) :
     m_guestDeviceManager(std::move(guestDeviceManager)),
     m_userToken(std::move(userToken)),
     m_gnsChannel(std::move(gnsChannel)),
     m_flags(flags),
-    m_dnsOptions(dnsOptions)
+    m_dnsOptions(dnsOptions),
+    m_swiotlbConfig(std::move(swiotlbConfig))
 {
 }
 
@@ -187,6 +193,8 @@ void VirtioNetworking::RefreshGuestConnection()
         appendOption(L"client_ip_ipv6", networkSettings->PreferredIpv6Address.AddressString);
     }
 
+    appendOption(L"swiotlb", m_swiotlbConfig);
+
     networking::DnsInfo currentDns{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))
     {
@@ -240,14 +248,14 @@ void VirtioNetworking::RefreshGuestConnection()
 
 void VirtioNetworking::SetupLoopbackDevice()
 {
+    std::wstring loopbackOptions = L"client_ip=127.0.0.1;client_mac=00:11:22:33:44:55";
+    if (!m_swiotlbConfig.empty())
+    {
+        loopbackOptions += std::format(L";swiotlb={}", m_swiotlbConfig);
+    }
+
     m_localhostAdapterId = m_guestDeviceManager->AddGuestDevice(
-        VIRTIO_NET_DEVICE_ID,
-        VIRTIO_NET_CLASS_ID,
-        c_loopbackDeviceName,
-        nullptr,
-        L"client_ip=127.0.0.1;client_mac=00:11:22:33:44:55",
-        0,
-        m_userToken.get());
+        VIRTIO_NET_DEVICE_ID, VIRTIO_NET_CLASS_ID, c_loopbackDeviceName, nullptr, loopbackOptions.c_str(), 0, m_userToken.get());
 
     // The loopback gateway (see LX_INIT_IPV4_LOOPBACK_GATEWAY_ADDRESS) is 169.254.73.152, so assign loopback0 an
     // address of 169.254.73.153 with a netmask of 30 so that the only addresses associated with this adapter are

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -193,8 +193,6 @@ void VirtioNetworking::RefreshGuestConnection()
         appendOption(L"client_ip_ipv6", networkSettings->PreferredIpv6Address.AddressString);
     }
 
-    appendOption(L"swiotlb", m_swiotlbConfig);
-
     networking::DnsInfo currentDns{};
     if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))
     {
@@ -217,8 +215,15 @@ void VirtioNetworking::RefreshGuestConnection()
     {
         if (!m_adapterId.has_value())
         {
+            const auto swiotlbOption = m_swiotlbConfig.empty() ? std::wstring{} : std::format(L"swiotlb={}", m_swiotlbConfig);
             m_adapterId = m_guestDeviceManager->AddGuestDevice(
-                VIRTIO_NET_DEVICE_ID, VIRTIO_NET_CLASS_ID, c_eth0DeviceName, nullptr, device_options.c_str(), 0, m_userToken.get());
+                VIRTIO_NET_DEVICE_ID,
+                VIRTIO_NET_CLASS_ID,
+                c_eth0DeviceName,
+                swiotlbOption.c_str(),
+                device_options.c_str(),
+                0,
+                m_userToken.get());
         }
         else
         {
@@ -249,13 +254,16 @@ void VirtioNetworking::RefreshGuestConnection()
 void VirtioNetworking::SetupLoopbackDevice()
 {
     std::wstring loopbackOptions = L"client_ip=127.0.0.1;client_mac=00:11:22:33:44:55";
-    if (!m_swiotlbConfig.empty())
-    {
-        loopbackOptions += std::format(L";swiotlb={}", m_swiotlbConfig);
-    }
+    const auto swiotlbOption = m_swiotlbConfig.empty() ? std::wstring{} : std::format(L"swiotlb={}", m_swiotlbConfig);
 
     m_localhostAdapterId = m_guestDeviceManager->AddGuestDevice(
-        VIRTIO_NET_DEVICE_ID, VIRTIO_NET_CLASS_ID, c_loopbackDeviceName, nullptr, loopbackOptions.c_str(), 0, m_userToken.get());
+        VIRTIO_NET_DEVICE_ID,
+        VIRTIO_NET_CLASS_ID,
+        c_loopbackDeviceName,
+        swiotlbOption.c_str(),
+        loopbackOptions.c_str(),
+        0,
+        m_userToken.get());
 
     // The loopback gateway (see LX_INIT_IPV4_LOOPBACK_GATEWAY_ADDRESS) is 169.254.73.152, so assign loopback0 an
     // address of 169.254.73.153 with a netmask of 30 so that the only addresses associated with this adapter are

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -22,7 +22,13 @@ DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
+    VirtioNetworking(
+        GnsChannel&& gnsChannel,
+        VirtioNetworkingFlags flags,
+        LPCWSTR dnsOptions,
+        std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+        wil::shared_handle userToken,
+        std::wstring swiotlbConfig);
 
     ~VirtioNetworking();
 
@@ -62,6 +68,7 @@ private:
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
     VirtioNetworkingFlags m_flags = VirtioNetworkingFlags::None;
     LPCWSTR m_dnsOptions = nullptr;
+    std::wstring m_swiotlbConfig;
     std::optional<GUID> m_localhostAdapterId;
     std::optional<GUID> m_adapterId;
 

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -14,6 +14,7 @@ Abstract:
 
 #include "precomp.h"
 #include "WslCoreConfig.h"
+#include "helpers.hpp"
 #include "Localization.h"
 #include "WslCoreFirewallSupport.h"
 #include "WslCoreNetworkingSupport.h"
@@ -61,6 +62,24 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         {
             DnsTunnelingIpAddress = address.S_un.S_addr;
         }
+    };
+
+    auto parseSwiotlb = [&](const char* name, const char* value, const wchar_t* fileName, unsigned long fileLine) {
+        // If the value does not conform to the expected format, SWIOTLB customization is disabled.
+        SwiotlbConfig.clear();
+        try
+        {
+            auto wideValue = wsl::shared::string::MultiByteToWide(value);
+            std::wregex swiotlbPattern(L"^(0x[0-9a-fA-F]+,[0-9]+[mk])$", std::regex::icase);
+            if (!std::regex_match(wideValue, swiotlbPattern))
+            {
+                EMIT_USER_WARNING(shared::Localization::MessageConfigInvalidSwiotlb(value, name, fileName, fileLine));
+                return;
+            }
+
+            SwiotlbConfig = std::move(wideValue);
+        }
+        CATCH_LOG()
     };
 
     ConfigKeyPresence earlyBootLoggingPresent{};
@@ -124,7 +143,8 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         ConfigKey(ConfigSetting::Experimental::InitialAutoProxyTimeout, InitialAutoProxyTimeout),
         ConfigKey(ConfigSetting::Experimental::IgnoredPorts, std::move(parseIgnoredPorts)),
         ConfigKey(ConfigSetting::Experimental::HostAddressLoopback, EnableHostAddressLoopback),
-        ConfigKey(ConfigSetting::Experimental::SetVersionDebug, SetVersionDebug)};
+        ConfigKey(ConfigSetting::Experimental::SetVersionDebug, SetVersionDebug),
+        ConfigKey(ConfigSetting::Experimental::Swiotlb, std::move(parseSwiotlb))};
 
     wil::unique_file ConfigFile;
     if (ConfigFilePath != nullptr)
@@ -398,22 +418,6 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
         }
     }
 
-    // Load NAT configuration from the registry.
-    if (NetworkingMode == wsl::core::NetworkingMode::Nat)
-    {
-        try
-        {
-            const auto machineKey = wsl::windows::common::registry::OpenLxssMachineKey();
-            NatGateway = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natGatewayAddress, L"");
-            NatNetwork = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natNetwork, L"");
-
-            auto runAsUser = wil::impersonate_token(UserToken);
-            const auto userKey = wsl::windows::common::registry::OpenLxssUserKey();
-            NatIpAddress = wsl::windows::common::registry::ReadString(userKey.get(), nullptr, c_natIpAddress, L"");
-        }
-        CATCH_LOG()
-    }
-
     // Due to an issue with Global Secure Access Client, do not use DNS tunneling if the service is present.
     if (EnableDnsTunneling)
     {
@@ -454,12 +458,26 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
     {
         VALIDATE_CONFIG_OPTION(!EnableVirtio, EnableVirtio9p, false);
         VALIDATE_CONFIG_OPTION(!EnableVirtio, EnableVirtioFs, false);
+        VALIDATE_CONFIG_OPTION(!EnableVirtio, SwiotlbConfig, std::wstring{});
+
+        if (NetworkingMode == NetworkingMode::VirtioProxy)
+        {
+            NetworkingMode = (defaultNetworkingMode == NetworkingMode::VirtioProxy) ? NetworkingMode::None : NetworkingMode::Nat;
+            EMIT_USER_WARNING(wsl::shared::Localization::MessageVirtioProxyRequiresVirtio(ToString(NetworkingMode)));
+        }
     }
 
     if (EnableVirtio9p)
     {
         EMIT_USER_WARNING(wsl::shared::Localization::MessageConfigVirtio9pDisabled());
         EnableVirtio9p = false;
+    }
+
+    // Compute a default swiotlb config only when a virtio device that requires bounce buffers is present.
+    // N.B. Must run after policy overrides so networking/fs modes reflect final values.
+    if (SwiotlbConfig.empty() && (EnableVirtioFs || EnableVirtio9p || (NetworkingMode == NetworkingMode::VirtioProxy)))
+    {
+        SwiotlbConfig = wsl::windows::common::helpers::ComputeDefaultSwiotlbConfig(MemorySizeBytes);
     }
 
     if (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::VirtioProxy)
@@ -480,6 +498,23 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
     {
         VALIDATE_CONFIG_OPTION((NetworkingMode != NetworkingMode::Mirrored), IgnoredPorts, std::set<uint16_t>{});
         VALIDATE_CONFIG_OPTION((NetworkingMode != NetworkingMode::Mirrored), EnableHostAddressLoopback, false);
+    }
+
+    // Load NAT configuration from the registry.
+    // N.B. This must be done after all networking mode adjustments (e.g. VirtioProxy -> NAT fallback).
+    if (NetworkingMode == wsl::core::NetworkingMode::Nat)
+    {
+        try
+        {
+            const auto machineKey = wsl::windows::common::registry::OpenLxssMachineKey();
+            NatGateway = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natGatewayAddress, L"");
+            NatNetwork = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natNetwork, L"");
+
+            auto runAsUser = wil::impersonate_token(UserToken);
+            const auto userKey = wsl::windows::common::registry::OpenLxssUserKey();
+            NatIpAddress = wsl::windows::common::registry::ReadString(userKey.get(), nullptr, c_natIpAddress, L"");
+        }
+        CATCH_LOG()
     }
 }
 

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -27,11 +27,11 @@ Abstract:
         T_VALUE(c, EnableHostAddressLoopback), T_VALUE(c, EnableHostFileSystemAccess), T_VALUE(c, EnableIpv6), \
         T_VALUE(c, EnableLocalhostRelay), T_VALUE(c, EnableNestedVirtualization), T_VALUE(c, EnableSafeMode), \
         T_VALUE(c, EnableSparseVhd), T_VALUE(c, EnableVirtio), T_VALUE(c, EnableVirtio9p), T_VALUE(c, EnableVirtioFs), \
-        T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), \
-        T_VALUE(c, KernelDebugPort), T_SET(c, KernelModulesPath), T_STRING(c, KernelModulesList), T_SET(c, KernelPath), \
-        T_VALUE(c, LoadDefaultKernelModules), T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), \
-        T_VALUE(c, MaximumProcessorCount), T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), \
-        T_ENUM(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), \
+        T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), T_VALUE(c, KernelDebugPort), \
+        T_STRING(c, KernelModulesList), T_SET(c, KernelModulesPath), T_SET(c, KernelPath), T_VALUE(c, LoadDefaultKernelModules), \
+        T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), T_VALUE(c, MaximumProcessorCount), \
+        T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), T_ENUM(c, NetworkingMode), \
+        T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_STRING(c, SwiotlbConfig), \
         T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
 namespace wsl::core {
@@ -289,6 +289,7 @@ namespace ConfigSetting {
         static constexpr auto IgnoredPorts = "experimental.ignoredPorts";
         static constexpr auto HostAddressLoopback = "experimental.hostAddressLoopback";
         static constexpr auto SetVersionDebug = "experimental.setVersionDebug";
+        static constexpr auto Swiotlb = "experimental.swiotlb";
 
     } // namespace Experimental
 } // namespace ConfigSetting
@@ -375,6 +376,7 @@ struct Config
     bool EnableHostAddressLoopback = false;
     std::filesystem::path CrashDumpFolder;
     int MaxCrashDumpCount = 10;
+    std::wstring SwiotlbConfig;
 
     // Temporary config value to help root cause the truncated archive errors in SetVersion()
     bool SetVersionDebug = false;

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -783,14 +783,17 @@ void wsl::windows::common::helpers::AppendCommonKernelCommandLine(
 
 std::wstring wsl::windows::common::helpers::ComputeDefaultSwiotlbConfig(_In_ UINT64 memoryBytes)
 {
-    // Skip swiotlb on VMs below 1 GiB; the buffer would be a meaningful chunk of RAM. Users can
-    // still opt in explicitly via experimental.swiotlb in .wslconfig.
-    if (memoryBytes < _1GB)
+    constexpr UINT64 c_swiotlbBase = _1GB;
+    constexpr UINT64 c_swiotlbSize = 64 * _1MB;
+
+    // Skip swiotlb on VMs that cannot fit the reserved buffer. Users can still opt in explicitly
+    // via experimental.swiotlb in .wslconfig.
+    if (memoryBytes < c_swiotlbBase + c_swiotlbSize)
     {
         return {};
     }
 
-    // 256 MiB base sits below 4 GiB (32-bit PCI BAR limit on ARM64 virtio), below the Hyper-V
-    // low PCI MMIO hole (starts at >= 3 GiB on both x64 and ARM64), and above the kernel image.
-    return L"0x10000000,64M";
+    // 1 GiB base sits below 4 GiB (32-bit PCI BAR limit on ARM64 virtio), below the Hyper-V
+    // low PCI MMIO hole (starts at >= 3 GiB on both x64 and ARM64), and above early boot allocations.
+    return L"0x40000000,64M";
 }

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -762,7 +762,8 @@ try
 }
 CATCH_LOG()
 
-void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder)
+void wsl::windows::common::helpers::AppendCommonKernelCommandLine(
+    _Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ const std::wstring& swiotlbConfig)
 {
     // Enable timesync workaround to sync on resume from sleep in modern standby.
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
@@ -772,4 +773,24 @@ void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::w
 
     // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
     kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", pageReportingOrder);
+
+    // Reserve a swiotlb bounce buffer for virtio devices.
+    if (!swiotlbConfig.empty())
+    {
+        kernelCmdLine += std::format(L" swiotlb=force hv_pci_swiotlb={}", swiotlbConfig);
+    }
+}
+
+std::wstring wsl::windows::common::helpers::ComputeDefaultSwiotlbConfig(_In_ UINT64 memoryBytes)
+{
+    // Skip swiotlb on VMs below 1 GiB; the buffer would be a meaningful chunk of RAM. Users can
+    // still opt in explicitly via experimental.swiotlb in .wslconfig.
+    if (memoryBytes < _1GB)
+    {
+        return {};
+    }
+
+    // 256 MiB base sits below 4 GiB (32-bit PCI BAR limit on ARM64 virtio), below the Hyper-V
+    // low PCI MMIO hole (starts at >= 3 GiB on both x64 and ARM64), and above the kernel image.
+    return L"0x10000000,64M";
 }

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -205,6 +205,11 @@ bool TryAttachConsole();
 
 void RegisterWithDcat(_In_ bool IncludeVersionNumber = true);
 
-void AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder);
+void AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ const std::wstring& swiotlbConfig = {});
+
+// Compute the default swiotlb device-options token ("0x<base>,<size>M") for the current
+// VM. Returns an empty string for VMs too small to host the bounce buffer. Used when the
+// user has not provided an explicit experimental.swiotlb value.
+std::wstring ComputeDefaultSwiotlbConfig(_In_ UINT64 memoryBytes);
 
 } // namespace wsl::windows::common::helpers

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -134,12 +134,18 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
 #endif
 
+    // Compute a swiotlb device-options token sized to fit this VM's RAM, used by the kernel
+    // command line, virtiofs shares, and the VirtioProxy virtio-net adapter.
+    // Only needed when a virtio device that requires bounce buffers will be attached.
+    if (FeatureEnabled(WslcFeatureFlagsVirtioFs) || m_networkingMode == WSLCNetworkingModeVirtioProxy)
+    {
+        m_swiotlbConfig = helpers::ComputeDefaultSwiotlbConfig(static_cast<UINT64>(Settings->MemoryMb) * _1MB);
+    }
+
     // Initialize kernel command line.
     std::wstring kernelCmdLine = L"initrd=\\" LXSS_VM_MODE_INITRD_NAME L" " TEXT(WSLC_ROOT_INIT_ENV) L"=1 panic=-1";
     kernelCmdLine += std::format(L" nr_cpus={}", Settings->CpuCount);
-
-    // Append common kernel parameters shared between WSL2 and WSLC.
-    helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder);
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder, m_swiotlbConfig);
 
     // Setup dmesg collector with optional DmesgOutput handle.
     // TODO: move dmesg collector to user session process.
@@ -456,7 +462,7 @@ try
         }
 
         m_networkEngine = std::make_unique<wsl::core::VirtioNetworking>(
-            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken);
+            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken, m_swiotlbConfig);
     }
     else
     {
@@ -573,11 +579,22 @@ try
     }
     else
     {
+        std::wstring options = ReadOnly ? L"ro" : L"";
+        if (!m_swiotlbConfig.empty())
+        {
+            if (!options.empty())
+            {
+                options += L";";
+            }
+
+            options += std::format(L"swiotlb={}", m_swiotlbConfig);
+        }
+
         it->second = m_guestDeviceManager->AddGuestDevice(
             VIRTIO_FS_DEVICE_ID,
             m_virtioFsClassId,
             shareName.c_str(),
-            ReadOnly ? L"ro" : L"",
+            options.c_str(),
             WindowsPath,
             VIRTIO_FS_FLAGS_TYPE_FILES,
             m_userToken.get());

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -79,6 +79,9 @@ private:
     WSLCFeatureFlags m_featureFlags{};
     WSLCNetworkingMode m_networkingMode{};
 
+    // Swiotlb device-options token sized to fit inside the VM's RAM (empty when too small).
+    std::wstring m_swiotlbConfig;
+
     wil::unique_socket m_listenSocket;
     std::shared_ptr<DmesgCollector> m_dmesgCollector;
     std::shared_ptr<GuestDeviceManager> m_guestDeviceManager;

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -415,6 +415,31 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
         addShare(TEXT(LXSS_GPU_PACKAGED_LIB_SHARE), path.c_str());
     }
 
+    // Accept a connection from mini_init with a receive timeout so the service does not get stuck waiting for a response from the VM.
+    m_miniInitChannel =
+        wsl::shared::SocketChannel{AcceptConnection(m_vmConfig.KernelBootTimeout), "mini_init", {m_terminatingEvent.get()}};
+
+    // Accept the connection from the Linux guest for notifications.
+    m_notifyChannel = AcceptConnection(m_vmConfig.KernelBootTimeout);
+
+    // Receive and parse the guest kernel version
+    ReadGuestCapabilities();
+
+    // Cache the effective swiotlb configuration. The wsldevicehost device-option token is only
+    // honored by kernels carrying the WSL hv_pci_swiotlb patch; if the running kernel lacks it,
+    // emit a single user warning and leave the cached value empty so all attachment sites skip it.
+    if (!m_vmConfig.SwiotlbConfig.empty())
+    {
+        if (m_kernelSupportsHvPciSwiotlb)
+        {
+            m_swiotlbConfig = m_vmConfig.SwiotlbConfig;
+        }
+        else
+        {
+            EMIT_USER_WARNING(wsl::shared::Localization::MessageSwiotlbKernelUnsupported());
+        }
+    }
+
     // Asynchronously add drvfs devices if supported.
     if (m_vmConfig.EnableHostFileSystemAccess)
     {
@@ -437,16 +462,6 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             }
         }).detach();
     }
-
-    // Accept a connection from mini_init with a receive timeout so the service does not get stuck waiting for a response from the VM.
-    m_miniInitChannel =
-        wsl::shared::SocketChannel{AcceptConnection(m_vmConfig.KernelBootTimeout), "mini_init", {m_terminatingEvent.get()}};
-
-    // Accept the connection from the Linux guest for notifications.
-    m_notifyChannel = AcceptConnection(m_vmConfig.KernelBootTimeout);
-
-    // Receive and parse the guest kernel version
-    ReadGuestCapabilities();
 
     // Mount the system distro.
     // N.B. If using SCSI, the system distro is added during VM creation.
@@ -586,8 +601,9 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
                 WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::DnsTunneling, m_vmConfig.EnableDnsTunneling);
                 // NAT may have fallen back to virtio proxy after the early-config message; drop the unused DNS hvsocket.
                 dnsTunnelingSocket.reset();
+
                 m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
-                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);
+                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken, m_swiotlbConfig);
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::Bridged)
             {
@@ -1539,13 +1555,7 @@ std::wstring WslCoreVm::GenerateConfigJson()
     kernelCmdLine += std::format(L" nr_cpus={}", m_vmConfig.ProcessorCount);
 
     // Append common kernel parameters shared between WSL2 and WSLC.
-    helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder);
-
-    // If using virtio features, enable SWIOTLB as a perf optimization (will cause VM to consume 64MB more memory).
-    if (m_vmConfig.EnableVirtio9p || m_vmConfig.EnableVirtioFs || m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)
-    {
-        kernelCmdLine += L" swiotlb=force";
-    }
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder, m_vmConfig.SwiotlbConfig);
 
     if (m_vmConfig.EnableVirtio && helpers::IsVirtioSerialConsoleSupported())
     {
@@ -2162,10 +2172,23 @@ std::pair<std::wstring, std::wstring> WslCoreVm::AddVirtioFsShare(_In_ bool Admi
 
     sharePath = std::filesystem::weakly_canonical(sharePath).wstring();
 
+    // Append the swiotlb token here so it covers fixed-drive, dynamic add, and remount paths.
+    // Duplicate swiotlb tokens are harmless: VirtioFsShare parses options into a map.
+    std::wstring effectiveOptions(Options);
+    if (!m_swiotlbConfig.empty())
+    {
+        if (!effectiveOptions.empty())
+        {
+            effectiveOptions += L';';
+        }
+
+        effectiveOptions += std::format(L"swiotlb={}", m_swiotlbConfig);
+    }
+
     // Check if a matching share already exists.
     bool created = false;
     std::wstring tag;
-    VirtioFsShare key(sharePath.c_str(), Options, Admin);
+    VirtioFsShare key(sharePath.c_str(), effectiveOptions.c_str(), Admin);
     if (!m_virtioFsShares.contains(key))
     {
         // Generate a new unique tag for the share.
@@ -2198,7 +2221,7 @@ std::pair<std::wstring, std::wstring> WslCoreVm::AddVirtioFsShare(_In_ bool Admi
         "WslCoreVmAddVirtioFsShare",
         TraceLoggingValue(Admin, "admin"),
         TraceLoggingValue(sharePath.c_str(), "path"),
-        TraceLoggingValue(Options, "options"),
+        TraceLoggingValue(effectiveOptions.c_str(), "options"),
         TraceLoggingValue(tag.c_str(), "tag"),
         TraceLoggingValue(created, "created"),
         TraceLoggingValue(m_virtioFsShares.size(), "shareCount"));
@@ -2309,9 +2332,11 @@ void WslCoreVm::ReadGuestCapabilities()
     }
 
     m_seccompAvailable = info.SeccompAvailable;
+    m_kernelSupportsHvPciSwiotlb = info.KernelSupportsHvPciSwiotlb;
     WSL_LOG(
         "GuestKernelInfo",
         TraceLoggingValue(m_seccompAvailable, "SeccompAvailable"),
+        TraceLoggingValue(m_kernelSupportsHvPciSwiotlb, "KernelSupportsHvPciSwiotlb"),
         TraceLoggingValue(std::get<0>(m_kernelVersion), "Version"),
         TraceLoggingValue(std::get<1>(m_kernelVersion), "Revision"),
         TraceLoggingValue(std::get<2>(m_kernelVersion), "Minor"));

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -304,6 +304,8 @@ private:
     std::tuple<std::uint32_t, std::uint32_t, std::uint32_t> m_kernelVersion;
     std::wstring m_kernelVersionString;
     bool m_seccompAvailable;
+    bool m_kernelSupportsHvPciSwiotlb = false;
+    std::wstring m_swiotlbConfig;
     std::wstring m_sharedMemoryRoot;
     std::filesystem::path m_installPath;
     std::wstring m_userProfile;

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2128,6 +2128,20 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
             L"[experimental]\nignoredPorts=65536",
             std::format(L"wsl: Invalid integer value '65536' for key 'experimental.ignoredPorts' in {}:22\r\n", wslConfigPath));
 
+        // Verify experimental.swiotlb parsing and validation.
+        //
+        // With wsl2.virtio enabled (the default), a valid swiotlb value is accepted silently.
+        validateWarnings(L"[experimental]\nswiotlb=0x100000000,64M", L"");
+
+        // Malformed values are rejected by the parser; only the parser warning is reported.
+        validateWarnings(
+            L"[experimental]\nswiotlb=garbage",
+            std::format(L"wsl: Invalid SWIOTLB value 'garbage' for key 'experimental.swiotlb' in {}:22. Expected format: '0x<hex>,<size>K|M'\r\n", wslConfigPath));
+
+        validateWarnings(
+            L"[experimental]\nswiotlb=0x100000000,64g",
+            std::format(L"wsl: Invalid SWIOTLB value '0x100000000,64g' for key 'experimental.swiotlb' in {}:22. Expected format: '0x<hex>,<size>K|M'\r\n", wslConfigPath));
+
         // Verify that the vhdSize setting is parsed correctly.
         validateWarnings(L"[wsl2]\ndefaultVhdSize=64GB\n", L"");
 


### PR DESCRIPTION
## Summary

Improve VirtioFs performance by adding swiotlb (Software Translation Lookaside Buffer) bounce buffer support for virtio devices. Swiotlb enables more efficient DMA handling for VirtioFs, reducing overhead in file system operations.

## PR Checklist
- [x] Builds clean (Release x64)
- [x] Code review passed

## Detailed Description

### Commit 1: Add experimental.swiotlb .wslconfig setting
- Adds a new `[experimental]` config key `swiotlb` to specify custom swiotlb configuration
- Adds localization strings and validation

### Commit 2: Swiotlb gating, vmId plumbing, and devicehost override
- **Swiotlb gating for VirtioFs perf**: Automatically compute default swiotlb bounce buffer config when VirtioFs (or other virtio devices) are enabled, enabling efficient DMA for file system operations
- **Virtio9p deprecation ordering**: Move the virtio9p deprecation/disable block before swiotlb computation so deprecated devices don't trigger unnecessary bounce buffer config
- **vmId plumbing**: Inject vmId=<machineId> into all virtio device options via \GuestDeviceManager::AddHdvShareWithOptions\ for proper device-to-VM association
- **WSL_DEVICE_HOST_DLL override**: Add CMake option to replace wsldevicehost.dll without a NuGet update (dev-loop improvement)
- **Fix empty-options guard**: Prevent double semicolons when appending to device options
- **Package update**: Update packages.config

## Validation Steps
- Built successfully in Release x64 configuration
- Code reviewed for logic correctness (swiotlb gating order verified)
