### PR TITLE
Deny guest binds to host ephemeral port range in mirrored mode

### DIFF
--- a/src/windows/service/exe/WslCoreGuestNetworkService.cpp
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.cpp
@@ -8,6 +8,7 @@
 #include <TraceLoggingProvider.h>
 
 #include "Stringify.h"
+#include "WmiService.h"
 #include "WslTelemetry.h"
 #include "hns_schema.h"
 
@@ -15,6 +16,8 @@ static constexpr auto c_computeNetworkModuleName = L"ComputeNetwork.dll";
 static constexpr auto c_dnsPortNumber = 53;
 static constexpr auto c_mdnsPortNumber = 5353;
 static constexpr auto c_llmnrPortNumber = 5355;
+
+static constexpr std::pair<uint16_t, uint16_t> c_invalidEphemeralPortRange = {UINT16_MAX, UINT16_MAX};
 
 using namespace wsl::shared;
 
@@ -51,6 +54,15 @@ void wsl::core::networking::GuestNetworkService::CreateGuestNetworkService(
     m_ignoredPorts = IgnoredPorts;
     // Always allow binds for 53. This is a workaround to unblock Docker Desktop and needs to be revisited in the future.
     m_ignoredPorts.insert(c_dnsPortNumber);
+
+    m_hostTcpEphemeralPortRange = QueryHostEphemeralPortRange(L"MSFT_NetTCPSetting");
+    m_hostUdpEphemeralPortRange = QueryHostEphemeralPortRange(L"MSFT_NetUDPSetting");
+    WSL_LOG(
+        "GuestNetworkService::CreateGuestNetworkService - host ephemeral port ranges",
+        TraceLoggingValue(m_hostTcpEphemeralPortRange.first, "tcpStartPort"),
+        TraceLoggingValue(m_hostTcpEphemeralPortRange.second, "tcpEndPort"),
+        TraceLoggingValue(m_hostUdpEphemeralPortRange.first, "udpStartPort"),
+        TraceLoggingValue(m_hostUdpEphemeralPortRange.second, "udpEndPort"));
 
     hns::GuestNetworkService request{};
     request.VirtualMachineId = VmId;
@@ -166,6 +178,47 @@ bool wsl::core::networking::GuestNetworkService::IsPortAllocationMulticast(const
     return false;
 }
 
+std::pair<uint16_t, uint16_t> wsl::core::networking::GuestNetworkService::QueryHostEphemeralPortRange(LPCWSTR WmiClassName) noexcept
+try
+{
+    const auto com = wil::CoInitializeEx();
+    WmiService service(L"ROOT\\StandardCimv2");
+    WmiEnumerate enumSetting(service);
+
+    auto query = std::format(L"SELECT DynamicPortRangeStartPort, DynamicPortRangeNumberOfPorts FROM {}", WmiClassName);
+    for (const auto& instance : enumSetting.query(query.c_str()))
+    {
+        unsigned int startPort = 0;
+        unsigned int numberOfPorts = 0;
+
+        if (instance.get(L"DynamicPortRangeStartPort", &startPort) &&
+            instance.get(L"DynamicPortRangeNumberOfPorts", &numberOfPorts) && startPort > 0 && numberOfPorts > 0)
+        {
+            const auto endPort = static_cast<uint16_t>(startPort + numberOfPorts - 1);
+            return {static_cast<uint16_t>(startPort), endPort};
+        }
+    }
+
+    LOG_HR_MSG(E_FAIL, "No valid ephemeral port range found in WMI class %ls", WmiClassName);
+    return c_invalidEphemeralPortRange;
+}
+catch (...)
+{
+    LOG_CAUGHT_EXCEPTION_MSG("Failed to query host ephemeral port range from WMI class %ls", WmiClassName);
+    return c_invalidEphemeralPortRange;
+}
+
+bool wsl::core::networking::GuestNetworkService::IsPortInHostEphemeralRange(uint16_t PortNumber, int Protocol) const noexcept
+{
+    const auto& range = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortRange : m_hostTcpEphemeralPortRange;
+    return PortNumber >= range.first && PortNumber <= range.second;
+}
+
+bool wsl::core::networking::GuestNetworkService::IsPortInGuestEphemeralRange(uint16_t PortNumber) const noexcept
+{
+    return PortNumber >= m_reservedPortRange.startingPort && PortNumber <= m_reservedPortRange.endingPort;
+}
+
 int wsl::core::networking::GuestNetworkService::OnPortAllocationRequest(const SOCKADDR_INET& Address, _In_ int Protocol, _In_ bool Allocate) noexcept
 try
 {
@@ -204,7 +257,22 @@ try
 
     const auto lock = m_dataLock.lock_exclusive();
 
-    if (PortNumber >= m_reservedPortRange.startingPort && PortNumber <= m_reservedPortRange.endingPort)
+    // The guest's reserved ephemeral range can overlap with the host range. Ports in
+    // the guest range are safe for the guest to use even if they fall within the host range.
+    if (IsPortInHostEphemeralRange(PortNumber, Protocol) && !IsPortInGuestEphemeralRange(PortNumber))
+    {
+        const auto& range = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortRange : m_hostTcpEphemeralPortRange;
+        WSL_LOG(
+            "GuestNetworkService::OnPortAllocationRequest - denying port in host ephemeral range",
+            TraceLoggingValue(StringAddress.c_str(), "IP address"),
+            TraceLoggingValue(Protocol == IPPROTO_TCP ? "TCP" : "UDP", "protocol"),
+            TraceLoggingValue(PortNumber, "portNumber"),
+            TraceLoggingValue(range.first, "hostEphemeralStart"),
+            TraceLoggingValue(range.second, "hostEphemeralEnd"));
+        return -LX_EADDRINUSE;
+    }
+
+    if (IsPortInGuestEphemeralRange(PortNumber))
     {
         WSL_LOG(
             "GuestNetworkService::OnPortAllocationRequest",

--- a/src/windows/service/exe/WslCoreGuestNetworkService.cpp
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.cpp
@@ -17,7 +17,7 @@ static constexpr auto c_dnsPortNumber = 53;
 static constexpr auto c_mdnsPortNumber = 5353;
 static constexpr auto c_llmnrPortNumber = 5355;
 
-static constexpr std::pair<uint16_t, uint16_t> c_invalidEphemeralPortRange = {UINT16_MAX, UINT16_MAX};
+static constexpr std::pair<uint16_t, uint16_t> c_invalidEphemeralPortRange = {1, 0};
 
 using namespace wsl::shared;
 
@@ -194,8 +194,14 @@ try
         if (instance.get(L"DynamicPortRangeStartPort", &startPort) &&
             instance.get(L"DynamicPortRangeNumberOfPorts", &numberOfPorts) && startPort > 0 && numberOfPorts > 0)
         {
-            const auto endPort = static_cast<uint16_t>(startPort + numberOfPorts - 1);
-            return {static_cast<uint16_t>(startPort), endPort};
+            const auto endPort = static_cast<uint64_t>(startPort) + numberOfPorts - 1;
+            if (startPort > UINT16_MAX || endPort > UINT16_MAX)
+            {
+                LOG_HR_MSG(E_FAIL, "Ephemeral port range overflows uint16_t: start=%u, count=%u", startPort, numberOfPorts);
+                return c_invalidEphemeralPortRange;
+            }
+
+            return {static_cast<uint16_t>(startPort), static_cast<uint16_t>(endPort)};
         }
     }
 

--- a/src/windows/service/exe/WslCoreGuestNetworkService.h
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.h
@@ -61,6 +61,7 @@ private:
 
     bool IsPortInHostEphemeralRange(uint16_t PortNumber, int Protocol) const noexcept;
 
+    _Requires_lock_held_(m_dataLock)
     bool IsPortInGuestEphemeralRange(uint16_t PortNumber) const noexcept;
 
     static std::pair<uint16_t, uint16_t> QueryHostEphemeralPortRange(LPCWSTR WmiClassName) noexcept;
@@ -77,6 +78,7 @@ private:
     _Guarded_by_(m_dataLock) std::map<std::pair<HCN_PORT_PROTOCOL, USHORT>, HcnPortReservation> m_reservedPorts;
     _Guarded_by_(m_dataLock) HCN_PORT_RANGE_RESERVATION m_reservedPortRange {};
 
+    // Host ephemeral port ranges can change. They are queried once at startup, if a change occurs, the service will need to be restarted.
     std::pair<uint16_t, uint16_t> m_hostTcpEphemeralPortRange{};
     std::pair<uint16_t, uint16_t> m_hostUdpEphemeralPortRange{};
 };

--- a/src/windows/service/exe/WslCoreGuestNetworkService.h
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.h
@@ -54,10 +54,16 @@ private:
         ULONG ReferenceCount;
     };
 
-    // Returns true if the port allocation should be always allowed, without Windows.
+    // Returns true if the port allocation should be always allowed, without asking HNS.
     static bool IsPortAllocationLoopbackException(const SOCKADDR_INET& Address) noexcept;
 
     static bool IsPortAllocationMulticast(const SOCKADDR_INET& Address, _In_ int Protocol) noexcept;
+
+    bool IsPortInHostEphemeralRange(uint16_t PortNumber, int Protocol) const noexcept;
+
+    bool IsPortInGuestEphemeralRange(uint16_t PortNumber) const noexcept;
+
+    static std::pair<uint16_t, uint16_t> QueryHostEphemeralPortRange(LPCWSTR WmiClassName) noexcept;
 
     static std::optional<LxssDynamicFunction<decltype(HcnReserveGuestNetworkServicePortRange)>> m_allocatePortRange;
     static std::optional<LxssDynamicFunction<decltype(HcnReserveGuestNetworkServicePort)>> m_allocatePort;
@@ -70,5 +76,8 @@ private:
     _Guarded_by_(m_dataLock) std::set<uint16_t> m_ignoredPorts;
     _Guarded_by_(m_dataLock) std::map<std::pair<HCN_PORT_PROTOCOL, USHORT>, HcnPortReservation> m_reservedPorts;
     _Guarded_by_(m_dataLock) HCN_PORT_RANGE_RESERVATION m_reservedPortRange {};
+
+    std::pair<uint16_t, uint16_t> m_hostTcpEphemeralPortRange{};
+    std::pair<uint16_t, uint16_t> m_hostUdpEphemeralPortRange{};
 };
 } // namespace wsl::core::networking

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4108,24 +4108,24 @@ class MirroredTests
         VERIFY_IS_TRUE(canBindUdp);
     }
 
-    WSL2_TEST_METHOD(GuestTcpBindToHostEphemeralRangeDenied)
+    void VerifyGuestBindToHostEphemeralRangeDenied(LPCWSTR ProtocolSettingClass, LPCWSTR SocatProtocolPrefix)
     {
         MIRRORED_NETWORKING_TEST_ONLY();
 
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
         WaitForMirroredStateInLinux();
 
-        // Query the host TCP ephemeral port range via PowerShell.
-        auto [startStr, _1] = LxsstuLaunchPowershellAndCaptureOutput(
-            L"(Get-NetTCPSetting | Where-Object { $_.DynamicPortRangeStartPort -gt 0 } | Select-Object -First "
-            L"1).DynamicPortRangeStartPort",
-            0);
+        // Query the host ephemeral port range via PowerShell.
+        auto startQuery =
+            std::wstring(L"(") + ProtocolSettingClass +
+            L" | Where-Object { $_.DynamicPortRangeStartPort -gt 0 } | Select-Object -First 1).DynamicPortRangeStartPort";
+        auto [startStr, _1] = LxsstuLaunchPowershellAndCaptureOutput(startQuery.c_str(), 0);
         const auto hostEphemeralStart = std::stoi(startStr);
 
-        auto [countStr, _2] = LxsstuLaunchPowershellAndCaptureOutput(
-            L"(Get-NetTCPSetting | Where-Object { $_.DynamicPortRangeNumberOfPorts -gt 0 } | Select-Object -First "
-            L"1).DynamicPortRangeNumberOfPorts",
-            0);
+        auto countQuery =
+            std::wstring(L"(") + ProtocolSettingClass +
+            L" | Where-Object { $_.DynamicPortRangeNumberOfPorts -gt 0 } | Select-Object -First 1).DynamicPortRangeNumberOfPorts";
+        auto [countStr, _2] = LxsstuLaunchPowershellAndCaptureOutput(countQuery.c_str(), 0);
         const auto hostEphemeralEnd = hostEphemeralStart + std::stoi(countStr) - 1;
 
         // Get the guest ephemeral port range.
@@ -4153,57 +4153,19 @@ class MirroredTests
             VERIFY_FAIL(L"Guest ephemeral range fully covers the host ephemeral range, cannot find a test port");
         }
 
-        auto [tcpListener, tcpSuccess, read] = NetworkTests::BindGuestPortHelper(L"TCP4-LISTEN:" + std::to_wstring(testPort));
-        VERIFY_IS_FALSE(tcpSuccess);
+        auto socatArg = std::wstring(SocatProtocolPrefix) + std::to_wstring(testPort);
+        auto [listener, success, read] = NetworkTests::BindGuestPortHelper(socatArg);
+        VERIFY_IS_FALSE(success);
+    }
+
+    WSL2_TEST_METHOD(GuestTcpBindToHostEphemeralRangeDenied)
+    {
+        VerifyGuestBindToHostEphemeralRangeDenied(L"Get-NetTCPSetting", L"TCP4-LISTEN:");
     }
 
     WSL2_TEST_METHOD(GuestUdpBindToHostEphemeralRangeDenied)
     {
-        MIRRORED_NETWORKING_TEST_ONLY();
-
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
-        WaitForMirroredStateInLinux();
-
-        // Query the host UDP ephemeral port range via PowerShell.
-        auto [startStr, _1] = LxsstuLaunchPowershellAndCaptureOutput(
-            L"(Get-NetUDPSetting | Where-Object { $_.DynamicPortRangeStartPort -gt 0 } | Select-Object -First "
-            L"1).DynamicPortRangeStartPort",
-            0);
-        const auto hostEphemeralStart = std::stoi(startStr);
-
-        auto [countStr, _2] = LxsstuLaunchPowershellAndCaptureOutput(
-            L"(Get-NetUDPSetting | Where-Object { $_.DynamicPortRangeNumberOfPorts -gt 0 } | Select-Object -First "
-            L"1).DynamicPortRangeNumberOfPorts",
-            0);
-        const auto hostEphemeralEnd = hostEphemeralStart + std::stoi(countStr) - 1;
-
-        // Get the guest ephemeral port range.
-        auto [start, err1] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f1", 0);
-        start.pop_back();
-        const auto guestEphemeralRangeStart = std::stoi(start);
-
-        auto [end, err2] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f2", 0);
-        end.pop_back();
-        const auto guestEphemeralRangeEnd = std::stoi(end);
-
-        // Pick a port in the host ephemeral range but not in the guest's assigned range.
-        // The ranges may overlap
-        int testPort = 0;
-        if (hostEphemeralStart < guestEphemeralRangeStart || hostEphemeralStart > guestEphemeralRangeEnd)
-        {
-            testPort = hostEphemeralStart;
-        }
-        else if (guestEphemeralRangeEnd < hostEphemeralEnd)
-        {
-            testPort = guestEphemeralRangeEnd + 1;
-        }
-        else
-        {
-            VERIFY_FAIL(L"Guest ephemeral range fully covers the host ephemeral range, cannot find a test port");
-        }
-
-        auto [udpListener, udpSuccess, udpRead] = NetworkTests::BindGuestPortHelper(L"UDP4-LISTEN:" + std::to_wstring(testPort));
-        VERIFY_IS_FALSE(udpSuccess);
+        VerifyGuestBindToHostEphemeralRangeDenied(L"Get-NetUDPSetting", L"UDP4-LISTEN:");
     }
 
     WSL2_TEST_METHOD(NonRootNamespaceEphemeralBind)

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4108,6 +4108,104 @@ class MirroredTests
         VERIFY_IS_TRUE(canBindUdp);
     }
 
+    WSL2_TEST_METHOD(GuestTcpBindToHostEphemeralRangeDenied)
+    {
+        MIRRORED_NETWORKING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+        WaitForMirroredStateInLinux();
+
+        // Query the host TCP ephemeral port range via PowerShell.
+        auto [startStr, _1] = LxsstuLaunchPowershellAndCaptureOutput(
+            L"(Get-NetTCPSetting | Where-Object { $_.DynamicPortRangeStartPort -gt 0 } | Select-Object -First "
+            L"1).DynamicPortRangeStartPort",
+            0);
+        const auto hostEphemeralStart = std::stoi(startStr);
+
+        auto [countStr, _2] = LxsstuLaunchPowershellAndCaptureOutput(
+            L"(Get-NetTCPSetting | Where-Object { $_.DynamicPortRangeNumberOfPorts -gt 0 } | Select-Object -First "
+            L"1).DynamicPortRangeNumberOfPorts",
+            0);
+        const auto hostEphemeralEnd = hostEphemeralStart + std::stoi(countStr) - 1;
+
+        // Get the guest ephemeral port range.
+        auto [start, err1] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f1", 0);
+        start.pop_back();
+        const auto guestEphemeralRangeStart = std::stoi(start);
+
+        auto [end, err2] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f2", 0);
+        end.pop_back();
+        const auto guestEphemeralRangeEnd = std::stoi(end);
+
+        // Pick a port in the host ephemeral range but not in the guest's assigned range.
+        // The ranges may overlap
+        int testPort = 0;
+        if (hostEphemeralStart < guestEphemeralRangeStart || hostEphemeralStart > guestEphemeralRangeEnd)
+        {
+            testPort = hostEphemeralStart;
+        }
+        else if (guestEphemeralRangeEnd < hostEphemeralEnd)
+        {
+            testPort = guestEphemeralRangeEnd + 1;
+        }
+        else
+        {
+            VERIFY_FAIL(L"Guest ephemeral range fully covers the host ephemeral range, cannot find a test port");
+        }
+
+        auto [tcpListener, tcpSuccess, read] = NetworkTests::BindGuestPortHelper(L"TCP4-LISTEN:" + std::to_wstring(testPort));
+        VERIFY_IS_FALSE(tcpSuccess);
+    }
+
+    WSL2_TEST_METHOD(GuestUdpBindToHostEphemeralRangeDenied)
+    {
+        MIRRORED_NETWORKING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+        WaitForMirroredStateInLinux();
+
+        // Query the host UDP ephemeral port range via PowerShell.
+        auto [startStr, _1] = LxsstuLaunchPowershellAndCaptureOutput(
+            L"(Get-NetUDPSetting | Where-Object { $_.DynamicPortRangeStartPort -gt 0 } | Select-Object -First "
+            L"1).DynamicPortRangeStartPort",
+            0);
+        const auto hostEphemeralStart = std::stoi(startStr);
+
+        auto [countStr, _2] = LxsstuLaunchPowershellAndCaptureOutput(
+            L"(Get-NetUDPSetting | Where-Object { $_.DynamicPortRangeNumberOfPorts -gt 0 } | Select-Object -First "
+            L"1).DynamicPortRangeNumberOfPorts",
+            0);
+        const auto hostEphemeralEnd = hostEphemeralStart + std::stoi(countStr) - 1;
+
+        // Get the guest ephemeral port range.
+        auto [start, err1] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f1", 0);
+        start.pop_back();
+        const auto guestEphemeralRangeStart = std::stoi(start);
+
+        auto [end, err2] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f2", 0);
+        end.pop_back();
+        const auto guestEphemeralRangeEnd = std::stoi(end);
+
+        // Pick a port in the host ephemeral range but not in the guest's assigned range.
+        // The ranges may overlap
+        int testPort = 0;
+        if (hostEphemeralStart < guestEphemeralRangeStart || hostEphemeralStart > guestEphemeralRangeEnd)
+        {
+            testPort = hostEphemeralStart;
+        }
+        else if (guestEphemeralRangeEnd < hostEphemeralEnd)
+        {
+            testPort = guestEphemeralRangeEnd + 1;
+        }
+        else
+        {
+            VERIFY_FAIL(L"Guest ephemeral range fully covers the host ephemeral range, cannot find a test port");
+        }
+
+        auto [udpListener, udpSuccess, udpRead] = NetworkTests::BindGuestPortHelper(L"UDP4-LISTEN:" + std::to_wstring(testPort));
+        VERIFY_IS_FALSE(udpSuccess);
+    }
+
     WSL2_TEST_METHOD(NonRootNamespaceEphemeralBind)
     {
         MIRRORED_NETWORKING_TEST_ONLY();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In mirrored mode, we pre-reserve a range for the guest to be used as guest ephemeral port range, but we don't prevent the guest from explicitly binding to the host ephemeral range
Update the wsl service to query the host ephemeral range and deny guest binds to that range

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual testing of binds to non-ephemeral ports, host ephemeral port range and guest ephemeral port range.
Added new automated tests to cover the fixed scenario
Ran existing Network Tests, which include multiple port tracker/bind tests
