### PR TITLE
Ignore GSL warning

### DIFF
--- a/src/windows/common/precomp.h
+++ b/src/windows/common/precomp.h
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-#pragma warning(disable : 4200 4214)
+#pragma warning(disable : 4200 4214 4875)
 
 #ifdef __cplusplus
 #define _WINSOCKAPI_

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -645,6 +645,8 @@ CATCH_LOG()
 
 void HcsVirtualMachine::OnExit(const HCS_EVENT* Event)
 {
+    m_vmExitEvent.SetEvent();
+
     const auto exitStatus = wsl::shared::FromJson<wsl::windows::common::hcs::SystemExitStatus>(Event->EventData);
 
     auto reason = WSLCVirtualMachineTerminationReasonUnknown;
@@ -670,8 +672,6 @@ void HcsVirtualMachine::OnExit(const HCS_EVENT* Event)
     {
         LOG_IF_FAILED(m_terminationCallback->OnTermination(reason, Event->EventData));
     }
-
-    m_vmExitEvent.SetEvent();
 }
 
 void HcsVirtualMachine::OnCrash(const HCS_EVENT* Event)

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -645,8 +645,6 @@ CATCH_LOG()
 
 void HcsVirtualMachine::OnExit(const HCS_EVENT* Event)
 {
-    m_vmExitEvent.SetEvent();
-
     const auto exitStatus = wsl::shared::FromJson<wsl::windows::common::hcs::SystemExitStatus>(Event->EventData);
 
     auto reason = WSLCVirtualMachineTerminationReasonUnknown;
@@ -672,6 +670,8 @@ void HcsVirtualMachine::OnExit(const HCS_EVENT* Event)
     {
         LOG_IF_FAILED(m_terminationCallback->OnTermination(reason, Event->EventData));
     }
+
+    m_vmExitEvent.SetEvent();
 }
 
 void HcsVirtualMachine::OnCrash(const HCS_EVENT* Event)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Ignore a new GSL warning that causes a build break on the latest VS 2022 compiler release.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
GSL headers are included in multiple locations throughout the code and this warning number appears to be targeted to this scenario tightly.  Ignored globally until a new release of GSL brings in the fix.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built.