### PR TITLE
Update Microsoft.WSLg to 1.0.74.1

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.WSL.Kernel" version="6.18.26.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
-  <package id="Microsoft.WSLg" version="1.0.73" />
+  <package id="Microsoft.WSLg" version="1.0.74.1" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="vswhere" version="3.1.7" />
   <package id="WinUIEx" version="2.9.0" />


### PR DESCRIPTION
Backport of #40568 to `release/2.7`.

Picks up the fix for GUI app icons disappearing from the Start menu after updating to 2.7.3 (Azure Linux 3 system distro).

**Root cause:** The system distro upgrade in WSLg 1.0.72 brought in librsvg 2.58, which lazily spawns a rayon thread pool the first time it has to render a complex SVG icon. Those worker threads share `fs_struct` with weston's app-list enumeration thread and break the subsequent `setns(CLONE_NEWNS)` into the user distro's mount namespace, causing every app processed after the first complex-icon one to drop off the Start menu. Adwaita-style flat icons stay on librsvg's single-threaded path; richer icons (Audacity, GIMP, JetBrains, Discord) trigger it.

**Fix:** microsoft/weston-mirror#162 — call `unshare(CLONE_FS)` inside `attach_app_list_namespace` before every `setns`. Rolled into Microsoft.WSLg 1.0.74.1.

**Validation:** Built a local system distro from the patched weston-mirror branch, swapped it into a fresh user distro, installed the trigger apps from the original repro (audacity / gimp / inkscape / vlc on top of the GNOME flat-icon set). All 18 apps published cleanly:

```
=== failures (expect 0) ===
0
=== notify_app_list count ===
18
=== unshare errors (expect 0) ===
0
```

And on the host:
```
PS> dir `C:\Users\benhill\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Ubuntu\*.lnk` | Measure-Object | % Count
18
```

Fixes microsoft/wslg#1444
Fixes #40538