### PR TITLE
Quote msiexec arguments in the InstallerTests

### DIFF
--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -190,13 +190,13 @@ class InstallerTests
         auto productCode = GetMsiProductCode();
         VERIFY_IS_FALSE(productCode.empty());
 
-        CallMsiExec(std::format(L"/qn /norestart /x {} /L*V {}", productCode, GenerateMsiLogPath()));
+        CallMsiExec(std::format(L"/qn /norestart /x \"{}\" /L*V \"{}\"", productCode, GenerateMsiLogPath()));
     }
 
     void InstallMsi()
     {
         PrepareForMsiOperation();
-        CallMsiExec(std::format(L"/qn /norestart /i {} /L*V {}", m_msiPath, GenerateMsiLogPath()));
+        CallMsiExec(std::format(L"/qn /norestart /i \"{}\" /L*V \"{}\"", m_msiPath, GenerateMsiLogPath()));
     }
 
     void InstallMsix() const
@@ -379,7 +379,7 @@ class InstallerTests
         if (wsl::shared::string::EndsWith<wchar_t>(installerFile, L".msi"))
         {
             PrepareForMsiOperation();
-            CallMsiExec(std::format(L"/qn /norestart /i {} /L*V {}", installerFile, GenerateMsiLogPath()));
+            CallMsiExec(std::format(L"/qn /norestart /i \"{}\" /L*V \"{}\"", installerFile, GenerateMsiLogPath()));
         }
         else
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The msiexec arguments can sometimes contain spaces. If that happens, msiexec displays a "help UI", which hangs the tests.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
