### PR TITLE
plan9: re-enable virtio9p now that the known virtio queue corruption issue has been root caused

### DIFF
--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -449,12 +449,6 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
         }
     }
 
-    if (EnableVirtio9p)
-    {
-        EMIT_USER_WARNING(wsl::shared::Localization::MessageConfigVirtio9pDisabled());
-        EnableVirtio9p = false;
-    }
-
     // Compute a default swiotlb config only when a virtio device that requires bounce buffers is present.
     // N.B. Must run after policy overrides so networking/fs modes reflect final values.
     if (SwiotlbSizeBytes == 0 && (EnableVirtioFs || EnableVirtio9p || (NetworkingMode == NetworkingMode::Consomme)))

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -324,8 +324,8 @@ struct Config
     ConfigKeyPresence LoadKernelModulesPresence = ConfigKeyPresence::Absent;
     bool LoadDefaultKernelModules = true;
     bool EnableNestedVirtualization = !shared::Arm64 && windows::common::helpers::IsWindows11OrAbove();
-    bool EnableVirtio9p = true;
     bool EnableVirtio = !shared::Arm64 || windows::common::helpers::IsWindows11OrAbove();
+    bool EnableVirtio9p = EnableVirtio;
     bool EnableVirtioFs = false;
     int KernelDebugPort = 0;
     bool EnableGpuSupport = true;

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -324,7 +324,7 @@ struct Config
     ConfigKeyPresence LoadKernelModulesPresence = ConfigKeyPresence::Absent;
     bool LoadDefaultKernelModules = true;
     bool EnableNestedVirtualization = !shared::Arm64 && windows::common::helpers::IsWindows11OrAbove();
-    bool EnableVirtio9p = false;
+    bool EnableVirtio9p = true;
     bool EnableVirtio = !shared::Arm64 || windows::common::helpers::IsWindows11OrAbove();
     bool EnableVirtioFs = false;
     int KernelDebugPort = 0;

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -1367,8 +1367,6 @@ WSL2_DRVFS_TEST_CLASS(Plan9);
 
 WSL2_DRVFS_TEST_CLASS(VirtioFs);
 
-// Disabled while an issue with the 6.1 Linux kernel causing disk corruption is investigated.
-// TODO: Enable again once the issue is resolved
-// WSL2_DRVFS_TEST_CLASS(Virtio9p);
+WSL2_DRVFS_TEST_CLASS(Virtio9p);
 
 } // namespace DrvFsTests


### PR DESCRIPTION
Plan9 with the virtio backend was disabled some time ago, but I believe the issue that was causing the reported issue has been root caused and resolved, so it should now be safe to re-enabled. Submitting the PR as a draft for now while I collect some perf measurements and run tests.