### PR TITLE
Prevent binfmt_misc unmount propagation across distros

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1551,11 +1551,19 @@ Return Value:
     }
 
     //
-    // Mount the binfmt_misc filesystem.
+    // Mount the binfmt_misc filesystem and mark it private so that unmounts
+    // in child mount namespaces (e.g. when a peer distro's systemd shuts down)
+    // do not propagate back and wipe the global registration table.
     //
 
     if (UtilMount(nullptr, BINFMT_PATH, "binfmt_misc", MS_RELATIME, nullptr) < 0)
     {
+        return -1;
+    }
+
+    if (mount(nullptr, BINFMT_PATH, nullptr, MS_PRIVATE, nullptr) < 0)
+    {
+        LOG_ERROR("mount({}, MS_PRIVATE) failed {}", BINFMT_PATH, errno);
         return -1;
     }
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -393,6 +393,90 @@ class UnitTests
         }
     }
 
+    WSL2_TEST_METHOD(InteropSurvivesPeerDistroShutdown)
+    {
+        //
+        // Validates that binfmt_misc registrations (Windows interop) survive when a peer
+        // distro running systemd terminates. Without MS_PRIVATE on the binfmt_misc mount,
+        // systemd's shutdown unmount propagates back through the shared mount peer group
+        // and wipes ALL registrations in the VM, causing "Exec format error" globally.
+        //
+
+        constexpr auto peerDistroName = L"binfmt-peer-test";
+
+        // Import a second distro from the same tarball as the test distro.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--import {} . \"{}\" --version 2", peerDistroName, g_testDistroPath)), 0L);
+
+        auto cleanupPeer = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LxsstuLaunchWsl(std::format(L"--terminate {}", peerDistroName));
+            LxsstuLaunchWsl(std::format(L"--unregister {}", peerDistroName));
+        });
+
+        // Enable systemd in the peer distro.
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(std::format(L"-d {} -- sh -c \"mkdir -p /etc && printf '[boot]\\nsystemd=true\\n' > /etc/wsl.conf\"", peerDistroName)),
+            0L);
+
+        // Terminate so the config takes effect on next start.
+        LxsstuLaunchWsl(std::format(L"--terminate {}", peerDistroName));
+
+        // Start the peer distro and wait for systemd to come up.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"-d {} -- true", peerDistroName)), 0L);
+
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() {
+                auto [out, _] =
+                    LxsstuLaunchWslAndCaptureOutput(std::format(L"-d {} -- systemctl is-system-running --wait", peerDistroName));
+                // Accept "running" or "degraded" — both mean systemd booted.
+                THROW_HR_IF(E_UNEXPECTED, out.find(L"running") == std::wstring::npos && out.find(L"degraded") == std::wstring::npos);
+            },
+            std::chrono::seconds(2),
+            std::chrono::minutes(2)));
+
+        // Verify interop works in the primary distro before the peer terminates.
+        {
+            auto [out, _] = LxsstuLaunchWslAndCaptureOutput(L"cmd.exe /c echo alive");
+            VERIFY_ARE_EQUAL(out, L"alive\r\n");
+        }
+
+        // Terminate the peer distro (triggers systemd shutdown -> unmounts binfmt_misc).
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--terminate {}", peerDistroName)), 0L);
+
+        // Wait for the peer distro to fully stop.
+        {
+            wsl::windows::common::SvcComm service;
+            VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+                [&]() {
+                    bool found = false;
+                    for (const auto& e : service.EnumerateDistributions())
+                    {
+                        if (wsl::shared::string::IsEqual(e.DistroName, peerDistroName))
+                        {
+                            found = true;
+                            THROW_HR_IF(E_UNEXPECTED, e.State == LxssDistributionStateRunning);
+                            break;
+                        }
+                    }
+
+                    THROW_HR_IF(E_UNEXPECTED, !found);
+                },
+                std::chrono::seconds(1),
+                std::chrono::seconds(30)));
+        }
+
+        // Verify interop still works in the primary distro.
+        {
+            auto [out, _] = LxsstuLaunchWslAndCaptureOutput(L"cmd.exe /c echo survived");
+            VERIFY_ARE_EQUAL(out, L"survived\r\n");
+        }
+
+        // Verify the binfmt entry still exists and has the F (fix-binary) flag.
+        {
+            auto [flags, _] = LxsstuLaunchWslAndCaptureOutput(L"grep ^flags /proc/sys/fs/binfmt_misc/WSLInterop");
+            VERIFY_IS_TRUE(flags.find(L"F") != std::wstring::npos);
+        }
+    }
+
     TEST_METHOD(Dup)
     {
         VERIFY_NO_THROW(LxsstuRunTest(L"/data/test/wsl_unit_tests dup", L"Dup"));


### PR DESCRIPTION
## Summary

Minimal cherry-pick of #40612 for the 2.7 release branch.

Fixes an `Exec format error` bug where Windows interop breaks in all running distros when a peer distro with systemd shuts down.

## Root Cause

`/proc` is mounted with `MS_SHARED`, so `binfmt_misc` inherits shared mount propagation. When a peer distro's systemd shuts down and unmounts `binfmt_misc` in its namespace, the unmount propagates back through the shared peer group to init's namespace, wiping ALL registrations globally.

## Fix

One additional `mount()` call with `MS_PRIVATE` immediately after mounting binfmt_misc. This is the minimal version — the master branch PR also extends `UtilMount` to handle propagation flags generically.

## PR Checklist

- [x] Builds cleanly
- [x] Includes regression test (`InteropSurvivesPeerDistroShutdown`)
- [x] Passes clang-format

Fixes #13885