### PR TITLE
validate-localization: downgrade ADML locked-token mismatch to warning

### DIFF
--- a/tools/devops/validate-localization.py
+++ b/tools/devops/validate-localization.py
@@ -265,13 +265,19 @@ def validate_adml(adml_folder: str, baseline_language: str) -> bool:
             print(f'error: ADML {locale_path} has unexpected presentation ids: {sorted(extra_p)}')
             result = False
 
+        # Note: we intentionally do not enforce that baseline {Locked="..."}
+        # tokens appear in translated ADML strings. The Touchdown pipeline does
+        # not honor `<!-- {Locked="..."} -->` XML comments in .adml files (it
+        # only honors the `<comment>` element used by .resw), so locked tokens
+        # are routinely translated. Failing CI here would block every nightly
+        # localization PR. The baseline check above still catches authoring
+        # mistakes in en-US.
         for sid in baseline_ids & set(translated.keys()):
             _, tokens = baseline[sid]
             tvalue, _ = translated[sid]
             for tok in tokens:
                 if tok not in tvalue:
-                    print(f'error: locked token "{tok}" not found in {locale_path} string {sid}: {tvalue}')
-                    result = False
+                    print(f'warning: locked token "{tok}" not preserved in {locale_path} string {sid}: {tvalue}')
 
     return result
 


### PR DESCRIPTION
The Touchdown `.adml` parser does not honor `<!-- {Locked=...} -->` XML comments the way the `.resw` parser honors `<comment>{Locked=...}</comment>`, so every nightly localization PR comes back with locked tokens translated (`Mirrored` -> `镜像`, `None` -> `Нет`, `wsl2.networkingMode` -> `wsl2.networkingmode`, etc.) and fails CI on the per-locale token check added in #40515.

This unblocks the loc PRs by downgrading the per-locale locked-token check to a `warning:`. Still enforced as errors:

- baseline en-US `{Locked=...}` tokens must appear in their own string (catches authoring mistakes),
- string-id and `<presentation>`-id parity between baseline and every locale,
- all the existing `.resw` inserts/locked checks.

Separate workstream: figure out the right LocVer placement for `.adml` with the Touchdown team. The ADMX schema has no `<comment>` element on `<string>`, so the existing XML-comment placement we picked is apparently not what their `.adml` parser expects. Once we know the supported form, we can re-enable this as an error.