### PR TITLE
CLI: Create alias to wslc.exe

### DIFF
--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -28,6 +28,7 @@
 
                 <File Id="wslg.exe" Name="wslg.exe" Source="${PACKAGE_INPUT_DIR}/wslg.exe" />
                 <File Id="wslc.exe" Name="wslc.exe" Source="${PACKAGE_INPUT_DIR}/wslc.exe" />
+                <File Id="container.exe" Name="container.exe" Source="${PACKAGE_INPUT_DIR}/wslc.exe" />
                 <File Id="wslhost.exe" Name="wslhost.exe" Source="${PACKAGE_INPUT_DIR}/wslhost.exe" />
                 <File Id="wslrelay.exe" Name="wslrelay.exe" Source="${PACKAGE_INPUT_DIR}/wslrelay.exe" />
                 <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${PACKAGE_INPUT_DIR}/wslserviceproxystub.dll" />

--- a/test/windows/wslc/e2e/WSLCE2EAliasTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EAliasTests.cpp
@@ -1,0 +1,72 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WSLCE2EAliasTests.cpp
+
+Abstract:
+
+    This file contains end-to-end tests for verifying the command alias functionality.
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCExecutor.h"
+
+namespace WSLCE2ETests {
+
+namespace {
+
+    inline std::wstring GetContainerExePath()
+    {
+        return (std::filesystem::path(wsl::windows::common::wslutil::GetMsiPackagePath().value()) / L"container.exe").wstring();
+    }
+
+    WSLCExecutionResult RunContainerExe(const std::wstring& commandLine)
+    {
+        auto cmd = L"\"" + GetContainerExePath() + L"\" " + commandLine;
+        wsl::windows::common::SubProcess process(nullptr, cmd.c_str());
+        const auto output = process.RunAndCaptureOutput();
+        return {.CommandLine = commandLine, .Stdout = output.Stdout, .Stderr = output.Stderr, .ExitCode = output.ExitCode};
+    }
+
+} // namespace
+
+class WSLCE2EAliasTests
+{
+    WSLC_TEST_CLASS(WSLCE2EAliasTests)
+
+    TEST_CLASS_SETUP(TestClassSetup)
+    {
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(TestClassCleanup)
+    {
+        return true;
+    }
+
+    // Verify that container.exe exists on disk as the deployed alias for wslc.exe.
+    WSLC_TEST_METHOD(WSLCE2E_ContainerExe_IsDeployed)
+    {
+        const auto containerExePath = GetContainerExePath();
+        VERIFY_IS_TRUE(std::filesystem::exists(containerExePath), (L"container.exe not found at: " + containerExePath).c_str());
+    }
+
+    // Verify that container.exe responds to --help identically to wslc.exe,
+    // confirming it is a functional alias and not just a placeholder.
+    WSLC_TEST_METHOD(WSLCE2E_ContainerExe_HelpCommand_MatchesWslc)
+    {
+        const auto wslcResult = RunWslc(L"--help");
+        wslcResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto containerResult = RunContainerExe(L"--help");
+        containerResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VERIFY_ARE_EQUAL(wslcResult.Stdout.value(), containerResult.Stdout.value());
+    }
+};
+
+} // namespace WSLCE2ETests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds alias for wslc.exe
Adds tests to confirm the alias works as expected and matches wslc.exe output.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Creates the alias by copying the executable to a new deployed name.
This was done very simply as a copy instead of a SymLink or hardlink because WIX does not support those.
I have a working custom action hard link version I can add in later, but for preview this was deemed the lowest risk option rather than introduce potential setup risks with a custom action. So for now, it's a simple and reliable copy of wslc.exe. In the future we may revisit using a custom action hardlink.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tests for alias pass
Manual execution also confirms