### PR TITLE
Fix system.vhd missing after update

### DIFF
--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -611,6 +611,29 @@
         <CustomAction Id="InstallMsix.SetProperty" Return="check" Property="InstallMsix" Value='[DATABASE]' Execute='immediate' />
         <CustomAction Id="CalculateWslSettingsProtocolIds" Impersonate="no" BinaryRef="wslinstall.dll" DllEntry="CalculateWslSettingsProtocolIds" Return="check" Execute='immediate' />
 
+        <!-- Builds the list of files this MSI will install (resolved to absolute target
+             paths) and stashes it into the property whose name matches the deferred CA
+             below. MSI propagates that property as CustomActionData. -->
+        <CustomAction Id="BuildPendingDeleteScrubList"
+            Impersonate="no"
+            BinaryRef="wslinstall.dll"
+            DllEntry="BuildPendingDeleteScrubList"
+            Return="check"
+            Execute="immediate" />
+
+        <!-- Walks HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations
+             and drops any delete-on-reboot entries whose source path matches a file this
+             MSI is about to (re)install. Required because the major-upgrade uninstall pass
+             can schedule delete-on-reboot for files held open by vmwp.exe (e.g. system.vhd
+             and tools\modules.vhd). Without this, Session Manager would wipe the
+             freshly-installed files at the next reboot. -->
+        <CustomAction Id="CancelPendingDeletesForInstalledFiles"
+            Impersonate="no"
+            BinaryRef="wslinstall.dll"
+            DllEntry="CancelPendingDeletesForInstalledFiles"
+            Return="check"
+            Execute="deferred" />
+
         <!-- See https://learn.microsoft.com/en-us/windows/win32/msi/examples-of-conditional-statement-syntax -->
         <InstallExecuteSequence>
             <Custom Action="ValidateInstall" After="InstallInitialize" Condition="(not INSTALLED) and (not SKIPVALIDATION = 1)" />
@@ -665,6 +688,14 @@
             <?endif?>
 
             <Custom Action="FinalizeInstall" After="PublishFeatures"/>
+
+            <Custom Action="BuildPendingDeleteScrubList"
+                After="CostFinalize"
+                Condition='(not REMOVE~="ALL") and (not UPGRADINGPRODUCTCODE)' />
+
+            <Custom Action="CancelPendingDeletesForInstalledFiles"
+                Before="InstallFiles"
+                Condition='(not REMOVE~="ALL") and (not UPGRADINGPRODUCTCODE)' />
 
         </InstallExecuteSequence>
 

--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -940,6 +940,243 @@ extern "C" UINT __stdcall CalculateWslSettingsProtocolIds(MSIHANDLE install)
     return NOERROR;
 }
 
+std::wstring GetRecordString(MSIHANDLE record, UINT field)
+{
+    DWORD size = 0;
+    std::wstring output(1, L'\0');
+    UINT result = MsiRecordGetStringW(record, field, output.data(), &size);
+    THROW_HR_IF_MSG(E_UNEXPECTED, result != ERROR_SUCCESS && result != ERROR_MORE_DATA, "MsiRecordGetString failed with %u", result);
+
+    output.resize(size);
+    size = static_cast<DWORD>(output.size() + 1);
+    result = MsiRecordGetStringW(record, field, output.data(), &size);
+    THROW_HR_IF_MSG(E_UNEXPECTED, result != ERROR_SUCCESS, "MsiRecordGetString failed with %u", result);
+
+    return output;
+}
+
+std::wstring GetTargetPath(MSIHANDLE install, LPCWSTR directory)
+{
+    DWORD size = 0;
+    std::wstring output(1, L'\0');
+    UINT result = MsiGetTargetPathW(install, directory, output.data(), &size);
+    THROW_HR_IF_MSG(E_UNEXPECTED, result != ERROR_SUCCESS && result != ERROR_MORE_DATA, "MsiGetTargetPath failed with %u", result);
+
+    output.resize(size);
+    size = static_cast<DWORD>(output.size() + 1);
+    result = MsiGetTargetPathW(install, directory, output.data(), &size);
+    THROW_HR_IF_MSG(E_UNEXPECTED, result != ERROR_SUCCESS, "MsiGetTargetPath failed with %u", result);
+
+    return output;
+}
+
+std::wstring NormalizePendingPath(std::wstring path)
+{
+    constexpr std::wstring_view prefix = LR"(\??\)";
+    if (path.starts_with(prefix))
+    {
+        path.erase(0, prefix.size());
+    }
+    std::transform(path.begin(), path.end(), path.begin(), [](wchar_t c) { return static_cast<wchar_t>(towlower(c)); });
+    return path;
+}
+
+// Immediate CA: enumerate the File table for components being installed, resolve
+// absolute target paths, and stash the '|'-separated list into the property whose
+// name matches the deferred CA "CancelPendingDeletesForInstalledFiles". MSI
+// propagates that property to the deferred CA as CustomActionData.
+extern "C" UINT __stdcall BuildPendingDeleteScrubList(MSIHANDLE install)
+try
+{
+    WSL_INSTALL_LOG("BuildPendingDeleteScrubList");
+
+    const MSIHANDLE rawDatabase = MsiGetActiveDatabase(install);
+    THROW_HR_IF(E_UNEXPECTED, rawDatabase == 0);
+    unique_msi_handle database{rawDatabase};
+
+    unique_msi_handle view;
+    THROW_IF_WIN32_ERROR(MsiDatabaseOpenViewW(
+        database.get(),
+        L"SELECT `File`.`FileName`, `File`.`Component_`, `Component`.`Directory_` "
+        L"FROM `File`, `Component` "
+        L"WHERE `File`.`Component_` = `Component`.`Component`",
+        &view));
+    THROW_IF_WIN32_ERROR(MsiViewExecute(view.get(), 0));
+
+    std::wstring paths;
+    for (;;)
+    {
+        MSIHANDLE rawRecord{};
+        const auto rc = MsiViewFetch(view.get(), &rawRecord);
+        if (rc == ERROR_NO_MORE_ITEMS)
+        {
+            break;
+        }
+        THROW_IF_WIN32_ERROR(rc);
+        unique_msi_handle record{rawRecord};
+
+        const auto fileName = GetRecordString(record.get(), 1);
+        const auto component = GetRecordString(record.get(), 2);
+        const auto directory = GetRecordString(record.get(), 3);
+        if (fileName.empty() || component.empty() || directory.empty())
+        {
+            continue;
+        }
+
+        // Only include files whose component will actually be (re)installed.
+        INSTALLSTATE installed = INSTALLSTATE_UNKNOWN;
+        INSTALLSTATE action = INSTALLSTATE_UNKNOWN;
+        if (MsiGetComponentStateW(install, component.c_str(), &installed, &action) != ERROR_SUCCESS || action != INSTALLSTATE_LOCAL)
+        {
+            continue;
+        }
+
+        // File.FileName is "shortname|longname"; prefer the long name when present.
+        const auto bar = fileName.find(L'|');
+        const std::wstring longName = (bar == std::wstring::npos) ? fileName : fileName.substr(bar + 1);
+
+        auto dir = GetTargetPath(install, directory.c_str());
+        if (dir.empty())
+        {
+            continue;
+        }
+        if (dir.back() != L'\\')
+        {
+            dir.push_back(L'\\');
+        }
+
+        if (!paths.empty())
+        {
+            paths.push_back(L'|');
+        }
+        paths.append(dir).append(longName);
+    }
+
+    THROW_IF_WIN32_ERROR(MsiSetPropertyW(install, L"CancelPendingDeletesForInstalledFiles", paths.c_str()));
+
+    return NOERROR;
+}
+catch (...)
+{
+    LOG_CAUGHT_EXCEPTION();
+    return NOERROR;
+}
+
+// Deferred CA (runs as LocalSystem): walk PendingFileRenameOperations and drop
+// any delete-on-reboot entries whose source path is one this MSI is about to
+// (re)install. This protects against the scenario where a previous version's
+// uninstall scheduled the old file for delete-on-reboot (because the file was
+// in use), and the next-boot Session Manager pass would otherwise wipe the
+// freshly-installed file at the same path.
+extern "C" UINT __stdcall CancelPendingDeletesForInstalledFiles(MSIHANDLE install)
+try
+{
+    WSL_INSTALL_LOG("CancelPendingDeletesForInstalledFiles");
+
+    const auto data = GetMsiProperty(install, L"CustomActionData");
+    if (data.empty())
+    {
+        return NOERROR;
+    }
+
+    std::unordered_set<std::wstring> installSet;
+    for (size_t pos = 0; pos < data.size();)
+    {
+        const auto next = data.find(L'|', pos);
+        const auto end = (next == std::wstring::npos) ? data.size() : next;
+        installSet.insert(NormalizePendingPath(data.substr(pos, end - pos)));
+        pos = (next == std::wstring::npos) ? data.size() : next + 1;
+    }
+
+    if (installSet.empty())
+    {
+        return NOERROR;
+    }
+
+    static constexpr auto c_keyPath = LR"(SYSTEM\CurrentControlSet\Control\Session Manager)";
+    static constexpr auto c_valueName = L"PendingFileRenameOperations";
+
+    wil::unique_hkey key;
+    auto status = RegOpenKeyExW(HKEY_LOCAL_MACHINE, c_keyPath, 0, KEY_QUERY_VALUE | KEY_SET_VALUE, &key);
+    if (status == ERROR_FILE_NOT_FOUND)
+    {
+        return NOERROR;
+    }
+    THROW_IF_WIN32_ERROR(status);
+
+    DWORD type = 0;
+    DWORD size = 0;
+    status = RegQueryValueExW(key.get(), c_valueName, nullptr, &type, nullptr, &size);
+    if (status == ERROR_FILE_NOT_FOUND || size == 0)
+    {
+        return NOERROR;
+    }
+    THROW_IF_WIN32_ERROR(status);
+    THROW_HR_IF(E_UNEXPECTED, type != REG_MULTI_SZ);
+
+    std::wstring buffer(size / sizeof(wchar_t), L'\0');
+    THROW_IF_WIN32_ERROR(RegQueryValueExW(key.get(), c_valueName, nullptr, nullptr, reinterpret_cast<BYTE*>(buffer.data()), &size));
+
+    // Each entry in PendingFileRenameOperations is a pair of NUL-terminated wide
+    // strings (source, target). The whole REG_MULTI_SZ value is terminated by an
+    // extra NUL.
+    std::wstring rebuilt;
+    rebuilt.reserve(buffer.size());
+    bool changed = false;
+
+    size_t i = 0;
+    while (i < buffer.size() && buffer[i] != L'\0')
+    {
+        const std::wstring source{buffer.data() + i};
+        i += source.size() + 1;
+        if (i >= buffer.size())
+        {
+            break; // malformed pair; bail without further damage
+        }
+        const std::wstring target{buffer.data() + i};
+        i += target.size() + 1;
+
+        if (target.empty() && installSet.contains(NormalizePendingPath(source)))
+        {
+            WSL_LOG("CancelPendingDelete", TraceLoggingValue(source.c_str(), "Path"));
+            changed = true;
+            continue;
+        }
+
+        rebuilt.append(source).push_back(L'\0');
+        rebuilt.append(target).push_back(L'\0');
+    }
+
+    if (!changed)
+    {
+        return NOERROR;
+    }
+
+    if (rebuilt.empty())
+    {
+        const auto rc = RegDeleteValueW(key.get(), c_valueName);
+        LOG_HR_IF_MSG(HRESULT_FROM_WIN32(rc), rc != ERROR_SUCCESS && rc != ERROR_FILE_NOT_FOUND, "RegDeleteValue failed with %u", rc);
+    }
+    else
+    {
+        rebuilt.push_back(L'\0'); // double-NUL terminator
+        THROW_IF_WIN32_ERROR(RegSetValueExW(
+            key.get(),
+            c_valueName,
+            0,
+            REG_MULTI_SZ,
+            reinterpret_cast<const BYTE*>(rebuilt.data()),
+            static_cast<DWORD>(rebuilt.size() * sizeof(wchar_t))));
+    }
+
+    return NOERROR;
+}
+catch (...)
+{
+    LOG_CAUGHT_EXCEPTION();
+    return NOERROR;
+}
+
 EXTERN_C BOOL STDAPICALLTYPE DllMain(_In_ HINSTANCE Instance, _In_ DWORD Reason, _In_opt_ LPVOID Reserved)
 {
     wil::DLLMain(Instance, Reason, Reserved);

--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -1161,12 +1161,7 @@ try
     {
         rebuilt.push_back(L'\0'); // double-NUL terminator
         THROW_IF_WIN32_ERROR(RegSetValueExW(
-            key.get(),
-            c_valueName,
-            0,
-            REG_MULTI_SZ,
-            reinterpret_cast<const BYTE*>(rebuilt.data()),
-            static_cast<DWORD>(rebuilt.size() * sizeof(wchar_t))));
+            key.get(), c_valueName, 0, REG_MULTI_SZ, reinterpret_cast<const BYTE*>(rebuilt.data()), static_cast<DWORD>(rebuilt.size() * sizeof(wchar_t))));
     }
 
     return NOERROR;

--- a/src/windows/wslinstall/wslinstall.def
+++ b/src/windows/wslinstall/wslinstall.def
@@ -14,3 +14,5 @@ EXPORTS
     RemoveRegistryKeyProtections
     UnregisterLspCategories
     CalculateWslSettingsProtocolIds
+    BuildPendingDeleteScrubList
+    CancelPendingDeletesForInstalledFiles

--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -1125,4 +1125,162 @@ class InstallerTests
         SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
         VerifyWslSettingsProtocolAssociationExistsWithRetry();
     }
+
+    TEST_METHOD(InstallScrubsPendingDeletesForInstalledFiles)
+    {
+        // Verify that the deferred CA "CancelPendingDeletesForInstalledFiles"
+        // removes delete-on-reboot entries pointing at files our MSI is about to
+        // install, while leaving renames and unrelated deletes untouched.
+        //
+        // See: msipackage/package.wix.in and src/windows/wslinstall/DllMain.cpp.
+
+        constexpr auto c_sessionManagerKey = LR"(SYSTEM\CurrentControlSet\Control\Session Manager)";
+        constexpr auto c_valueName = L"PendingFileRenameOperations";
+
+        const auto key = wsl::windows::common::registry::OpenKey(HKEY_LOCAL_MACHINE, c_sessionManagerKey, KEY_QUERY_VALUE | KEY_SET_VALUE);
+
+        // Snapshot the existing value (if any) so we can restore it on exit.
+        const auto readValue = [&]() -> std::optional<std::vector<wchar_t>> {
+            DWORD type = 0;
+            DWORD size = 0;
+            const auto rc = RegQueryValueExW(key.get(), c_valueName, nullptr, &type, nullptr, &size);
+            if (rc == ERROR_FILE_NOT_FOUND)
+            {
+                return std::nullopt;
+            }
+            VERIFY_ARE_EQUAL(static_cast<LSTATUS>(ERROR_SUCCESS), rc);
+            VERIFY_ARE_EQUAL(static_cast<DWORD>(REG_MULTI_SZ), type);
+            std::vector<wchar_t> buffer(size / sizeof(wchar_t));
+            VERIFY_ARE_EQUAL(
+                static_cast<LSTATUS>(ERROR_SUCCESS),
+                RegQueryValueExW(key.get(), c_valueName, nullptr, nullptr, reinterpret_cast<BYTE*>(buffer.data()), &size));
+            return buffer;
+        };
+
+        const auto writeValue = [&](const std::optional<std::vector<wchar_t>>& value) {
+            if (!value.has_value())
+            {
+                const auto rc = RegDeleteValueW(key.get(), c_valueName);
+                if (rc != ERROR_SUCCESS && rc != ERROR_FILE_NOT_FOUND)
+                {
+                    THROW_WIN32(rc);
+                }
+            }
+            else
+            {
+                THROW_IF_WIN32_ERROR(RegSetValueExW(
+                    key.get(),
+                    c_valueName,
+                    0,
+                    REG_MULTI_SZ,
+                    reinterpret_cast<const BYTE*>(value->data()),
+                    static_cast<DWORD>(value->size() * sizeof(wchar_t))));
+            }
+        };
+
+        // Encode (source, target) pairs into a REG_MULTI_SZ buffer.
+        const auto encode = [](const std::vector<std::pair<std::wstring, std::wstring>>& pairs) {
+            std::vector<wchar_t> buffer;
+            for (const auto& [src, dst] : pairs)
+            {
+                buffer.insert(buffer.end(), src.begin(), src.end());
+                buffer.push_back(L'\0');
+                buffer.insert(buffer.end(), dst.begin(), dst.end());
+                buffer.push_back(L'\0');
+            }
+            buffer.push_back(L'\0'); // double-NUL terminator
+            return buffer;
+        };
+
+        // Decode a REG_MULTI_SZ buffer into (source, target) pairs.
+        const auto decode = [](const std::vector<wchar_t>& buffer) {
+            std::vector<std::pair<std::wstring, std::wstring>> pairs;
+            size_t i = 0;
+            while (i < buffer.size() && buffer[i] != L'\0')
+            {
+                std::wstring src{buffer.data() + i};
+                i += src.size() + 1;
+                if (i >= buffer.size())
+                {
+                    break;
+                }
+                std::wstring dst{buffer.data() + i};
+                i += dst.size() + 1;
+                pairs.emplace_back(std::move(src), std::move(dst));
+            }
+            return pairs;
+        };
+
+        const auto saved = readValue();
+        auto restore = wil::scope_exit([&]() {
+            try
+            {
+                writeValue(saved);
+            }
+            CATCH_LOG();
+        });
+
+        // Uninstall first so the subsequent InstallMsi() is a fresh install
+        // where every component's action is INSTALLSTATE_LOCAL. A maintenance
+        // reinstall over the existing product leaves component states as Null,
+        // so the CA's File-table walk would produce an empty CustomActionData
+        // and the scrub would be a no-op.
+        UninstallMsi();
+        VERIFY_IS_FALSE(IsMsiPackageInstalled());
+
+        const auto installedSystemVhd = m_installedPath / L"system.vhd";
+        const auto installedModulesVhd = m_installedPath / L"tools" / L"modules.vhd";
+        const auto orphanPath = (m_installedPath / L"wsltest-orphan.tmp").wstring();
+        const auto renameSourcePath = (m_installedPath / L"wsltest-rename-src.tmp").wstring();
+
+        const auto ntPrefixed = [](const std::wstring& path) { return LR"(\??\)" + path; };
+
+        std::vector<std::pair<std::wstring, std::wstring>> injected;
+
+        // Two delete entries for files this MSI installs - both should be scrubbed.
+        injected.emplace_back(ntPrefixed(installedSystemVhd.wstring()), L"");
+        injected.emplace_back(ntPrefixed(installedModulesVhd.wstring()), L"");
+
+        // Delete entry for an unrelated path - must survive scrub.
+        injected.emplace_back(ntPrefixed(orphanPath), L"");
+
+        // Rename entry pointing AT one of our installed paths - must survive scrub.
+        injected.emplace_back(ntPrefixed(renameSourcePath), ntPrefixed(installedSystemVhd.wstring()));
+
+        writeValue(encode(injected));
+
+        // Re-install the MSI in place; the deferred CA fires inside InstallFinalize.
+        InstallMsi();
+        VERIFY_IS_TRUE(IsMsiPackageInstalled());
+        ValidatePackageInstalledProperly();
+
+        // Read back and verify exactly which test entries survived.
+        const auto post = readValue();
+        VERIFY_IS_TRUE(post.has_value(), L"PendingFileRenameOperations should still exist after the install");
+        const auto postPairs = decode(*post);
+
+        const auto containsDelete = [&](const std::wstring& source) {
+            return std::any_of(
+                postPairs.begin(), postPairs.end(), [&](const auto& p) { return p.first == source && p.second.empty(); });
+        };
+
+        const auto containsRename = [&](const std::wstring& source, const std::wstring& target) {
+            return std::any_of(
+                postPairs.begin(), postPairs.end(), [&](const auto& p) { return p.first == source && p.second == target; });
+        };
+
+        // Both delete entries pointing at installed files should be gone.
+        VERIFY_IS_FALSE(
+            containsDelete(ntPrefixed(installedSystemVhd.wstring())),
+            L"Delete-on-reboot entry for system.vhd should have been scrubbed");
+        VERIFY_IS_FALSE(
+            containsDelete(ntPrefixed(installedModulesVhd.wstring())),
+            L"Delete-on-reboot entry for tools\\modules.vhd should have been scrubbed");
+
+        // Orphan delete and the rename pointing at an installed path must survive.
+        VERIFY_IS_TRUE(containsDelete(ntPrefixed(orphanPath)), L"Unrelated delete-on-reboot entry must be preserved");
+        VERIFY_IS_TRUE(
+            containsRename(ntPrefixed(renameSourcePath), ntPrefixed(installedSystemVhd.wstring())),
+            L"Rename entry pointing at an installed path must be preserved (only deletes are dropped)");
+    }
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When these events happen during an update. The system.vhd could be missing afterwards:
1. During uninstall, the system.vhd is held. So, it's removal is delayed to next reboot.
2. During install, the system.vhd is no longer held. So, it's replacement is done without a reboot.
3. The installer requests for a reboot.
4. After the reboot. The system executes the scheduled delete and delete the newly installed system.vhd.

This PR fixes this issue by adding two steps in the installer that:
1. Get the file list in the new installation.
2. Cancel any scheduled reboot delete on files that's in the new installation. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/40488
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

According to this user provided log: https://gist.github.com/BBQ4ever/52e437af3324aafe02bf511027f7573e
line 1608: MSIRMSHUTDOWN was set to 1.
line 5014 - 5025: system.vhd was still held. And it was scheduled to be reboot deleted.
line 9505 - 9509: system.vhd was no longer held. Copying the new file succeeded.
line 12195: installer returned with 1641, telling the system to reboot.


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Add new test InstallerTests::InstallScrubsPendingDeletesForInstalledFiles.