### PR TITLE
virtio: improve virtiofs and VirtioProxy performance with per-device SWIOTLB pool

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1126,6 +1126,14 @@ Attempting web download...</value>
   <data name="MessageConfigVirtio9pDisabled" xml:space="preserve">
     <value>wsl2.virtio9p is disabled, falling back to 9p with vsock transport.</value>
   </data>
+  <data name="MessageVirtioProxyRequiresVirtio" xml:space="preserve">
+    <value>VirtioProxy networking is not supported when wsl2.virtio is disabled; falling back to networkingMode {}.</value>
+    <comment>{Locked="wsl2.virtio"}{Locked="VirtioProxy"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageSwiotlbKernelUnsupported" xml:space="preserve">
+    <value>The running kernel is missing a patch that significantly improves virtio device performance. Update to a more recent WSL kernel to enable this optimization.</value>
+    <comment>{Locked="virtio"}</comment>
+  </data>
   <data name="MessageInstallationCorrupted" xml:space="preserve">
     <value>WSL installation appears to be corrupted (Error code: {}).
 Press any key to repair WSL, or CTRL-C to cancel.

--- a/packages.config
+++ b/packages.config
@@ -19,8 +19,8 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.23-0" />
-  <package id="Microsoft.WSL.Kernel" version="6.18.26.1-1" targetFramework="native" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.29-0" />
+  <package id="Microsoft.WSL.Kernel" version="6.18.26.3-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -106,6 +106,23 @@ void HandleMessageImpl(
 }
 
 void HandleMessageImpl(
+    wsl::shared::SocketChannel& Channel,
+    wsl::shared::Transaction& Transaction,
+    const WSLC_GET_GUEST_CAPABILITIES& Message,
+    const gsl::span<gsl::byte>& Buffer)
+{
+    WSLC_GET_GUEST_CAPABILITIES_RESULT response{};
+    response.Header.MessageType = WSLC_GET_GUEST_CAPABILITIES_RESULT::Type;
+    response.Header.MessageSize = sizeof(response);
+
+    auto pool = UtilReadHvPciSwiotlbPool();
+    response.HvPciSwiotlbBase = pool.Base;
+    response.HvPciSwiotlbSize = pool.Size;
+
+    Transaction.Send<WSLC_GET_GUEST_CAPABILITIES_RESULT>(response);
+}
+
+void HandleMessageImpl(
     wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const WSLC_ACCEPT& Message, const gsl::span<gsl::byte>& Buffer)
 {
     sockaddr_vm SocketAddress{};
@@ -836,7 +853,7 @@ void ProcessMessage(wsl::shared::SocketChannel& Channel, wsl::shared::Transactio
 {
     try
     {
-        HandleMessage<WSLC_GET_DISK, WSLC_MOUNT, WSLC_EXEC, WSLC_FORK, WSLC_CONNECT, WSLC_SIGNAL, WSLC_TTY_RELAY, WSLC_PORT_RELAY, WSLC_UNMOUNT, WSLC_DETACH, WSLC_ACCEPT, WSLC_WATCH_PROCESSES, WSLC_UNIX_CONNECT>(
+        HandleMessage<WSLC_GET_DISK, WSLC_MOUNT, WSLC_EXEC, WSLC_FORK, WSLC_CONNECT, WSLC_SIGNAL, WSLC_TTY_RELAY, WSLC_PORT_RELAY, WSLC_UNMOUNT, WSLC_DETACH, WSLC_ACCEPT, WSLC_WATCH_PROCESSES, WSLC_UNIX_CONNECT, WSLC_GET_GUEST_CAPABILITIES>(
             Channel, Transaction, Type, Buffer);
     }
     catch (...)

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3391,14 +3391,15 @@ try
     wsl::shared::MessageWriter<LX_INIT_GUEST_CAPABILITIES> Message(LxMiniInitMessageGuestCapabilities);
     Message.WriteString(Version.release);
 
-    //
     // SECCOMP_USER_NOTIF_FLAG_CONTINUE is the latest flag that flow steering needs
     // but there's no way to test for its presence. The assumption is that if seccomp is available
-    // and the kernel version is >= 5.10, then SECCOMP_USER_NOTIF_FLAG_CONTINUE is available
-    //
-
+    // and the kernel version is >= 5.10, then SECCOMP_USER_NOTIF_FLAG_CONTINUE is available.
     uint32_t SeccompFlag = SECCOMP_RET_USER_NOTIF;
     Message->SeccompAvailable = syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 0, &SeccompFlag) == 0;
+
+    auto pool = UtilReadHvPciSwiotlbPool();
+    Message->HvPciSwiotlbBase = pool.Base;
+    Message->HvPciSwiotlbSize = pool.Size;
 
     Channel.SendMessage<LX_INIT_GUEST_CAPABILITIES>(Message.Span());
     return 0;

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3326,6 +3326,22 @@ std::string UtilReadFileContent(std::string_view path)
     return {std::istreambuf_iterator<char>(file), {}};
 }
 
+HvPciSwiotlbPool UtilReadHvPciSwiotlbPool()
+{
+    HvPciSwiotlbPool pool{};
+    try
+    {
+        pool.Base = std::stoull(UtilReadFileContent("/sys/bus/vmbus/drivers/hv_pci/swiotlb_base"), nullptr, 0);
+        pool.Size = std::stoull(UtilReadFileContent("/sys/bus/vmbus/drivers/hv_pci/swiotlb_size"), nullptr, 0);
+    }
+    catch (...)
+    {
+        pool = {};
+    }
+
+    return pool;
+}
+
 uint16_t UtilWinAfToLinuxAf(uint16_t WinAddressFamily)
 {
     uint16_t LinuxAddressFamily = AF_UNSPEC;

--- a/src/linux/init/util.h
+++ b/src/linux/init/util.h
@@ -311,6 +311,17 @@ std::wstring UtilReadFileContentW(std::string_view path);
 
 std::string UtilReadFileContent(std::string_view path);
 
+// Holds the hv_pci swiotlb pool the WSL kernel reserved at boot and published
+// under /sys/bus/vmbus/drivers/hv_pci/swiotlb_{base,size}. Both fields are zero
+// when running on a kernel that does not publish these files.
+struct HvPciSwiotlbPool
+{
+    uint64_t Base = 0;
+    uint64_t Size = 0;
+};
+
+HvPciSwiotlbPool UtilReadHvPciSwiotlbPool();
+
 uint16_t UtilWinAfToLinuxAf(uint16_t AddressFamily);
 
 int WriteToFile(const char* Path, const char* Content, int permissions = 0644);

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -403,6 +403,8 @@ typedef enum _LX_MESSAGE_TYPE
     LxMessageWSLCWatchProcesses,
     LxMessageWSLCProcessExited,
     LxMessageWSLCUnixConnect,
+    LxMessageWSLCGetGuestCapabilities,
+    LxMessageWSLCGetGuestCapabilitiesResult,
 } LX_MESSAGE_TYPE,
     *PLX_MESSAGE_TYPE;
 
@@ -513,6 +515,8 @@ inline auto ToString(LX_MESSAGE_TYPE messageType)
         X(LxMessageWSLCWatchProcesses)
         X(LxMessageWSLCProcessExited)
         X(LxMessageWSLCUnixConnect)
+        X(LxMessageWSLCGetGuestCapabilities)
+        X(LxMessageWSLCGetGuestCapabilitiesResult)
 
     default:
         return "<unexpected LX_MESSAGE_TYPE>";
@@ -1430,9 +1434,11 @@ typedef struct _LX_INIT_GUEST_CAPABILITIES
 
     MESSAGE_HEADER Header;
     bool SeccompAvailable;
+    uint64_t HvPciSwiotlbBase;
+    uint64_t HvPciSwiotlbSize;
     char Buffer[]; // Contains the kernel version string
 
-    PRETTY_PRINT(FIELD(Header), FIELD(SeccompAvailable), BUFFER_FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(SeccompAvailable), FIELD(HvPciSwiotlbBase), FIELD(HvPciSwiotlbSize), BUFFER_FIELD(Buffer));
 } LX_INIT_GUEST_CAPABILITIES, *PLX_INIT_GUEST_CAPABILITIES;
 
 typedef struct _LX_MINI_INIT_WAIT_FOR_PMEM_DEVICE_MESSAGE
@@ -1834,6 +1840,29 @@ struct WSLC_UNIX_CONNECT
     char Buffer[];
 
     PRETTY_PRINT(FIELD(Header), STRING_FIELD(PathOffset));
+};
+
+struct WSLC_GET_GUEST_CAPABILITIES_RESULT
+{
+    static inline auto Type = LxMessageWSLCGetGuestCapabilitiesResult;
+
+    MESSAGE_HEADER Header{};
+    uint64_t HvPciSwiotlbBase{};
+    uint64_t HvPciSwiotlbSize{};
+
+    PRETTY_PRINT(FIELD(Header), FIELD(HvPciSwiotlbBase), FIELD(HvPciSwiotlbSize));
+};
+
+struct WSLC_GET_GUEST_CAPABILITIES
+{
+    static inline auto Type = LxMessageWSLCGetGuestCapabilities;
+    using TResponse = WSLC_GET_GUEST_CAPABILITIES_RESULT;
+
+    DECLARE_MESSAGE_CTOR(WSLC_GET_GUEST_CAPABILITIES);
+
+    MESSAGE_HEADER Header{};
+
+    PRETTY_PRINT(FIELD(Header));
 };
 
 typedef struct _LX_MINI_INIT_IMPORT_RESULT

--- a/src/windows/common/GuestDeviceManager.cpp
+++ b/src/windows/common/GuestDeviceManager.cpp
@@ -35,12 +35,15 @@ GUID GuestDeviceManager::AddHdvShareWithOptions(
     // Options are appended to the name with a semi-colon separator.
     //  "name;key1=value1;key2=value2"
     // The AddSharePath implementation is responsible for separating them out and interpreting them.
+    // N.B. A ";vm_id=<guid>" option is always appended so the device host can identify the owning VM.
     std::wstring nameWithOptions{AccessName};
-    if (ARGUMENT_PRESENT(Options))
+    if (ARGUMENT_PRESENT(Options) && Options[0] != L'\0')
     {
         nameWithOptions += L";";
         nameWithOptions += Options;
     }
+
+    nameWithOptions += std::format(L";vm_id={}", m_machineId);
 
     {
         auto revert = wil::impersonate_token(UserToken);

--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -15,12 +15,18 @@ static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
 VirtioNetworking::VirtioNetworking(
-    GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken) :
+    GnsChannel&& gnsChannel,
+    VirtioNetworkingFlags flags,
+    LPCWSTR dnsOptions,
+    std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+    wil::shared_handle userToken,
+    std::wstring swiotlbConfig) :
     m_guestDeviceManager(std::move(guestDeviceManager)),
     m_userToken(std::move(userToken)),
     m_gnsChannel(std::move(gnsChannel)),
     m_flags(flags),
-    m_dnsOptions(dnsOptions)
+    m_dnsOptions(dnsOptions),
+    m_swiotlbOption(std::move(swiotlbConfig))
 {
 }
 
@@ -210,7 +216,13 @@ void VirtioNetworking::RefreshGuestConnection()
         if (!m_adapterId.has_value())
         {
             m_adapterId = m_guestDeviceManager->AddGuestDevice(
-                VIRTIO_NET_DEVICE_ID, VIRTIO_NET_CLASS_ID, c_eth0DeviceName, nullptr, device_options.c_str(), 0, m_userToken.get());
+                VIRTIO_NET_DEVICE_ID,
+                VIRTIO_NET_CLASS_ID,
+                c_eth0DeviceName,
+                m_swiotlbOption.c_str(),
+                device_options.c_str(),
+                0,
+                m_userToken.get());
         }
         else
         {
@@ -244,7 +256,7 @@ void VirtioNetworking::SetupLoopbackDevice()
         VIRTIO_NET_DEVICE_ID,
         VIRTIO_NET_CLASS_ID,
         c_loopbackDeviceName,
-        nullptr,
+        m_swiotlbOption.c_str(),
         L"client_ip=127.0.0.1;client_mac=00:11:22:33:44:55",
         0,
         m_userToken.get());

--- a/src/windows/common/VirtioNetworking.h
+++ b/src/windows/common/VirtioNetworking.h
@@ -22,7 +22,13 @@ DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
 class VirtioNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(GnsChannel&& gnsChannel, VirtioNetworkingFlags flags, LPCWSTR dnsOptions, std::shared_ptr<GuestDeviceManager> guestDeviceManager, wil::shared_handle userToken);
+    VirtioNetworking(
+        GnsChannel&& gnsChannel,
+        VirtioNetworkingFlags flags,
+        LPCWSTR dnsOptions,
+        std::shared_ptr<GuestDeviceManager> guestDeviceManager,
+        wil::shared_handle userToken,
+        std::wstring swiotlbConfig);
 
     ~VirtioNetworking();
 
@@ -62,6 +68,7 @@ private:
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
     VirtioNetworkingFlags m_flags = VirtioNetworkingFlags::None;
     LPCWSTR m_dnsOptions = nullptr;
+    std::wstring m_swiotlbOption;
     std::optional<GUID> m_localhostAdapterId;
     std::optional<GUID> m_adapterId;
 

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -14,6 +14,7 @@ Abstract:
 
 #include "precomp.h"
 #include "WslCoreConfig.h"
+#include "helpers.hpp"
 #include "Localization.h"
 #include "WslCoreFirewallSupport.h"
 #include "WslCoreNetworkingSupport.h"
@@ -124,7 +125,8 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         ConfigKey(ConfigSetting::Experimental::InitialAutoProxyTimeout, InitialAutoProxyTimeout),
         ConfigKey(ConfigSetting::Experimental::IgnoredPorts, std::move(parseIgnoredPorts)),
         ConfigKey(ConfigSetting::Experimental::HostAddressLoopback, EnableHostAddressLoopback),
-        ConfigKey(ConfigSetting::Experimental::SetVersionDebug, SetVersionDebug)};
+        ConfigKey(ConfigSetting::Experimental::SetVersionDebug, SetVersionDebug),
+        ConfigKey(ConfigSetting::Experimental::Swiotlb, MemoryString(SwiotlbSizeBytes))};
 
     wil::unique_file ConfigFile;
     if (ConfigFilePath != nullptr)
@@ -398,22 +400,6 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
         }
     }
 
-    // Load NAT configuration from the registry.
-    if (NetworkingMode == wsl::core::NetworkingMode::Nat)
-    {
-        try
-        {
-            const auto machineKey = wsl::windows::common::registry::OpenLxssMachineKey();
-            NatGateway = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natGatewayAddress, L"");
-            NatNetwork = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natNetwork, L"");
-
-            auto runAsUser = wil::impersonate_token(UserToken);
-            const auto userKey = wsl::windows::common::registry::OpenLxssUserKey();
-            NatIpAddress = wsl::windows::common::registry::ReadString(userKey.get(), nullptr, c_natIpAddress, L"");
-        }
-        CATCH_LOG()
-    }
-
     // Due to an issue with Global Secure Access Client, do not use DNS tunneling if the service is present.
     if (EnableDnsTunneling)
     {
@@ -454,12 +440,26 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
     {
         VALIDATE_CONFIG_OPTION(!EnableVirtio, EnableVirtio9p, false);
         VALIDATE_CONFIG_OPTION(!EnableVirtio, EnableVirtioFs, false);
+        VALIDATE_CONFIG_OPTION(!EnableVirtio, SwiotlbSizeBytes, 0);
+
+        if (NetworkingMode == NetworkingMode::VirtioProxy)
+        {
+            NetworkingMode = (defaultNetworkingMode == NetworkingMode::VirtioProxy) ? NetworkingMode::None : NetworkingMode::Nat;
+            EMIT_USER_WARNING(wsl::shared::Localization::MessageVirtioProxyRequiresVirtio(ToString(NetworkingMode)));
+        }
     }
 
     if (EnableVirtio9p)
     {
         EMIT_USER_WARNING(wsl::shared::Localization::MessageConfigVirtio9pDisabled());
         EnableVirtio9p = false;
+    }
+
+    // Compute a default swiotlb config only when a virtio device that requires bounce buffers is present.
+    // N.B. Must run after policy overrides so networking/fs modes reflect final values.
+    if (SwiotlbSizeBytes == 0 && (EnableVirtioFs || EnableVirtio9p || (NetworkingMode == NetworkingMode::VirtioProxy)))
+    {
+        SwiotlbSizeBytes = wsl::windows::common::helpers::ComputeDefaultSwiotlbConfig(MemorySizeBytes);
     }
 
     if (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::VirtioProxy)
@@ -480,6 +480,23 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
     {
         VALIDATE_CONFIG_OPTION((NetworkingMode != NetworkingMode::Mirrored), IgnoredPorts, std::set<uint16_t>{});
         VALIDATE_CONFIG_OPTION((NetworkingMode != NetworkingMode::Mirrored), EnableHostAddressLoopback, false);
+    }
+
+    // Load NAT configuration from the registry.
+    // N.B. This must be done after all networking mode adjustments (e.g. VirtioProxy -> NAT fallback).
+    if (NetworkingMode == wsl::core::NetworkingMode::Nat)
+    {
+        try
+        {
+            const auto machineKey = wsl::windows::common::registry::OpenLxssMachineKey();
+            NatGateway = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natGatewayAddress, L"");
+            NatNetwork = wsl::windows::common::registry::ReadString(machineKey.get(), nullptr, c_natNetwork, L"");
+
+            auto runAsUser = wil::impersonate_token(UserToken);
+            const auto userKey = wsl::windows::common::registry::OpenLxssUserKey();
+            NatIpAddress = wsl::windows::common::registry::ReadString(userKey.get(), nullptr, c_natIpAddress, L"");
+        }
+        CATCH_LOG()
     }
 }
 

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -27,11 +27,11 @@ Abstract:
         T_VALUE(c, EnableHostAddressLoopback), T_VALUE(c, EnableHostFileSystemAccess), T_VALUE(c, EnableIpv6), \
         T_VALUE(c, EnableLocalhostRelay), T_VALUE(c, EnableNestedVirtualization), T_VALUE(c, EnableSafeMode), \
         T_VALUE(c, EnableSparseVhd), T_VALUE(c, EnableVirtio), T_VALUE(c, EnableVirtio9p), T_VALUE(c, EnableVirtioFs), \
-        T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), \
-        T_VALUE(c, KernelDebugPort), T_SET(c, KernelModulesPath), T_STRING(c, KernelModulesList), T_SET(c, KernelPath), \
-        T_VALUE(c, LoadDefaultKernelModules), T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), \
-        T_VALUE(c, MaximumProcessorCount), T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), \
-        T_ENUM(c, NetworkingMode), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), \
+        T_ENUM(c, FirewallConfigPresence), T_VALUE(c, KernelBootTimeout), T_SET(c, KernelCommandLine), T_VALUE(c, KernelDebugPort), \
+        T_STRING(c, KernelModulesList), T_SET(c, KernelModulesPath), T_SET(c, KernelPath), T_VALUE(c, LoadDefaultKernelModules), \
+        T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), T_VALUE(c, MaximumProcessorCount), \
+        T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), T_ENUM(c, NetworkingMode), \
+        T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_VALUE(c, SwiotlbSizeBytes), \
         T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
 namespace wsl::core {
@@ -289,6 +289,7 @@ namespace ConfigSetting {
         static constexpr auto IgnoredPorts = "experimental.ignoredPorts";
         static constexpr auto HostAddressLoopback = "experimental.hostAddressLoopback";
         static constexpr auto SetVersionDebug = "experimental.setVersionDebug";
+        static constexpr auto Swiotlb = "experimental.swiotlb";
 
     } // namespace Experimental
 } // namespace ConfigSetting
@@ -375,6 +376,7 @@ struct Config
     bool EnableHostAddressLoopback = false;
     std::filesystem::path CrashDumpFolder;
     int MaxCrashDumpCount = 10;
+    UINT64 SwiotlbSizeBytes = 0;
 
     // Temporary config value to help root cause the truncated archive errors in SetVersion()
     bool SetVersionDebug = false;

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -762,7 +762,7 @@ try
 }
 CATCH_LOG()
 
-void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder)
+void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ ULONG64 swiotlbSizeBytes)
 {
     // Enable timesync workaround to sync on resume from sleep in modern standby.
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
@@ -772,4 +772,24 @@ void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::w
 
     // Configure page reporting order - minimum order of pages reported as free to the hypervisor.
     kernelCmdLine += std::format(L" page_reporting.page_reporting_order={}", pageReportingOrder);
+
+    // Reserve a swiotlb bounce buffer for virtio devices.
+    if (swiotlbSizeBytes != 0)
+    {
+        kernelCmdLine += std::format(L" swiotlb=force hv_pci_swiotlb={}", swiotlbSizeBytes);
+    }
+}
+
+UINT64 wsl::windows::common::helpers::ComputeDefaultSwiotlbConfig(_In_ UINT64 memoryBytes)
+{
+    constexpr UINT64 c_swiotlbSize = 64 * _1MB;
+
+    // Skip swiotlb on VMs that cannot fit the reserved buffer. Users can still opt in explicitly
+    // via experimental.swiotlb in .wslconfig.
+    if (memoryBytes < _1GB + c_swiotlbSize)
+    {
+        return {};
+    }
+
+    return c_swiotlbSize;
 }

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -205,6 +205,8 @@ bool TryAttachConsole();
 
 void RegisterWithDcat(_In_ bool IncludeVersionNumber = true);
 
-void AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder);
+void AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ ULONG64 swiotlbSizeBytes);
+
+UINT64 ComputeDefaultSwiotlbConfig(_In_ UINT64 memoryBytes);
 
 } // namespace wsl::windows::common::helpers

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -134,12 +134,19 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
 #endif
 
+    // Compute a swiotlb device-options token sized to fit this VM's RAM, used by the kernel
+    // command line, virtiofs shares, and the VirtioProxy virtio-net adapter.
+    // Only needed when a virtio device that requires bounce buffers will be attached.
+    ULONG64 swiotlbSizeBytes = 0;
+    if (FeatureEnabled(WslcFeatureFlagsVirtioFs) || m_networkingMode == WSLCNetworkingModeVirtioProxy)
+    {
+        swiotlbSizeBytes = helpers::ComputeDefaultSwiotlbConfig(static_cast<UINT64>(Settings->MemoryMb) * _1MB);
+    }
+
     // Initialize kernel command line.
     std::wstring kernelCmdLine = L"initrd=\\" LXSS_VM_MODE_INITRD_NAME L" " TEXT(WSLC_ROOT_INIT_ENV) L"=1 panic=-1";
     kernelCmdLine += std::format(L" nr_cpus={}", Settings->CpuCount);
-
-    // Append common kernel parameters shared between WSL2 and WSLC.
-    helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder);
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder, swiotlbSizeBytes);
 
     // Setup dmesg collector with optional DmesgOutput handle.
     // TODO: move dmesg collector to user session process.
@@ -456,7 +463,7 @@ try
         }
 
         m_networkEngine = std::make_unique<wsl::core::VirtioNetworking>(
-            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken);
+            wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken, m_swiotlbOption);
     }
     else
     {
@@ -573,11 +580,22 @@ try
     }
     else
     {
+        std::wstring options = ReadOnly ? L"ro" : L"";
+        if (!m_swiotlbOption.empty())
+        {
+            if (!options.empty())
+            {
+                options += L";";
+            }
+
+            options += m_swiotlbOption;
+        }
+
         it->second = m_guestDeviceManager->AddGuestDevice(
             VIRTIO_FS_DEVICE_ID,
             m_virtioFsClassId,
             shareName.c_str(),
-            ReadOnly ? L"ro" : L"",
+            options.c_str(),
             WindowsPath,
             VIRTIO_FS_FLAGS_TYPE_FILES,
             m_userToken.get());
@@ -609,6 +627,29 @@ try
     }
 
     m_shares.erase(it);
+
+    return S_OK;
+}
+CATCH_RETURN()
+
+HRESULT HcsVirtualMachine::ApplyGuestCapabilities(_In_ const WSLCGuestCapabilities* Capabilities)
+try
+{
+    RETURN_HR_IF_NULL(E_POINTER, Capabilities);
+
+    std::lock_guard lock(m_lock);
+
+    THROW_HR_IF(E_INVALIDARG, !m_swiotlbOption.empty());
+
+    if (Capabilities->HvPciSwiotlbBase != 0 && Capabilities->HvPciSwiotlbSize != 0)
+    {
+        m_swiotlbOption = std::format(L"swiotlb=0x{:x},{}", Capabilities->HvPciSwiotlbBase, Capabilities->HvPciSwiotlbSize);
+    }
+
+    WSL_LOG(
+        "WSLCApplyGuestCapabilities",
+        TraceLoggingValue(Capabilities->HvPciSwiotlbBase, "HvPciSwiotlbBase"),
+        TraceLoggingValue(Capabilities->HvPciSwiotlbSize, "HvPciSwiotlbSize"));
 
     return S_OK;
 }

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -44,6 +44,7 @@ public:
     IFACEMETHOD(DetachDisk)(_In_ ULONG Lun) override;
     IFACEMETHOD(AddShare)(_In_ LPCWSTR WindowsPath, _In_ BOOL ReadOnly, _Out_ GUID* ShareId) override;
     IFACEMETHOD(RemoveShare)(_In_ REFGUID ShareId) override;
+    IFACEMETHOD(ApplyGuestCapabilities)(_In_ const WSLCGuestCapabilities* Capabilities) override;
     IFACEMETHOD(GetTerminationEvent)(_Out_ HANDLE* Event) override;
 
 private:
@@ -78,6 +79,9 @@ private:
 
     WSLCFeatureFlags m_featureFlags{};
     WSLCNetworkingMode m_networkingMode{};
+
+    // Swiotlb device-options token sized to fit inside the VM's RAM (empty when too small).
+    std::wstring m_swiotlbOption;
 
     wil::unique_socket m_listenSocket;
     std::shared_ptr<DmesgCollector> m_dmesgCollector;

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -415,6 +415,28 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
         addShare(TEXT(LXSS_GPU_PACKAGED_LIB_SHARE), path.c_str());
     }
 
+    // Accept a connection from mini_init with a receive timeout so the service does not get stuck waiting for a response from the VM.
+    m_miniInitChannel =
+        wsl::shared::SocketChannel{AcceptConnection(m_vmConfig.KernelBootTimeout), "mini_init", {m_terminatingEvent.get()}};
+
+    // Accept the connection from the Linux guest for notifications.
+    m_notifyChannel = AcceptConnection(m_vmConfig.KernelBootTimeout);
+
+    // Receive and parse the guest kernel version
+    ReadGuestCapabilities();
+
+    // Cache the effective swiotlb configuration. The kernel picks a valid GPA, allocates the pool,
+    // and publishes the actual (base, size) via sysfs. Only warn when swiotlb was actually
+    // requested via the kernel command line; otherwise the kernel correctly doesn't allocate.
+    if (m_hvPciSwiotlbBase != 0 && m_hvPciSwiotlbSize != 0)
+    {
+        m_swiotlbOption = std::format(L"swiotlb=0x{:x},{}", m_hvPciSwiotlbBase, m_hvPciSwiotlbSize);
+    }
+    else if (m_vmConfig.SwiotlbSizeBytes != 0)
+    {
+        EMIT_USER_WARNING(wsl::shared::Localization::MessageSwiotlbKernelUnsupported());
+    }
+
     // Asynchronously add drvfs devices if supported.
     if (m_vmConfig.EnableHostFileSystemAccess)
     {
@@ -437,16 +459,6 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             }
         }).detach();
     }
-
-    // Accept a connection from mini_init with a receive timeout so the service does not get stuck waiting for a response from the VM.
-    m_miniInitChannel =
-        wsl::shared::SocketChannel{AcceptConnection(m_vmConfig.KernelBootTimeout), "mini_init", {m_terminatingEvent.get()}};
-
-    // Accept the connection from the Linux guest for notifications.
-    m_notifyChannel = AcceptConnection(m_vmConfig.KernelBootTimeout);
-
-    // Receive and parse the guest kernel version
-    ReadGuestCapabilities();
 
     // Mount the system distro.
     // N.B. If using SCSI, the system distro is added during VM creation.
@@ -586,8 +598,9 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
                 WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::DnsTunneling, m_vmConfig.EnableDnsTunneling);
                 // NAT may have fallen back to virtio proxy after the early-config message; drop the unused DNS hvsocket.
                 dnsTunnelingSocket.reset();
+
                 m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
-                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken);
+                    std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken, m_swiotlbOption);
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::Bridged)
             {
@@ -1539,13 +1552,7 @@ std::wstring WslCoreVm::GenerateConfigJson()
     kernelCmdLine += std::format(L" nr_cpus={}", m_vmConfig.ProcessorCount);
 
     // Append common kernel parameters shared between WSL2 and WSLC.
-    helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder);
-
-    // If using virtio features, enable SWIOTLB as a perf optimization (will cause VM to consume 64MB more memory).
-    if (m_vmConfig.EnableVirtio9p || m_vmConfig.EnableVirtioFs || m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)
-    {
-        kernelCmdLine += L" swiotlb=force";
-    }
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder, m_vmConfig.SwiotlbSizeBytes);
 
     if (m_vmConfig.EnableVirtio && helpers::IsVirtioSerialConsoleSupported())
     {
@@ -2162,10 +2169,23 @@ std::pair<std::wstring, std::wstring> WslCoreVm::AddVirtioFsShare(_In_ bool Admi
 
     sharePath = std::filesystem::weakly_canonical(sharePath).wstring();
 
+    // Append the swiotlb token here so it covers fixed-drive, dynamic add, and remount paths.
+    // Duplicate swiotlb tokens are harmless: VirtioFsShare parses options into a map.
+    std::wstring effectiveOptions(Options);
+    if (!m_swiotlbOption.empty())
+    {
+        if (!effectiveOptions.empty())
+        {
+            effectiveOptions += L';';
+        }
+
+        effectiveOptions += m_swiotlbOption;
+    }
+
     // Check if a matching share already exists.
     bool created = false;
     std::wstring tag;
-    VirtioFsShare key(sharePath.c_str(), Options, Admin);
+    VirtioFsShare key(sharePath.c_str(), effectiveOptions.c_str(), Admin);
     if (!m_virtioFsShares.contains(key))
     {
         // Generate a new unique tag for the share.
@@ -2198,7 +2218,7 @@ std::pair<std::wstring, std::wstring> WslCoreVm::AddVirtioFsShare(_In_ bool Admi
         "WslCoreVmAddVirtioFsShare",
         TraceLoggingValue(Admin, "admin"),
         TraceLoggingValue(sharePath.c_str(), "path"),
-        TraceLoggingValue(Options, "options"),
+        TraceLoggingValue(effectiveOptions.c_str(), "options"),
         TraceLoggingValue(tag.c_str(), "tag"),
         TraceLoggingValue(created, "created"),
         TraceLoggingValue(m_virtioFsShares.size(), "shareCount"));
@@ -2309,9 +2329,13 @@ void WslCoreVm::ReadGuestCapabilities()
     }
 
     m_seccompAvailable = info.SeccompAvailable;
+    m_hvPciSwiotlbBase = info.HvPciSwiotlbBase;
+    m_hvPciSwiotlbSize = info.HvPciSwiotlbSize;
     WSL_LOG(
         "GuestKernelInfo",
         TraceLoggingValue(m_seccompAvailable, "SeccompAvailable"),
+        TraceLoggingValue(m_hvPciSwiotlbBase, "HvPciSwiotlbBase"),
+        TraceLoggingValue(m_hvPciSwiotlbSize, "HvPciSwiotlbSize"),
         TraceLoggingValue(std::get<0>(m_kernelVersion), "Version"),
         TraceLoggingValue(std::get<1>(m_kernelVersion), "Revision"),
         TraceLoggingValue(std::get<2>(m_kernelVersion), "Minor"));

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -304,6 +304,9 @@ private:
     std::tuple<std::uint32_t, std::uint32_t, std::uint32_t> m_kernelVersion;
     std::wstring m_kernelVersionString;
     bool m_seccompAvailable;
+    uint64_t m_hvPciSwiotlbBase = 0;
+    uint64_t m_hvPciSwiotlbSize = 0;
+    std::wstring m_swiotlbOption;
     std::wstring m_sharedMemoryRoot;
     std::filesystem::path m_installPath;
     std::wstring m_userProfile;

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -440,6 +440,21 @@ cpp_quote("#define WSLCFeatureFlagsValid (WslcFeatureFlagsDnsTunneling | WslcFea
 cpp_quote("DEFINE_ENUM_FLAG_OPERATORS(WSLCFeatureFlags);")
 
 //
+// Values discovered from the guest kernel after the VM has booted, forwarded
+// from wslcsession via IWSLCVirtualMachine::ApplyGuestCapabilities. Add new
+// fields here instead of new IDL methods so the interface does not need a new
+// IID for each kernel-published value.
+//
+typedef struct _WSLCGuestCapabilities
+{
+    // (base, size) of the hv_pci swiotlb pool the kernel reserved and
+    // published under /sys/bus/vmbus/drivers/hv_pci/swiotlb_{base,size}.
+    // Both zero means the running kernel does not support hv_pci swiotlb.
+    UINT64 HvPciSwiotlbBase;
+    UINT64 HvPciSwiotlbSize;
+} WSLCGuestCapabilities;
+
+//
 // IWSLCVirtualMachine - Interface representing a single VM instance.
 // Operations are scoped to this VM. The VM ID is stored internally,
 // so only the holder of this interface can operate on the VM.
@@ -478,6 +493,14 @@ interface IWSLCVirtualMachine : IUnknown
 
     // Removes a previously added filesystem share.
     HRESULT RemoveShare([in] REFGUID ShareId);
+
+    // Configures the per-VM state discovered from the guest kernel after boot
+    // (currently the hv_pci swiotlb pool). Subsequent calls to AddShare and
+    // ConfigureNetworking forward these values to wsldevicehost via the
+    // swiotlb device-options token. A capabilities struct whose fields are
+    // all zero means the guest kernel does not support the feature; the
+    // token is then omitted.
+    HRESULT ApplyGuestCapabilities([in] const WSLCGuestCapabilities* Capabilities);
 
     // Returns an event that is signaled when the VM exits (graceful or forced).
     HRESULT GetTerminationEvent([out, system_handle(sh_event)] HANDLE* Event);

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -298,6 +298,11 @@ void WSLCVirtualMachine::Initialize()
     const auto modulesDevice = GetVhdDevicePath(1);
     Mount(m_initChannel, modulesDevice.c_str(), "", "ext4", "ro", WSLC_MOUNT::KernelModules);
 
+    // Discover the per-VM guest capabilities (currently the hv_pci swiotlb pool) and forward them
+    // to the service so virtio device-options (virtiofs shares, VirtioProxy networking) can include
+    // the swiotlb token.
+    ReadGuestCapabilities();
+
     // Configure GPU mounts if enabled
     MountGpuLibraries(c_gpuLibrariesPath, c_gpuDriversPath);
 
@@ -398,6 +403,28 @@ void WSLCVirtualMachine::ConfigureNetworking()
 
     // Launch port relay for port forwarding
     LaunchPortRelay();
+}
+
+void WSLCVirtualMachine::ReadGuestCapabilities()
+{
+    WSLC_GET_GUEST_CAPABILITIES message{};
+    const auto& response = m_initChannel.Transaction(message, nullptr, m_initChannelTimeout);
+
+    m_hvPciSwiotlbBase = response.HvPciSwiotlbBase;
+    m_hvPciSwiotlbSize = response.HvPciSwiotlbSize;
+
+    WSL_LOG(
+        "WSLCReadGuestCapabilities",
+        TraceLoggingValue(m_hvPciSwiotlbBase, "HvPciSwiotlbBase"),
+        TraceLoggingValue(m_hvPciSwiotlbSize, "HvPciSwiotlbSize"));
+
+    // Forward the values to the service so AddShare and ConfigureNetworking can include the
+    // swiotlb device-options token. Passing zero for both means the guest kernel does not
+    // support hv_pci swiotlb; the service then omits the token.
+    WSLCGuestCapabilities capabilities{};
+    capabilities.HvPciSwiotlbBase = m_hvPciSwiotlbBase;
+    capabilities.HvPciSwiotlbSize = m_hvPciSwiotlbSize;
+    THROW_IF_FAILED(m_vm->ApplyGuestCapabilities(&capabilities));
 }
 
 bool WSLCVirtualMachine::FeatureEnabled(WSLCFeatureFlags Value) const

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -175,6 +175,11 @@ private:
     // Initial setup during Connect()
     void ConfigureNetworking();
 
+    // Queries the guest kernel for per-VM capabilities (currently the hv_pci swiotlb pool
+    // reserved at boot) and forwards them to the service so that subsequent virtio device-options
+    // can include the swiotlb token. Called after the root filesystem is mounted.
+    void ReadGuestCapabilities();
+
     static void Mount(wsl::shared::SocketChannel& Channel, LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags);
     void MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_ LPCSTR DriversMountpoint);
 
@@ -229,6 +234,10 @@ private:
 
     wsl::shared::SocketChannel m_initChannel;
     DWORD m_initChannelTimeout = 30 * 1000;
+
+    // Swiotlb pool reserved by the guest kernel (zero when the kernel lacks the WSL patch).
+    uint64_t m_hvPciSwiotlbBase = 0;
+    uint64_t m_hvPciSwiotlbSize = 0;
 
     // Job object that terminates child processes (wslrelay.exe) when the VM shuts down.
     // Declared before the port relay pipes so it is destroyed after them: any remaining

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2128,6 +2128,17 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
             L"[experimental]\nignoredPorts=65536",
             std::format(L"wsl: Invalid integer value '65536' for key 'experimental.ignoredPorts' in {}:22\r\n", wslConfigPath));
 
+        // Verify experimental.swiotlb parsing and validation.
+        //
+        // With wsl2.virtio enabled (the default), a valid swiotlb value is accepted silently.
+        validateWarnings(L"[experimental]\nswiotlb=64M", L"");
+        validateWarnings(L"[experimental]\nswiotlb=4096K", L"");
+
+        // Malformed values are rejected by the parser; only the parser warning is reported.
+        validateWarnings(
+            L"[experimental]\nswiotlb=garbage",
+            std::format(L"wsl: Invalid memory string 'garbage' for .wslconfig entry 'experimental.swiotlb' in {}:22\r\n", wslConfigPath));
+
         // Verify that the vhdSize setting is parsed correctly.
         validateWarnings(L"[wsl2]\ndefaultVhdSize=64GB\n", L"");
 


### PR DESCRIPTION
Improves virtiofs and VirtioProxy performance by giving each virtio device its own SWIOTLB aperture instead of sharing a single global pool. The guest kernel reserves a contiguous physical range at boot, publishes the (base, size), and the host programs a matching per-device aperture in wsldevicehost.

Handshake:

1. Guest kernel allocates a contiguous range (`alloc_contig_pages`, `__GFP_DMA32 | __GFP_ZERO`) and exposes it under `/sys/bus/vmbus/drivers/hv_pci/swiotlb_{base,size}`.
2. `mini_init` (WSL2) and the WSLC init handler read the sysfs files and return the values in `LX_INIT_GUEST_CAPABILITIES` / `WSLC_GET_GUEST_CAPABILITIES_RESULT`.
3. `WslCoreVm::ReadGuestCapabilities` and `WSLCVirtualMachine::ReadGuestCapabilities` capture them. WSLC forwards them via the new `HcsVirtualMachine::ApplyGuestCapabilities` IDL method (taking a `WSLCGuestCapabilities` struct).
4. Both VM owners format `swiotlb=0x{base:x},{size}` once into `m_swiotlbOption` and pass it to `AddGuestDevice` / `AddSharePath` for every virtiofs share and virtio-net adapter (VirtioProxy networking).

Bumps `Microsoft.WSL.Kernel` to 6.18.26.3-1 (first official kernel with the patch) and `Microsoft.WSL.DeviceHost` to 1.2.29-0 (consumes the swiotlb device-options token).