### PR TITLE
Update Microsoft.WSL to version 1.0.73.2

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.WSL.Kernel" version="6.18.26.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
-  <package id="Microsoft.WSLg" version="1.0.74.1" />
+  <package id="Microsoft.WSLg" version="1.0.73.2" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="vswhere" version="3.1.7" />
   <package id="WinUIEx" version="2.9.0" />


### PR DESCRIPTION
This version of WSLg is identical to the previous, but has the correct version number.