### PR TITLE
Use RegisterWaitForSingleObject() in MultiHandleIOWait

### DIFF
--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -930,6 +930,11 @@ MultiHandleWait& MultiHandleWait::operator=(MultiHandleWait&& other) noexcept
         m_handleSignaledEvent = std::move(other.m_handleSignaledEvent);
         m_cancel = other.m_cancel;
 
+        for (auto& entry : m_handles)
+        {
+            entry->self = this;
+        }
+
         // N.B. moving a MultiHandleWait() while running is not supported
         WI_ASSERT(m_signaledHandles.empty());
     }

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -914,9 +914,37 @@ void DockerIORelayHandle::OnRead(const gsl::span<char>& Buffer)
 
 // MultiHandleWait
 
+MultiHandleWait::MultiHandleWait() : m_state(std::make_unique<SharedState>())
+{
+}
+
+MultiHandleWait::~MultiHandleWait()
+{
+    // Unregister before any other member is destroyed, so the wait callbacks can no longer
+    // fire when m_state is torn down.
+    UnregisterAllWaits();
+}
+
+MultiHandleWait& MultiHandleWait::operator=(MultiHandleWait&& other) noexcept
+{
+    if (this != &other)
+    {
+        UnregisterAllWaits();
+        m_handles = std::move(other.m_handles);
+        m_state = std::move(other.m_state);
+        m_cancel = other.m_cancel;
+    }
+
+    return *this;
+}
+
 void MultiHandleWait::AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags)
 {
-    m_handles.emplace_back(flags, std::move(handle));
+    auto entry = std::make_unique<Entry>();
+    entry->HandleFlags = flags;
+    entry->Handle = std::move(handle);
+    entry->State = m_state.get();
+    m_handles.emplace_back(std::move(entry));
 }
 
 void MultiHandleWait::Cancel()
@@ -924,122 +952,156 @@ void MultiHandleWait::Cancel()
     m_cancel = true;
 }
 
+void NTAPI MultiHandleWait::WaitCallback(PVOID Context, BOOLEAN /*TimerOrWaitFired*/)
+{
+    // The callback's sole job is to record which Entry was signaled and wake Run().
+    // Run() does the actual Collect() work on its own thread.
+    auto* entry = static_cast<Entry*>(Context);
+
+    auto lock = entry->State->Lock.lock_exclusive();
+    entry->State->Signaled.push_back(entry);
+    entry->State->Notification.SetEvent();
+}
+
+void MultiHandleWait::RegisterWait(Entry& entry)
+{
+    WI_ASSERT(!entry.WaitRegistration);
+
+    // WT_EXECUTEINWAITTHREAD: run the callback directly on the wait thread instead of
+    //     queuing to a worker. The callback is tiny (push to queue + SetEvent), so the
+    //     extra hop would be wasted work.
+    // WT_EXECUTEONLYONCE: fire once per RegisterWaitForSingleObject. Run() re-registers
+    //     after every iteration, so there is no need for the kernel to re-arm.
+    THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
+        entry.WaitRegistration.put(), entry.Handle->GetHandle(), &WaitCallback, &entry, INFINITE, WT_EXECUTEINWAITTHREAD | WT_EXECUTEONLYONCE));
+}
+
+void MultiHandleWait::UnregisterAllWaits() noexcept
+{
+    // unique_registered_wait's deleter calls UnregisterWaitEx(INVALID_HANDLE_VALUE), which
+    // blocks until any in-flight callback completes. After this loop returns, no callback
+    // is running and no more callbacks can fire until we re-register.
+    for (auto& entry : m_handles)
+    {
+        entry->WaitRegistration.reset();
+    }
+}
+
 bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
 {
     m_cancel = false; // Run may be called multiple times.
 
-    std::optional<std::chrono::steady_clock::time_point> deadline;
+    auto cleanup = wil::scope_exit([&] { UnregisterAllWaits(); });
 
+    std::optional<std::chrono::steady_clock::time_point> deadline;
     if (Timeout.has_value())
     {
         deadline = std::chrono::steady_clock::now() + Timeout.value();
     }
 
-    // Run until all handles are completed.
-
-    while (!m_handles.empty() && !m_cancel)
+    while (!m_cancel)
     {
-        // Schedule IO on each handle until all are either pending, or completed.
-        for (size_t i = 0; i < m_handles.size() && !m_cancel; i++)
+        // Drop every active wait so no callbacks can mutate the queue while we process
+        // state. UnregisterWaitEx(INVALID_HANDLE_VALUE) waits for any in-flight callback,
+        // so once this returns the queue is exclusively ours.
+        UnregisterAllWaits();
+
+        // Move the queue out under the lock. Defensive locking - no callbacks should be
+        // running at this point, but it keeps the access pattern obvious.
+        std::vector<Entry*> signaled;
         {
-            while (m_handles[i].second->GetState() == IOHandleStatus::Standby && !m_cancel)
+            auto lock = m_state->Lock.lock_exclusive();
+            signaled = std::move(m_state->Signaled);
+            m_state->Notification.ResetEvent();
+        }
+
+        // Collect() runs on the Run() thread, preserving the historical contract.
+        for (auto* entry : signaled)
+        {
+            try
             {
-                try
+                entry->Handle->Collect();
+            }
+            catch (...)
+            {
+                if (WI_IsFlagSet(entry->HandleFlags, Flags::IgnoreErrors))
                 {
-                    m_handles[i].second->Schedule();
+                    entry->Handle.reset();
+                    continue;
                 }
-                catch (...)
-                {
-                    if (WI_IsFlagSet(m_handles[i].first, Flags::IgnoreErrors))
-                    {
-                        m_handles[i].second.reset(); // Reset the handle so it can be deleted.
-                        break;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
+
+                throw;
             }
         }
 
-        // Remove completed handles from m_handles.
+        // Walk the handle list: schedule Standby handles, drop Completed ones, and
+        // re-register a wait for every Pending handle so it can fire next iteration.
         bool hasHandleToWaitFor = false;
         for (auto it = m_handles.begin(); it != m_handles.end();)
         {
-            if (!it->second)
+            auto& entry = **it;
+
+            while (entry.Handle && entry.Handle->GetState() == IOHandleStatus::Standby && !m_cancel)
             {
-                it = m_handles.erase(it);
-            }
-            else if (it->second->GetState() == IOHandleStatus::Completed)
-            {
-                if (WI_IsFlagSet(it->first, Flags::CancelOnCompleted))
+                try
                 {
-                    m_cancel = true; // Cancel the IO if a handle with CancelOnCompleted is in the completed state.
+                    entry.Handle->Schedule();
+                }
+                catch (...)
+                {
+                    if (WI_IsFlagSet(entry.HandleFlags, Flags::IgnoreErrors))
+                    {
+                        entry.Handle.reset();
+                        break;
+                    }
+
+                    throw;
+                }
+            }
+
+            if (!entry.Handle || entry.Handle->GetState() == IOHandleStatus::Completed)
+            {
+                if (entry.Handle && WI_IsFlagSet(entry.HandleFlags, Flags::CancelOnCompleted))
+                {
+                    m_cancel = true;
                 }
 
                 it = m_handles.erase(it);
+                continue;
             }
-            else
+
+            RegisterWait(entry);
+
+            if (WI_IsFlagClear(entry.HandleFlags, Flags::NeedNotComplete))
             {
-                // If only NeedNotComplete handles are left, we want to exit Run.
-                if (WI_IsFlagClear(it->first, Flags::NeedNotComplete))
-                {
-                    hasHandleToWaitFor = true;
-                }
-                ++it;
+                hasHandleToWaitFor = true;
             }
+
+            ++it;
         }
 
-        if (!hasHandleToWaitFor || m_cancel)
+        if (m_handles.empty() || !hasHandleToWaitFor || m_cancel)
         {
             break;
-        }
-
-        // Wait for the next operation to complete.
-        std::vector<HANDLE> waitHandles;
-        for (const auto& e : m_handles)
-        {
-            waitHandles.emplace_back(e.second->GetHandle());
         }
 
         DWORD waitTimeout = INFINITE;
         if (deadline.has_value())
         {
-            auto miliseconds =
+            auto milliseconds =
                 std::chrono::duration_cast<std::chrono::milliseconds>(deadline.value() - std::chrono::steady_clock::now()).count();
 
-            waitTimeout = static_cast<DWORD>(std::max(0LL, miliseconds));
+            waitTimeout = static_cast<DWORD>(std::max<long long>(0, milliseconds));
         }
 
-        auto result = WaitForMultipleObjects(static_cast<DWORD>(waitHandles.size()), waitHandles.data(), false, waitTimeout);
+        auto result = WaitForSingleObject(m_state->Notification.get(), waitTimeout);
         if (result == WAIT_TIMEOUT)
         {
             THROW_WIN32(ERROR_TIMEOUT);
         }
-        else if (result >= WAIT_OBJECT_0 && result < WAIT_OBJECT_0 + m_handles.size())
+        else if (result != WAIT_OBJECT_0)
         {
-            auto index = result - WAIT_OBJECT_0;
-
-            try
-            {
-                m_handles[index].second->Collect();
-            }
-            catch (...)
-            {
-                if (WI_IsFlagSet(m_handles[index].first, Flags::IgnoreErrors))
-                {
-                    m_handles.erase(m_handles.begin() + index);
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
-        else
-        {
-            THROW_LAST_ERROR_MSG("Timeout: %lu, Count: %llu", waitTimeout, waitHandles.size());
+            THROW_LAST_ERROR_MSG("Timeout: %lu, Count: %llu", waitTimeout, m_handles.size());
         }
     }
 

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -976,8 +976,6 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
         // Cancel any pending callback.
         callbacks.clear();
 
-        // Move the queue out under the lock. Defensive locking - no callbacks should be
-        // running at this point, but it keeps the access pattern obvious.
         Entry* signaledEntry = nullptr;
         while (m_signaledHandles.try_pop(signaledEntry))
         {

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -922,6 +922,11 @@ void DockerIORelayHandle::OnRead(const gsl::span<char>& Buffer)
 
 // MultiHandleWait
 
+MultiHandleWait::MultiHandleWait(MultiHandleWait&& other) noexcept
+{
+    *this = std::move(other);
+}
+
 MultiHandleWait& MultiHandleWait::operator=(MultiHandleWait&& other) noexcept
 {
     if (this != &other)

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -61,6 +61,14 @@ void CancelPendingIo(auto Handle, OVERLAPPED& Overlapped)
     }
 }
 
+inline void UnregisterWait(HANDLE waitHandle) noexcept
+{
+    // INVALID_HANDLE_VALUE makes UnregisterWaitEx block until any in-flight wait callback returns.
+    LOG_LAST_ERROR_IF(!UnregisterWaitEx(waitHandle, INVALID_HANDLE_VALUE));
+}
+
+using unique_registered_wait = wil::unique_any_handle_null<decltype(&UnregisterWait), &UnregisterWait>;
+
 } // namespace
 
 // HandleWrapper
@@ -914,25 +922,16 @@ void DockerIORelayHandle::OnRead(const gsl::span<char>& Buffer)
 
 // MultiHandleWait
 
-MultiHandleWait::MultiHandleWait() : m_state(std::make_unique<SharedState>())
-{
-}
-
-MultiHandleWait::~MultiHandleWait()
-{
-    // Unregister before any other member is destroyed, so the wait callbacks can no longer
-    // fire when m_state is torn down.
-    UnregisterAllWaits();
-}
-
 MultiHandleWait& MultiHandleWait::operator=(MultiHandleWait&& other) noexcept
 {
     if (this != &other)
     {
-        UnregisterAllWaits();
         m_handles = std::move(other.m_handles);
-        m_state = std::move(other.m_state);
+        m_handleSignaledEvent = std::move(other.m_handleSignaledEvent);
         m_cancel = other.m_cancel;
+
+        // N.B. moving a MultiHandleWait() while running is not supported
+        WI_ASSERT(m_signaledHandles.empty());
     }
 
     return *this;
@@ -943,7 +942,7 @@ void MultiHandleWait::AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Fl
     auto entry = std::make_unique<Entry>();
     entry->HandleFlags = flags;
     entry->Handle = std::move(handle);
-    entry->State = m_state.get();
+    entry->self = this;
     m_handles.emplace_back(std::move(entry));
 }
 
@@ -954,44 +953,15 @@ void MultiHandleWait::Cancel()
 
 void NTAPI MultiHandleWait::WaitCallback(PVOID Context, BOOLEAN /*TimerOrWaitFired*/)
 {
-    // The callback's sole job is to record which Entry was signaled and wake Run().
-    // Run() does the actual Collect() work on its own thread.
     auto* entry = static_cast<Entry*>(Context);
 
-    auto lock = entry->State->Lock.lock_exclusive();
-    entry->State->Signaled.push_back(entry);
-    entry->State->Notification.SetEvent();
-}
-
-void MultiHandleWait::RegisterWait(Entry& entry)
-{
-    WI_ASSERT(!entry.WaitRegistration);
-
-    // WT_EXECUTEINWAITTHREAD: run the callback directly on the wait thread instead of
-    //     queuing to a worker. The callback is tiny (push to queue + SetEvent), so the
-    //     extra hop would be wasted work.
-    // WT_EXECUTEONLYONCE: fire once per RegisterWaitForSingleObject. Run() re-registers
-    //     after every iteration, so there is no need for the kernel to re-arm.
-    THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
-        entry.WaitRegistration.put(), entry.Handle->GetHandle(), &WaitCallback, &entry, INFINITE, WT_EXECUTEINWAITTHREAD | WT_EXECUTEONLYONCE));
-}
-
-void MultiHandleWait::UnregisterAllWaits() noexcept
-{
-    // unique_registered_wait's deleter calls UnregisterWaitEx(INVALID_HANDLE_VALUE), which
-    // blocks until any in-flight callback completes. After this loop returns, no callback
-    // is running and no more callbacks can fire until we re-register.
-    for (auto& entry : m_handles)
-    {
-        entry->WaitRegistration.reset();
-    }
+    entry->self->m_signaledHandles.push(entry);
+    entry->self->m_handleSignaledEvent.SetEvent();
 }
 
 bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
 {
     m_cancel = false; // Run may be called multiple times.
-
-    auto cleanup = wil::scope_exit([&] { UnregisterAllWaits(); });
 
     std::optional<std::chrono::steady_clock::time_point> deadline;
     if (Timeout.has_value())
@@ -999,34 +969,27 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
         deadline = std::chrono::steady_clock::now() + Timeout.value();
     }
 
+    std::vector<unique_registered_wait> callbacks;
+
     while (!m_cancel)
     {
-        // Drop every active wait so no callbacks can mutate the queue while we process
-        // state. UnregisterWaitEx(INVALID_HANDLE_VALUE) waits for any in-flight callback,
-        // so once this returns the queue is exclusively ours.
-        UnregisterAllWaits();
+        // Cancel any pending callback.
+        callbacks.clear();
 
         // Move the queue out under the lock. Defensive locking - no callbacks should be
         // running at this point, but it keeps the access pattern obvious.
-        std::vector<Entry*> signaled;
-        {
-            auto lock = m_state->Lock.lock_exclusive();
-            signaled = std::move(m_state->Signaled);
-            m_state->Notification.ResetEvent();
-        }
-
-        // Collect() runs on the Run() thread, preserving the historical contract.
-        for (auto* entry : signaled)
+        Entry* signaledEntry = nullptr;
+        while (m_signaledHandles.try_pop(signaledEntry))
         {
             try
             {
-                entry->Handle->Collect();
+                signaledEntry->Handle->Collect();
             }
             catch (...)
             {
-                if (WI_IsFlagSet(entry->HandleFlags, Flags::IgnoreErrors))
+                if (WI_IsFlagSet(signaledEntry->HandleFlags, Flags::IgnoreErrors))
                 {
-                    entry->Handle.reset();
+                    signaledEntry->Handle.reset();
                     continue;
                 }
 
@@ -1034,8 +997,8 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
             }
         }
 
-        // Walk the handle list: schedule Standby handles, drop Completed ones, and
-        // re-register a wait for every Pending handle so it can fire next iteration.
+        m_handleSignaledEvent.ResetEvent();
+
         bool hasHandleToWaitFor = false;
         for (auto it = m_handles.begin(); it != m_handles.end();)
         {
@@ -1070,7 +1033,10 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
                 continue;
             }
 
-            RegisterWait(entry);
+            auto& callback = callbacks.emplace_back();
+
+            THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(
+                &callback, entry.Handle->GetHandle(), &WaitCallback, &entry, INFINITE, WT_EXECUTEINWAITTHREAD | WT_EXECUTEONLYONCE));
 
             if (WI_IsFlagClear(entry.HandleFlags, Flags::NeedNotComplete))
             {
@@ -1094,15 +1060,12 @@ bool MultiHandleWait::Run(std::optional<std::chrono::milliseconds> Timeout)
             waitTimeout = static_cast<DWORD>(std::max<long long>(0, milliseconds));
         }
 
-        auto result = WaitForSingleObject(m_state->Notification.get(), waitTimeout);
-        if (result == WAIT_TIMEOUT)
-        {
-            THROW_WIN32(ERROR_TIMEOUT);
-        }
-        else if (result != WAIT_OBJECT_0)
-        {
-            THROW_LAST_ERROR_MSG("Timeout: %lu, Count: %llu", waitTimeout, m_handles.size());
-        }
+        THROW_HR_IF_MSG(
+            HRESULT_FROM_WIN32(ERROR_TIMEOUT),
+            !m_handleSignaledEvent.wait(waitTimeout),
+            "Timed out waiting for %llu handles. Timeout: %lu",
+            m_handles.size(),
+            waitTimeout);
     }
 
     return !m_cancel;

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -350,11 +350,34 @@ private:
     size_t RemainingBytes = 0;
 };
 
+namespace details {
+    inline void UnregisterRegisteredWait(HANDLE waitHandle) noexcept
+    {
+        // INVALID_HANDLE_VALUE makes UnregisterWaitEx block until any in-flight wait callback
+        // returns, so resources captured by the callback (Entry, SharedState) can be safely
+        // freed once the unique_any goes out of scope.
+        LOG_LAST_ERROR_IF(!UnregisterWaitEx(waitHandle, INVALID_HANDLE_VALUE));
+    }
+} // namespace details
+
+using unique_registered_wait = wil::unique_any_handle_null<decltype(&details::UnregisterRegisteredWait), &details::UnregisterRegisteredWait>;
+
+// MultiHandleWait runs a set of OverlappedIOHandle to completion using the system thread
+// pool's wait infrastructure (RegisterWaitForSingleObject) so it can wait for more than
+// MAXIMUM_WAIT_OBJECTS (64) handles at once.
+//
+// Threading model: the wait callback runs on a thread pool thread and only enqueues the
+// signaled Entry into a queue, then sets a notification event. Run() owns the actual work:
+// it drains the queue and calls Collect() on each signaled handle from the Run() thread,
+// preserving the original guarantee that Schedule() and Collect() execute on the caller's
+// thread. To simplify lifetime management, Run() unregisters every wait at the top of each
+// iteration before processing state, then re-registers a fresh wait for every Pending
+// handle. The first handle to signal wakes Run(), which then processes whatever the
+// callbacks queued before re-arming.
 class MultiHandleWait
 {
 public:
     NON_COPYABLE(MultiHandleWait);
-    DEFAULT_MOVABLE(MultiHandleWait);
 
     enum Flags
     {
@@ -364,14 +387,44 @@ public:
         NeedNotComplete = 4,
     };
 
-    MultiHandleWait() = default;
+    MultiHandleWait();
+    ~MultiHandleWait();
+    MultiHandleWait(MultiHandleWait&&) noexcept = default;
+    MultiHandleWait& operator=(MultiHandleWait&&) noexcept;
 
     void AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags = Flags::None);
     bool Run(std::optional<std::chrono::milliseconds> Timeout);
     void Cancel();
 
 private:
-    std::vector<std::pair<Flags, std::unique_ptr<OverlappedIOHandle>>> m_handles;
+    struct Entry;
+
+    // SharedState is heap-allocated so the address captured by wait callbacks remains
+    // stable when the owning MultiHandleWait is moved.
+    struct SharedState
+    {
+        wil::srwlock Lock;
+        wil::unique_event Notification{wil::EventOptions::None};
+        _Guarded_by_(Lock) std::vector<Entry*> Signaled;
+    };
+
+    // Entry is the callback context passed to RegisterWaitForSingleObject. Each Entry is
+    // heap-allocated (unique_ptr) so its address - and the OverlappedIOHandle pointer
+    // embedded in it - remains stable across m_handles reallocations.
+    struct Entry
+    {
+        Flags HandleFlags{};
+        std::unique_ptr<OverlappedIOHandle> Handle;
+        unique_registered_wait WaitRegistration;
+        SharedState* State{};
+    };
+
+    static void NTAPI WaitCallback(PVOID Context, BOOLEAN TimerOrWaitFired);
+    void RegisterWait(Entry& entry);
+    void UnregisterAllWaits() noexcept;
+
+    std::vector<std::unique_ptr<Entry>> m_handles;
+    std::unique_ptr<SharedState> m_state;
     bool m_cancel = false;
 };
 

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -351,20 +351,6 @@ private:
     WriteHandle* ActiveHandle = nullptr;
     size_t RemainingBytes = 0;
 };
-
-
-// MultiHandleWait runs a set of OverlappedIOHandle to completion using the system thread
-// pool's wait infrastructure (RegisterWaitForSingleObject) so it can wait for more than
-// MAXIMUM_WAIT_OBJECTS (64) handles at once.
-//
-// Threading model: the wait callback runs on a thread pool thread and only enqueues the
-// signaled Entry into a queue, then sets a notification event. Run() owns the actual work:
-// it drains the queue and calls Collect() on each signaled handle from the Run() thread,
-// preserving the original guarantee that Schedule() and Collect() execute on the caller's
-// thread. To simplify lifetime management, Run() unregisters every wait at the top of each
-// iteration before processing state, then re-registers a fresh wait for every Pending
-// handle. The first handle to signal wakes Run(), which then processes whatever the
-// callbacks queued before re-arming.
 class MultiHandleWait
 {
 public:

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <concurrent_queue.h>
+
 #define LX_RELAY_BUFFER_SIZE 0x1000
 
 namespace wsl::windows::common::io {
@@ -350,17 +352,6 @@ private:
     size_t RemainingBytes = 0;
 };
 
-namespace details {
-    inline void UnregisterRegisteredWait(HANDLE waitHandle) noexcept
-    {
-        // INVALID_HANDLE_VALUE makes UnregisterWaitEx block until any in-flight wait callback
-        // returns, so resources captured by the callback (Entry, SharedState) can be safely
-        // freed once the unique_any goes out of scope.
-        LOG_LAST_ERROR_IF(!UnregisterWaitEx(waitHandle, INVALID_HANDLE_VALUE));
-    }
-} // namespace details
-
-using unique_registered_wait = wil::unique_any_handle_null<decltype(&details::UnregisterRegisteredWait), &details::UnregisterRegisteredWait>;
 
 // MultiHandleWait runs a set of OverlappedIOHandle to completion using the system thread
 // pool's wait infrastructure (RegisterWaitForSingleObject) so it can wait for more than
@@ -387,8 +378,7 @@ public:
         NeedNotComplete = 4,
     };
 
-    MultiHandleWait();
-    ~MultiHandleWait();
+    MultiHandleWait() = default;
     MultiHandleWait(MultiHandleWait&&) noexcept = default;
     MultiHandleWait& operator=(MultiHandleWait&&) noexcept;
 
@@ -399,32 +389,26 @@ public:
 private:
     struct Entry;
 
-    // SharedState is heap-allocated so the address captured by wait callbacks remains
-    // stable when the owning MultiHandleWait is moved.
-    struct SharedState
+    struct WaitState
     {
         wil::srwlock Lock;
         wil::unique_event Notification{wil::EventOptions::None};
         _Guarded_by_(Lock) std::vector<Entry*> Signaled;
     };
 
-    // Entry is the callback context passed to RegisterWaitForSingleObject. Each Entry is
-    // heap-allocated (unique_ptr) so its address - and the OverlappedIOHandle pointer
-    // embedded in it - remains stable across m_handles reallocations.
     struct Entry
     {
         Flags HandleFlags{};
         std::unique_ptr<OverlappedIOHandle> Handle;
-        unique_registered_wait WaitRegistration;
-        SharedState* State{};
+        MultiHandleWait* self;
     };
 
     static void NTAPI WaitCallback(PVOID Context, BOOLEAN TimerOrWaitFired);
-    void RegisterWait(Entry& entry);
-    void UnregisterAllWaits() noexcept;
+
+    concurrency::concurrent_queue<Entry*> m_signaledHandles;
+    wil::unique_event m_handleSignaledEvent{wil::EventOptions::ManualReset};
 
     std::vector<std::unique_ptr<Entry>> m_handles;
-    std::unique_ptr<SharedState> m_state;
     bool m_cancel = false;
 };
 

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -373,15 +373,6 @@ public:
     void Cancel();
 
 private:
-    struct Entry;
-
-    struct WaitState
-    {
-        wil::srwlock Lock;
-        wil::unique_event Notification{wil::EventOptions::None};
-        _Guarded_by_(Lock) std::vector<Entry*> Signaled;
-    };
-
     struct Entry
     {
         Flags HandleFlags{};

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -365,7 +365,7 @@ public:
     };
 
     MultiHandleWait() = default;
-    MultiHandleWait(MultiHandleWait&&) noexcept = default;
+    MultiHandleWait(MultiHandleWait&&) noexcept;
     MultiHandleWait& operator=(MultiHandleWait&&) noexcept;
 
     void AddHandle(std::unique_ptr<OverlappedIOHandle>&& handle, Flags flags = Flags::None);

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -6832,6 +6832,94 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         }
     }
 
+    TEST_METHOD(MultiHandleWaitAboveMaximumWaitObjects)
+    {
+        // Validate that MultiHandleWait can wait on more than MAXIMUM_WAIT_OBJECTS (64) handles.
+        constexpr size_t handleCount = 100;
+        static_assert(handleCount > MAXIMUM_WAIT_OBJECTS);
+
+        // Scenario 1: signal every event before Run(); all callbacks must fire and Run() must return.
+        {
+            std::vector<wil::unique_event> events;
+            events.reserve(handleCount);
+            for (size_t i = 0; i < handleCount; ++i)
+            {
+                events.emplace_back(wil::EventOptions::ManualReset);
+            }
+
+            std::vector<bool> fired(handleCount, false);
+            std::atomic<size_t> firedCount{0};
+            std::mutex firedLock;
+
+            wsl::windows::common::io::MultiHandleWait io;
+            for (size_t i = 0; i < handleCount; ++i)
+            {
+                io.AddHandle(std::make_unique<wsl::windows::common::io::EventHandle>(
+                    wsl::windows::common::io::HandleWrapper{events[i].get()}, [&fired, &firedCount, &firedLock, i]() {
+                        std::lock_guard lock{firedLock};
+                        VERIFY_IS_FALSE(fired[i]);
+                        fired[i] = true;
+                        firedCount.fetch_add(1);
+                    }));
+            }
+
+            for (auto& e : events)
+            {
+                e.SetEvent();
+            }
+
+            VERIFY_IS_TRUE(io.Run(std::chrono::seconds(60)));
+            VERIFY_ARE_EQUAL(firedCount.load(), handleCount);
+            for (size_t i = 0; i < handleCount; ++i)
+            {
+                VERIFY_IS_TRUE(fired[i]);
+            }
+        }
+
+        // Scenario 2: signal events one at a time from another thread while Run() processes them.
+        {
+            std::vector<wil::unique_event> events;
+            events.reserve(handleCount);
+            for (size_t i = 0; i < handleCount; ++i)
+            {
+                events.emplace_back(wil::EventOptions::ManualReset);
+            }
+
+            std::vector<bool> fired(handleCount, false);
+            std::atomic<size_t> firedCount{0};
+            std::mutex firedLock;
+
+            wsl::windows::common::io::MultiHandleWait io;
+            for (size_t i = 0; i < handleCount; ++i)
+            {
+                io.AddHandle(std::make_unique<wsl::windows::common::io::EventHandle>(
+                    wsl::windows::common::io::HandleWrapper{events[i].get()}, [&fired, &firedCount, &firedLock, i]() {
+                        std::lock_guard lock{firedLock};
+                        VERIFY_IS_FALSE(fired[i]);
+                        fired[i] = true;
+                        firedCount.fetch_add(1);
+                    }));
+            }
+
+            std::thread signaller([&events]() {
+                for (auto& e : events)
+                {
+                    e.SetEvent();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+            });
+
+            VERIFY_IS_TRUE(io.Run(std::chrono::seconds(60)));
+            signaller.join();
+
+            VERIFY_ARE_EQUAL(firedCount.load(), handleCount);
+            for (size_t i = 0; i < handleCount; ++i)
+            {
+                VERIFY_IS_TRUE(fired[i]);
+            }
+        }
+    }
+
     TEST_METHOD(SocketChannel)
     {
         // Read exactly `size` bytes from a raw socket into the destination buffer.

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8333,6 +8333,60 @@ class WSLCTests
         }
     }
 
+    WSLC_TEST_METHOD(ContainerLogsManyConcurrentFollowers)
+    {
+        constexpr size_t followerCount = 100;
+        static_assert(followerCount > MAXIMUM_WAIT_OBJECTS);
+
+        WSLCContainerLauncher launcher(
+            "debian:latest", "logs-test-many-followers", {"/bin/cat"}, {}, {}, WSLCProcessFlagsStdin);
+        auto container = launcher.Launch(*m_defaultSession);
+        auto initProcess = container.GetInitProcess();
+
+        auto containerStdin = initProcess.GetStdHandle(0);
+        VERIFY_WIN32_BOOL_SUCCEEDED(WriteFile(containerStdin.get(), "OK\n", 3, nullptr, nullptr));
+
+        std::atomic<size_t> readersReady{0};
+        std::atomic<size_t> readersSucceeded{0};
+        std::vector<std::thread> threads;
+        threads.reserve(followerCount);
+
+        for (size_t i = 0; i < followerCount; ++i)
+        {
+            threads.emplace_back([&]() {
+                try
+                {
+                    COMOutputHandle stdoutHandle{};
+                    COMOutputHandle stderrHandle{};
+                    VERIFY_SUCCEEDED(container.Get().Logs(WSLCLogsFlagsFollow, &stdoutHandle, &stderrHandle, 0, 0, 0));
+
+                    PartialHandleRead reader(stdoutHandle.Get());
+                    reader.Expect("OK\n");
+                    readersReady.fetch_add(1);
+                    reader.ExpectClosed();
+                    readersSucceeded.fetch_add(1);
+                }
+                CATCH_LOG();
+            });
+        }
+
+        // Wait until every follower has observed the marker before killing the container.
+        wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() { THROW_HR_IF(E_ABORT, readersReady.load() < followerCount); },
+            std::chrono::milliseconds(100),
+            std::chrono::seconds(120));
+
+        // Kill the container so all follow handles are closed.
+        VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
+
+        for (auto& t : threads)
+        {
+            t.join();
+        }
+
+        VERIFY_ARE_EQUAL(readersSucceeded.load(), followerCount);
+    }
+
     WSLC_TEST_METHOD(ContainerLabels)
     {
         // Docker labels do not have a size limit, so test with a very large label value to validate that the API can handle it.

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8338,8 +8338,7 @@ class WSLCTests
         constexpr size_t followerCount = 100;
         static_assert(followerCount > MAXIMUM_WAIT_OBJECTS);
 
-        WSLCContainerLauncher launcher(
-            "debian:latest", "logs-test-many-followers", {"/bin/cat"}, {}, {}, WSLCProcessFlagsStdin);
+        WSLCContainerLauncher launcher("debian:latest", "logs-test-many-followers", {"/bin/cat"}, {}, {}, WSLCProcessFlagsStdin);
         auto container = launcher.Launch(*m_defaultSession);
         auto initProcess = container.GetInitProcess();
 
@@ -8372,9 +8371,7 @@ class WSLCTests
 
         // Wait until every follower has observed the marker before killing the container.
         wsl::shared::retry::RetryWithTimeout<void>(
-            [&]() { THROW_HR_IF(E_ABORT, readersReady.load() < followerCount); },
-            std::chrono::milliseconds(100),
-            std::chrono::seconds(120));
+            [&]() { THROW_HR_IF(E_ABORT, readersReady.load() < followerCount); }, std::chrono::milliseconds(100), std::chrono::seconds(120));
 
         // Kill the container so all follow handles are closed.
         VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change switches the IO scheduling logic to use `RegisterWaitForSingleObject()` instead of `WaitForMultipleObject()`, which allows us to wait for more than 64 handles at the same time.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

I also experimented with IO completion ports, but the change became too complex (see https://github.com/microsoft/WSL/pull/40569).

This solution is self contained and works well with our current design

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
