### PR TITLE
Fix message handling and variable assignment

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -3052,7 +3052,6 @@ Return Value:
 
 {
     std::vector<gsl::byte> Buffer;
-    MESSAGE_HEADER* Header{};
     struct sigaction SignalAction;
 
     //

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -3102,7 +3102,7 @@ Return Value:
             break;
 
         default:
-            FATAL_ERROR("Unexpected message {}", Header->MessageType);
+            FATAL_ERROR("Unexpected message {}", Message->Header.MessageType);
         }
     }
 
@@ -3207,7 +3207,7 @@ bool StopPlan9Server(bool Force, wsl::linux::WslDistributionConfig& Config)
     LX_INIT_STOP_PLAN9_SERVER Message{};
     Message.Header.MessageType = LxInitMessageStopPlan9Server;
     Message.Header.MessageSize = sizeof(Message);
-    Message.Force = Message.Force;
+    Message.Force = Force;
 
     const auto& Response = Config.Plan9ControlChannel.Transaction(Message);
 


### PR DESCRIPTION
## Summary 

This PR fixes two small bugs in `init.cpp` 
1. Corrected a self-assignment issue 
2. Fixed an variable reference in error logging for `SessionLeaderEntryUtilityVm`

Both changes ensure the code behaves as intended and improve error reporting accuracy.



## Description of the Pull Request
# Changes Applied 

This file contains both bug fixes that were applied.

## Change 1: StopPlan9Server 

**Fixed self-assignment bug**

```diff
  LX_INIT_STOP_PLAN9_SERVER Message{};
  Message.Header.MessageType = LxInitMessageStopPlan9Server;
  Message.Header.MessageSize = sizeof(Message);
- Message.Force = Message.Force;
+ Message.Force = Force;
```

## Change 2: SessionLeaderEntryUtilityVm (Line 3105)

**Fixed null pointer dereference in error logging**

```diff
  switch (Message->Header.MessageType)
  {
  case LxInitMessageCreateProcessUtilityVm:
      // ...
      break;

  default:
-     FATAL_ERROR("Unexpected message {}", Header->MessageType);
+     FATAL_ERROR("Unexpected message {}", Message->Header.MessageType);
  }
```

**Note:** The fix uses `Message->Header.MessageType` because in this function, `Message` is a pointer (returned from `transaction.ReceiveOrClosed<>()`). This is consistent with line 3094 in the same function which also uses the arrow operator.

---

Both fixes have been successfully applied to init.cpp

This file contains both bug fixes that were applied.

## Change 1: StopPlan9Server (Line 3210)

**Fixed self-assignment bug**

```diff
  LX_INIT_STOP_PLAN9_SERVER Message{};
  Message.Header.MessageType = LxInitMessageStopPlan9Server;
  Message.Header.MessageSize = sizeof(Message);
- Message.Force = Message.Force;
+ Message.Force = Force;
```

## Change 2: SessionLeaderEntryUtilityVm
**Fixed null pointer dereference in error logging**

```diff
  switch (Message->Header.MessageType)
  {
  case LxInitMessageCreateProcessUtilityVm:
      // ...
      break;

  default:
-     FATAL_ERROR("Unexpected message {}", Header->MessageType);
+     FATAL_ERROR("Unexpected message {}", Message->Header.MessageType);
  }
```
