### PR TITLE
Prevent binfmt_misc unmount propagation across distros

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1515,10 +1515,12 @@ Return Value:
     }
 
     //
-    // Mount the binfmt_misc filesystem.
+    // Mount the binfmt_misc filesystem as private so that unmounts in child
+    // mount namespaces (e.g. when a peer distro's systemd shuts down) do not
+    // propagate back and wipe the global registration table.
     //
 
-    if (UtilMount(nullptr, BINFMT_PATH, "binfmt_misc", MS_RELATIME, nullptr) < 0)
+    if (UtilMount(nullptr, BINFMT_PATH, "binfmt_misc", MS_RELATIME | MS_PRIVATE, nullptr) < 0)
     {
         return -1;
     }

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -1773,11 +1773,31 @@ Return Value:
     //      - For Plan9 (9p): device is busy or not found
     //      - For VirtioFS: invalid tag (device not ready)
     //
-    // N.B. MS_SHARED must be applied in a separate mount() call, so it is
-    //      stripped from the initial mount flags and applied after the mount.
+    // N.B. Propagation flags (MS_SHARED, MS_PRIVATE, MS_SLAVE, MS_UNBINDABLE) are
+    //      mutually exclusive and must be applied in a separate mount() call after
+    //      the initial mount. The kernel rejects propagation flags combined with
+    //      MS_BIND, MS_MOVE, or MS_REMOUNT in a single syscall (EINVAL).
+    //      MS_REC may be combined with a propagation flag to apply it recursively.
     //
 
-    const unsigned long initialFlags = MountFlags & ~MS_SHARED;
+    constexpr unsigned long propagationFlags = MS_SHARED | MS_PRIVATE | MS_SLAVE | MS_UNBINDABLE;
+    const unsigned long propagation = MountFlags & propagationFlags;
+    if (propagation != 0 && (propagation & (propagation - 1)) != 0)
+    {
+        LOG_ERROR("mount({}) invalid: multiple propagation flags specified ({:#x})", Target, propagation);
+        return -EINVAL;
+    }
+
+    if (propagation != 0 && WI_IsAnyFlagSet(MountFlags, MS_BIND | MS_MOVE | MS_REMOUNT))
+    {
+        LOG_ERROR("mount({}) invalid: propagation flags cannot combine with MS_BIND/MS_MOVE/MS_REMOUNT", Target);
+        return -EINVAL;
+    }
+
+    // MS_REC is passed through with the propagation flag when one is present,
+    // otherwise it stays in initialFlags (e.g. for MS_BIND | MS_REC).
+    const unsigned long propagationCallFlags = propagation != 0 ? propagation | (MountFlags & MS_REC) : 0;
+    const unsigned long initialFlags = MountFlags & ~(propagationFlags | (propagation != 0 ? MS_REC : 0));
 
     try
     {
@@ -1820,12 +1840,12 @@ Return Value:
         return -errno;
     }
 
-    // N.B. The shared flag must be applied in a separate mount() call.
-    if (WI_IsFlagSet(MountFlags, MS_SHARED))
+    // Apply the propagation flag in a separate mount() call.
+    if (propagationCallFlags != 0)
     {
-        if (mount(nullptr, Target, nullptr, MS_SHARED, nullptr) < 0)
+        if (mount(nullptr, Target, nullptr, propagationCallFlags, nullptr) < 0)
         {
-            LOG_ERROR("Failed to make shared mount {} {}", Target, errno);
+            LOG_ERROR("mount({}, {:#x}) propagation failed {}", Target, propagationCallFlags, errno);
             return -errno;
         }
     }

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -413,6 +413,90 @@ class UnitTests
         VERIFY_ARE_EQUAL(out, L"hello\n");
     }
 
+    WSL2_TEST_METHOD(InteropSurvivesPeerDistroShutdown)
+    {
+        //
+        // Validates that binfmt_misc registrations (Windows interop) survive when a peer
+        // distro running systemd terminates. Without MS_PRIVATE on the binfmt_misc mount,
+        // systemd's shutdown unmount propagates back through the shared mount peer group
+        // and wipes ALL registrations in the VM, causing "Exec format error" globally.
+        //
+
+        constexpr auto peerDistroName = L"binfmt-peer-test";
+
+        // Import a second distro from the same tarball as the test distro.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--import {} . \"{}\" --version 2", peerDistroName, g_testDistroPath)), 0L);
+
+        auto cleanupPeer = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LxsstuLaunchWsl(std::format(L"--terminate {}", peerDistroName));
+            LxsstuLaunchWsl(std::format(L"--unregister {}", peerDistroName));
+        });
+
+        // Enable systemd in the peer distro.
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(std::format(L"-d {} -- sh -c \"mkdir -p /etc && printf '[boot]\\nsystemd=true\\n' > /etc/wsl.conf\"", peerDistroName)),
+            0L);
+
+        // Terminate so the config takes effect on next start.
+        LxsstuLaunchWsl(std::format(L"--terminate {}", peerDistroName));
+
+        // Start the peer distro and wait for systemd to come up.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"-d {} -- true", peerDistroName)), 0L);
+
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() {
+                auto [out, _] =
+                    LxsstuLaunchWslAndCaptureOutput(std::format(L"-d {} -- systemctl is-system-running --wait", peerDistroName));
+                // Accept "running" or "degraded" — both mean systemd booted.
+                THROW_HR_IF(E_UNEXPECTED, out.find(L"running") == std::wstring::npos && out.find(L"degraded") == std::wstring::npos);
+            },
+            std::chrono::seconds(2),
+            std::chrono::minutes(2)));
+
+        // Verify interop works in the primary distro before the peer terminates.
+        {
+            auto [out, _] = LxsstuLaunchWslAndCaptureOutput(L"cmd.exe /c echo alive");
+            VERIFY_ARE_EQUAL(out, L"alive\r\n");
+        }
+
+        // Terminate the peer distro (triggers systemd shutdown -> unmounts binfmt_misc).
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--terminate {}", peerDistroName)), 0L);
+
+        // Wait for the peer distro to fully stop.
+        {
+            wsl::windows::common::SvcComm service;
+            VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+                [&]() {
+                    bool found = false;
+                    for (const auto& e : service.EnumerateDistributions())
+                    {
+                        if (wsl::shared::string::IsEqual(e.DistroName, peerDistroName))
+                        {
+                            found = true;
+                            THROW_HR_IF(E_UNEXPECTED, e.State == LxssDistributionStateRunning);
+                            break;
+                        }
+                    }
+
+                    THROW_HR_IF(E_UNEXPECTED, !found);
+                },
+                std::chrono::seconds(1),
+                std::chrono::seconds(30)));
+        }
+
+        // Verify interop still works in the primary distro.
+        {
+            auto [out, _] = LxsstuLaunchWslAndCaptureOutput(L"cmd.exe /c echo survived");
+            VERIFY_ARE_EQUAL(out, L"survived\r\n");
+        }
+
+        // Verify the binfmt entry still exists and has the F (fix-binary) flag.
+        {
+            auto [flags, _] = LxsstuLaunchWslAndCaptureOutput(L"grep ^flags /proc/sys/fs/binfmt_misc/WSLInterop");
+            VERIFY_IS_TRUE(flags.find(L"F") != std::wstring::npos);
+        }
+    }
+
     TEST_METHOD(Dup)
     {
         VERIFY_NO_THROW(LxsstuRunTest(L"/data/test/wsl_unit_tests dup", L"Dup"));


### PR DESCRIPTION
## Summary

Fixes an `Exec format error` bug where Windows interop breaks in all running distros when a peer distro with systemd shuts down.

## Root Cause

`/proc` is mounted with `MS_SHARED`, so `binfmt_misc` (mounted under `/proc/sys/fs/binfmt_misc`) inherits shared mount propagation. When a peer distro's systemd shuts down and unmounts `binfmt_misc` in its mount namespace, the unmount propagates back through the shared peer group to init's namespace, wiping ALL binfmt_misc registrations globally.

## Fix

Mark `binfmt_misc` as `MS_PRIVATE` immediately after mounting so that unmounts in child namespaces are isolated and cannot propagate back. Also extends `UtilMount` to properly handle all mount propagation flags (`MS_SHARED`, `MS_PRIVATE`, `MS_SLAVE`, `MS_UNBINDABLE`) with mutual exclusivity validation and `MS_REC` support.

## PR Checklist

- [x] Builds cleanly
- [x] Includes regression test (`InteropSurvivesPeerDistroShutdown`)
- [x] Passes clang-format
- [x] Manually verified: entry survives peer distro termination, interop works, F-flag works in new mount namespaces

## Validation Steps

1. Import a second distro with systemd enabled
2. Start it and wait for systemd to come up
3. Terminate the peer distro (`wsl --terminate`)
4. Verify `cmd.exe /c echo test` still works in the primary distro
5. Verify `/proc/sys/fs/binfmt_misc/WSLInterop` still exists with F flag

Fixes #13885