### PR TITLE
Pipelines: exclude .ps1 from CodeSign in package stage

### DIFF
--- a/.pipelines/package-stage.yml
+++ b/.pipelines/package-stage.yml
@@ -45,6 +45,7 @@ stages:
           ob_outputDirectory: '$(Build.SourcesDirectory)\out'
           ob_artifactBaseName: 'drop_wsl'
           ob_artifactSuffix: '_package'
+          ob_sdl_codeSignValidation_excludes: -|**\*.ps1
           buildStagePackageVersion: $[ stageDependencies.build_x64.build_x64.outputs['version.WSL_PACKAGE_VERSION'] ]
           buildStageNugetVersion: $[ stageDependencies.build_x64.build_x64.outputs['version.WSL_NUGET_PACKAGE_VERSION'] ]
 


### PR DESCRIPTION
## Summary

The Guardian CodeSign post-analysis in the **package** job (build [147884488](https://dev.azure.com/microsoft/Microsoft.WSL/_build/results?buildId=147884488)) is failing on in-repo .ps1 scripts (`diagnostics/collect-wsl-logs.ps1`, `tools/deploy/*.ps1`, `triage/install-latest-wsl.ps1`, etc.) that are not shipped and don't need signing.

PR #40541 fixed this for the build job and added `ob_sdl_codeSignValidation_excludes: -|**\*.ps1` as a pipeline-level variable in the three `wsl-build-*-onebranch.yml` files. However, the `package` job in `package-stage.yml` declares its own job-level `variables:` block, and OneBranch's SDL injection only honors `ob_sdl_*` variables at job scope — so the pipeline-level value isn't being applied to the package job.

## PR Checklist

- [x] Issue exists in the WSL repo for this change
- [x] Validation steps below

## Detailed Description of the PR

Add `ob_sdl_codeSignValidation_excludes: -|**\*.ps1` to the `package` job's `variables:` block in `.pipelines/package-stage.yml`, mirroring what `build-job.yml` already does.

## Validation Steps

Run the release / nightly pipeline and confirm the package stage's 🛡 Guardian: Post Analysis step no longer reports `CodeSign.MissingSigningCert` errors for in-repo `.ps1` files.