### PR TITLE
Tests: retry powershell.exe on unhandled CLR exception

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -502,7 +502,46 @@ s
 {
     auto CommandLine = L"Powershell -NoProfile -Command \"" + Cmd + L"\"";
     LogInfo("Running the command: %ls\n", CommandLine.c_str());
-    return LxsstuLaunchCommandAndCaptureOutput(CommandLine.data(), ExpectedExitCode);
+
+    //
+    // PowerShell has been observed to crash on the test agents with an unhandled CLR
+    // exception (e.g., AccessViolationException while JIT-compiling cmdlet code), exiting
+    // with a non-zero status and printing "Unhandled Exception:" to stderr before the
+    // requested command runs. Retry once on that signature so that infrastructure flakes
+    // don't fail the test.
+    //
+
+    constexpr int c_maxAttempts = 2;
+    for (int attempt = 1; attempt <= c_maxAttempts; ++attempt)
+    {
+        auto [Out, Err, ExitCode] = LxsstuLaunchCommandAndCaptureOutputWithResult(CommandLine.data());
+        if (ExitCode == ExpectedExitCode)
+        {
+            return std::make_pair(std::move(Out), std::move(Err));
+        }
+
+        const bool powershellCrashed = Err.find(L"Unhandled Exception:") != std::wstring::npos;
+        if (attempt < c_maxAttempts && powershellCrashed)
+        {
+            LogWarning("Powershell crashed (exit code %lu); retrying. Stderr: '%ls'", static_cast<unsigned long>(ExitCode), Err.c_str());
+            Sleep(1000);
+            continue;
+        }
+
+        THROW_HR_MSG(
+            E_UNEXPECTED,
+            "Command \"%ls\" "
+            "returned unexpected exit code (%lu != %i). "
+            "Stdout: '%ls' "
+            "Stderr: '%ls'",
+            CommandLine.c_str(),
+            ExitCode,
+            ExpectedExitCode,
+            Out.c_str(),
+            Err.c_str());
+    }
+
+    THROW_HR(E_UNEXPECTED);
 }
 
 // LxsstuUninitialize


### PR DESCRIPTION
## Summary

Test infrastructure fix: retry `powershell.exe` once when it crashes with an unhandled CLR exception before running the requested cmdlet.

## Background

While investigating an intermittent `MountTests::TestDeviceCantBeMountedIfInUse` failure, the test attachment showed this stderr from the child process spawned by `LxsstuLaunchPowershellAndCaptureOutput`:

`
Unhandled Exception: System.AccessViolationException: Attempted to read or write protected memory...
   at System.Delegate.BindToMethodInfo(...)
   at System.Delegate.CreateDelegateInternal(...)
   at System.Linq.Expressions.Compiler.LambdaCompiler.EmitDynamicExpression(...)
`

with exit code `57005` (`0xDEAD`). This is `powershell.exe` itself crashing inside the .NET DLR while JIT-compiling a lambda for the Storage cmdlet bindings — i.e., before `Clear-Disk` ever ran. It's an environment flake on the agent, not a WSL regression.

## Change

In `LxsstuLaunchPowershellAndCaptureOutput`, when the exit code doesn't match the expected one **and** stderr contains `"Unhandled Exception:"` (the CLR's unhandled-exception banner), wait one second and retry the invocation once. Anything else still throws immediately, so legitimate non-zero exits (including callers that pass a non-zero `ExpectedExitCode`) are unaffected — real cmdlet errors don't print that banner.

## Risk

Low / test-only. Worst case is a single extra `powershell.exe` launch on a flake.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>