### PR TITLE
Use inline _locComment syntax for locked tokens in en-US WSL.adml

### DIFF
--- a/intune/en-US/WSL.adml
+++ b/intune/en-US/WSL.adml
@@ -5,84 +5,58 @@
   <description>Windows Subsystem for Linux</description>
   <resources>
     <stringTable>
-        <!-- {Locked="Windows Subsystem for Linux"} -->
-        <string id="WindowsSubsystemForLinux">Windows Subsystem for Linux</string>
+        <string id="WindowsSubsystemForLinux"><!-- _locComment='{Locked="Windows Subsystem for Linux"}' -->Windows Subsystem for Linux</string>
 
-        <!-- {Locked="Windows Subsystem for Linux"} -->
-        <string id="AllowWSL">Allow the Windows Subsystem for Linux</string>
-        <!-- {Locked="Windows Subsystem for Linux"} -->
-        <string id="AllowWSLExplain">When set to disabled, this policy disables access to running Linux distributions in the Windows Subsystem for Linux for all users on the machine.</string>
+        <string id="AllowWSL"><!-- _locComment='{Locked="Windows Subsystem for Linux"}' -->Allow the Windows Subsystem for Linux</string>
+        <string id="AllowWSLExplain"><!-- _locComment='{Locked="Windows Subsystem for Linux"}' -->When set to disabled, this policy disables access to running Linux distributions in the Windows Subsystem for Linux for all users on the machine.</string>
 
-        <!-- {Locked="Windows Subsystem for Linux"} -->
-        <string id="AllowInboxWSL">Allow the Inbox version of the Windows Subsystem for Linux</string>
-        <!-- {Locked="Windows Subsystem for Linux"}{Locked="WSL"} -->
-        <string id="AllowInboxWSLExplain">When set to disabled, this policy disables the inbox version (optional component) of the Windows Subsystem for Linux. If this policy is disabled, only the store version of WSL can be used.</string>
+        <string id="AllowInboxWSL"><!-- _locComment='{Locked="Windows Subsystem for Linux"}' -->Allow the Inbox version of the Windows Subsystem for Linux</string>
+        <string id="AllowInboxWSLExplain"><!-- _locComment='{Locked="Windows Subsystem for Linux"}{Locked="WSL"}' -->When set to disabled, this policy disables the inbox version (optional component) of the Windows Subsystem for Linux. If this policy is disabled, only the store version of WSL can be used.</string>
 
-        <!-- {Locked="WSL1"} -->
-        <string id="AllowWSL1">Allow WSL1</string>
-        <!-- {Locked="WSL1"}{Locked="WSL2"} -->
-        <string id="AllowWSL1Explain">When set to disabled, this policy disables WSL1. When disabled, only WSL2 distributions can be used.</string>
+        <string id="AllowWSL1"><!-- _locComment='{Locked="WSL1"}' -->Allow WSL1</string>
+        <string id="AllowWSL1Explain"><!-- _locComment='{Locked="WSL1"}{Locked="WSL2"}' -->When set to disabled, this policy disables WSL1. When disabled, only WSL2 distributions can be used.</string>
 
         <string id="CustomKernelUserSettingConfigurable">Allow custom kernel configuration</string>
-        <!-- {Locked=".wslconfig"}{Locked="wsl2.kernel"}{Locked="Store WSL"} -->
-        <string id="CustomKernelExplain">When set to disabled, this policy disables custom kernel configuration via .wslconfig (wsl2.kernel). This policy only applies to Store WSL.</string>
+        <string id="CustomKernelExplain"><!-- _locComment='{Locked=".wslconfig"}{Locked="wsl2.kernel"}{Locked="Store WSL"}' -->When set to disabled, this policy disables custom kernel configuration via .wslconfig (wsl2.kernel). This policy only applies to Store WSL.</string>
 
         <string id="CustomSystemDistroUserSettingConfigurable">Allow custom system distribution configuration</string>
-        <!-- {Locked=".wslconfig"}{Locked="wsl2.systemDistro"}{Locked="Store WSL"} -->
-        <string id="CustomSystemDistroExplain">When set to disabled, this policy disables custom system distribution configuration via .wslconfig (wsl2.systemDistro). This policy only applies to Store WSL.</string>
+        <string id="CustomSystemDistroExplain"><!-- _locComment='{Locked=".wslconfig"}{Locked="wsl2.systemDistro"}{Locked="Store WSL"}' -->When set to disabled, this policy disables custom system distribution configuration via .wslconfig (wsl2.systemDistro). This policy only applies to Store WSL.</string>
 
         <string id="CustomKernelCommandLineUserSettingConfigurable">Allow kernel command line configuration</string>
-        <!-- {Locked=".wslconfig"}{Locked="wsl2.kernelCommandLine"}{Locked="Store WSL"} -->
-        <string id="CustomKernelCommandLineExplain">When set to disabled, this policy disables kernel command line configuration via .wslconfig (wsl2.kernelCommandLine). This policy only applies to Store WSL.</string>
+        <string id="CustomKernelCommandLineExplain"><!-- _locComment='{Locked=".wslconfig"}{Locked="wsl2.kernelCommandLine"}{Locked="Store WSL"}' -->When set to disabled, this policy disables kernel command line configuration via .wslconfig (wsl2.kernelCommandLine). This policy only applies to Store WSL.</string>
 
         <string id="AllowDebugShell">Allow the debug shell</string>
-        <!-- {Locked="wsl.exe"}{Locked="debug-shell"}{Locked="Store WSL"} -->
-        <string id="AllowDebugShellExplain">When set to disabled, this policy disables the debug shell (wsl.exe --debug-shell). This policy only applies to Store WSL.</string>
+        <string id="AllowDebugShellExplain"><!-- _locComment='{Locked="wsl.exe"}{Locked="debug-shell"}{Locked="Store WSL"}' -->When set to disabled, this policy disables the debug shell (wsl.exe --debug-shell). This policy only applies to Store WSL.</string>
 
         <string id="NestedVirtualizationUserSettingConfigurable">Allow nested virtualization</string>
-        <!-- {Locked=".wslconfig"}{Locked="wsl2.nestedVirtualization"}{Locked="Store WSL"} -->
-        <string id="NestedVirtualizationExplain">When set to disabled, this policy disables nested virtualization configuration via .wslconfig (wsl2.nestedVirtualization). This policy only applies to Store WSL.</string>
+        <string id="NestedVirtualizationExplain"><!-- _locComment='{Locked=".wslconfig"}{Locked="wsl2.nestedVirtualization"}{Locked="Store WSL"}' -->When set to disabled, this policy disables nested virtualization configuration via .wslconfig (wsl2.nestedVirtualization). This policy only applies to Store WSL.</string>
 
         <string id="KernelDebugUserSettingConfigurable">Allow kernel debugging</string>
-        <!-- {Locked=".wslconfig"}{Locked="wsl2.kernelDebugPort"}{Locked="Store WSL"} -->
-        <string id="KernelDebugExplain">When set to disabled, this policy disables kernel debugging configuration via .wslconfig (wsl2.kernelDebugPort). This policy only applies to Store WSL.</string>
+        <string id="KernelDebugExplain"><!-- _locComment='{Locked=".wslconfig"}{Locked="wsl2.kernelDebugPort"}{Locked="Store WSL"}' -->When set to disabled, this policy disables kernel debugging configuration via .wslconfig (wsl2.kernelDebugPort). This policy only applies to Store WSL.</string>
 
         <string id="CustomNetworkingUserSettingConfigurable">Allow custom networking configuration</string>
-        <!-- {Locked=".wslconfig"}{Locked="wsl2.networkingMode"}{Locked="Store WSL"} -->
-        <string id="CustomNetworkingExplain">When set to disabled, this policy disables custom networking configuration via .wslconfig (wsl2.networkingMode). This policy only applies to Store WSL.</string>
+        <string id="CustomNetworkingExplain"><!-- _locComment='{Locked=".wslconfig"}{Locked="wsl2.networkingMode"}{Locked="Store WSL"}' -->When set to disabled, this policy disables custom networking configuration via .wslconfig (wsl2.networkingMode). This policy only applies to Store WSL.</string>
 
         <string id="FirewallUserSettingConfigurable">Allow user setting firewall configuration</string>
-        <!-- {Locked=".wslconfig"}{Locked="wsl2.firewall"}{Locked="Store WSL"} -->
-        <string id="FirewallExplain">When set to disabled, this policy disables firewall configuration via .wslconfig (wsl2.firewall). This policy only applies to Store WSL.</string>
+        <string id="FirewallExplain"><!-- _locComment='{Locked=".wslconfig"}{Locked="wsl2.firewall"}{Locked="Store WSL"}' -->When set to disabled, this policy disables firewall configuration via .wslconfig (wsl2.firewall). This policy only applies to Store WSL.</string>
 
         <string id="AllowDiskMount">Allow passthrough disk mount</string>
-        <!-- {Locked="WSL2"}{Locked="wsl.exe"}{Locked="mount"}{Locked="Store WSL"} -->
-        <string id="AllowDiskMountExplain">When set to disabled, this policy disables passthrough disk mounting in WSL2 (wsl.exe --mount). This policy only applies to Store WSL.</string>
+        <string id="AllowDiskMountExplain"><!-- _locComment='{Locked="WSL2"}{Locked="wsl.exe"}{Locked="mount"}{Locked="Store WSL"}' -->When set to disabled, this policy disables passthrough disk mounting in WSL2 (wsl.exe --mount). This policy only applies to Store WSL.</string>
 
         <string id="DefaultNetworkingMode">Configure default networking mode</string>
-        <!-- {Locked="WSL2"} -->
-        <string id="DefaultNetworkingModeExplain">This policy specifies the default networking mode to be used for WSL2.</string>
-        <!-- {Locked="None"} -->
-        <string id="NetworkingModeNone">None</string>
-        <!-- {Locked="NAT"} -->
-        <string id="NetworkingModeNAT">NAT</string>
-        <!-- {Locked="Mirrored"} -->
-        <string id="NetworkingModeMirrored">Mirrored</string>
-        <!-- {Locked="VirtioProxy"} -->
-        <string id="NetworkingModeVirtioProxy">VirtioProxy</string>
+        <string id="DefaultNetworkingModeExplain"><!-- _locComment='{Locked="WSL2"}' -->This policy specifies the default networking mode to be used for WSL2.</string>
+        <string id="NetworkingModeNone"><!-- _locComment="{Locked}" -->None</string>
+        <string id="NetworkingModeNAT"><!-- _locComment="{Locked}" -->NAT</string>
+        <string id="NetworkingModeMirrored"><!-- _locComment="{Locked}" -->Mirrored</string>
+        <string id="NetworkingModeVirtioProxy"><!-- _locComment="{Locked}" -->VirtioProxy</string>
 
-        <!-- {Locked="WSL"} -->
-        <string id="WSLContainer">WSL container</string>
+        <string id="WSLContainer"><!-- _locComment='{Locked="WSL"}' -->WSL container</string>
 
-        <!-- {Locked="WSL"} -->
-        <string id="AllowWSLContainer">Allow WSL container</string>
-        <!-- {Locked="WSL"}{Locked="Disabled"} -->
-        <string id="AllowWSLContainerExplain">This policy controls whether WSL container can be used on this machine. When enabled or not configured, users and Windows applications can run Linux containers via WSL. When set to disabled, WSL container is blocked for all users and Windows apps cannot run Linux containers. Warning: Setting this to 'Disabled' can break Windows apps that depend on Linux containers.</string>
+        <string id="AllowWSLContainer"><!-- _locComment='{Locked="WSL"}' -->Allow WSL container</string>
+        <string id="AllowWSLContainerExplain"><!-- _locComment='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL container can be used on this machine. When enabled or not configured, users and Windows applications can run Linux containers via WSL. When set to disabled, WSL container is blocked for all users and Windows apps cannot run Linux containers. Warning: Setting this to 'Disabled' can break Windows apps that depend on Linux containers.</string>
 
-        <!-- {Locked="WSL"} -->
-        <string id="WSLContainerRegistryAllowlist">Allowlist for WSL container registries</string>
-        <!-- {Locked="WSL"} -->
-        <string id="WSLContainerRegistryAllowlistExplain">When enabled, WSL container will only be allowed to pull images from the registries listed here. This affects both the WSL container CLI and all applications using the WSL container API.</string>
+        <string id="WSLContainerRegistryAllowlist"><!-- _locComment='{Locked="WSL"}' -->Allowlist for WSL container registries</string>
+        <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment='{Locked="WSL"}' -->When enabled, WSL container will only be allowed to pull images from the registries listed here. This affects both the WSL container CLI and all applications using the WSL container API.</string>
     </stringTable>
     <presentationTable>
       <presentation id="DefaultNetworkingMode">

--- a/tools/devops/validate-localization.py
+++ b/tools/devops/validate-localization.py
@@ -187,12 +187,15 @@ def get_adml_entries(path: str) -> tuple[dict, set]:
     """Parse an .adml file.
 
     Returns ({string_id: (value, [locked_tokens])}, {presentation_id, ...}).
-    Locked tokens are extracted from XML comments of the form
-    `<!-- {Locked="..."}{Locked="..."} -->` placed immediately before a
-    `<string>` element. Non-Locked comments are ignored.
+    Locked tokens are extracted from inline comments inside <string> elements:
+      `<string id="X"><!-- _locComment='{Locked="..."}' -->...text...</string>`
+    The whole-string `{Locked}` form is also recognized but contributes no
+    specific tokens to verify. This is the only form honored by the Touchdown
+    POMXML parser; standalone comments preceding a <string> are ignored by
+    Touchdown and so are not recognized here either.
     """
     # Parse with a TreeBuilder that preserves comments so we can associate
-    # {Locked="..."} tokens with the <string> element that follows them.
+    # {Locked="..."} tokens with the <string> element they belong to.
     parser = xml.etree.ElementTree.XMLParser(
         target=xml.etree.ElementTree.TreeBuilder(insert_comments=True))
     root = xml.etree.ElementTree.parse(path, parser=parser).getroot()
@@ -202,17 +205,21 @@ def get_adml_entries(path: str) -> tuple[dict, set]:
         raise RuntimeError(f'error: {path} is missing the required <stringTable> element')
 
     strings = {}
-    pending_tokens = []
     for child in string_table:
-        if child.tag is xml.etree.ElementTree.Comment:
-            pending_tokens.extend(re.findall(r'\{Locked="([^"]*)"\}', child.text or ''))
-        elif child.tag == f'{ADML_NS}string':
-            sid = child.get('id')
-            if sid is not None:
-                strings[sid] = (child.text or '', pending_tokens)
-            pending_tokens = []
-        else:
-            pending_tokens = []
+        if child.tag != f'{ADML_NS}string':
+            continue
+        sid = child.get('id')
+        if sid is None:
+            continue
+        # The string value is the text before the first child, plus the tail of
+        # any inline comment children (which is where the actual visible text
+        # ends up when the comment precedes it inside the <string>).
+        value = (child.text or '') + ''.join((c.tail or '') for c in child)
+        tokens = []
+        for c in child:
+            if c.tag is xml.etree.ElementTree.Comment:
+                tokens.extend(re.findall(r'\{Locked="([^"]*)"\}', c.text or ''))
+        strings[sid] = (value, tokens)
 
     presentation_table = root.find(f'.//{ADML_NS}presentationTable')
     if presentation_table is None:
@@ -269,12 +276,11 @@ def validate_adml(adml_folder: str, baseline_language: str) -> bool:
             result = False
 
         # Note: we intentionally do not enforce that baseline {Locked="..."}
-        # tokens appear in translated ADML strings. The Touchdown pipeline does
-        # not honor `<!-- {Locked="..."} -->` XML comments in .adml files (it
-        # only honors the `<comment>` element used by .resw), so locked tokens
-        # are routinely translated. Failing CI here would block every nightly
-        # localization PR. The baseline check above still catches authoring
-        # mistakes in en-US.
+        # tokens appear in translated ADML strings. Translated locale files
+        # generated before the en-US source migrated to inline _locComment
+        # directives still contain translated tokens; failing CI here would
+        # block every nightly localization PR until those caches refresh. The
+        # baseline check above still catches authoring mistakes in en-US.
         for sid in baseline_ids & set(translated.keys()):
             _, tokens = baseline[sid]
             tvalue, _ = translated[sid]


### PR DESCRIPTION
The standalone `<!-- {Locked="..."} -->` XML comments above each `<string>` in `intune/en-US/WSL.adml` are silently ignored by the POMXML parser used by `TouchdownBuildTask`, so locked tokens were getting translated in every locale (e.g. `NetworkingMode` values `Mirrored`/`None`/`NAT` were translated; `.wslconfig` key names were translated; etc.).

Move the directives inside each `<string>` using the inline form the parser actually honors:

```xml
<string id="AllowWSL"><!-- _locComment='{Locked="Windows Subsystem for Linux"}' -->Allow the Windows Subsystem for Linux</string>
<string id="NetworkingModeMirrored"><!-- _locComment="{Locked}" -->Mirrored</string>
```

Also update `tools/devops/validate-localization.py` so its ADML parser extracts locked tokens from the inline form (instead of standalone sibling comments) — keeps the baseline-token-presence check catching authoring mistakes in en-US.

Localized `intune/<locale>/WSL.adml` files are intentionally not touched here; Touchdown will regenerate them on the next nightly run, after which their existing translations of locked tokens will get cleaned up. The validator continues to emit warnings (not errors) for translated-but-not-preserved tokens so the transition period doesn't fail CI.
