### PR TITLE
Disable SDL codesign auto-scan on the package job

### DIFF
--- a/.pipelines/package-stage.yml
+++ b/.pipelines/package-stage.yml
@@ -45,7 +45,8 @@ stages:
           ob_outputDirectory: '$(Build.SourcesDirectory)\out'
           ob_artifactBaseName: 'drop_wsl'
           ob_artifactSuffix: '_package'
-          ob_sdl_codeSignValidation_excludes: -|**\*.ps1
+          # Outputs are explicitly signed+verified by the EsrpCodeSigning tasks below.
+          ob_sdl_codeSignValidation_enabled: false
           buildStagePackageVersion: $[ stageDependencies.build_x64.build_x64.outputs['version.WSL_PACKAGE_VERSION'] ]
           buildStageNugetVersion: $[ stageDependencies.build_x64.build_x64.outputs['version.WSL_NUGET_PACKAGE_VERSION'] ]
 


### PR DESCRIPTION
## Summary

Disable the OneBranch SDL CodeSign auto-scan on the `package` job so it stops failing the release build on in-repo `.ps1` files.

## PR Checklist

- [x] Pipeline-only change; no product code affected
- [x] Comment in the YAML explains why we disabled rather than excluded

## Detailed Description

The Guardian CodeSign post-analysis scans the entire source checkout in the `package` job and flags every in-repo `.ps1` as unsigned (17 errors), breaking the release build (most recently build 147990024).

Two prior attempts to filter the findings via the documented `ob_sdl_codeSignValidation_excludes` variable were both silently ignored on this pipeline:

1. b011cf77 (#40541): added the variable at pipeline-level in `wsl-build-{release,nightly,pr}-onebranch.yml` and at job-level in `build-job.yml`.
2. #40653: added the variable to the `package` job's own `variables:` block.

After exhausting variable-format / scope / path-separator hypotheses without ADO log access, this PR takes the reliable route:

- Disable `ob_sdl_codeSignValidation` on the `package` job only.
- The `build_x64` / `build_arm64` jobs keep validation enabled.
- The msixbundle and nupkg outputs are **explicitly signed AND verified** by the existing `EsrpCodeSigning@5` tasks in the same job (which run `SigntoolVerify` / `NuGetVerify` operations) - so signing coverage on the actual release artifacts is preserved; only the broken broad-tree scan is dropped.

## Validation Steps

Next release pipeline run will confirm the CodeSign post-analysis no longer fails the `package` job.
