### PR TITLE
Bundle and mount Linux kernel headers in WSL2 distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,6 +497,7 @@ if (DEFINED WSL_DEV_BINARY_PATH) # Development shortcut to make the package smal
     add_compile_definitions(WSL_SYSTEM_DISTRO_PATH="${WSL_DEV_BINARY_PATH}/system.vhd"
                             WSL_KERNEL_PATH="${WSL_DEV_BINARY_PATH}/kernel"
                             WSL_KERNEL_MODULES_PATH="${WSL_DEV_BINARY_PATH}/modules.vhd"
+                            WSL_KERNEL_HEADERS_PATH="${WSL_DEV_BINARY_PATH}/linux-headers"
                             WSL_DEV_INSTALL_PATH="${WSL_DEV_BINARY_PATH}"
                             WSL_GPU_LIB_PATH="${WSL_DEV_BINARY_PATH}/lib")
 endif()

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -12,6 +12,8 @@ if(WSL_DEV_BINARY_PATH)
     file(COPY_FILE "${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd" "${WSL_DEV_BINARY_PATH}/system.vhd" ONLY_IF_DIFFERENT)
     file(COPY_FILE "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/modules.vhd" "${WSL_DEV_BINARY_PATH}/modules.vhd" ONLY_IF_DIFFERENT)
 
+    file(CREATE_LINK "${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/linux-headers" "${WSL_DEV_BINARY_PATH}/linux-headers" SYMBOLIC)
+
     # read-only VHDs need to be world readable to mount successfully.
     execute_process(
         COMMAND icacls.exe "${WSL_DEV_BINARY_PATH}/system.vhd" "/grant:r" "Everyone:(R)" /Q

--- a/doc/docs/technical-documentation/boot-process.md
+++ b/doc/docs/technical-documentation/boot-process.md
@@ -83,7 +83,7 @@ When started, the virtual machine will boot into the provided kernel, and then e
 - An entropy buffer, to seed the virtual machine's entropy
 - Information about the GPU drivers shares to mount, if any
 - Whether [wslg](https://github.com/microsoft/wslg) is enabled
-- Whether to mount the bundled Linux kernel headers (mounted from a read-only plan9 share into `/usr/src/linux-headers-$(uname -r)/include` in each distribution, with `/lib/modules/$(uname -r)/{build,source}` symlinked to the headers root)
+- Whether to mount the bundled Linux kernel headers (mounted from a read-only plan9 share into `/usr/src/linux-headers-$(uname -r)/include` in each distribution, with `/lib/modules/$(uname -r)/build` symlinked to the headers root)
 
 After applying all the configuration requested by [wslservice.exe](wslservice.exe.md), the virtual machine is ready to start Linux distributions.
 

--- a/doc/docs/technical-documentation/boot-process.md
+++ b/doc/docs/technical-documentation/boot-process.md
@@ -83,6 +83,7 @@ When started, the virtual machine will boot into the provided kernel, and then e
 - An entropy buffer, to seed the virtual machine's entropy
 - Information about the GPU drivers shares to mount, if any
 - Whether [wslg](https://github.com/microsoft/wslg) is enabled
+- Whether to mount the bundled Linux kernel headers (mounted from a read-only plan9 share into `/usr/src/linux-headers-$(uname -r)/include` in each distribution, with `/lib/modules/$(uname -r)/{build,source}` symlinked to the headers root)
 
 After applying all the configuration requested by [wslservice.exe](wslservice.exe.md), the virtual machine is ready to start Linux distributions.
 

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -648,6 +648,10 @@ Build time: {}</value>
     <value>The custom kernel modules VHD in {} was not found: '{}'.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. {Locked="VHD"}"VHD" (Virtual Hard Disk) is a technical format name and should not be translated.</comment>
   </data>
+  <data name="MessageCustomKernelHeadersNotFound" xml:space="preserve">
+    <value>The custom kernel headers directory specified by 'wsl2.kernelHeaders' in {} was not found: '{}'.</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. {Locked="wsl2.kernelHeaders"}This is a configuration setting name and should not be translated.</comment>
+  </data>
   <data name="MessageCustomSystemDistroError" xml:space="preserve">
     <value>The custom system distribution specified in {} was not found or is not the correct format.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
@@ -1171,6 +1175,10 @@ Error code: {}</value>
   <data name="MessageMismatchedKernelModulesError" xml:space="preserve">
     <value>Customised kernel modules were supplied without specifying a customised kernel. Please see https://aka.ms/wslcustomkernel for more information.</value>
   </data>
+  <data name="MessageMismatchedKernelHeadersError" xml:space="preserve">
+    <value>Customised kernel headers were supplied without specifying a customised kernel. The 'wsl2.kernelHeaders' setting requires 'wsl2.kernel' to also be set. Please see https://aka.ms/wslcustomkernel for more information.</value>
+    <comment>{Locked="wsl2.kernelHeaders"}{Locked="wsl2.kernel"}These are configuration setting names and should not be translated.</comment>
+  </data>
   <data name="MessageDnsTunnelingDisabled" xml:space="preserve">
     <value>Due to a current compatibility issue with Global Secure Access Client, DNS Tunneling is disabled.</value>
     <comment>{Locked="DNS"}"DNS" (Domain Name System) should not be translated.</comment>
@@ -1292,6 +1300,21 @@ See recovery instructions on: https://aka.ms/wsldiskmountrecovery</value>
   <data name="Settings_CustomKernelModulesPathTextBox.AutomationProperties.HelpText" xml:space="preserve">
     <value>An absolute Windows path to a custom Linux kernel modules VHD.</value>
     <comment>{Locked="VHD"}"VHD" (Virtual Hard Disk) is a technical format name and should not be translated.</comment>
+  </data>
+  <data name="Settings_CustomKernelHeadersPath.Header" xml:space="preserve">
+    <value>Custom kernel headers</value>
+  </data>
+  <data name="Settings_CustomKernelHeadersPath.Description" xml:space="preserve">
+    <value>An absolute Windows path to a directory containing Linux kernel headers. Requires a custom kernel to also be set.</value>
+  </data>
+  <data name="Settings_CustomKernelHeadersPathBrowseButton.Content" xml:space="preserve">
+    <value>Browse kernel headers</value>
+  </data>
+  <data name="Settings_CustomKernelHeadersPathTextBox.AutomationProperties.Name" xml:space="preserve">
+    <value>Custom kernel headers</value>
+  </data>
+  <data name="Settings_CustomKernelHeadersPathTextBox.AutomationProperties.HelpText" xml:space="preserve">
+    <value>An absolute Windows path to a directory containing Linux kernel headers. Requires a custom kernel to also be set.</value>
   </data>
   <data name="Settings_CustomSystemDistroPath.Header" xml:space="preserve">
     <value>Custom system distro</value>

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -5,7 +5,11 @@
 
         <StandardDirectory Id="ProgramFiles64Folder">
             <Directory Id="INSTALLDIR" Name="WSL">
-                <Directory Id="TOOLSFOLDER" Name="tools" />
+                <Directory Id="TOOLSFOLDER" Name="tools">
+                    <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
+                        <Directory Id="LINUX_HEADERS_FOLDER" Name="linux-headers" />
+                    <?endif?>
+                </Directory>
                 <Directory Id="LIBFOLDER" Name="lib" />
                 <?if "${WSL_BUILD_WSL_SETTINGS}" = "true" ?>
                     <Directory Id="WSLSETTINGS" Name="wslsettings"/>
@@ -484,6 +488,13 @@
         </DirectoryRef>
 
         <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
+            <ComponentGroup Id="linux_headers" Directory="LINUX_HEADERS_FOLDER" Source="${KERNEL_SOURCE_DIR}/bin/${TARGET_PLATFORM}/linux-headers">
+                <Component Id="linux_headers_component" Guid="8F57D60A-104C-4EE7-8B2A-79624CBC4D10" Bitness="always64" UninstallWhenSuperseded="yes" />
+                <Files Include="**/*.h" />
+            </ComponentGroup>
+        <?endif?>
+
+        <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
             <ComponentGroup Id="msrdc_localization" Directory="INSTALLDIR" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}">
                 <Component Id="msrdc_mui" Guid="EDBB5FC5-058D-45D7-BB03-FB1337B3B577" Bitness="always64"  UninstallWhenSuperseded="yes" />
                 <Files Include="**.mui" />
@@ -581,6 +592,7 @@
                 <ComponentRef Id="msal" />
                 <ComponentGroupRef Id="msrdc_localization" />
                 <ComponentRef Id="directx" />
+                <ComponentGroupRef Id="linux_headers" />
             <?endif?>
 
             <?if "${WSL_BUILD_WSL_SETTINGS}" = "true" ?>

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1121,6 +1121,68 @@ Return Value:
     CATCH_LOG()
 
     //
+    // Move the kernel headers temporary mount into its final location and create the symlinks
+    // expected by Debian/Ubuntu tooling. The target path is supplied by mini_init as
+    // /usr/src/linux-headers-<uname -r>/include.
+    //
+    // N.B. Failure to install the headers is non-fatal; the distro will simply boot without
+    //      them, mirroring the kernel modules behavior above.
+    //
+
+    try
+    {
+        auto tempMount = RemoveMountAndEnvironmentOnScopeExit(LX_WSL2_KERNEL_HEADERS_MOUNT_ENV);
+        if (tempMount)
+        {
+            const char* target = getenv(LX_WSL2_KERNEL_HEADERS_PATH_ENV);
+            if (target)
+            {
+                std::string targetPath{target};
+                unsetenv(LX_WSL2_KERNEL_HEADERS_PATH_ENV);
+
+                if (tempMount.MoveMount(targetPath.c_str()))
+                {
+                    // Derive the headers root directory by stripping the trailing "/include".
+                    constexpr std::string_view c_includeSuffix = "/include";
+                    if (targetPath.ends_with(c_includeSuffix))
+                    {
+                        const std::string headersRoot = targetPath.substr(0, targetPath.size() - c_includeSuffix.size());
+
+                        utsname unameBuffer{};
+                        if (uname(&unameBuffer) == 0)
+                        {
+                            // See main.cpp; convert release to std::string so subsequent appends
+                            // don't follow embedded NUL bytes from the char[65] buffer.
+                            const std::string release{unameBuffer.release};
+                            const std::string modulesDir = std::format("/lib/modules/{}", release);
+                            if (UtilMkdirPath(modulesDir.c_str(), 0755) == 0)
+                            {
+                                for (const auto* linkName : {"build", "source"})
+                                {
+                                    const std::string linkPath = modulesDir + "/" + linkName;
+                                    if ((symlink(headersRoot.c_str(), linkPath.c_str()) < 0) && (errno != EEXIST))
+                                    {
+                                        LOG_ERROR("symlink({}, {}) failed {}", headersRoot, linkPath, errno);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                LOG_ERROR("UtilMkdirPath({}) failed {}", modulesDir, errno);
+                            }
+                        }
+                        else
+                        {
+                            LOG_ERROR("uname failed {}", errno);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    CATCH_LOG()
+
+    //
     // Change the permission of some devtmpfs devices to be more permissive.
     //
     // N.B. These devices may not be present with a custom kernel config.

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1120,15 +1120,6 @@ Return Value:
     }
     CATCH_LOG()
 
-    //
-    // Move the kernel headers temporary mount into its final location and create the symlinks
-    // expected by Debian/Ubuntu tooling. The target path is supplied by mini_init as
-    // /usr/src/linux-headers-<uname -r>/include.
-    //
-    // N.B. Failure to install the headers is non-fatal; the distro will simply boot without
-    //      them, mirroring the kernel modules behavior above.
-    //
-
     try
     {
         auto tempMount = RemoveMountAndEnvironmentOnScopeExit(LX_WSL2_KERNEL_HEADERS_MOUNT_ENV);
@@ -1142,38 +1133,27 @@ Return Value:
 
                 if (tempMount.MoveMount(targetPath.c_str()))
                 {
-                    // Derive the headers root directory by stripping the trailing "/include".
                     constexpr std::string_view c_includeSuffix = "/include";
                     if (targetPath.ends_with(c_includeSuffix))
                     {
                         const std::string headersRoot = targetPath.substr(0, targetPath.size() - c_includeSuffix.size());
 
                         utsname unameBuffer{};
-                        if (uname(&unameBuffer) == 0)
+                        THROW_LAST_ERROR_IF(uname(&unameBuffer) < 0);
+
+                        const std::string release{unameBuffer.release};
+                        const std::string modulesDir = std::format("/lib/modules/{}", release);
+                        if (UtilMkdirPath(modulesDir.c_str(), 0755) == 0)
                         {
-                            // See main.cpp; convert release to std::string so subsequent appends
-                            // don't follow embedded NUL bytes from the char[65] buffer.
-                            const std::string release{unameBuffer.release};
-                            const std::string modulesDir = std::format("/lib/modules/{}", release);
-                            if (UtilMkdirPath(modulesDir.c_str(), 0755) == 0)
+                            const std::string linkPath = modulesDir + "/build";
+                            if ((symlink(headersRoot.c_str(), linkPath.c_str()) < 0) && (errno != EEXIST))
                             {
-                                for (const auto* linkName : {"build", "source"})
-                                {
-                                    const std::string linkPath = modulesDir + "/" + linkName;
-                                    if ((symlink(headersRoot.c_str(), linkPath.c_str()) < 0) && (errno != EEXIST))
-                                    {
-                                        LOG_ERROR("symlink({}, {}) failed {}", headersRoot, linkPath, errno);
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                LOG_ERROR("UtilMkdirPath({}) failed {}", modulesDir, errno);
+                                LOG_ERROR("symlink({}, {}) failed {}", headersRoot, linkPath, errno);
                             }
                         }
                         else
                         {
-                            LOG_ERROR("uname failed {}", errno);
+                            LOG_ERROR("UtilMkdirPath({}) failed {}", modulesDir, errno);
                         }
                     }
                 }

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3225,30 +3225,11 @@ try
 
         if (ConfigMessage->MountKernelHeaders)
         {
-            // Mount the kernel headers 9p share at a temporary path. The headers will be moved
-            // to /usr/src/linux-headers-<uname -r>/include by the distro init process. Failure
-            // here is non-fatal; if the headers cannot be mounted the distro will simply boot
-            // without them.
-            //
-            // N.B. uname() is called first so a (highly unlikely) failure does not leave behind
-            //      an orphaned mount at KERNEL_HEADERS_TEMP_PATH that the distro init wouldn't
-            //      know to clean up.
             utsname UnameBuffer{};
-            if (uname(&UnameBuffer) < 0)
+            THROW_LAST_ERROR_IF(uname(&UnameBuffer) < 0);
+
+            if (MountPlan9(LXSS_KERNEL_HEADERS_SHARE, KERNEL_HEADERS_TEMP_PATH, true) == 0)
             {
-                LOG_ERROR("uname failed, {}", errno);
-            }
-            else if (MountPlan9(LXSS_KERNEL_HEADERS_SHARE, KERNEL_HEADERS_TEMP_PATH, true) < 0)
-            {
-                LOG_ERROR("Failed to mount kernel headers 9p share, {}", errno);
-            }
-            else
-            {
-                // N.B. Convert UnameBuffer.release (a char[65] array) to std::string first so
-                //      std::format treats it as a null-terminated C-string. Otherwise the format
-                //      will splice the entire 65-byte array (including trailing NULs) into the
-                //      result, hiding any literal characters appended after the {} placeholder
-                //      when the resulting std::string is later used as a C-string.
                 const std::string release{UnameBuffer.release};
                 Config.KernelHeadersTarget = std::format("{}{}/include", KERNEL_HEADERS_PATH_PREFIX, release);
             }

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -85,6 +85,8 @@ Abstract:
 #define KERNEL_MODULES_PATH "/lib/modules"
 #define KERNEL_MODULES_VHD_PATH "/modules"
 #define KERNEL_MODULES_OVERLAY "/modules_overlay"
+#define KERNEL_HEADERS_TEMP_PATH "/kernel_headers"
+#define KERNEL_HEADERS_PATH_PREFIX "/usr/src/linux-headers-"
 #define MODPROBE_PATH "/sbin/modprobe"
 #define PROCFS_PATH "/proc"
 #define RESOLV_CONF_FILE "resolv.conf"
@@ -112,6 +114,7 @@ struct VmConfiguration
     bool EnableSystemDistro = false;
     bool EnableCrashDumpCollection = false;
     std::string KernelModulesPath;
+    std::string KernelHeadersTarget;
     LX_MINI_INIT_NETWORKING_MODE NetworkingMode = LxMiniInitNetworkingModeNone;
 };
 
@@ -1608,6 +1611,19 @@ try
     {
         AddTemporaryMount(LX_WSL2_KERNEL_MODULES_MOUNT_ENV, Config.KernelModulesPath.c_str(), (MS_MOVE | MS_REC));
         AddEnvironmentVariable(LX_WSL2_KERNEL_MODULES_PATH_ENV, Config.KernelModulesPath.c_str());
+    }
+
+    //
+    // If kernel headers were mounted, move them to a temporary location and pass the desired
+    // target path to the distro init via an environment variable. Distro init will move the
+    // mount to /usr/src/linux-headers-<uname -r>/include and create the
+    // /lib/modules/<release>/{build,source} symlinks.
+    //
+
+    if (!Config.KernelHeadersTarget.empty())
+    {
+        AddTemporaryMount(LX_WSL2_KERNEL_HEADERS_MOUNT_ENV, KERNEL_HEADERS_TEMP_PATH, (MS_MOVE | MS_REC));
+        AddEnvironmentVariable(LX_WSL2_KERNEL_HEADERS_PATH_ENV, Config.KernelHeadersTarget.c_str());
     }
 
     //
@@ -3204,6 +3220,37 @@ try
                 {
                     return -1;
                 }
+            }
+        }
+
+        if (ConfigMessage->MountKernelHeaders)
+        {
+            // Mount the kernel headers 9p share at a temporary path. The headers will be moved
+            // to /usr/src/linux-headers-<uname -r>/include by the distro init process. Failure
+            // here is non-fatal; if the headers cannot be mounted the distro will simply boot
+            // without them.
+            //
+            // N.B. uname() is called first so a (highly unlikely) failure does not leave behind
+            //      an orphaned mount at KERNEL_HEADERS_TEMP_PATH that the distro init wouldn't
+            //      know to clean up.
+            utsname UnameBuffer{};
+            if (uname(&UnameBuffer) < 0)
+            {
+                LOG_ERROR("uname failed, {}", errno);
+            }
+            else if (MountPlan9(LXSS_KERNEL_HEADERS_SHARE, KERNEL_HEADERS_TEMP_PATH, true) < 0)
+            {
+                LOG_ERROR("Failed to mount kernel headers 9p share, {}", errno);
+            }
+            else
+            {
+                // N.B. Convert UnameBuffer.release (a char[65] array) to std::string first so
+                //      std::format treats it as a null-terminated C-string. Otherwise the format
+                //      will splice the entire 65-byte array (including trailing NULs) into the
+                //      result, hiding any literal characters appended after the {} placeholder
+                //      when the resulting std::string is later used as a C-string.
+                const std::string release{UnameBuffer.release};
+                Config.KernelHeadersTarget = std::format("{}{}/include", KERNEL_HEADERS_PATH_PREFIX, release);
             }
         }
 

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1617,7 +1617,7 @@ try
     // If kernel headers were mounted, move them to a temporary location and pass the desired
     // target path to the distro init via an environment variable. Distro init will move the
     // mount to /usr/src/linux-headers-<uname -r>/include and create the
-    // /lib/modules/<release>/{build,source} symlinks.
+    // /lib/modules/<release>/build symlink.
     //
 
     if (!Config.KernelHeadersTarget.empty())

--- a/src/shared/inc/lxfsshares.h
+++ b/src/shared/inc/lxfsshares.h
@@ -28,6 +28,7 @@ typedef struct _LXSS_SHARED_DIRECTORY
 #define LXSS_GPU_LIB_SHARE "lib"
 #define LXSS_GPU_INBOX_LIB_SHARE LXSS_GPU_LIB_SHARE "_inbox"
 #define LXSS_GPU_PACKAGED_LIB_SHARE LXSS_GPU_LIB_SHARE "_packaged"
+#define LXSS_KERNEL_HEADERS_SHARE "kernel_headers"
 
 //
 // Shared directories for GPU compute support.

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -261,6 +261,8 @@ Abstract:
 #define LX_WSL2_GUI_APP_SUPPORT_ENV "WSL2_GUI_APPS_ENABLED"
 #define LX_WSL2_KERNEL_MODULES_MOUNT_ENV "WSL2_KERNEL_MODULES_MOUNT"
 #define LX_WSL2_KERNEL_MODULES_PATH_ENV "WSL2_KERNEL_MODULES_PATH"
+#define LX_WSL2_KERNEL_HEADERS_MOUNT_ENV "WSL2_KERNEL_HEADERS_MOUNT"
+#define LX_WSL2_KERNEL_HEADERS_PATH_ENV "WSL2_KERNEL_HEADERS_PATH"
 #define LX_WSL2_SYSTEM_DISTRO_SHARE_ENV "WSL2_SYSTEM_DISTRO_SHARE"
 #define LX_WSL2_GPU_SHARE_ENV "WSL2_GPU_SHARE_ENV_"
 #define LX_WSL2_SHARED_MEMORY_OB_DIRECTORY "WSL2_SHARED_MEMORY_OB_DIRECTORY"
@@ -1332,6 +1334,7 @@ typedef struct _LX_MINI_INIT_CONFIG_MESSAGE
     bool EnableGuiApps;
     bool MountGpuShares;
     bool EnableInboxGpuLibs;
+    bool MountKernelHeaders;
     LX_MINI_INIT_NETWORKING_CONFIGURATION NetworkingConfiguration;
     char Buffer[];
 
@@ -1341,6 +1344,7 @@ typedef struct _LX_MINI_INIT_CONFIG_MESSAGE
         FIELD(MountGpuShares),
         FIELD(EntropyOffset),
         FIELD(EnableInboxGpuLibs),
+        FIELD(MountKernelHeaders),
         FIELD(NetworkingConfiguration.NetworkingMode),
         FIELD(NetworkingConfiguration.PortTrackerType),
         FIELD(NetworkingConfiguration.EphemeralPortRangeStart),

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -73,6 +73,7 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         ConfigKey(ConfigSetting::Kernel, KernelPath),
         ConfigKey(ConfigSetting::KernelCommandLine, KernelCommandLine),
         ConfigKey(ConfigSetting::KernelModules, KernelModulesPath),
+        ConfigKey(ConfigSetting::KernelHeaders, KernelHeadersPath),
         ConfigKey(ConfigSetting::Memory, MemoryString(MemorySizeBytes)),
         ConfigKey(ConfigSetting::Processors, ProcessorCount),
         ConfigKey(ConfigSetting::DebugConsole, EnableDebugConsole),
@@ -340,6 +341,7 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
 
     applyOverride(wsl::windows::policies::c_allowCustomKernelUserSetting, L"wsl2.kernel", KernelPath);
     applyOverride(wsl::windows::policies::c_allowCustomKernelUserSetting, L"wsl2.kernelModules", KernelModulesPath);
+    applyOverride(wsl::windows::policies::c_allowCustomKernelUserSetting, L"wsl2.kernelHeaders", KernelHeadersPath);
     applyOverride(wsl::windows::policies::c_allowCustomSystemDistroUserSetting, L"wsl2.systemDistro", SystemDistroPath);
     applyOverride(wsl::windows::policies::c_allowCustomKernelCommandLineUserSetting, L"wsl2.kernelCommandLine", KernelCommandLine);
     applyOverride(wsl::windows::policies::c_allowKernelDebuggingUserSetting, L"wsl2.kernelDebugPort", KernelDebugPort);
@@ -431,6 +433,7 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
         VALIDATE_CONFIG_OPTION(EnableSafeMode, SwapSizeBytes, 0);
         VALIDATE_CONFIG_OPTION(EnableSafeMode, KernelPath, std::filesystem::path{});
         VALIDATE_CONFIG_OPTION(EnableSafeMode, KernelModulesPath, std::filesystem::path{});
+        VALIDATE_CONFIG_OPTION(EnableSafeMode, KernelHeadersPath, std::filesystem::path{});
         VALIDATE_CONFIG_OPTION(EnableSafeMode, NetworkingMode, NetworkingMode::None);
         VALIDATE_CONFIG_OPTION(EnableSafeMode, EnableDnsTunneling, false);
         VALIDATE_CONFIG_OPTION(EnableSafeMode, EnableAutoProxy, false);

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -27,12 +27,13 @@ Abstract:
         T_VALUE(c, EnableHostAddressLoopback), T_VALUE(c, EnableHostFileSystemAccess), T_VALUE(c, EnableIpv6), \
         T_VALUE(c, EnableLocalhostRelay), T_VALUE(c, EnableNestedVirtualization), T_VALUE(c, EnableSafeMode), \
         T_VALUE(c, EnableSparseVhd), T_VALUE(c, EnableVirtio), T_VALUE(c, EnableVirtio9p), T_VALUE(c, EnableVirtioFs), \
-        T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), T_VALUE(c, KernelDebugPort), \
-        T_SET(c, KernelHeadersPath), T_STRING(c, KernelModulesList), T_SET(c, KernelModulesPath), T_SET(c, KernelPath), \
-        T_VALUE(c, LoadDefaultKernelModules), T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), \
-        T_VALUE(c, MaximumProcessorCount), T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), \
-        T_ENUM(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_VALUE(c, SwiotlbSizeBytes), \
-        T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
+        T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), \
+        T_VALUE(c, KernelDebugPort), T_SET(c, KernelHeadersPath), T_STRING(c, KernelModulesList), T_SET(c, KernelModulesPath), \
+        T_SET(c, KernelPath), T_VALUE(c, LoadDefaultKernelModules), T_PRESENT(c, LoadKernelModulesPresence), \
+        T_VALUE(c, MaximumMemorySizeBytes), T_VALUE(c, MaximumProcessorCount), T_ENUM(c, MemoryReclaim), \
+        T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), T_ENUM(c, NetworkingMode), T_VALUE(c, ProcessorCount), \
+        T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_VALUE(c, SwiotlbSizeBytes), T_SET(c, SystemDistroPath), \
+        T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
 namespace wsl::core {
 constexpr auto ToString(ConfigKeyPresence key)

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -28,10 +28,10 @@ Abstract:
         T_VALUE(c, EnableLocalhostRelay), T_VALUE(c, EnableNestedVirtualization), T_VALUE(c, EnableSafeMode), \
         T_VALUE(c, EnableSparseVhd), T_VALUE(c, EnableVirtio), T_VALUE(c, EnableVirtio9p), T_VALUE(c, EnableVirtioFs), \
         T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), T_VALUE(c, KernelDebugPort), \
-        T_STRING(c, KernelModulesList), T_SET(c, KernelModulesPath), T_SET(c, KernelPath), T_VALUE(c, LoadDefaultKernelModules), \
-        T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), T_VALUE(c, MaximumProcessorCount), \
-        T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), T_ENUM(c, NetworkingMode), \
-        T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_VALUE(c, SwiotlbSizeBytes), \
+        T_SET(c, KernelHeadersPath), T_STRING(c, KernelModulesList), T_SET(c, KernelModulesPath), T_SET(c, KernelPath), \
+        T_VALUE(c, LoadDefaultKernelModules), T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), \
+        T_VALUE(c, MaximumProcessorCount), T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), \
+        T_ENUM(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_VALUE(c, SwiotlbSizeBytes), \
         T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
 namespace wsl::core {
@@ -235,6 +235,7 @@ struct FirewallConfiguration
 namespace ConfigSetting {
     static constexpr auto Kernel = "wsl2.kernel";
     static constexpr auto KernelCommandLine = "wsl2.kernelCommandLine";
+    static constexpr auto KernelHeaders = "wsl2.kernelHeaders";
     static constexpr auto KernelModules = "wsl2.kernelModules";
     static constexpr auto Memory = "wsl2.memory";
     static constexpr auto Processors = "wsl2.processors";
@@ -311,6 +312,7 @@ struct Config
     std::wstring KernelCommandLine;
     std::wstring KernelModulesList;
     std::filesystem::path KernelModulesPath;
+    std::filesystem::path KernelHeadersPath;
     UINT64 MemorySizeBytes = 0;
     UINT64 MaximumMemorySizeBytes = 0;
     int ProcessorCount = 0;

--- a/src/windows/inc/WslCoreConfigInterface.h
+++ b/src/windows/inc/WslCoreConfigInterface.h
@@ -47,6 +47,7 @@ enum WslConfigEntry
     KernelPath,
     SystemDistroPath,
     KernelModulesPath,
+    KernelHeadersPath,
 };
 
 enum NetworkingConfiguration

--- a/src/windows/libwsl/WslCoreConfigInterface.cpp
+++ b/src/windows/libwsl/WslCoreConfigInterface.cpp
@@ -195,6 +195,10 @@ WslConfigSetting GetWslConfigSetting(WslConfig_t wslConfig, WslConfigEntry wslCo
         static_assert(std::is_same<decltype(wslConfigSetting.StringValue), decltype(wslConfig->Config.KernelModulesPath.c_str())>::value);
         wslConfigSetting.StringValue = wslConfig->Config.KernelModulesPath.c_str();
         break;
+    case KernelHeadersPath:
+        static_assert(std::is_same<decltype(wslConfigSetting.StringValue), decltype(wslConfig->Config.KernelHeadersPath.c_str())>::value);
+        wslConfigSetting.StringValue = wslConfig->Config.KernelHeadersPath.c_str();
+        break;
     default:
         FAIL_FAST();
     }
@@ -559,6 +563,20 @@ unsigned long SetWslConfigSetting(WslConfig_t wslConfig, WslConfigSetting wslCon
             defaultConfig.KernelModulesPath,
             wslConfigSetting.StringValue,
             wslConfig->Config.KernelModulesPath);
+    }
+    case KernelHeadersPath:
+    {
+        if (wslConfigSetting.StringValue == nullptr)
+        {
+            return ERROR_INVALID_PARAMETER;
+        }
+
+        return SetWslConfigSetting(
+            wslConfig,
+            ConfigSetting::KernelHeaders,
+            defaultConfig.KernelHeadersPath,
+            wslConfigSetting.StringValue,
+            wslConfig->Config.KernelHeadersPath);
     }
     default:
         FAIL_FAST();

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -462,7 +462,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     // Add a read-only 9p share for the kernel headers directory. Mini-init mounts this share at a
     // temporary path and hands it off to distro init, which moves it under
     // /usr/src/linux-headers-$(uname -r)/include and creates the /lib/modules/$(uname -r)/build
-    // and /source symlinks expected by Debian/Ubuntu tooling.
+    // symlink expected by out-of-tree module tooling.
     if (m_mountKernelHeaders)
     {
         constexpr auto flags = (hcs::Plan9ShareFlags::ReadOnly | hcs::Plan9ShareFlags::AllowOptions);

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -257,6 +257,46 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
         }
     }
 
+    // Resolve the kernel headers directory. The bundled headers ship as loose files in the kernel
+    // nuget (and are installed under tools/linux-headers/ in the MSI), and are mounted into the
+    // distro via a read-only 9p share. A custom path is only valid when a custom kernel is also
+    // specified. Safe mode skips the mount entirely.
+    if (!m_vmConfig.EnableSafeMode)
+    {
+        if (m_vmConfig.KernelHeadersPath.empty())
+        {
+            if (m_defaultKernel)
+            {
+#ifdef WSL_KERNEL_HEADERS_PATH
+
+                m_vmConfig.KernelHeadersPath = std::wstring(TEXT(WSL_KERNEL_HEADERS_PATH));
+
+#else
+
+                m_vmConfig.KernelHeadersPath = m_installPath / LXSS_TOOLS_DIRECTORY / L"linux-headers";
+
+#endif
+            }
+        }
+        else if (m_defaultKernel)
+        {
+            THROW_HR_WITH_USER_ERROR(WSL_E_CUSTOM_KERNEL_NOT_FOUND, Localization::MessageMismatchedKernelHeadersError());
+        }
+
+        if (!m_vmConfig.KernelHeadersPath.empty())
+        {
+            if (!wsl::windows::common::filesystem::FileExists(m_vmConfig.KernelHeadersPath.c_str()))
+            {
+                THROW_HR_WITH_USER_ERROR(
+                    WSL_E_CUSTOM_KERNEL_NOT_FOUND,
+                    Localization::MessageCustomKernelHeadersNotFound(
+                        wsl::windows::common::helpers::GetWslConfigPath(m_userToken.get()), m_vmConfig.KernelHeadersPath.c_str()));
+            }
+
+            m_mountKernelHeaders = true;
+        }
+    }
+
     // If debug console was requested, create a randomly-named pipe and spawn a wslhost process to read from the pipe.
     //
     // N.B. wslhost.exe is launched at medium integrity level and its lifetime
@@ -417,6 +457,17 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
 #endif
 
         addShare(TEXT(LXSS_GPU_PACKAGED_LIB_SHARE), path.c_str());
+    }
+
+    // Add a read-only 9p share for the kernel headers directory. Mini-init mounts this share at a
+    // temporary path and hands it off to distro init, which moves it under
+    // /usr/src/linux-headers-$(uname -r)/include and creates the /lib/modules/$(uname -r)/build
+    // and /source symlinks expected by Debian/Ubuntu tooling.
+    if (m_mountKernelHeaders)
+    {
+        constexpr auto flags = (hcs::Plan9ShareFlags::ReadOnly | hcs::Plan9ShareFlags::AllowOptions);
+        wsl::windows::common::hcs::AddPlan9Share(
+            m_system.get(), TEXT(LXSS_KERNEL_HEADERS_SHARE), TEXT(LXSS_KERNEL_HEADERS_SHARE), m_vmConfig.KernelHeadersPath.c_str(), LX_INIT_UTILITY_VM_PLAN9_PORT, flags);
     }
 
     // Accept a connection from mini_init with a receive timeout so the service does not get stuck waiting for a response from the VM.
@@ -1871,6 +1922,7 @@ void WslCoreVm::InitializeGuest()
     message->EnableGuiApps = LXSS_ENABLE_GUI_APPS();
     message->MountGpuShares = m_vmConfig.EnableGpuSupport;
     message->EnableInboxGpuLibs = m_enableInboxGpuLibs;
+    message->MountKernelHeaders = m_mountKernelHeaders;
     if (m_networkingEngine)
     {
         m_networkingEngine->FillInitialConfiguration(message->NetworkingConfiguration);

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -291,6 +291,7 @@ private:
     bool m_enableInboxGpuLibs;
     bool m_defaultKernel = true;
     bool m_privateKernelModules = false;
+    bool m_mountKernelHeaders = false;
     LX_MINI_INIT_MOUNT_DEVICE_TYPE m_systemDistroDeviceType = LxMiniInitMountDeviceTypeInvalid;
     ULONG m_systemDistroDeviceId = ULONG_MAX;
     ULONG m_kernelModulesDeviceId = ULONG_MAX;

--- a/src/windows/wslsettings/Contracts/Services/IWslConfigService.cs
+++ b/src/windows/wslsettings/Contracts/Services/IWslConfigService.cs
@@ -72,7 +72,8 @@ public static class WslConfigEntryExtensions
         WslConfigEntry.IgnoredPorts or
         WslConfigEntry.KernelPath or
         WslConfigEntry.SystemDistroPath or
-        WslConfigEntry.KernelModulesPath => WslConfigValueKind.String,
+        WslConfigEntry.KernelModulesPath or
+        WslConfigEntry.KernelHeadersPath => WslConfigValueKind.String,
 
         WslConfigEntry.ProcessorCount or
         WslConfigEntry.InitialAutoProxyTimeout or

--- a/src/windows/wslsettings/Helpers/RuntimeHelper.cs
+++ b/src/windows/wslsettings/Helpers/RuntimeHelper.cs
@@ -39,6 +39,19 @@ public class RuntimeHelper
         return openPicker.PickSingleFileAsync();
     }
 
+    public static Windows.Foundation.IAsyncOperation<Windows.Storage.StorageFolder> PickSingleFolderAsync()
+    {
+        var folderPicker = new FolderPicker();
+        var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
+
+        WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hWnd);
+
+        folderPicker.ViewMode = PickerViewMode.List;
+        folderPicker.FileTypeFilter.Add("*");
+
+        return folderPicker.PickSingleFolderAsync();
+    }
+
     public static void TryMoveFocusPreviousControl(Button? button)
     {
         if (button == null)

--- a/src/windows/wslsettings/LibWsl.cs
+++ b/src/windows/wslsettings/LibWsl.cs
@@ -43,7 +43,8 @@ namespace LibWsl
         HardwarePerformanceCountersEnabled = 23,
         KernelPath = 24,
         SystemDistroPath = 25,
-        KernelModulesPath = 26
+        KernelModulesPath = 26,
+        KernelHeadersPath = 27
     }
 
     public enum NetworkingConfiguration

--- a/src/windows/wslsettings/ViewModels/Settings/DeveloperViewModel.cs
+++ b/src/windows/wslsettings/ViewModels/Settings/DeveloperViewModel.cs
@@ -10,6 +10,7 @@ public partial class DeveloperViewModel : WslConfigSettingViewModel
     private IWslConfigSetting? _hWPerfCounters;
     private IWslConfigSetting? _kernelPath;
     private IWslConfigSetting? _kernelModulesPath;
+    private IWslConfigSetting? _kernelHeadersPath;
     private IWslConfigSetting? _systemDistroPath;
 
     public DeveloperViewModel()
@@ -24,6 +25,7 @@ public partial class DeveloperViewModel : WslConfigSettingViewModel
         _hWPerfCounters = wslConfigService.GetWslConfigSetting(WslConfigEntry.HardwarePerformanceCountersEnabled);
         _kernelPath = wslConfigService.GetWslConfigSetting(WslConfigEntry.KernelPath);
         _kernelModulesPath = wslConfigService.GetWslConfigSetting(WslConfigEntry.KernelModulesPath);
+        _kernelHeadersPath = wslConfigService.GetWslConfigSetting(WslConfigEntry.KernelHeadersPath);
         _systemDistroPath = wslConfigService.GetWslConfigSetting(WslConfigEntry.SystemDistroPath);
     }
 
@@ -49,6 +51,12 @@ public partial class DeveloperViewModel : WslConfigSettingViewModel
     {
         get { return _kernelModulesPath!.StringValue; }
         set { Set(ref _kernelModulesPath!, value); }
+    }
+
+    public string CustomKernelHeadersPath
+    {
+        get { return _kernelHeadersPath!.StringValue; }
+        set { Set(ref _kernelHeadersPath!, value); }
     }
 
     public string CustomSystemDistroPath

--- a/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml
+++ b/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml
@@ -54,6 +54,19 @@
                         </ctControls:SettingsCard>
                     </ctControls:SettingsExpander.Items>
                 </ctControls:SettingsExpander>
+                <ctControls:SettingsExpander x:Name="CustomKernelHeadersPathExpander" x:Uid="Settings_CustomKernelHeadersPath">
+                    <TextBlock Style="{StaticResource TextBlockFilePathStyle}" Text="{x:Bind ViewModel.CustomKernelHeadersPath, Mode=OneWay}"/>
+                    <ctControls:SettingsExpander.Items>
+                        <ctControls:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left" Margin="{StaticResource SettingsExpanderItemMargin}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox x:Name="CustomKernelHeadersPathTextBox" x:Uid="Settings_CustomKernelHeadersPathTextBox" Style="{StaticResource TextBoxFilePathStyle}" Margin="{StaticResource InputControlSpacingMargin}"
+                                    Text="{x:Bind ViewModel.CustomKernelHeadersPath, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
+                                <Button x:Uid="Settings_CustomKernelHeadersPathBrowseButton" Style="{StaticResource ButtonSettingStyle}" Margin="{StaticResource InputControlSpacingMargin}"
+                                    Click="CustomKernelHeadersPath_Click"/>
+                            </StackPanel>
+                        </ctControls:SettingsCard>
+                    </ctControls:SettingsExpander.Items>
+                </ctControls:SettingsExpander>
                 <ctControls:SettingsExpander x:Name="CustomSystemDistroPathExpander" x:Uid="Settings_CustomSystemDistroPath">
                     <ctControls:SettingsExpander.Description>
                         <controls:HyperlinkTextBlock x:Uid="Settings_CustomSystemDistroPathDescription"/>

--- a/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml.cs
+++ b/src/windows/wslsettings/Views/Settings/DeveloperPage.xaml.cs
@@ -36,6 +36,7 @@ public sealed partial class DeveloperPage : Page
         DeveloperPageRoot.Focus(FocusState.Programmatic);
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "CustomKernelPathExpander", "CustomKernelPathTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "CustomKernelModulesPathExpander", "CustomKernelModulesPathTextBox");
+        RuntimeHelper.SetupExpanderFocusManagementByName(this, "CustomKernelHeadersPathExpander", "CustomKernelHeadersPathTextBox");
         RuntimeHelper.SetupExpanderFocusManagementByName(this, "CustomSystemDistroPathExpander", "CustomSystemDistroPathTextBox");
     }
 
@@ -61,6 +62,16 @@ public sealed partial class DeveloperPage : Page
         if (file != null)
         {
             ViewModel.CustomKernelModulesPath = file.Path;
+        }
+    }
+
+    public async void CustomKernelHeadersPath_Click(object sender, RoutedEventArgs e)
+    {
+        // Headers ship as a directory tree of loose .h files, so prompt for a folder.
+        Windows.Storage.StorageFolder folder = await RuntimeHelper.PickSingleFolderAsync();
+        if (folder != null)
+        {
+            ViewModel.CustomKernelHeadersPath = folder.Path;
         }
     }
 

--- a/src/windows/wslsettings/Views/Settings/SettingsApplyHelper.cs
+++ b/src/windows/wslsettings/Views/Settings/SettingsApplyHelper.cs
@@ -161,6 +161,7 @@ internal static class SettingsApplyHelper
             { WslConfigEntry.KernelPath, "Settings_CustomKernelPath/Header" },
             { WslConfigEntry.SystemDistroPath, "Settings_CustomSystemDistroPath/Header" },
             { WslConfigEntry.KernelModulesPath, "Settings_CustomKernelModulesPath/Header" },
+            { WslConfigEntry.KernelHeadersPath, "Settings_CustomKernelHeadersPath/Header" },
         };
 
     private static string FormatValue(WslConfigEntry entry, object value)

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1560,6 +1560,11 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         newConfig += L"kernelModules=" + EscapePath(Default.kernelModules.value()) + L"\n";
     }
 
+    if (Default.kernelHeaders.has_value())
+    {
+        newConfig += L"kernelHeaders=" + EscapePath(Default.kernelHeaders.value()) + L"\n";
+    }
+
     if (Default.loadKernelModules.has_value())
     {
         newConfig += L"loadKernelModules=" + Default.loadKernelModules.value() + L"\n";

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -567,6 +567,7 @@ struct TestConfigDefaults
     std::optional<std::wstring> kernel;
     std::optional<std::wstring> kernelCommandLine;
     std::optional<std::wstring> kernelModules;
+    std::optional<std::wstring> kernelHeaders;
     std::optional<std::wstring> loadKernelModules;
     std::optional<bool> loadDefaultKernelModules;
     std::optional<std::wstring> systemDistro;

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2886,6 +2886,99 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         ValidateOutput(L"dmesg | grep -iF \"failed to load module 'not-found'\" | wc -l", L"1\n", L"", 0);
     }
 
+    WSL2_TEST_METHOD(KernelHeaders)
+    {
+        // The headers are mounted at /usr/src/linux-headers-$(uname -r)/include and
+        // /lib/modules/$(uname -r)/build is symlinked to the parent directory.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"test -L /lib/modules/$(uname -r)/build", nullptr, nullptr, nullptr, nullptr), 0u);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"test -L /lib/modules/$(uname -r)/source", nullptr, nullptr, nullptr, nullptr), 0u);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"test -s /lib/modules/$(uname -r)/build/include/linux/version.h", nullptr, nullptr, nullptr, nullptr), 0u);
+
+        // Compile a tiny C program against the mounted headers and run it. This proves the
+        // headers are usable and that recent uapi symbols added after the test distro's
+        // bundled linux-libc-dev snapshot are present (BPF_PROG_TYPE_NETFILTER added in 6.4,
+        // IORING_OP_FUTEX_WAKE added in 6.7). The compiled program prints
+        // <MAJOR>.<PATCHLEVEL>.<SUBLEVEL> from <linux/version.h>; the script verifies that
+        // string is a prefix of the running kernel's `uname -r`.
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(
+                LR"BASH(bash -ec '
+                    d=$(mktemp -d)
+                    trap "rm -rf $d" EXIT
+                    cat > "$d/t.c" <<EOF
+#include <stdio.h>
+#include <linux/version.h>
+#include <linux/bpf.h>
+#include <linux/io_uring.h>
+int main(void){
+    printf("%u.%u.%u\n",
+        LINUX_VERSION_MAJOR, LINUX_VERSION_PATCHLEVEL, LINUX_VERSION_SUBLEVEL);
+    return (BPF_PROG_TYPE_NETFILTER >= 32 && IORING_OP_FUTEX_WAKE >= 50) ? 0 : 7;
+}
+EOF
+                    cc -isystem /lib/modules/$(uname -r)/build/include -o "$d/t" "$d/t.c"
+                    v=$("$d/t")
+                    case "$(uname -r)" in "$v"*) exit 0 ;; *) exit 8 ;; esac
+                ')BASH",
+                nullptr,
+                nullptr,
+                nullptr,
+                nullptr),
+            0u);
+
+        // Resolve the bundled kernel + headers paths up front so they can be paired with the
+        // negative-test inputs below.
+#ifdef WSL_DEV_INSTALL_PATH
+
+        std::wstring kernelPath = WSL_DEV_INSTALL_PATH L"/kernel";
+        std::wstring kernelHeadersPath = WSL_DEV_INSTALL_PATH L"/linux-headers";
+
+#else
+
+        auto installPath = wsl::windows::common::wslutil::GetMsiPackagePath();
+        VERIFY_IS_TRUE(installPath.has_value());
+
+        std::filesystem::path wslInstallPath(installPath.value());
+
+        std::wstring kernelPath = wslInstallPath / "tools" / "kernel";
+        std::wstring kernelHeadersPath = wslInstallPath / "tools" / "linux-headers";
+
+#endif
+
+        kernelPath = std::regex_replace(kernelPath, std::wregex(L"\\\\"), L"\\\\");
+        kernelHeadersPath = std::regex_replace(kernelHeadersPath, std::wregex(L"\\\\"), L"\\\\");
+
+        // Verify the error message if a non-existent custom kernel headers path is specified.
+        // A valid custom kernel must also be set; otherwise the "kernelHeaders requires kernel"
+        // guard fires first (covered by the next case).
+        const std::wstring wslConfigPath = wsl::windows::common::helpers::GetWslConfigPath();
+        const std::wstring nonExistentFile = L"DoesNotExist";
+        WslConfigChange configChange(LxssGenerateTestConfig({.kernel = kernelPath.c_str(), .kernelHeaders = nonExistentFile.c_str()}));
+        ValidateOutput(
+            L"echo ok",
+            std::format(
+                L"{}\r\nError code: Wsl/Service/CreateInstance/CreateVm/WSL_E_CUSTOM_KERNEL_NOT_FOUND\r\n",
+                wsl::shared::Localization::MessageCustomKernelHeadersNotFound(wslConfigPath, nonExistentFile)),
+            L"");
+
+        // Verify the error message if custom kernel headers are used with the default kernel.
+        configChange.Update(LxssGenerateTestConfig({.kernelHeaders = kernelHeadersPath.c_str()}));
+        ValidateOutput(
+            L"echo ok",
+            std::format(
+                L"{}\r\nError code: Wsl/Service/CreateInstance/CreateVm/WSL_E_CUSTOM_KERNEL_NOT_FOUND\r\n",
+                wsl::shared::Localization::MessageMismatchedKernelHeadersError()),
+            L"");
+
+        // Custom kernel + custom headers: validate the headers are mounted and discoverable.
+        configChange.Update(LxssGenerateTestConfig({.kernel = kernelPath.c_str(), .kernelHeaders = kernelHeadersPath.c_str()}));
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"test -s /lib/modules/$(uname -r)/build/include/linux/version.h", nullptr, nullptr, nullptr, nullptr), 0u);
+
+        configChange.Update(LxssGenerateTestConfig());
+    }
+
     WSL2_TEST_METHOD(CrashCollection)
     {
         const auto folder = std::filesystem::absolute(L"test-crash-dumps");

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2891,7 +2891,6 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         // The headers are mounted at /usr/src/linux-headers-$(uname -r)/include and
         // /lib/modules/$(uname -r)/build is symlinked to the parent directory.
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"test -L /lib/modules/$(uname -r)/build", nullptr, nullptr, nullptr, nullptr), 0u);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"test -L /lib/modules/$(uname -r)/source", nullptr, nullptr, nullptr, nullptr), 0u);
         VERIFY_ARE_EQUAL(
             LxsstuLaunchWsl(L"test -s /lib/modules/$(uname -r)/build/include/linux/version.h", nullptr, nullptr, nullptr, nullptr), 0u);
 


### PR DESCRIPTION
## Summary

Bundles the Linux kernel UAPI headers shipped in the `Microsoft.WSL.Kernel` nuget package and mounts them read-only into every WSL2 distro by default. Pattern mirrors the existing `kernelModules` plumbing.

## What it does

- **Build**: stages `linux-headers/` next to the kernel image in the dev binary path (`CMakeLists.txt`, `UserConfig.cmake.sample`) and packages them in the MSI (`msipackage/package.wix.in`).
- **Service**: new `kernelHeaders=` setting in `.wslconfig` (empty = bundled default, or a custom path). Validated alongside `kernel`/`kernelModules` in `WslCoreVm`.
- **Guest**: mounted via 9p at `/usr/src/linux-headers-$(uname -r)` with a `/lib/modules/$(uname -r)/build` symlink so out-of-tree module builds and tools that key off `uname -r` find them.
- **UI**: Developer page in wslsettings exposes the path with the same UX as the kernel/kernelModules controls.

## Testing

- New `KernelHeaders` TAEF unit test covers default-mount, custom path, and validation errors.
- Manually verified a fresh distro shows `/usr/src/linux-headers-*` populated and `make headers_check` works against it.