### PR TITLE
Refactor IsContainerNetworkMode into ParseContainerNetworkMode

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -151,32 +151,20 @@ uint16_t AllocateEphemeralPort(int family, const char* address)
 
 constexpr std::string_view c_containerNetworkPrefix = "container:";
 
-// Returns the target container name (the part after "container:") if Mode is a
-// container-mode network spec; std::nullopt otherwise.
-std::optional<std::string> ParseContainerNetworkMode(LPCSTR Mode)
+// Returns the target name after "container:" if present, std::nullopt otherwise.
+std::optional<std::string> ParseContainerNetworkMode(std::string_view mode)
 {
-    if (Mode == nullptr)
+    if (!mode.starts_with(c_containerNetworkPrefix))
     {
         return std::nullopt;
     }
 
-    const std::string_view view{Mode};
-    if (!view.starts_with(c_containerNetworkPrefix))
-    {
-        return std::nullopt;
-    }
-
-    return std::string{view.substr(c_containerNetworkPrefix.size())};
+    return std::string{mode.substr(c_containerNetworkPrefix.size())};
 }
 
-std::optional<std::string> ParseContainerNetworkMode(std::string_view Mode)
+std::optional<std::string> ParseContainerNetworkMode(LPCSTR mode)
 {
-    if (!Mode.starts_with(c_containerNetworkPrefix))
-    {
-        return std::nullopt;
-    }
-
-    return std::string{Mode.substr(c_containerNetworkPrefix.size())};
+    return mode != nullptr ? ParseContainerNetworkMode(std::string_view{mode}) : std::nullopt;
 }
 
 // Builds port mapping list from container options and returns the network mode string.

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -152,7 +152,7 @@ uint16_t AllocateEphemeralPort(int family, const char* address)
 constexpr std::string_view c_containerNetworkPrefix = "container:";
 
 // Returns the target name after "container:" if present, std::nullopt otherwise.
-std::optional<std::string> ParseContainerNetworkMode(std::string_view mode)
+std::optional<std::string> ParseContainerTarget(std::string_view mode)
 {
     if (!mode.starts_with(c_containerNetworkPrefix))
     {
@@ -162,9 +162,9 @@ std::optional<std::string> ParseContainerNetworkMode(std::string_view mode)
     return std::string{mode.substr(c_containerNetworkPrefix.size())};
 }
 
-std::optional<std::string> ParseContainerNetworkMode(LPCSTR mode)
+std::optional<std::string> ParseContainerTarget(LPCSTR mode)
 {
-    return mode != nullptr ? ParseContainerNetworkMode(std::string_view{mode}) : std::nullopt;
+    return mode != nullptr ? ParseContainerTarget(std::string_view{mode}) : std::nullopt;
 }
 
 // Builds port mapping list from container options and returns the network mode string.
@@ -183,6 +183,7 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
 
     // Determine network mode string.
     std::string networkMode;
+    std::optional<std::string> containerTarget;
     if (networkType == WSLCContainerNetworkTypeBridged)
     {
         networkMode = "bridge";
@@ -200,21 +201,22 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
         THROW_HR_WITH_USER_ERROR_IF(
             E_INVALIDARG, Localization::MessageWslcContainerNetworkNameRequired(), !containerNetworkName || strlen(containerNetworkName) == 0);
 
-        if (auto target = ParseContainerNetworkMode(containerNetworkName))
+        containerTarget = ParseContainerTarget(containerNetworkName);
+        if (containerTarget)
         {
-            THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcContainerModeRequiresTarget(), target->empty());
+            THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcContainerModeRequiresTarget(), containerTarget->empty());
 
             THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcContainerModeNoPorts(), !requestedPorts.empty());
 
             try
             {
-                auto targetInspect = dockerClient.InspectContainer(*target);
+                auto targetInspect = dockerClient.InspectContainer(*containerTarget);
                 networkMode = std::format("container:{}", targetInspect.Id);
             }
             catch (const DockerHTTPException& e)
             {
                 THROW_HR_WITH_USER_ERROR_IF(
-                    WSLC_E_CONTAINER_NOT_FOUND, Localization::MessageWslcContainerModeTargetNotFound(*target), e.StatusCode() == 404);
+                    WSLC_E_CONTAINER_NOT_FOUND, Localization::MessageWslcContainerModeTargetNotFound(*containerTarget), e.StatusCode() == 404);
                 throw;
             }
         }
@@ -250,8 +252,7 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
         auto& entry = ports.emplace_back(VMPortMapping::FromWSLCPortMapping(e), e.ContainerPort);
 
         // Allocate VM ports for bridged and custom networks. Host mode ports are allocated when the container starts.
-        if (networkType == WSLCContainerNetworkTypeBridged ||
-            (networkType == WSLCContainerNetworkTypeCustom && !ParseContainerNetworkMode(containerNetworkName)))
+        if (networkType == WSLCContainerNetworkTypeBridged || (networkType == WSLCContainerNetworkTypeCustom && !containerTarget))
         {
             entry.VmMapping.AssignVmPort(virtualMachine.AllocatePort(e.Family, e.Protocol));
         }
@@ -345,7 +346,7 @@ DockerNetworkMode ParseDockerNetworkMode(const std::string& mode)
         return {WSLCContainerNetworkTypeBridged, {}};
     }
 
-    if (auto target = ParseContainerNetworkMode(mode))
+    if (auto target = ParseContainerTarget(mode))
     {
         THROW_HR_IF_MSG(E_INVALIDARG, target->empty(), "Invalid Docker network mode: missing container id/name in '%hs'", mode.c_str());
         return {WSLCContainerNetworkTypeCustom, std::move(*target)};
@@ -479,7 +480,7 @@ void ProcessAdditionalNetworks(
     THROW_HR_WITH_USER_ERROR_IF(
         E_INVALIDARG,
         Localization::MessageWslcContainerModeNoAdditionalNetworks(),
-        ParseContainerNetworkMode(GetPrimaryNetworkName(network)).has_value());
+        ParseContainerTarget(GetPrimaryNetworkName(network)).has_value());
 
     THROW_HR_WITH_USER_ERROR_IF(
         E_INVALIDARG,

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -151,9 +151,32 @@ uint16_t AllocateEphemeralPort(int family, const char* address)
 
 constexpr std::string_view c_containerNetworkPrefix = "container:";
 
-bool IsContainerNetworkMode(LPCSTR name)
+// Returns the target container name (the part after "container:") if Mode is a
+// container-mode network spec; std::nullopt otherwise.
+std::optional<std::string> ParseContainerNetworkMode(LPCSTR Mode)
 {
-    return name != nullptr && std::string_view(name).starts_with(c_containerNetworkPrefix);
+    if (Mode == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    const std::string_view view{Mode};
+    if (!view.starts_with(c_containerNetworkPrefix))
+    {
+        return std::nullopt;
+    }
+
+    return std::string{view.substr(c_containerNetworkPrefix.size())};
+}
+
+std::optional<std::string> ParseContainerNetworkMode(std::string_view Mode)
+{
+    if (!Mode.starts_with(c_containerNetworkPrefix))
+    {
+        return std::nullopt;
+    }
+
+    return std::string{Mode.substr(c_containerNetworkPrefix.size())};
 }
 
 // Builds port mapping list from container options and returns the network mode string.
@@ -189,22 +212,21 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
         THROW_HR_WITH_USER_ERROR_IF(
             E_INVALIDARG, Localization::MessageWslcContainerNetworkNameRequired(), !containerNetworkName || strlen(containerNetworkName) == 0);
 
-        if (IsContainerNetworkMode(containerNetworkName))
+        if (auto target = ParseContainerNetworkMode(containerNetworkName))
         {
-            auto target = std::string_view(containerNetworkName).substr(c_containerNetworkPrefix.size());
-            THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcContainerModeRequiresTarget(), target.empty());
+            THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcContainerModeRequiresTarget(), target->empty());
 
             THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcContainerModeNoPorts(), !requestedPorts.empty());
 
             try
             {
-                auto targetInspect = dockerClient.InspectContainer(std::string(target));
+                auto targetInspect = dockerClient.InspectContainer(*target);
                 networkMode = std::format("container:{}", targetInspect.Id);
             }
             catch (const DockerHTTPException& e)
             {
                 THROW_HR_WITH_USER_ERROR_IF(
-                    WSLC_E_CONTAINER_NOT_FOUND, Localization::MessageWslcContainerModeTargetNotFound(std::string(target)), e.StatusCode() == 404);
+                    WSLC_E_CONTAINER_NOT_FOUND, Localization::MessageWslcContainerModeTargetNotFound(*target), e.StatusCode() == 404);
                 throw;
             }
         }
@@ -241,7 +263,7 @@ std::pair<std::vector<ContainerPortMapping>, std::string> ProcessPortMappings(
 
         // Allocate VM ports for bridged and custom networks. Host mode ports are allocated when the container starts.
         if (networkType == WSLCContainerNetworkTypeBridged ||
-            (networkType == WSLCContainerNetworkTypeCustom && !IsContainerNetworkMode(containerNetworkName)))
+            (networkType == WSLCContainerNetworkTypeCustom && !ParseContainerNetworkMode(containerNetworkName)))
         {
             entry.VmMapping.AssignVmPort(virtualMachine.AllocatePort(e.Family, e.Protocol));
         }
@@ -335,11 +357,10 @@ DockerNetworkMode ParseDockerNetworkMode(const std::string& mode)
         return {WSLCContainerNetworkTypeBridged, {}};
     }
 
-    if (mode.starts_with(c_containerNetworkPrefix))
+    if (auto target = ParseContainerNetworkMode(mode))
     {
-        auto target = mode.substr(c_containerNetworkPrefix.size());
-        THROW_HR_IF_MSG(E_INVALIDARG, target.empty(), "Invalid Docker network mode: missing container id/name in '%hs'", mode.c_str());
-        return {WSLCContainerNetworkTypeCustom, std::move(target)};
+        THROW_HR_IF_MSG(E_INVALIDARG, target->empty(), "Invalid Docker network mode: missing container id/name in '%hs'", mode.c_str());
+        return {WSLCContainerNetworkTypeCustom, std::move(*target)};
     }
 
     // Reject other Docker special syntaxes (service:<name>, etc.);
@@ -468,7 +489,9 @@ void ProcessAdditionalNetworks(
     }
 
     THROW_HR_WITH_USER_ERROR_IF(
-        E_INVALIDARG, Localization::MessageWslcContainerModeNoAdditionalNetworks(), IsContainerNetworkMode(GetPrimaryNetworkName(network)));
+        E_INVALIDARG,
+        Localization::MessageWslcContainerModeNoAdditionalNetworks(),
+        ParseContainerNetworkMode(GetPrimaryNetworkName(network)).has_value());
 
     THROW_HR_WITH_USER_ERROR_IF(
         E_INVALIDARG,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Replaces the IsContainerNetworkMode boolean helper with ParseContainerNetworkMode which returns the parsed target name directly. This eliminates duplicated prefix+substr+validate logic that was hand-rolled in multiple places.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This is a followup PR to #40601 addressing review comment to consolidate the container network mode parsing logic.
The container:<name|id> prefix parsing was done in two different ways:

-  IsContainerNetworkMode() check followed by manual substr()
- Direct starts_with() + substr() without using the helper at all
ParseContainerNetworkMode consolidates both patterns into a single function that returns std::optional<std::string> - the target name if the mode matches, std::nullopt otherwise. Two overloads are provided: one for LPCSTR (user-input paths) and one for std::string_view (Docker inspect recovery path).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
