### PR TITLE
Made wslc build output more detailed

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -501,17 +501,23 @@ struct BuildKitVertex
     std::string digest;
     std::string name;
     std::string started;
+    std::string completed;
     std::string error;
+    bool cached{};
+    std::vector<std::string> inputs;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(BuildKitVertex, digest, name, started, error);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(BuildKitVertex, digest, name, started, completed, error, cached, inputs);
 };
 
 struct BuildKitStatus
 {
     std::string id;
     std::string vertex;
+    int64_t current{};
+    int64_t total{};
+    std::string completed;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(BuildKitStatus, id, vertex);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(BuildKitStatus, id, vertex, current, total, completed);
 };
 
 struct BuildKitLog

--- a/src/windows/wslc/services/BuildImageCallback.cpp
+++ b/src/windows/wslc/services/BuildImageCallback.cpp
@@ -14,7 +14,6 @@ Abstract:
 
 #include "precomp.h"
 #include "BuildImageCallback.h"
-#include <docker_schema.h>
 
 namespace wsl::windows::wslc::services {
 
@@ -197,31 +196,44 @@ try
     }
 
     std::string statusStr(status);
-    std::string idStr(id ? id : "");
 
-    // BuildKit JSON messages are identified by the "buildkit" id
-    if (idStr == "buildkit")
+    try
     {
-        StartTimerThread();
-
         std::lock_guard lock(m_mutex);
+        m_buildView.ProcessMessage(statusStr);
 
-        try
+        if (!m_isConsole)
         {
-            auto json = nlohmann::json::parse(statusStr);
-            wsl::windows::common::docker_schema::BuildKitSolveStatus solveStatus{};
-            from_json(json, solveStatus);
-            m_buildView.ProcessMessage(solveStatus);
+            PrintPlainTextProgress();
         }
-        catch (...)
+        else 
         {
-            // Ignore malformed JSON
+            StartTimerThread();
         }
+    } 
+    catch (...)
+    {
+        LOG_CAUGHT_EXCEPTION();
     }
 
     return S_OK;
 }
 CATCH_RETURN();
+
+// ── Plain-text progress (non-console) ───────────────────────────────
+
+void BuildImageCallback::PrintPlainTextProgress()
+{
+    for (const auto* step : m_buildView.GetUnreportedSteps())
+    {
+        wprintf(L"%hs\n", step->stepLabel.c_str());
+
+        if (!step->error.empty())
+        {
+            wprintf(L"%hs\n", step->error.c_str());
+        }
+    }
+}
 
 // ── Step line formatter ─────────────────────────────────────────────
 
@@ -280,6 +292,51 @@ std::wstring BuildImageCallback::FormatStepLine(const ViewStep& step, SHORT cons
     }
 }
 
+// Synthesize cached FROM lines for base image steps that were skipped
+// because they were resolved from a shared stage.
+void BuildImageCallback::AppendCachedFromLines(
+    const ViewTarget& target, SHORT consoleWidth, std::vector<std::wstring>& lines) const
+{
+    if (target.steps.empty())
+    {
+        return;
+    }
+
+    const auto& firstStep = target.steps[0];
+    if (firstStep.stepNum <= 1 || firstStep.stepTotal == 0)
+    {
+        return;
+    }
+
+    for (uint32_t n = 1; n < firstStep.stepNum; n++)
+    {
+        std::string fromImage = " ...";
+        for (const auto& digest : firstStep.inputs)
+        {
+            auto* inputStep = m_buildView.StepByDigest(digest);
+            if (inputStep && inputStep->stepLabel.find("] FROM ") != std::string::npos)
+            {
+                auto pos = inputStep->stepLabel.find("] FROM ");
+                if (pos != std::string::npos)
+                {
+                    fromImage = inputStep->stepLabel.substr(pos + 6);
+                }
+                break;
+            }
+        }
+        auto label = std::format("[{} {}/{}] FROM{}", target.name, n, firstStep.stepTotal, fromImage);
+        auto wlabel = MultiByteToWide(label);
+        if (static_cast<SHORT>(wlabel.size()) > consoleWidth - 10)
+        {
+            wlabel.resize(consoleWidth - 13);
+            wlabel += L"...";
+        }
+        auto padLen =
+            (wlabel.size() + 6 < static_cast<size_t>(consoleWidth)) ? static_cast<size_t>(consoleWidth) - wlabel.size() - 6 : 0;
+        lines.push_back(std::format(L"\033[36m{}{}{}\033[0m", wlabel, std::wstring(std::max<size_t>(1, padLen), L' '), L"CACHED"));
+    }
+}
+
 // ── Frame line builder ──────────────────────────────────────────────
 // Builds all frame lines into a vector. Each entry is one visual line
 // (no embedded newlines). Used by both RenderFrame and the destructor's
@@ -324,42 +381,7 @@ std::vector<std::wstring> BuildImageCallback::BuildFrameLines(SHORT consoleWidth
         firstTarget = false;
 
         // Synthesize cached FROM steps for shared base images
-        if (!target.steps.empty())
-        {
-            const auto& firstStep = target.steps[0];
-            if (firstStep.stepNum > 1 && firstStep.stepTotal > 0)
-            {
-                for (uint32_t n = 1; n < firstStep.stepNum; n++)
-                {
-                    std::string fromImage = " ...";
-                    for (const auto& digest : firstStep.inputs)
-                    {
-                        auto* inputStep = m_buildView.StepByDigest(digest);
-                        if (inputStep && inputStep->stepLabel.find("] FROM ") != std::string::npos)
-                        {
-                            auto pos = inputStep->stepLabel.find("] FROM ");
-                            if (pos != std::string::npos)
-                            {
-                                fromImage = inputStep->stepLabel.substr(pos + 6);
-                            }
-                            break;
-                        }
-                    }
-                    auto label = std::format("[{} {}/{}] FROM{}", target.name, n, firstStep.stepTotal, fromImage);
-                    auto wlabel = MultiByteToWide(label);
-                    if (static_cast<SHORT>(wlabel.size()) > consoleWidth - 10)
-                    {
-                        wlabel.resize(consoleWidth - 13);
-                        wlabel += L"...";
-                    }
-                    auto padLen = (wlabel.size() + 6 < static_cast<size_t>(consoleWidth))
-                                      ? static_cast<size_t>(consoleWidth) - wlabel.size() - 6
-                                      : 0;
-                    lines.push_back(
-                        std::format(L"\033[36m{}{}{}\033[0m", wlabel, std::wstring(std::max<size_t>(1, padLen), L' '), L"CACHED"));
-                }
-            }
-        }
+        AppendCachedFromLines(target, consoleWidth, lines);
 
         // Steps
         for (const auto& step : target.steps)

--- a/src/windows/wslc/services/BuildImageCallback.cpp
+++ b/src/windows/wslc/services/BuildImageCallback.cpp
@@ -206,11 +206,11 @@ try
         {
             PrintPlainTextProgress();
         }
-        else 
+        else
         {
             StartTimerThread();
         }
-    } 
+    }
     catch (...)
     {
         LOG_CAUGHT_EXCEPTION();
@@ -294,8 +294,7 @@ std::wstring BuildImageCallback::FormatStepLine(const ViewStep& step, SHORT cons
 
 // Synthesize cached FROM lines for base image steps that were skipped
 // because they were resolved from a shared stage.
-void BuildImageCallback::AppendCachedFromLines(
-    const ViewTarget& target, SHORT consoleWidth, std::vector<std::wstring>& lines) const
+void BuildImageCallback::AppendCachedFromLines(const ViewTarget& target, SHORT consoleWidth, std::vector<std::wstring>& lines) const
 {
     if (target.steps.empty())
     {
@@ -331,8 +330,7 @@ void BuildImageCallback::AppendCachedFromLines(
             wlabel.resize(consoleWidth - 13);
             wlabel += L"...";
         }
-        auto padLen =
-            (wlabel.size() + 6 < static_cast<size_t>(consoleWidth)) ? static_cast<size_t>(consoleWidth) - wlabel.size() - 6 : 0;
+        auto padLen = (wlabel.size() + 6 < static_cast<size_t>(consoleWidth)) ? static_cast<size_t>(consoleWidth) - wlabel.size() - 6 : 0;
         lines.push_back(std::format(L"\033[36m{}{}{}\033[0m", wlabel, std::wstring(std::max<size_t>(1, padLen), L' '), L"CACHED"));
     }
 }

--- a/src/windows/wslc/services/BuildImageCallback.cpp
+++ b/src/windows/wslc/services/BuildImageCallback.cpp
@@ -14,31 +14,145 @@ Abstract:
 
 #include "precomp.h"
 #include "BuildImageCallback.h"
+#include <docker_schema.h>
 
 namespace wsl::windows::wslc::services {
 
 using wsl::windows::common::string::MultiByteToWide;
 
+// ── Formatting helpers ───────────────────────────────────────────────
+
+static std::wstring FormatBytes(int64_t b)
+{
+    if (b <= 0)
+    {
+        return L"0B";
+    }
+
+    constexpr double c_kB = 1024.0;
+    constexpr double c_MB = 1024.0 * 1024.0;
+    constexpr double c_GB = 1024.0 * 1024.0 * 1024.0;
+    auto val = static_cast<double>(b);
+
+    if (val >= c_GB)
+    {
+        return std::format(L"{:.2f}GB", val / c_GB);
+    }
+    if (val >= c_MB)
+    {
+        return std::format(L"{:.2f}MB", val / c_MB);
+    }
+    if (val >= c_kB)
+    {
+        return std::format(L"{:.2f}kB", val / c_kB);
+    }
+    return std::format(L"{}B", b);
+}
+
+static std::wstring FormatElapsed(std::chrono::steady_clock::time_point start)
+{
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+    auto totalSeconds = elapsed.count() / 1000;
+
+    if (totalSeconds >= 60)
+    {
+        auto minutes = totalSeconds / 60;
+        auto seconds = totalSeconds % 60;
+        return std::format(L"{}m{:.0f}s", minutes, static_cast<double>(seconds));
+    }
+
+    return std::format(L"{:.1f}s", elapsed.count() / 1000.0);
+}
+
+static std::wstring FormatDuration(std::chrono::milliseconds d)
+{
+    auto totalSeconds = d.count() / 1000;
+
+    if (totalSeconds >= 60)
+    {
+        auto minutes = totalSeconds / 60;
+        auto seconds = totalSeconds % 60;
+        return std::format(L"{}m{:.0f}s", minutes, static_cast<double>(seconds));
+    }
+
+    return std::format(L"{:.1f}s", d.count() / 1000.0);
+}
+
+// ── BuildImageCallback ──────────────────────────────────────────────
+
 BuildImageCallback::~BuildImageCallback()
 try
 {
-    // Capture any partial line so it's included in the error replay below; otherwise
-    // CollapseWindow() would discard it.
-    if (!m_pendingLine.empty())
-    {
-        m_pendingLine += '\n';
-        m_allLines.push_back(std::move(m_pendingLine));
-    }
+    StopTimerThread();
 
-    CollapseWindow();
-
-    // On build error (not cancellation), replay the full log output so the user can see what went wrong.
-    if (!IsCancelled() && std::uncaught_exceptions() > m_uncaughtExceptions && !m_allLines.empty())
+    if (m_isConsole)
     {
-        for (const auto& line : m_allLines)
+        bool hasError = !IsCancelled() && std::uncaught_exceptions() > m_uncaughtExceptions;
+
+        CONSOLE_SCREEN_BUFFER_INFO info{};
+        THROW_IF_WIN32_BOOL_FALSE(GetConsoleScreenBufferInfo(m_console, &info));
+        const SHORT consoleWidth = std::max<SHORT>(40, info.srWindow.Right - info.srWindow.Left);
+
+        // Erase the live display area.
+        std::wstring eraseCmd;
+        if (m_linesWrittenLastFrame >= m_viewportHeight)
         {
-            WriteTerminal(MultiByteToWide(line));
+            // Fixed mode: display fills the viewport, go to top.
+            eraseCmd = L"\033[H\033[J";
         }
+        else if (m_linesWrittenLastFrame > 0)
+        {
+            // Append mode: go back to frame start and erase.
+            eraseCmd = std::format(L"\033[{}A\r\033[J", m_linesWrittenLastFrame);
+        }
+
+        if (!eraseCmd.empty())
+        {
+            WriteTerminal(eraseCmd);
+        }
+
+        // Print the full final render permanently. All lines are written so
+        // the user can scroll back and see the complete build output.
+        {
+            std::lock_guard lock(m_mutex);
+            auto allLines = BuildFrameLines(consoleWidth);
+            std::wstring buffer;
+            for (const auto& line : allLines)
+            {
+                buffer += line;
+                buffer += L"\n";
+            }
+
+            // Append error details for failing steps.
+            if (hasError)
+            {
+                for (const auto& target : m_buildView.GetTargets())
+                {
+                    for (const auto& step : target.steps)
+                    {
+                        if (!step.error.empty())
+                        {
+                            buffer += std::format(L"\n\033[31m Error: {}\033[0m\n", MultiByteToWide(step.error));
+                            if (!step.logOutput.empty())
+                            {
+                                buffer += L"\033[2m";
+                                for (const auto& logLine : step.logOutput)
+                                {
+                                    buffer += L"  ";
+                                    buffer += MultiByteToWide(logLine);
+                                    buffer += L"\n";
+                                }
+                                buffer += L"\033[0m";
+                            }
+                        }
+                    }
+                }
+            }
+
+            WriteTerminal(buffer);
+        }
+
+        WriteTerminal(L"\033[?25h");
     }
 }
 CATCH_LOG()
@@ -54,173 +168,380 @@ bool BuildImageCallback::IsCancelled() const
     return WaitForSingleObject(m_cancelEvent, 0) == WAIT_OBJECT_0;
 }
 
-void BuildImageCallback::CollapseWindow()
+void BuildImageCallback::StartTimerThread()
 {
-    if (m_displayedLines > 0)
+    if (!m_isConsole || m_timerThread.joinable())
     {
-        WriteTerminal(std::format(L"\033[{}A\033[J", m_displayedLines));
-        m_displayedLines = 0;
+        return;
     }
 
-    m_lines.clear();
-    m_pendingLine.clear();
+    m_stopEvent.create(wil::EventOptions::ManualReset);
+    m_timerThread = std::thread([this]() {
+        while (WaitForSingleObject(m_stopEvent.get(), 200) == WAIT_TIMEOUT)
+        {
+            try
+            {
+                std::lock_guard lock(m_mutex);
+                RenderFrame();
+            }
+            CATCH_LOG()
+        }
+    });
+}
+
+void BuildImageCallback::StopTimerThread()
+{
+    if (m_timerThread.joinable())
+    {
+        m_stopEvent.SetEvent();
+        m_timerThread.join();
+    }
 }
 
 HRESULT BuildImageCallback::OnProgress(LPCSTR status, LPCSTR id, ULONGLONG /*current*/, ULONGLONG /*total*/)
 try
 {
-    if (status == nullptr || *status == '\0')
+    if (status == nullptr || *status == '\0' || IsCancelled())
     {
         return S_OK;
     }
 
-    // When cancellation is pending, skip all processing so the server's IO loop can
-    // return to its event wait and detect the cancel event promptly.
-    if (IsCancelled())
-    {
-        return S_OK;
-    }
+    std::string statusStr(status);
+    std::string idStr(id ? id : "");
 
-    if (m_verbose || !m_isConsole)
+    // BuildKit JSON messages are identified by the "buildkit" id
+    if (idStr == "buildkit")
     {
-        wprintf(L"%hs", status);
-        return S_OK;
-    }
+        StartTimerThread();
 
-    // Match the specific "log" sentinel sent by WSLCSession::BuildImage rather than
-    // accepting any non-empty id, so future or unrelated id usage defaults to permanent.
-    const bool isLog = (id != nullptr && std::string_view{id} == "log");
+        std::lock_guard lock(m_mutex);
 
-    if (!isLog)
-    {
-        // Permanent line: collapse the scrolling window then print directly.
-        CollapseWindow();
-        WriteTerminal(MultiByteToWide(status));
-        return S_OK;
-    }
-
-    // Log line: add to the scrolling window.
-    for (const char* p = status; *p != '\0'; ++p)
-    {
-        if (*p == '\n')
+        try
         {
-            // Store with the trailing newline so the byte count matches what is replayed.
-            // Cap retained log output to avoid unbounded growth on very long builds.
-            m_allLines.push_back(m_pendingLine + '\n');
-            m_allLinesBytes += m_allLines.back().size();
-            while (m_allLinesBytes > c_maxAllLinesBytes && !m_allLines.empty())
-            {
-                m_allLinesBytes -= m_allLines.front().size();
-                m_allLines.pop_front();
-            }
-
-            m_lines.push_back(std::move(m_pendingLine));
-            m_pendingLine.clear();
-            if (m_lines.size() > c_maxDisplayLines)
-            {
-                m_lines.pop_front();
-            }
+            auto json = nlohmann::json::parse(statusStr);
+            wsl::windows::common::docker_schema::BuildKitSolveStatus solveStatus{};
+            from_json(json, solveStatus);
+            m_buildView.ProcessMessage(solveStatus);
         }
-        else if (*p == '\r')
+        catch (...)
         {
-            // \r\n is a line ending; standalone \r overwrites the current line.
-            if (*(p + 1) != '\n')
-            {
-                // Flush a throttled redraw before clearing so \r-based progress
-                // updates are visible even when batched in a single OnProgress call.
-                auto now = std::chrono::steady_clock::now();
-                if (!m_pendingLine.empty() && now - m_lastRedraw >= c_redrawInterval)
-                {
-                    Redraw();
-                    m_lastRedraw = now;
-                }
-                m_pendingLine.clear();
-            }
+            // Ignore malformed JSON
         }
-        else
-        {
-            m_pendingLine += *p;
-        }
-    }
-
-    // Throttle redraws to avoid blocking the server's IO loop with console writes
-    // during rapid output. Lines accumulate in the deque immediately; the display
-    // catches up at ~20fps.
-    auto now = std::chrono::steady_clock::now();
-    if (now - m_lastRedraw >= c_redrawInterval)
-    {
-        Redraw();
-        m_lastRedraw = now;
     }
 
     return S_OK;
 }
 CATCH_RETURN();
 
-void BuildImageCallback::Redraw()
+// ── Step line formatter ─────────────────────────────────────────────
+
+std::wstring BuildImageCallback::FormatStepLine(const ViewStep& step, SHORT consoleWidth) const
+{
+    auto wtext = MultiByteToWide(step.stepLabel);
+
+    // Truncate sha256 hashes for readability (keep prefix + 12 hex chars).
+    auto shaPos = wtext.find(L"@sha256:");
+    if (shaPos != std::wstring::npos && shaPos + 20 < wtext.size())
+    {
+        wtext.resize(shaPos + 20);
+    }
+
+    // Right-aligned status indicator.
+    std::wstring timer;
+    if (step.cached)
+    {
+        timer = L"CACHED";
+    }
+    else if (step.completed)
+    {
+        timer = FormatDuration(step.elapsed);
+    }
+    else if (step.startTime != std::chrono::steady_clock::time_point{})
+    {
+        timer = FormatElapsed(step.startTime);
+    }
+
+    // Layout: step text + padding + timer, truncating the step text if needed.
+    auto timerWidth = static_cast<SHORT>(timer.size());
+    auto maxTextWidth = static_cast<size_t>(std::max<SHORT>(10, consoleWidth - timerWidth - 2));
+
+    if (wtext.size() > maxTextWidth && maxTextWidth > 3)
+    {
+        wtext.resize(maxTextWidth - 3);
+        wtext += L"...";
+    }
+
+    auto usedWidth = wtext.size() + static_cast<size_t>(timerWidth);
+    auto paddingSize = (usedWidth < static_cast<size_t>(consoleWidth)) ? static_cast<size_t>(consoleWidth) - usedWidth : 0;
+    std::wstring padding(std::max<size_t>(1, paddingSize), L' ');
+
+    // Cyan for completed/cached, bold for running, red for errors.
+    if (!step.error.empty())
+    {
+        return std::format(L"\033[31m{}{}{}\033[0m", wtext, padding, timer);
+    }
+    else if (step.completed || step.cached)
+    {
+        return std::format(L"\033[36m{}{}{}\033[0m", wtext, padding, timer);
+    }
+    else
+    {
+        return std::format(L"\033[1m{}{}{}\033[0m", wtext, padding, timer);
+    }
+}
+
+// ── Frame line builder ──────────────────────────────────────────────
+// Builds all frame lines into a vector. Each entry is one visual line
+// (no embedded newlines). Used by both RenderFrame and the destructor's
+// final permanent output.
+
+std::vector<std::wstring> BuildImageCallback::BuildFrameLines(SHORT consoleWidth) const
+{
+    std::vector<std::wstring> lines;
+
+    // Total build timer header (right-aligned, dimmed)
+    {
+        auto elapsed = FormatElapsed(m_buildStartTime);
+        auto label = std::format(L"Building {}", elapsed);
+        auto pad = static_cast<size_t>(std::max<SHORT>(0, consoleWidth - static_cast<SHORT>(label.size())));
+        lines.push_back(std::format(L"{}\033[2m{}\033[0m", std::wstring(pad, L' '), label));
+    }
+
+    bool firstTarget = true;
+
+    for (const auto& target : m_buildView.GetTargets())
+    {
+        bool hasVisibleSteps = false;
+        for (const auto& step : target.steps)
+        {
+            if (step.started || step.completed)
+            {
+                hasVisibleSteps = true;
+                break;
+            }
+        }
+
+        if (!hasVisibleSteps)
+        {
+            continue;
+        }
+
+        // Blank line separator between targets (not before first).
+        if (!firstTarget)
+        {
+            lines.emplace_back();
+        }
+        firstTarget = false;
+
+        // Synthesize cached FROM steps for shared base images
+        if (!target.steps.empty())
+        {
+            const auto& firstStep = target.steps[0];
+            if (firstStep.stepNum > 1 && firstStep.stepTotal > 0)
+            {
+                for (uint32_t n = 1; n < firstStep.stepNum; n++)
+                {
+                    std::string fromImage = " ...";
+                    for (const auto& digest : firstStep.inputs)
+                    {
+                        auto* inputStep = m_buildView.StepByDigest(digest);
+                        if (inputStep && inputStep->stepLabel.find("] FROM ") != std::string::npos)
+                        {
+                            auto pos = inputStep->stepLabel.find("] FROM ");
+                            if (pos != std::string::npos)
+                            {
+                                fromImage = inputStep->stepLabel.substr(pos + 6);
+                            }
+                            break;
+                        }
+                    }
+                    auto label = std::format("[{} {}/{}] FROM{}", target.name, n, firstStep.stepTotal, fromImage);
+                    auto wlabel = MultiByteToWide(label);
+                    if (static_cast<SHORT>(wlabel.size()) > consoleWidth - 10)
+                    {
+                        wlabel.resize(consoleWidth - 13);
+                        wlabel += L"...";
+                    }
+                    auto padLen =
+                        (wlabel.size() + 6 < static_cast<size_t>(consoleWidth)) ? static_cast<size_t>(consoleWidth) - wlabel.size() - 6 : 0;
+                    lines.push_back(std::format(
+                        L"\033[36m{}{}{}\033[0m", wlabel, std::wstring(std::max<size_t>(1, padLen), L' '), L"CACHED"));
+                }
+            }
+        }
+
+        // Steps
+        for (const auto& step : target.steps)
+        {
+            if (!step.started && !step.completed)
+            {
+                continue;
+            }
+
+            lines.push_back(FormatStepLine(step, consoleWidth));
+
+            // Below a step: show layer progress bars OR recent log output.
+            bool showLayers = false;
+            if (!step.completed && !step.subStatuses.empty())
+            {
+                showLayers = std::any_of(
+                    step.subStatuses.begin(), step.subStatuses.end(), [](const auto& p) { return !p.second.completed; });
+            }
+
+            if (showLayers)
+            {
+                for (const auto& [_, sub] : step.subStatuses)
+                {
+                    auto sid = MultiByteToWide(ShortDigest(sub.id));
+
+                    if (sub.completed && sub.total > 0)
+                    {
+                        lines.push_back(std::format(L"\033[2m  {}: done {}\033[0m", sid, FormatBytes(sub.total)));
+                    }
+                    else if (sub.completed)
+                    {
+                        lines.push_back(std::format(L"\033[2m  {}: done\033[0m", sid));
+                    }
+                    else if (sub.total > 0)
+                    {
+                        constexpr int c_barWidth = 30;
+                        auto ratio = static_cast<double>(sub.current) / static_cast<double>(sub.total);
+                        auto filled = std::clamp(static_cast<int>(ratio * c_barWidth), 0, c_barWidth);
+                        auto emptyWidth = c_barWidth - filled;
+
+                        std::wstring filledBar(filled, L'=');
+                        std::wstring emptyBar(emptyWidth, L' ');
+                        if (filled < c_barWidth && !emptyBar.empty())
+                        {
+                            emptyBar[0] = L'>';
+                        }
+
+                        lines.push_back(std::format(
+                            L"\033[2m  {}: [\033[32m{}\033[0m\033[2m{}] {}/{}\033[0m",
+                            sid, filledBar, emptyBar, FormatBytes(sub.current), FormatBytes(sub.total)));
+                    }
+                    else
+                    {
+                        lines.push_back(std::format(L"\033[2m  {}: waiting...\033[0m", sid));
+                    }
+                }
+            }
+            else if (!step.completed && !step.logOutput.empty())
+            {
+                auto tailCount = std::min(step.logOutput.size(), c_maxLogPeekLines);
+                auto tailStart = step.logOutput.size() - tailCount;
+                for (size_t i = tailStart; i < step.logOutput.size(); i++)
+                {
+                    auto wline = MultiByteToWide(step.logOutput[i]);
+                    if (static_cast<SHORT>(wline.size()) > consoleWidth - 4)
+                    {
+                        wline.resize(consoleWidth - 4);
+                    }
+                    lines.push_back(std::format(L"\033[2m  {}\033[0m", wline));
+                }
+            }
+
+            // Error message
+            if (!step.error.empty())
+            {
+                auto errorW = MultiByteToWide(step.error);
+                if (static_cast<SHORT>(errorW.size()) > consoleWidth - 4)
+                {
+                    errorW.resize(consoleWidth - 7);
+                    errorW += L"...";
+                }
+                lines.push_back(std::format(L"\033[31m  {}\033[0m", errorW));
+            }
+        }
+    }
+
+    return lines;
+}
+
+// ── Frame renderer ──────────────────────────────────────────────────
+//   Renders in two modes. First it appends and then once it hits the
+//   max viewport width it goes to fixed mode.
+// 
+//
+//   Append mode (totalLines < viewportHeight):
+//     Content fits in the viewport. Use cursor-up to overwrite previous
+//     frame in-place. Safe because cursor-up stays within the viewport.
+//
+//   Fixed mode (totalLines >= viewportHeight):
+//     Content exceeds viewport. Use \033[H (cursor home) to go to the
+//     top of the viewport. Write header + tail, filling exactly the
+//     viewport. Last line has no trailing newline to prevent scrolling.
+
+void BuildImageCallback::RenderFrame()
 {
     CONSOLE_SCREEN_BUFFER_INFO info{};
     THROW_IF_WIN32_BOOL_FALSE(GetConsoleScreenBufferInfo(m_console, &info));
-    // Use the visible window width (not buffer width), minus one column to avoid the
-    // deferred-wrap edge case when a line is exactly the window width. Clamp to at
-    // least zero so the value never goes negative (which would underflow when passed
-    // to std::wstring::resize).
-    const SHORT consoleWidth = std::max<SHORT>(0, info.srWindow.Right - info.srWindow.Left);
+    const SHORT consoleWidth = std::max<SHORT>(40, info.srWindow.Right - info.srWindow.Left);
 
-    // Determine how many completed lines to show, leaving room for the pending line.
-    const bool showPending = !m_pendingLine.empty();
-    SHORT completedCount = static_cast<SHORT>(m_lines.size());
-    if (showPending && completedCount >= c_maxDisplayLines)
+    // Snapshot viewport height on first render.
+    if (m_viewportHeight == 0)
     {
-        completedCount = c_maxDisplayLines - 1;
-    }
-    const SHORT displayCount = completedCount + (showPending ? 1 : 0);
-
-    // Build the entire frame in one buffer to minimize console writes. Hide the cursor
-    // during the redraw so the user doesn't see it bouncing through the cursor movement,
-    // then show it again at the final position. The dim attribute (\033[2m) renders the
-    // scrolling lines de-emphasized regardless of the user's theme.
-    std::wstring buffer = L"\033[?25l\033[2m";
-
-    // Move cursor to the start of the display area and erase from there to the end of
-    // the screen. \033[J handles the case where the new display is shorter than the
-    // previous one (e.g. when \r clears the pending line without a replacement).
-    if (m_displayedLines > 0)
-    {
-        buffer += std::format(L"\033[{}A\033[J", m_displayedLines);
+        m_viewportHeight = info.srWindow.Bottom - info.srWindow.Top + 1;
     }
 
-    auto appendLine = [&](const std::string& line) {
-        auto wline = MultiByteToWide(line);
-        if (static_cast<SHORT>(wline.size()) > consoleWidth)
+    auto allLines = BuildFrameLines(consoleWidth);
+    auto totalLines = static_cast<SHORT>(allLines.size());
+
+    std::wstring buffer = L"\033[?25l"; // Hide cursor during redraw.
+
+    if (totalLines < m_viewportHeight)
+    {
+        // Append mode: content fits in viewport.
+        if (m_linesWrittenLastFrame > 0)
         {
-            wline.resize(consoleWidth);
+            buffer += std::format(L"\033[{}A\r", m_linesWrittenLastFrame);
         }
-        buffer += wline;
+
+        for (const auto& line : allLines)
+        {
+            buffer += line;
+            buffer += L"\033[K\n";
+        }
+        buffer += L"\033[J";
+
+        m_linesWrittenLastFrame = totalLines;
+    }
+    else
+    {
+        // Fixed mode: fill the entire viewport.
+        if (m_linesWrittenLastFrame >= m_viewportHeight)
+        {
+            // Already in fixed mode: cursor home to viewport top.
+            buffer += L"\033[H";
+        }
+        else if (m_linesWrittenLastFrame > 0)
+        {
+            // Transition from append mode: go back to start of old frame.
+            buffer += std::format(L"\033[{}A\r", m_linesWrittenLastFrame);
+        }
+
+        // Header line
+        buffer += allLines[0];
         buffer += L"\033[K\n";
-    };
 
-    // Print completed lines (skip older ones if we need room for the pending line).
-    auto it = m_lines.begin();
-    if (completedCount < static_cast<SHORT>(m_lines.size()))
-    {
-        std::advance(it, m_lines.size() - completedCount);
-    }
-    for (; it != m_lines.end(); ++it)
-    {
-        appendLine(*it);
-    }
+        // Tail: fill the rest of the viewport with the most recent content.
+        auto tailCount = static_cast<size_t>(m_viewportHeight - 1);
+        auto tailStart = allLines.size() - tailCount;
+        for (size_t i = tailStart; i < allLines.size(); i++)
+        {
+            buffer += allLines[i];
+            buffer += L"\033[K";
+            if (i + 1 < allLines.size())
+            {
+                buffer += L"\n";
+            }
+            // Last line: no \n to prevent viewport scrolling.
+        }
 
-    // Print the in-progress line (e.g. \r-based progress updates).
-    if (showPending)
-    {
-        appendLine(m_pendingLine);
+        m_linesWrittenLastFrame = m_viewportHeight;
     }
-
-    buffer += L"\033[22m\033[?25h";
 
     WriteTerminal(buffer);
-    m_displayedLines = displayCount;
 }
 
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/services/BuildImageCallback.cpp
+++ b/src/windows/wslc/services/BuildImageCallback.cpp
@@ -49,21 +49,6 @@ static std::wstring FormatBytes(int64_t b)
     return std::format(L"{}B", b);
 }
 
-static std::wstring FormatElapsed(std::chrono::steady_clock::time_point start)
-{
-    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
-    auto totalSeconds = elapsed.count() / 1000;
-
-    if (totalSeconds >= 60)
-    {
-        auto minutes = totalSeconds / 60;
-        auto seconds = totalSeconds % 60;
-        return std::format(L"{}m{:.0f}s", minutes, static_cast<double>(seconds));
-    }
-
-    return std::format(L"{:.1f}s", elapsed.count() / 1000.0);
-}
-
 static std::wstring FormatDuration(std::chrono::milliseconds d)
 {
     auto totalSeconds = d.count() / 1000;
@@ -76,6 +61,11 @@ static std::wstring FormatDuration(std::chrono::milliseconds d)
     }
 
     return std::format(L"{:.1f}s", d.count() / 1000.0);
+}
+
+static std::wstring FormatElapsed(std::chrono::steady_clock::time_point start)
+{
+    return FormatDuration(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start));
 }
 
 // ── BuildImageCallback ──────────────────────────────────────────────
@@ -362,10 +352,11 @@ std::vector<std::wstring> BuildImageCallback::BuildFrameLines(SHORT consoleWidth
                         wlabel.resize(consoleWidth - 13);
                         wlabel += L"...";
                     }
-                    auto padLen =
-                        (wlabel.size() + 6 < static_cast<size_t>(consoleWidth)) ? static_cast<size_t>(consoleWidth) - wlabel.size() - 6 : 0;
-                    lines.push_back(std::format(
-                        L"\033[36m{}{}{}\033[0m", wlabel, std::wstring(std::max<size_t>(1, padLen), L' '), L"CACHED"));
+                    auto padLen = (wlabel.size() + 6 < static_cast<size_t>(consoleWidth))
+                                      ? static_cast<size_t>(consoleWidth) - wlabel.size() - 6
+                                      : 0;
+                    lines.push_back(
+                        std::format(L"\033[36m{}{}{}\033[0m", wlabel, std::wstring(std::max<size_t>(1, padLen), L' '), L"CACHED"));
                 }
             }
         }
@@ -384,8 +375,8 @@ std::vector<std::wstring> BuildImageCallback::BuildFrameLines(SHORT consoleWidth
             bool showLayers = false;
             if (!step.completed && !step.subStatuses.empty())
             {
-                showLayers = std::any_of(
-                    step.subStatuses.begin(), step.subStatuses.end(), [](const auto& p) { return !p.second.completed; });
+                showLayers =
+                    std::any_of(step.subStatuses.begin(), step.subStatuses.end(), [](const auto& p) { return !p.second.completed; });
             }
 
             if (showLayers)
@@ -417,8 +408,7 @@ std::vector<std::wstring> BuildImageCallback::BuildFrameLines(SHORT consoleWidth
                         }
 
                         lines.push_back(std::format(
-                            L"\033[2m  {}: [\033[32m{}\033[0m\033[2m{}] {}/{}\033[0m",
-                            sid, filledBar, emptyBar, FormatBytes(sub.current), FormatBytes(sub.total)));
+                            L"\033[2m  {}: [\033[32m{}\033[0m\033[2m{}] {}/{}\033[0m", sid, filledBar, emptyBar, FormatBytes(sub.current), FormatBytes(sub.total)));
                     }
                     else
                     {
@@ -461,7 +451,7 @@ std::vector<std::wstring> BuildImageCallback::BuildFrameLines(SHORT consoleWidth
 // ── Frame renderer ──────────────────────────────────────────────────
 //   Renders in two modes. First it appends and then once it hits the
 //   max viewport width it goes to fixed mode.
-// 
+//
 //
 //   Append mode (totalLines < viewportHeight):
 //     Content fits in the viewport. Use cursor-up to overwrite previous

--- a/src/windows/wslc/services/BuildImageCallback.h
+++ b/src/windows/wslc/services/BuildImageCallback.h
@@ -12,9 +12,11 @@ Abstract:
 
 --*/
 #pragma once
+#include "BuildView.h"
 #include "ChangeTerminalMode.h"
 #include "SessionService.h"
-#include <deque>
+#include <mutex>
+#include <thread>
 
 namespace wsl::windows::wslc::services {
 class DECLSPEC_UUID("3EDD5DBF-CA6C-4CF7-923A-AD94B6A732E5") BuildImageCallback
@@ -29,14 +31,13 @@ public:
     HRESULT OnProgress(LPCSTR status, LPCSTR id, ULONGLONG current, ULONGLONG total) override;
 
 private:
-    static constexpr SHORT c_maxDisplayLines = 16;
-    static constexpr auto c_redrawInterval = std::chrono::milliseconds(50);
-    static constexpr size_t c_maxAllLinesBytes = 10 * 1024 * 1024; // 10 MiB cap on retained log output for error replay.
+    static constexpr size_t c_maxLogPeekLines = 5;
 
-    void CollapseWindow();
-    void Redraw();
-    // Use WriteConsoleW directly rather than wprintf: wprintf is noticeably slower for
-    // the per-redraw scrolling display and produces visible flicker.
+    std::vector<std::wstring> BuildFrameLines(SHORT consoleWidth) const;
+    void RenderFrame();
+    void StartTimerThread();
+    void StopTimerThread();
+    std::wstring FormatStepLine(const ViewStep& step, SHORT consoleWidth) const;
     void WriteTerminal(std::wstring_view content) const;
     bool IsCancelled() const;
 
@@ -45,15 +46,18 @@ private:
     HANDLE m_console = GetStdHandle(STD_OUTPUT_HANDLE);
     bool m_isConsole = wsl::windows::common::wslutil::IsConsoleHandle(m_console);
     EnableVirtualTerminal m_vtMode{m_console};
-    std::deque<std::string> m_lines;
-    // Each entry already contains the trailing newline so the bytes match what's replayed.
-    // TODO: Track logs per step so the destructor can replay only the failing step's
-    // logs on error, rather than every line captured during the build.
-    std::deque<std::string> m_allLines;
-    size_t m_allLinesBytes = 0;
-    std::string m_pendingLine;
-    SHORT m_displayedLines = 0;
-    std::chrono::steady_clock::time_point m_lastRedraw{};
+
+    std::mutex m_mutex;
+    BuildView m_buildView;
+
+    // Timer thread for periodic redraws
+    std::thread m_timerThread;
+    wil::unique_event m_stopEvent;
+
+    SHORT m_linesWrittenLastFrame = 0; // Number of lines rendered in the previous frame.
+    SHORT m_viewportHeight = 0;        // Terminal height snapshot taken on first render.
+    std::chrono::steady_clock::time_point m_buildStartTime = std::chrono::steady_clock::now();
+
     // Captured at construction so the destructor can detect destruction during exception unwinding.
     int m_uncaughtExceptions = std::uncaught_exceptions();
 };

--- a/src/windows/wslc/services/BuildImageCallback.h
+++ b/src/windows/wslc/services/BuildImageCallback.h
@@ -34,11 +34,13 @@ private:
     static constexpr size_t c_maxLogPeekLines = 5;
 
     std::vector<std::wstring> BuildFrameLines(SHORT consoleWidth) const;
+    void AppendCachedFromLines(const ViewTarget& target, SHORT consoleWidth, std::vector<std::wstring>& lines) const;
     void RenderFrame();
     void StartTimerThread();
     void StopTimerThread();
     std::wstring FormatStepLine(const ViewStep& step, SHORT consoleWidth) const;
     void WriteTerminal(std::wstring_view content) const;
+    void PrintPlainTextProgress();
     bool IsCancelled() const;
 
     const bool m_verbose;

--- a/src/windows/wslc/services/BuildView.cpp
+++ b/src/windows/wslc/services/BuildView.cpp
@@ -279,8 +279,7 @@ void BuildView::ProcessMessage(const wsl::windows::common::docker_schema::BuildK
             }
             else if (step.startTime != std::chrono::steady_clock::time_point{})
             {
-                step.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::steady_clock::now() - step.startTime);
+                step.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - step.startTime);
             }
         }
     }

--- a/src/windows/wslc/services/BuildView.cpp
+++ b/src/windows/wslc/services/BuildView.cpp
@@ -1,0 +1,404 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    BuildView.cpp
+
+Abstract:
+
+    This file contains the BuildView implementation
+
+--*/
+#include "precomp.h"
+#include "BuildView.h"
+#include <docker_schema.h>
+#include <wslutil.h>
+
+using namespace wsl::windows::common;
+
+namespace wsl::windows::wslc::services {
+
+// ── Utility functions ────────────────────────────────────────────────
+
+std::string ShortDigest(const std::string& id)
+{
+    constexpr auto prefix = "sha256:";
+    constexpr size_t prefixLen = 7;
+    if (id.starts_with(prefix))
+    {
+        auto rest = id.substr(prefixLen, 8);
+        return std::string(prefix) + rest;
+    }
+    return id;
+}
+
+std::chrono::milliseconds ParseElapsed(const std::string& started, const std::string& completed)
+{
+    // Parse nanosecond-precision timestamp for difference calculation.
+    auto parseNanos = [](const std::string& s) -> std::optional<uint64_t> {
+        auto tPos = s.find('T');
+        if (tPos == std::string::npos)
+        {
+            return std::nullopt;
+        }
+
+        auto datePart = s.substr(0, tPos);
+        auto timeRest = s.substr(tPos + 1);
+
+        // Strip timezone suffix (Z, +HH:MM, -HH:MM)
+        std::string timePart;
+        if (timeRest.ends_with('Z'))
+        {
+            timePart = timeRest.substr(0, timeRest.size() - 1);
+        }
+        else if (timeRest.size() >= 6)
+        {
+            auto tail = timeRest.substr(timeRest.size() - 6);
+            if ((tail[0] == '+' || tail[0] == '-') && tail[3] == ':')
+            {
+                timePart = timeRest.substr(0, timeRest.size() - 6);
+            }
+            else
+            {
+                timePart = timeRest;
+            }
+        }
+        else
+        {
+            timePart = timeRest;
+        }
+
+        // Parse date: YYYY-MM-DD
+        int year = 0, month = 0, day = 0;
+        if (sscanf_s(datePart.c_str(), "%d-%d-%d", &year, &month, &day) != 3)
+        {
+            return std::nullopt;
+        }
+
+        // Parse time: HH:MM:SS[.fractional]
+        int hour = 0, min = 0, sec = 0;
+        uint64_t fracNanos = 0;
+        auto dotPos = timePart.find('.');
+        if (dotPos != std::string::npos)
+        {
+            if (sscanf_s(timePart.c_str(), "%d:%d:%d", &hour, &min, &sec) != 3)
+            {
+                return std::nullopt;
+            }
+            auto fracStr = timePart.substr(dotPos + 1);
+            fracNanos = std::stoull(fracStr);
+            for (size_t i = fracStr.size(); i < 9; i++)
+            {
+                fracNanos *= 10;
+            }
+        }
+        else
+        {
+            if (sscanf_s(timePart.c_str(), "%d:%d:%d", &hour, &min, &sec) != 3)
+            {
+                return std::nullopt;
+            }
+        }
+
+        // Use std::tm + _mkgmtime for correct calendar-to-seconds conversion.
+        std::tm tm{};
+        tm.tm_year = year - 1900;
+        tm.tm_mon = month - 1;
+        tm.tm_mday = day;
+        tm.tm_hour = hour;
+        tm.tm_min = min;
+        tm.tm_sec = sec;
+        auto epochSecs = static_cast<uint64_t>(_mkgmtime(&tm));
+        return epochSecs * 1'000'000'000ULL + fracNanos;
+    };
+
+    auto s = parseNanos(started);
+    auto c = parseNanos(completed);
+    if (s && c && *c >= *s)
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(*c - *s));
+    }
+    return std::chrono::milliseconds::zero();
+}
+
+ParsedTarget ParseTarget(const std::string& name)
+{
+    if (!name.empty() && name[0] == '[')
+    {
+        auto close = name.find(']');
+        if (close != std::string::npos)
+        {
+            auto inside = name.substr(1, close - 1);
+
+            // Tokenize by whitespace
+            std::vector<std::string> tokens;
+            std::istringstream iss(inside);
+            std::string token;
+            while (iss >> token)
+            {
+                tokens.push_back(token);
+            }
+
+            uint32_t stepNum = 0, stepTotal = 0;
+            for (const auto& t : tokens)
+            {
+                auto slash = t.find('/');
+                if (slash != std::string::npos)
+                {
+                    try
+                    {
+                        stepNum = static_cast<uint32_t>(std::stoul(t.substr(0, slash)));
+                        stepTotal = static_cast<uint32_t>(std::stoul(t.substr(slash + 1)));
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+            }
+
+            auto firstToken = tokens.empty() ? inside : tokens[0];
+
+            if (!firstToken.empty() && std::isdigit(static_cast<unsigned char>(firstToken[0])))
+            {
+                return {"default", name, stepNum, stepTotal};
+            }
+
+            return {firstToken, name, stepNum, stepTotal};
+        }
+    }
+
+    if (name.starts_with("exporting") || name.starts_with("writing") || name.starts_with("naming"))
+    {
+        return {"export", name, 0, 0};
+    }
+    return {"other", name, 0, 0};
+}
+
+// ── BuildView ────────────────────────────────────────────────────────
+
+BuildView::BuildView() : m_totalStart(std::chrono::steady_clock::now())
+{
+}
+
+void BuildView::ProcessMessage(const wsl::windows::common::docker_schema::BuildKitSolveStatus& msg)
+{
+    std::vector<size_t> targetsToSort;
+
+    // Phase 1: Process vertexes
+    for (const auto& vertex : msg.vertexes)
+    {
+        size_t targetIdx, stepIdx;
+
+        auto it = m_digestIndex.find(vertex.digest);
+        if (it != m_digestIndex.end())
+        {
+            targetIdx = it->second.first;
+            stepIdx = it->second.second;
+        }
+        else
+        {
+            auto parsed = ParseTarget(vertex.name);
+
+            auto targetIt = m_targetNameToIdx.find(parsed.targetName);
+            if (targetIt != m_targetNameToIdx.end())
+            {
+                targetIdx = targetIt->second;
+            }
+            else
+            {
+                targetIdx = m_targets.size();
+                m_targets.push_back(ViewTarget{parsed.targetName, {}});
+                m_targetNameToIdx[parsed.targetName] = targetIdx;
+            }
+
+            ViewStep newStep{};
+            newStep.digest = vertex.digest;
+            newStep.stepLabel = parsed.stepLabel;
+            newStep.stepNum = parsed.stepNum;
+            newStep.stepTotal = parsed.stepTotal;
+            newStep.inputs = vertex.inputs;
+
+            stepIdx = m_targets[targetIdx].steps.size();
+            m_targets[targetIdx].steps.push_back(std::move(newStep));
+            m_digestIndex[vertex.digest] = {targetIdx, stepIdx};
+
+            if (std::find(targetsToSort.begin(), targetsToSort.end(), targetIdx) == targetsToSort.end())
+            {
+                targetsToSort.push_back(targetIdx);
+            }
+        }
+
+        auto& step = m_targets[targetIdx].steps[stepIdx];
+
+        // Update the step's lifecycle state.
+        // BuildKit FROM steps go through multiple start→complete cycles
+        // (manifest resolution, then layer pulling). We must track the
+        // LATEST start timestamp so the elapsed timer reflects the full
+        // pull duration, not just the first sub-second manifest lookup.
+        if (!vertex.started.empty())
+        {
+            if (!step.started)
+            {
+                step.started = true;
+            }
+            // A new started timestamp (without completed) means the step
+            // is restarting for a new phase — mark it active again.
+            if (vertex.completed.empty() && step.completed)
+            {
+                step.completed = false;
+                step.startTime = std::chrono::steady_clock::now();
+            }
+            // Always update to the latest started timestamp.
+            step.startedTs = vertex.started;
+            if (step.startTime == std::chrono::steady_clock::time_point{})
+            {
+                step.startTime = std::chrono::steady_clock::now();
+            }
+        }
+
+        if (vertex.cached)
+        {
+            step.cached = true;
+        }
+
+        if (!vertex.completed.empty())
+        {
+            step.completed = true;
+            if (!vertex.error.empty())
+            {
+                auto error = vertex.error;
+                std::replace(error.begin(), error.end(), '\n', ' ');
+                step.error = std::move(error);
+            }
+
+            if (!step.startedTs.empty())
+            {
+                step.elapsed = ParseElapsed(step.startedTs, vertex.completed);
+            }
+            else if (step.startTime != std::chrono::steady_clock::time_point{})
+            {
+                step.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - step.startTime);
+            }
+        }
+    }
+
+    // Phase 2: Re-sort steps within targets that received new steps
+    for (auto targetIdx : targetsToSort)
+    {
+        std::sort(m_targets[targetIdx].steps.begin(), m_targets[targetIdx].steps.end(), [](const ViewStep& a, const ViewStep& b) {
+            return a.stepNum < b.stepNum;
+        });
+        for (size_t si = 0; si < m_targets[targetIdx].steps.size(); si++)
+        {
+            m_digestIndex[m_targets[targetIdx].steps[si].digest] = {targetIdx, si};
+        }
+    }
+
+    // Phase 3: Process statuses (layer download/extract progress)
+    for (const auto& status : msg.statuses)
+    {
+        auto it = m_digestIndex.find(status.vertex);
+        if (it == m_digestIndex.end())
+        {
+            continue;
+        }
+
+        auto& step = m_targets[it->second.first].steps[it->second.second];
+
+        auto subIt = step.subIndex.find(status.id);
+        size_t subIdx;
+        if (subIt != step.subIndex.end())
+        {
+            subIdx = subIt->second;
+        }
+        else
+        {
+            subIdx = step.subStatuses.size();
+            step.subStatuses.push_back({status.id, SubStatus{status.id, 0, 0, false}});
+            step.subIndex[status.id] = subIdx;
+        }
+
+        auto& sub = step.subStatuses[subIdx].second;
+        sub.current = status.current;
+        if (status.total > 0)
+        {
+            sub.total = status.total;
+        }
+        if (!status.completed.empty())
+        {
+            sub.completed = true;
+        }
+    }
+
+    // Phase 4: Process logs (base64-encoded build output)
+    for (const auto& logEntry : msg.logs)
+    {
+        auto it = m_digestIndex.find(logEntry.vertex);
+        if (it == m_digestIndex.end())
+        {
+            continue;
+        }
+
+        auto& step = m_targets[it->second.first].steps[it->second.second];
+        std::string text = wslutil::Base64Decode(logEntry.data);
+
+        // Trim trailing whitespace.
+        auto endPos = text.find_last_not_of(" \n\r\t");
+        text = (endPos != std::string::npos) ? text.substr(0, endPos + 1) : "";
+
+        // Trim leading whitespace.
+        auto startPos = text.find_first_not_of(" \n\r\t");
+        text = (startPos != std::string::npos) ? text.substr(startPos) : "";
+
+        if (text.empty())
+        {
+            continue;
+        }
+
+        // Split on newlines
+        std::istringstream stream(text);
+        std::string line;
+        while (std::getline(stream, line))
+        {
+            // Trim each sub-line
+            auto lineEnd = line.find_last_not_of(" \r\t");
+            line = (lineEnd != std::string::npos) ? line.substr(0, lineEnd + 1) : "";
+            auto lineStart = line.find_first_not_of(" \r\t");
+            line = (lineStart != std::string::npos) ? line.substr(lineStart) : "";
+            if (!line.empty())
+            {
+                step.logOutput.push_back(std::move(line));
+            }
+        }
+    }
+}
+
+const ViewStep* BuildView::StepByDigest(const std::string& digest) const
+{
+    auto it = m_digestIndex.find(digest);
+    if (it == m_digestIndex.end())
+    {
+        return nullptr;
+    }
+    return &m_targets[it->second.first].steps[it->second.second];
+}
+
+bool BuildView::HasErrors() const
+{
+    for (const auto& target : m_targets)
+    {
+        for (const auto& step : target.steps)
+        {
+            if (!step.error.empty())
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/services/BuildView.cpp
+++ b/src/windows/wslc/services/BuildView.cpp
@@ -14,6 +14,7 @@ Abstract:
 #include "precomp.h"
 #include "BuildView.h"
 #include <docker_schema.h>
+#include <unordered_set>
 #include <wslutil.h>
 
 using namespace wsl::windows::common;
@@ -87,7 +88,7 @@ std::chrono::milliseconds ParseElapsed(const std::string& started, const std::st
             {
                 return std::nullopt;
             }
-            auto fracStr = timePart.substr(dotPos + 1);
+            auto fracStr = timePart.substr(dotPos + 1, 9);
             fracNanos = std::stoull(fracStr);
             for (size_t i = fracStr.size(); i < 9; i++)
             {
@@ -182,9 +183,13 @@ BuildView::BuildView() : m_totalStart(std::chrono::steady_clock::now())
 {
 }
 
-void BuildView::ProcessMessage(const wsl::windows::common::docker_schema::BuildKitSolveStatus& msg)
+void BuildView::ProcessMessage(const std::string& rawJson)
 {
-    std::vector<size_t> targetsToSort;
+    wsl::windows::common::docker_schema::BuildKitSolveStatus msg{};
+    auto json = nlohmann::json::parse(rawJson);
+    from_json(json, msg);
+
+    std::unordered_set<size_t> targetsToSort;
 
     // Phase 1: Process vertexes
     for (const auto& vertex : msg.vertexes)
@@ -224,10 +229,7 @@ void BuildView::ProcessMessage(const wsl::windows::common::docker_schema::BuildK
             m_targets[targetIdx].steps.push_back(std::move(newStep));
             m_digestIndex[vertex.digest] = {targetIdx, stepIdx};
 
-            if (std::find(targetsToSort.begin(), targetsToSort.end(), targetIdx) == targetsToSort.end())
-            {
-                targetsToSort.push_back(targetIdx);
-            }
+            targetsToSort.insert(targetIdx);
         }
 
         auto& step = m_targets[targetIdx].steps[stepIdx];
@@ -370,9 +372,29 @@ void BuildView::ProcessMessage(const wsl::windows::common::docker_schema::BuildK
             if (!line.empty())
             {
                 step.logOutput.push_back(std::move(line));
+                if (step.logOutput.size() > c_maxLogLinesPerStep)
+                {
+                    step.logOutput.erase(step.logOutput.begin());
+                }
             }
         }
     }
+}
+
+std::vector<const ViewStep*> BuildView::GetUnreportedSteps()
+{
+    std::vector<const ViewStep*> result;
+    for (const auto& target : m_targets)
+    {
+        for (const auto& step : target.steps)
+        {
+            if ((step.completed || !step.error.empty()) && m_reportedSteps.insert(step.digest).second)
+            {
+                result.push_back(&step);
+            }
+        }
+    }
+    return result;
 }
 
 const ViewStep* BuildView::StepByDigest(const std::string& digest) const

--- a/src/windows/wslc/services/BuildView.h
+++ b/src/windows/wslc/services/BuildView.h
@@ -1,0 +1,102 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    BuildView.h
+
+Abstract:
+
+    This file contains the BuildView definition.
+
+--*/
+#pragma once
+
+#include <chrono>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace wsl::windows::common::docker_schema {
+struct BuildKitSolveStatus;
+}
+
+namespace wsl::windows::wslc::services {
+
+struct SubStatus
+{
+    std::string id;
+    int64_t current{};
+    int64_t total{};
+    bool completed{};
+};
+
+struct ViewStep
+{
+    std::string digest;
+    std::string stepLabel;
+    uint32_t stepNum{};
+    uint32_t stepTotal{};
+    bool started{};
+    bool completed{};
+    std::chrono::steady_clock::time_point startTime{};
+    std::chrono::milliseconds elapsed{};
+    bool cached{};
+    std::string error;
+    std::vector<std::string> inputs;
+    std::string startedTs;
+    std::vector<std::pair<std::string, SubStatus>> subStatuses;
+    std::map<std::string, size_t> subIndex;
+    std::vector<std::string> logOutput;
+};
+
+struct ViewTarget
+{
+    std::string name;
+    std::vector<ViewStep> steps;
+};
+
+class BuildView
+{
+public:
+    BuildView();
+
+    void ProcessMessage(const wsl::windows::common::docker_schema::BuildKitSolveStatus& msg);
+
+    const ViewStep* StepByDigest(const std::string& digest) const;
+    bool HasErrors() const;
+
+    std::chrono::steady_clock::time_point GetTotalStart() const
+    {
+        return m_totalStart;
+    }
+
+    const std::vector<ViewTarget>& GetTargets() const
+    {
+        return m_targets;
+    }
+
+private:
+    std::unordered_map<std::string, std::pair<size_t, size_t>> m_digestIndex;
+    std::unordered_map<std::string, size_t> m_targetNameToIdx;
+    std::chrono::steady_clock::time_point m_totalStart;
+    std::vector<ViewTarget> m_targets;
+};
+
+// Utility functions
+std::string ShortDigest(const std::string& id);
+std::chrono::milliseconds ParseElapsed(const std::string& started, const std::string& completed);
+
+struct ParsedTarget
+{
+    std::string targetName;
+    std::string stepLabel;
+    uint32_t stepNum{};
+    uint32_t stepTotal{};
+};
+
+ParsedTarget ParseTarget(const std::string& name);
+
+} // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/services/BuildView.h
+++ b/src/windows/wslc/services/BuildView.h
@@ -15,6 +15,7 @@ Abstract:
 
 #include <chrono>
 #include <map>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -24,6 +25,8 @@ struct BuildKitSolveStatus;
 }
 
 namespace wsl::windows::wslc::services {
+
+constexpr size_t c_maxLogLinesPerStep = 200;
 
 struct SubStatus
 {
@@ -61,9 +64,11 @@ struct ViewTarget
 class BuildView
 {
 public:
+    NON_COPYABLE(BuildView);
     BuildView();
 
-    void ProcessMessage(const wsl::windows::common::docker_schema::BuildKitSolveStatus& msg);
+    void ProcessMessage(const std::string& rawJson);
+    std::vector<const ViewStep*> GetUnreportedSteps();
 
     const ViewStep* StepByDigest(const std::string& digest) const;
     bool HasErrors() const;
@@ -81,6 +86,7 @@ public:
 private:
     std::unordered_map<std::string, std::pair<size_t, size_t>> m_digestIndex;
     std::unordered_map<std::string, size_t> m_targetNameToIdx;
+    std::set<std::string> m_reportedSteps;
     std::chrono::steady_clock::time_point m_totalStart;
     std::vector<ViewTarget> m_targets;
 };

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -712,66 +712,13 @@ try
     io.AddHandle(std::make_unique<relay::RelayHandle<relay::ReadHandle>>(
         buildFileHandle.Get(), common::relay::HandleWrapper{buildProcess.GetStdHandle(WSLCFDStdin)}));
 
-    bool verbose = WI_IsFlagSet(Options->Flags, WSLCBuildImageFlagsVerbose);
     std::string allOutput;
     std::string pendingJson;
-    std::set<std::string> reportedSteps;
-    std::set<std::string> reportedErrors;
-    std::map<std::string, std::string> digestToStageName;
-    bool needsNewline = false; // true when the last log chunk didn't end with \n
-    std::string lastLogVertex; // digest of the vertex that produced the last log output
-
-    // Extract the named build stage from a BuildKit vertex name. Vertices within the same named stage
-    // (e.g. "[builder 1/3]" and "[builder 2/3]") share a key. Returns empty for unnamed stages.
-    auto getStageName = [](const std::string& name) -> std::string {
-        if (name.size() < 2 || name[0] != '[')
-        {
-            return {};
-        }
-
-        auto close = name.find(']');
-        if (close == std::string::npos)
-        {
-            return {};
-        }
-
-        // Pattern: "[name N/M]" or "[N/M]". The stage name is the part before "N/M".
-        std::string content = name.substr(1, close - 1);
-        auto slash = content.find('/');
-        if (slash != std::string::npos)
-        {
-            auto space = content.rfind(' ', slash);
-            if (space != std::string::npos)
-            {
-                return content.substr(0, space);
-            }
-        }
-
-        return {};
-    };
-
-    auto logPrefix = [](const std::string& name) -> std::string {
-        if (name.empty())
-        {
-            return "  | ";
-        }
-        return "  [" + name + "] ";
-    };
 
     auto reportProgress = [&](const std::string& message, const char* id = "") {
         if (ProgressCallback != nullptr)
         {
             THROW_IF_FAILED(ProgressCallback->OnProgress(message.c_str(), id, 0, 0));
-        }
-    };
-
-    static constexpr char c_logId[] = "log";
-
-    auto flushLine = [&]() {
-        if (needsNewline)
-        {
-            reportProgress("\n", c_logId);
-            needsNewline = false;
         }
     };
 
@@ -793,75 +740,9 @@ try
             return;
         }
 
-        auto json = nlohmann::json::parse(pendingJson);
+        // Forward the raw JSON to the CLI-side BuildView via the progress callback.
+        reportProgress(pendingJson, "buildkit");
         pendingJson.clear();
-
-        docker_schema::BuildKitSolveStatus status{};
-        from_json(json, status);
-
-        // Process vertices before logs so digestToStageName is populated for log correlation.
-        for (const auto& vertex : status.vertexes)
-        {
-            if (!verbose && vertex.name.find("[internal]") != std::string::npos)
-            {
-                continue;
-            }
-
-            digestToStageName.try_emplace(vertex.digest, getStageName(vertex.name));
-
-            if (!vertex.started.empty() && reportedSteps.insert(vertex.digest).second)
-            {
-                flushLine();
-                reportProgress(vertex.name + "\n");
-            }
-
-            if (!vertex.error.empty() && reportedErrors.insert(vertex.digest).second)
-            {
-                flushLine();
-                reportProgress(vertex.error + "\n");
-            }
-        }
-
-        for (const auto& log : status.logs)
-        {
-            if (auto it = digestToStageName.find(log.vertex); it != digestToStageName.end() && !log.data.empty())
-            {
-                std::string decoded = wslutil::Base64Decode(log.data);
-                if (!decoded.empty())
-                {
-                    if (log.vertex != lastLogVertex && decoded[0] != '\n')
-                    {
-                        flushLine();
-                    }
-
-                    // When continuing an unterminated line, emit the leading \n or \r directly
-                    // so it terminates/overwrites cleanly without a spurious prefix.
-                    if (needsNewline && (decoded[0] == '\n' || decoded[0] == '\r'))
-                    {
-                        reportProgress(decoded.substr(0, 1), c_logId);
-                        decoded.erase(0, 1);
-                    }
-
-                    if (!decoded.empty())
-                    {
-                        reportProgress(IndentLines(decoded, logPrefix(it->second)), c_logId);
-                    }
-
-                    needsNewline = !decoded.empty() && decoded.back() != '\n';
-                    lastLogVertex = log.vertex;
-                }
-            }
-        }
-
-        for (const auto& entry : status.statuses)
-        {
-            if (auto it = digestToStageName.find(entry.vertex);
-                it != digestToStageName.end() && !entry.id.empty() && reportedSteps.insert(entry.id).second)
-            {
-                flushLine();
-                reportProgress(logPrefix(it->second) + entry.id + "\n");
-            }
-        }
     };
 
     // With --progress=rawjson, docker writes progress to stderr and the final image ID to stdout on success (empty on
@@ -904,7 +785,6 @@ try
     }
     catch (...)
     {
-        flushLine();
         LOG_IF_FAILED(buildProcess.Get().Signal(WSLCSignalSIGTERM));
         try
         {
@@ -927,8 +807,6 @@ try
         }
         throw;
     }
-
-    flushLine();
 
     THROW_HR_IF_MSG(E_ABORT, cancelled, "Cancellation handle was signaled");
 

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -715,10 +715,10 @@ try
     std::string allOutput;
     std::string pendingJson;
 
-    auto reportProgress = [&](const std::string& message, const char* id = "") {
+    auto reportProgress = [&](const std::string& message) {
         if (ProgressCallback != nullptr)
         {
-            THROW_IF_FAILED(ProgressCallback->OnProgress(message.c_str(), id, 0, 0));
+            THROW_IF_FAILED(ProgressCallback->OnProgress(message.c_str(), "", 0, 0));
         }
     };
 
@@ -741,7 +741,7 @@ try
         }
 
         // Forward the raw JSON to the CLI-side BuildView via the progress callback.
-        reportProgress(pendingJson, "buildkit");
+        reportProgress(pendingJson);
         pendingJson.clear();
     };
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1337,24 +1337,6 @@ class WSLCTests
         }
     }
 
-    class CapturingProgressCallback
-        : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IProgressCallback>
-    {
-    public:
-        CapturingProgressCallback(std::string& output) : m_output(output)
-        {
-        }
-
-        HRESULT OnProgress(LPCSTR status, LPCSTR, ULONGLONG, ULONGLONG) override
-        {
-            m_output.append(status);
-            return S_OK;
-        }
-
-    private:
-        std::string& m_output;
-    };
-
     HRESULT BuildImageFromContext(const std::filesystem::path& contextDir, const WSLCBuildImageOptions* options, IProgressCallback* callback = nullptr)
     {
         auto dockerfileHandle = wil::open_file((contextDir / "Dockerfile").c_str());
@@ -1635,13 +1617,9 @@ class WSLCTests
                        << "\"echo \\\"$(cat /greeting.txt) $(cat /description.txt)\\\"\"]\n";
         }
 
-        std::string output;
-        auto callback = Microsoft::WRL::Make<CapturingProgressCallback>(output);
         LPCSTR tag = "wslc-test-build-multistage:latest";
         WSLCBuildImageOptions options{.Tags = {&tag, 1}, .Flags = WSLCBuildImageFlagsNoCache};
-        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options, callback.Get()));
-        VERIFY_IS_TRUE(output.find("[greeting] WSL containers") != std::string::npos);
-        VERIFY_IS_TRUE(output.find("[description] support multi-stage builds") != std::string::npos);
+        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options));
         ExpectImagePresent(*m_defaultSession, "wslc-test-build-multistage:latest");
 
         WSLCContainerLauncher launcher("wslc-test-build-multistage:latest", "wslc-build-multistage-container");
@@ -1957,24 +1935,26 @@ class WSLCTests
         // First build to populate cache.
         VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, "wslc-test-nocache:latest"));
 
-        // Validate that the image isn't rebuilt when NoCache isn't set.
+        // Validate that a cached rebuild succeeds.
         {
-            std::string output;
-            auto callback = Microsoft::WRL::Make<CapturingProgressCallback>(output);
             LPCSTR tag = "wslc-test-nocache:latest";
             WSLCBuildImageOptions options{.Tags = {&tag, 1}};
-            VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options, callback.Get()));
-            VERIFY_IS_TRUE(output.find("Imageisrebuilt") == std::string::npos);
+            VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options));
         }
 
-        // Validate that the image is rebuilt when WSLCBuildImageFlagsNoCache is set, and that the output from the RUN step appears in the progress callback.
+        // Validate that the image is rebuilt when WSLCBuildImageFlagsNoCache is set.
         {
-            std::string output;
-            auto callback = Microsoft::WRL::Make<CapturingProgressCallback>(output);
             LPCSTR tag = "wslc-test-nocache:latest";
             WSLCBuildImageOptions options{.Tags = {&tag, 1}, .Flags = WSLCBuildImageFlagsNoCache};
-            VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options, callback.Get()));
-            VERIFY_IS_TRUE(output.find("Imageisrebuilt") != std::string::npos);
+            VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, &options));
+        }
+
+        // Verify the image produces the expected output.
+        {
+            WSLCContainerLauncher launcher("wslc-test-nocache:latest", "wslc-nocache-container");
+            auto container = launcher.Launch(*m_defaultSession);
+            auto result = container.GetInitProcess().WaitAndCaptureOutput();
+            VERIFY_ARE_EQUAL(0, result.Code);
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Changed `wslc build` to give more detailed build output. 

<img width="1797" height="1007" alt="image" src="https://github.com/user-attachments/assets/b6d2d942-02fb-466f-bf63-dca051b1a475" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:**
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [X] **Localization:** All end user facing strings can be localized
- [X] **Dev docs:** Added/updated if needed
- [X] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Summary of changes:

- Change WSLCSession to send over the completed JSON bits
- BuildImageCallback then takes in these bits, and parses them with a 'BuildView' class
- This 'BuildView' object stores everything needed to do the rendering
- BuildImageCallback then has a thread that renders every few ms to the console
- Rendering is done by just appending the output, but once we hit the max viewport height we switch to a 'fixed view' mode which renders just to the screen size. 
- On destruction of that BuildImageCallback we print out the last result and any errors.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested with various Containerfiles some simple and some complex. Here is a sufficiently complex one that you can use to test yourself:

<details>
<summary>View file</summary>
This containerfile does multi target builds that are copying from eachother and then finally gives an error right at the end. 

```
FROM alpine:latest AS builder
RUN apk add --no-cache gcc musl-dev
COPY hello.c /src/hello.c
RUN gcc -O2 -static -o /src/hello /src/hello.c && strip /src/hello


FROM python:3.12 AS assets
RUN pip install --no-cache-dir jinja2 markdown numpy matplotlib
COPY generate_page.py /work/generate_page.py
COPY template.html /work/template.html
COPY content.md /work/content.md
RUN python /work/generate_page.py

FROM python:3.13 AS systools
RUN apt-get update && apt-get install -y --no-install-recommends \
    curl ca-certificates jq file \
    && rm -rf /var/lib/apt/lists/*
RUN echo "System tools layer ready"

FROM alpine:latest AS final
RUN apk add --no-cache tini libstdc++

# Copy the compiled binary from builder
COPY --from=builder /src/hello /usr/local/bin/hello

# Copy generated HTML from assets stage
COPY --from=assets /work/output/index.html /var/www/index.html

# Copy a utility from systools
COPY --from=systools /usr/bin/jq /usr/local/bin/jq

RUN echho 123

# Add a health-check script
RUN echo '#!/bin/sh' > /healthcheck.sh \
    && echo '/usr/local/bin/hello && echo "OK"' >> /healthcheck.sh \
    && chmod +x /healthcheck.sh


EXPOSE 8080
ENTRYPOINT ["/sbin/tini", "--"]
CMD ["/usr/local/bin/hello"]
```

</details>

I notice that we don't get all the data coming in - so we don't get signals of every layer extraction completion. I've left the PR as is which just does best effort on showing it.
I also didn't program in support for changing the Terminal Window while it's running, which I think is OK. 