### PR TITLE
Make it easier to make a local WSLC SDK NuGet

### DIFF
--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -39,6 +39,9 @@ endif()
 # # Uncomment to build the C# WSLC sdk
 # set(WSL_BUILD_SDKCS true)
 
+# # Uncomment to configure the WSLC SDK NuGet to only target the current platform
+# set(WSL_NUGET_SINGLE_PLATFORM true)
+
 # # Uncomment to generate a "thin" MSI package which builds and installs faster
 # set(WSL_BUILD_THIN_PACKAGE true)
 

--- a/nuget/CMakeLists.txt
+++ b/nuget/CMakeLists.txt
@@ -1,10 +1,49 @@
 set(NUGET_PACKAGES Microsoft.WSL.PluginApi.nuspec Microsoft.WSL.Containers.nuspec)
 set(WSL_NUGET_TARGET_FRAMEWORK "net8.0-windows10.0.19041.0")
 
-# generate vars with native paths since nuget won't accept unix path separators
+# Generate vars with native paths since nuget won't accept unix path separators.
 cmake_path(NATIVE_PATH CMAKE_SOURCE_DIR CMAKE_SOURCE_DIR_NATIVE)
 cmake_path(NATIVE_PATH CMAKE_BINARY_DIR CMAKE_BINARY_DIR_NATIVE)
 
+# For the WSLC SDK, we allow packaging only one platform or not including the C# projection
+# to make it easier to build a local package for development.
+# The list files needed in each case are included conditionally from a nuspec fragment.
+
+# Read a nuspec fragment .in file and expand its CMake variables into the named variable.
+# Pass PLATFORM <arch> to bind the ${PLATFORM} placeholder in the fragment.
+function(read_nuspec_fragment var path)
+    cmake_parse_arguments(ARG "" "PLATFORM" "" ${ARGN})
+    if(DEFINED ARG_PLATFORM)
+        set(PLATFORM "${ARG_PLATFORM}")
+    endif()
+    file(READ "${path}" content)
+    string(CONFIGURE "${content}" content)
+    set(${var} "${content}" PARENT_SCOPE)
+endfunction()
+
+# C# SDK wrapper DLL — AnyCPU, produced for any TARGET_PLATFORM.
+# Only include it when the C# SDK was actually built (WSL_BUILD_SDKCS).
+if(WSL_BUILD_SDKCS)
+    read_nuspec_fragment(NUGET_SDKCS_FILE "${CMAKE_CURRENT_LIST_DIR}/fragments/wslc-cs.nuspec.in")
+else()
+    set(NUGET_SDKCS_FILE "")
+endif()
+
+# x64 native runtime — include when this is an x64 build, or for a multi-arch package.
+if(TARGET_PLATFORM STREQUAL "x64" OR NOT WSL_NUGET_SINGLE_PLATFORM)
+    read_nuspec_fragment(NUGET_X64_RUNTIMES "${CMAKE_CURRENT_LIST_DIR}/fragments/wslc-runtime.nuspec.in" PLATFORM x64)
+else()
+    set(NUGET_X64_RUNTIMES "")
+endif()
+
+# arm64 native runtime — include when this is an arm64 build, or for a multi-arch package.
+if(TARGET_PLATFORM STREQUAL "arm64" OR NOT WSL_NUGET_SINGLE_PLATFORM)
+    read_nuspec_fragment(NUGET_ARM64_RUNTIMES "${CMAKE_CURRENT_LIST_DIR}/fragments/wslc-runtime.nuspec.in" PLATFORM arm64)
+else()
+    set(NUGET_ARM64_RUNTIMES "")
+endif()
+
+# Generate the .nuspec files
 foreach(PACKAGE ${NUGET_PACKAGES})
     configure_file("${CMAKE_CURRENT_LIST_DIR}/${PACKAGE}.in" "${CMAKE_BINARY_DIR}/${PACKAGE}")
 endforeach()

--- a/nuget/Microsoft.WSL.Containers.nuspec.in
+++ b/nuget/Microsoft.WSL.Containers.nuspec.in
@@ -17,17 +17,10 @@
   </metadata>
   <files>
     <file src="${CMAKE_SOURCE_DIR_NATIVE}\src\windows\WslcSDK\wslcsdk.h" target="include"/>
-
-    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\x64\${CMAKE_BUILD_TYPE}\wslcsdkcs.dll" target="lib\${WSL_NUGET_TARGET_FRAMEWORK}\"/>
-    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\x64\${CMAKE_BUILD_TYPE}\Microsoft.WSL.Containers.winmd" target="winmd\Microsoft.WSL.Containers.winmd"/>
-
-    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\x64\${CMAKE_BUILD_TYPE}\wslcsdk.lib" target="runtimes\win-x64\"/>
-    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\x64\${CMAKE_BUILD_TYPE}\wslcsdk.dll" target="runtimes\win-x64\native\"/>
-
-    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\arm64\${CMAKE_BUILD_TYPE}\wslcsdk.lib" target="runtimes\win-arm64\"/>
-    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\arm64\${CMAKE_BUILD_TYPE}\wslcsdk.dll" target="runtimes\win-arm64\native\"/>
-
+    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\${TARGET_PLATFORM}\${CMAKE_BUILD_TYPE}\Microsoft.WSL.Containers.winmd" target="winmd\Microsoft.WSL.Containers.winmd"/>
     <file src="${CMAKE_SOURCE_DIR_NATIVE}\nuget\Microsoft.WSL.Containers\**" exclude="**\net\**"/>
-    <file src="${CMAKE_SOURCE_DIR_NATIVE}\nuget\Microsoft.WSL.Containers\build\net\**" target="build\${WSL_NUGET_TARGET_FRAMEWORK}"/>
+${NUGET_SDKCS_FILE}
+${NUGET_X64_RUNTIMES}
+${NUGET_ARM64_RUNTIMES}
   </files>
 </package>

--- a/nuget/fragments/wslc-cs.nuspec.in
+++ b/nuget/fragments/wslc-cs.nuspec.in
@@ -1,0 +1,2 @@
+    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\${TARGET_PLATFORM}\${CMAKE_BUILD_TYPE}\wslcsdkcs.dll" target="lib\${WSL_NUGET_TARGET_FRAMEWORK}\"/>
+    <file src="${CMAKE_SOURCE_DIR_NATIVE}\nuget\Microsoft.WSL.Containers\build\net\**" target="build\${WSL_NUGET_TARGET_FRAMEWORK}"/>

--- a/nuget/fragments/wslc-runtime.nuspec.in
+++ b/nuget/fragments/wslc-runtime.nuspec.in
@@ -1,0 +1,2 @@
+    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\${PLATFORM}\${CMAKE_BUILD_TYPE}\wslcsdk.lib" target="runtimes\win-${PLATFORM}\"/>
+    <file src="${CMAKE_SOURCE_DIR_NATIVE}\bin\${PLATFORM}\${CMAKE_BUILD_TYPE}\wslcsdk.dll" target="runtimes\win-${PLATFORM}\native\"/>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR enables creating a NuGet package that only targets a single platform by setting the `WSL_NUGET_SINGLE_PLATFORM` flag. This allows for creating a local NuGet during development more easily.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

To allow the conditional inclusion of the binaries, the lists of files to include are moved to separate "fragments" that are only included in the `.nuspec` if needed. Since CMake only allows for variable replacement in `.in` files, we do this by replacing variables that list the files and populating those variables conditionally.

The NuGet also includes the C# projection conditionally based on whether it's built.

In the build pipeline, everything is included in the NuGet.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
