### PR TITLE
CLI: Fix parser treating stdin positional ('-') as an argument specifier error.

### DIFF
--- a/src/windows/wslc/arguments/ArgumentParser.cpp
+++ b/src/windows/wslc/arguments/ArgumentParser.cpp
@@ -67,31 +67,24 @@ void ParseArgumentsStateMachine::ThrowIfError() const
     }
 }
 
+void ParseArgumentsStateMachine::AdvanceToNextPositional(std::vector<Argument>::iterator& itr) const
+{
+    while (itr != m_positionalArgs.end() && (m_executionArgs.Count(itr->Type()) == itr->Limit()))
+    {
+        ++itr;
+    }
+}
+
 const Argument* ParseArgumentsStateMachine::NextPositional()
 {
-    // Find the next appropriate positional arg if the current itr isn't one or has hit its limit.
-    while (m_positionalSearchItr != m_positionalArgs.end() &&
-           (m_executionArgs.Count(m_positionalSearchItr->Type()) == m_positionalSearchItr->Limit()))
-    {
-        ++m_positionalSearchItr;
-    }
-
-    if (m_positionalSearchItr == m_positionalArgs.end())
-    {
-        return nullptr;
-    }
-
-    return &*m_positionalSearchItr;
+    AdvanceToNextPositional(m_positionalSearchItr);
+    return m_positionalSearchItr != m_positionalArgs.end() ? &*m_positionalSearchItr : nullptr;
 }
 
 bool ParseArgumentsStateMachine::HasNextPositional() const
 {
     auto itr = m_positionalSearchItr;
-    while (itr != m_positionalArgs.end() && (m_executionArgs.Count(itr->Type()) == itr->Limit()))
-    {
-        ++itr;
-    }
-
+    AdvanceToNextPositional(itr);
     return itr != m_positionalArgs.end();
 }
 

--- a/src/windows/wslc/arguments/ArgumentParser.cpp
+++ b/src/windows/wslc/arguments/ArgumentParser.cpp
@@ -184,15 +184,6 @@ ParseArgumentsStateMachine::State ParseArgumentsStateMachine::ProcessAnchoredPos
     if ((m_executionArgs.Count(m_anchorPositional.value().Type()) < m_anchorPositional.value().Limit()) ||
         (m_anchorPositional.value().Limit() == NO_LIMIT))
     {
-        // Validate that we don't have any invalid argument specifiers.
-        // Anchor positionals with multiple values should be order-independent, which means a
-        // '-' at the start of the first one would be invalid, so it should also be invalid for
-        // all other anchor positionals of the same type.
-        if (!currArg.empty() && currArg[0] == WSLC_CLI_ARG_ID_CHAR)
-        {
-            return ArgumentException(Localization::WSLCCLI_InvalidArgumentSpecifierError(currArg));
-        }
-
         m_executionArgs.Add(m_anchorPositional.value().Type(), std::wstring{currArg});
         return {};
     }

--- a/src/windows/wslc/arguments/ArgumentParser.cpp
+++ b/src/windows/wslc/arguments/ArgumentParser.cpp
@@ -84,6 +84,17 @@ const Argument* ParseArgumentsStateMachine::NextPositional()
     return &*m_positionalSearchItr;
 }
 
+bool ParseArgumentsStateMachine::HasNextPositional() const
+{
+    auto itr = m_positionalSearchItr;
+    while (itr != m_positionalArgs.end() && (m_executionArgs.Count(itr->Type()) == itr->Limit()))
+    {
+        ++itr;
+    }
+
+    return itr != m_positionalArgs.end();
+}
+
 // Parse arguments as such:
 //  1. If argument starts with a single -, the alias is considered (can be 1-2 characters).
 //      a. If the named argument alias (a or ab) needs a VALUE, it can be provided in these ways:
@@ -127,7 +138,14 @@ ParseArgumentsStateMachine::State ParseArgumentsStateMachine::StepInternal()
     // The currentArg is non-empty, and starts with a -.
     if (currArg.length() == 1)
     {
-        // If it is only one character, then it is an error since it is neither an alias nor a named argument.
+        if (HasNextPositional())
+        {
+            // The '-' character may be a valid positional argument value (ex: stdin), so treat this
+            // as a positional argument if there are any positionals left to fill.
+            return ProcessPositionalArgument(currArg);
+        }
+
+        // No positional argument remaining means this is an invalid argument.
         return ArgumentException(Localization::WSLCCLI_InvalidArgumentSpecifierError(currArg));
     }
 
@@ -141,10 +159,10 @@ ParseArgumentsStateMachine::State ParseArgumentsStateMachine::StepInternal()
     return ProcessNamedArgument(currArg);
 }
 
-// Assumes non-empty and does not begin with '-'.
+// Assumes non-empty.
 ParseArgumentsStateMachine::State ParseArgumentsStateMachine::ProcessPositionalArgument(const std::wstring_view& currArg)
 {
-    WI_ASSERT(!currArg.empty() && currArg[0] != WSLC_CLI_ARG_ID_CHAR);
+    WI_ASSERT(!currArg.empty());
 
     const Argument* nextPositional = NextPositional();
     if (!nextPositional)

--- a/src/windows/wslc/arguments/ArgumentParser.h
+++ b/src/windows/wslc/arguments/ArgumentParser.h
@@ -89,6 +89,9 @@ struct ParseArgumentsStateMachine
     // Gets the next positional argument, or nullptr if there is not one.
     const Argument* NextPositional();
 
+    // Returns true if there is a next positional argument available, without advancing the iterator.
+    bool HasNextPositional() const;
+
     const std::vector<Argument>& Arguments() const
     {
         return m_arguments;

--- a/src/windows/wslc/arguments/ArgumentParser.h
+++ b/src/windows/wslc/arguments/ArgumentParser.h
@@ -105,6 +105,9 @@ private:
     State ProcessNamedArgument(const std::wstring_view& currArg);
     void ProcessAdjoinedValue(ArgType type, std::wstring_view value);
 
+    // Advances the given iterator past any positionals that have reached their limit.
+    void AdvanceToNextPositional(std::vector<Argument>::iterator& itr) const;
+
     Invocation& m_invocation;
     ArgMap& m_executionArgs;
     std::vector<Argument> m_arguments;

--- a/test/windows/wslc/ParserTestCases.h
+++ b/test/windows/wslc/ParserTestCases.h
@@ -121,6 +121,12 @@ WSLC_PARSER_TEST_CASE(Run, true, LR"(wslc image1 \\command\\?"" --f -z forward h
 WSLC_PARSER_TEST_CASE(Run, true, LR"(wslc jrottenberg/ffmpeg:4.4-alpine ffmpeg -i http://url/to/media.mp4 -stats)") \
 WSLC_PARSER_TEST_CASE(Run, true, L"wslc jrottenberg/ffmpeg:4.4-alpine \\\nffmpeg \\\n-i http://url/to/media.mp4 \\\n-stats") \
 \
+/* Stdin dash ('-') as a positional value. A lone '-' conventionally means stdin and must  \
+ * be accepted as a valid positional rather than treated as an invalid flag specifier. */  \
+WSLC_PARSER_TEST_CASE(Run, true, LR"(wslc -)") \
+WSLC_PARSER_TEST_CASE(Run, true, LR"(wslc - command)") \
+WSLC_PARSER_TEST_CASE(Run, true, LR"(wslc --verbose -)") \
+\
 /* List cases with multiple args and flags that can come after the optional multi-positional. */ \
 WSLC_PARSER_TEST_CASE(List, true, LR"(wslc)") \
 WSLC_PARSER_TEST_CASE(List, true, LR"(wslc cont1)") \

--- a/test/windows/wslc/WSLCCLIParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIParserUnitTests.cpp
@@ -46,8 +46,7 @@ class WSLCCLIParserUnitTests
         return true;
     }
 
-    // Test: Verify command line to argv mapping and GetRemainingRawCommandLineFromIndex
-    TEST_METHOD(ParserTest_StateMachine_PositionalForward)
+    TEST_METHOD(ParserTest_ParserCases)
     {
         // Build test cases from x-macro
         std::vector<ParserTestCase> testCases = {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The parser was treating '-' as an invalid argument specifier when it is a valid positional argument value when used to specify 'stdin'. This fixes it by checking first if there is a positional argument available, and if so then we treat it as the value and only consider it an argument error if there are no positionals remaining.  The assert in positional processing was also updated to allow a single '-' as input.

Parser test cases were added to verify this and the generic parser test cases test case was renamed for clarity.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually verified argument is valid

Ran updated parser test cases and confirmed the - argument positional cases pass.