### PR TITLE
Bump Microsoft.NETCore.App.Runtime to 10.0.8 (CVE-2026-32175)

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="10.0.0" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.6" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.6" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.8" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.8" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6676" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.CsWinRT" version="2.2.0" />


### PR DESCRIPTION
## Summary of the Pull Request

Bumps `Microsoft.NETCore.App.Runtime.win-x64` and `Microsoft.NETCore.App.Runtime.win-arm64` from 10.0.6 to 10.0.8 to address [CVE-2026-32175](https://github.com/dotnet/runtime/security/advisories/GHSA-rg75-q538-x34v) (.NET Core Tampering Vulnerability, high severity).

## PR Checklist

- [x] **Closes:** Dependabot alerts #24 and #25
- [ ] **Communication:** N/A (security patch)
- [x] **Tests:** No code changes; existing tests cover the runtime
- [x] **Localization:** No user-facing string changes
- [x] **Dev docs:** N/A
- [ ] **Documentation updated:** N/A

## Detailed Description of the Pull Request / Additional comments

Two open Dependabot alerts flagged the bundled .NET 10 runtime packages at 10.0.6 as vulnerable to CVE-2026-32175 (vulnerable range `>= 10.0.0, <= 10.0.7`; patched in `10.0.8`). Both x64 and arm64 variants are updated in lockstep.

Verified 10.0.8 is published on nuget.org for both `Microsoft.NETCore.App.Runtime.win-x64` and `...win-arm64`. No other files in the repo reference the old version (`packages.config` is the only consumer; `CMakeLists.txt` resolves the package generically via `find_nuget_package`).

## Validation Steps Performed

- `git grep` confirmed `packages.config` is the only place pinning these runtime versions.
- Confirmed 10.0.8 exists on nuget.org for both architectures.
- Full build will be exercised by CI.
