### PR TITLE
Add C# files to nuspec used in package stage

### DIFF
--- a/.pipelines/build-job.yml
+++ b/.pipelines/build-job.yml
@@ -124,7 +124,7 @@ jobs:
         displayName: "CMake ${{ parameters.platform }}"
         inputs:
           workingDirectory: "."
-          cmakeArgs: . --fresh -A ${{ parameters.platform }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }} -DOFFICIAL_BUILD=${{ parameters.isRelease }} -DINCLUDE_PACKAGE_STAGE=${{ or(parameters.isRelease, parameters.isNightly) }} -DPIPELINE_BUILD_ID=$(Build.BuildId) -DVSO_ORG=${{ parameters.vsoOrg }} -DVSO_PROJECT=${{ parameters.vsoProject }} -DWSL_BUILD_WSL_SETTINGS=true -DWSL_BUILD_SDKCS=true $(packageInputDirArg)\${{ parameters.platform }}
+          cmakeArgs: . --fresh -A ${{ parameters.platform }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DSKIP_PACKAGE_SIGNING=${{ parameters.isRelease }} -DOFFICIAL_BUILD=${{ parameters.isRelease }} -DINCLUDE_PACKAGE_STAGE=${{ or(parameters.isRelease, parameters.isNightly) }} -DPIPELINE_BUILD_ID=$(Build.BuildId) -DVSO_ORG=${{ parameters.vsoOrg }} -DVSO_PROJECT=${{ parameters.vsoProject }} -DWSL_BUILD_WSL_SETTINGS=true -DWSL_INCLUDE_SDK_CSHARP=true $(packageInputDirArg)\${{ parameters.platform }}
 
       # Workaround for WSL Settings NuGet restore authentication issue
       - script: _deps\nuget.exe restore -NonInteractive

--- a/.pipelines/package-stage.yml
+++ b/.pipelines/package-stage.yml
@@ -98,7 +98,7 @@ stages:
             displayName: "CMake configure (bundle-only)"
             inputs:
               workingDirectory: "."
-              cmakeArgs: . -DBUNDLE_ONLY=TRUE -DCMAKE_BUILD_TYPE=Release -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DWSL_BUILD_SDKCS=true
+              cmakeArgs: . -DBUNDLE_ONLY=TRUE -DCMAKE_BUILD_TYPE=Release -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DWSL_INCLUDE_SDK_CSHARP=true
 
           - script: cmake --build . --config Release --target bundle -- -m
             displayName: Create msixbundle

--- a/.pipelines/package-stage.yml
+++ b/.pipelines/package-stage.yml
@@ -98,7 +98,7 @@ stages:
             displayName: "CMake configure (bundle-only)"
             inputs:
               workingDirectory: "."
-              cmakeArgs: . -DBUNDLE_ONLY=TRUE -DCMAKE_BUILD_TYPE=Release -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION)
+              cmakeArgs: . -DBUNDLE_ONLY=TRUE -DCMAKE_BUILD_TYPE=Release -DPACKAGE_VERSION=$(version.WSL_PACKAGE_VERSION) -DWSL_NUGET_PACKAGE_VERSION=$(version.WSL_NUGET_PACKAGE_VERSION) -DWSL_BUILD_SDKCS=true
 
           - script: cmake --build . --config Release --target bundle -- -m
             displayName: Create msixbundle

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,8 +175,8 @@ if (NOT DEFINED WSL_BUILD_WSL_SETTINGS)
     set(WSL_BUILD_WSL_SETTINGS false)
 endif ()
 
-if (NOT DEFINED WSL_BUILD_SDKCS)
-    set(WSL_BUILD_SDKCS false)
+if (NOT DEFINED WSL_INCLUDE_SDK_CSHARP)
+    set(WSL_INCLUDE_SDK_CSHARP false)
 endif ()
 
 find_commit_hash(COMMIT_HASH)

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -37,7 +37,7 @@ endif()
 # set(WSL_BUILD_WSL_SETTINGS true)
 
 # # Uncomment to build the C# WSLC sdk
-# set(WSL_BUILD_SDKCS true)
+# set(WSL_INCLUDE_SDK_CSHARP true)
 
 # # Uncomment to configure the WSLC SDK NuGet to only target the current platform
 # set(WSL_NUGET_SINGLE_PLATFORM true)

--- a/nuget/CMakeLists.txt
+++ b/nuget/CMakeLists.txt
@@ -22,8 +22,7 @@ function(read_nuspec_fragment var path)
 endfunction()
 
 # C# SDK wrapper DLL — AnyCPU, produced for any TARGET_PLATFORM.
-# Only include it when the C# SDK was actually built (WSL_BUILD_SDKCS).
-if(WSL_BUILD_SDKCS)
+if(WSL_INCLUDE_SDK_CSHARP)
     read_nuspec_fragment(NUGET_SDKCS_FILE "${CMAKE_CURRENT_LIST_DIR}/fragments/wslc-cs.nuspec.in")
 else()
     set(NUGET_SDKCS_FILE "")

--- a/src/windows/WslcSDK/CMakeLists.txt
+++ b/src/windows/WslcSDK/CMakeLists.txt
@@ -23,7 +23,7 @@ set_target_properties(wslcsdk
 
 add_subdirectory(winrt)
 
-if (WSL_BUILD_SDKCS)
+if (WSL_INCLUDE_SDK_CSHARP)
     add_subdirectory(csharp)
 endif()
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

In #40623 I made the inclusion of files in the SDK nuget conditional on what was configured to build. The package stage of the build pipeline does not use the .nuspec from the build stage, so by default it does not include the C# files. This change tells the package stage to include them.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
