### PR TITLE
Fix race condition in SDK IO callback

### DIFF
--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -81,15 +81,20 @@ IOCallback::IOCallback(IWSLCProcess* process, const WslcContainerProcessIOCallba
 IOCallback::~IOCallback()
 {
     Cancel();
-    if (m_thread.joinable())
-    {
-        m_thread.join();
-    }
+    Complete();
 }
 
 void IOCallback::Cancel()
 {
     m_cancelEvent.SetEvent();
+}
+
+void IOCallback::Complete()
+{
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
 }
 
 bool IOCallback::HasIOCallback(const WslcContainerProcessOptionsInternal* options)

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -79,10 +79,12 @@ IOCallback::IOCallback(IWSLCProcess* process, const WslcContainerProcessIOCallba
 }
 
 IOCallback::~IOCallback()
+try
 {
     Cancel();
-    Complete();
+        Complete();
 }
+CATCH_LOG();
 
 void IOCallback::Cancel()
 {
@@ -91,10 +93,20 @@ void IOCallback::Cancel()
 
 void IOCallback::Complete()
 {
-    if (m_thread.joinable())
-    {
-        m_thread.join();
-    }
+    // Complete can be called by multiple threads. Make sure that it's only ever called onced since join() is not thread safe.
+    std::call_once(m_join, [this]() {
+        if (m_thread.joinable())
+        {
+            THROW_HR_IF(ERROR_INVALID_HANDLE_STATE, IsOnIOCallbackThread());
+
+            m_thread.join();
+        }
+    });
+}
+
+bool IOCallback::IsOnIOCallbackThread() const noexcept
+{
+    return m_thread.get_id() == std::this_thread::get_id();
 }
 
 bool IOCallback::HasIOCallback(const WslcContainerProcessOptionsInternal* options)

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -82,7 +82,7 @@ IOCallback::~IOCallback()
 try
 {
     Cancel();
-        Complete();
+    Complete();
 }
 CATCH_LOG();
 

--- a/src/windows/WslcSDK/IOCallback.cpp
+++ b/src/windows/WslcSDK/IOCallback.cpp
@@ -93,11 +93,11 @@ void IOCallback::Cancel()
 
 void IOCallback::Complete()
 {
-    // Complete can be called by multiple threads. Make sure that it's only ever called onced since join() is not thread safe.
+    // Complete can be called by multiple threads. Make sure that it's only ever called once since join() is not thread safe.
     std::call_once(m_join, [this]() {
         if (m_thread.joinable())
         {
-            THROW_HR_IF(ERROR_INVALID_HANDLE_STATE, IsOnIOCallbackThread());
+            THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE_STATE), IsOnIOCallbackThread());
 
             m_thread.join();
         }

--- a/src/windows/WslcSDK/IOCallback.h
+++ b/src/windows/WslcSDK/IOCallback.h
@@ -27,6 +27,8 @@ struct IOCallback
     void Cancel();
     void Complete();
 
+    bool IsOnIOCallbackThread() const noexcept;
+
     static bool HasIOCallback(const WslcContainerProcessOptionsInternal* options);
     static bool HasIOCallback(const WslcContainerProcessIOCallbackOptions& options);
 
@@ -38,4 +40,5 @@ private:
     std::thread m_thread;
     wsl::windows::common::io::MultiHandleWait m_io;
     wil::unique_event m_cancelEvent{wil::EventOptions::ManualReset};
+    std::once_flag m_join;
 };

--- a/src/windows/WslcSDK/IOCallback.h
+++ b/src/windows/WslcSDK/IOCallback.h
@@ -25,6 +25,7 @@ struct IOCallback
     ~IOCallback();
 
     void Cancel();
+    void Complete();
 
     static bool HasIOCallback(const WslcContainerProcessOptionsInternal* options);
     static bool HasIOCallback(const WslcContainerProcessIOCallbackOptions& options);

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -616,17 +616,24 @@ CATCH_RETURN();
 STDAPI WslcReleaseContainer(_In_ WslcContainer container)
 try
 {
+    // Reject release attempts originating from the container's own IO thread.
+    {
+        auto* peek = CheckAndGetInternalType(container);
+        auto ioCallback = peek->ioCallbacks.load();
+        RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE_STATE), ioCallback && ioCallback->IsOnIOCallbackThread());
+    }
+
     auto internalType = CheckAndGetInternalTypeUniquePointer(container);
     auto ioCallback = internalType->ioCallbacks.load();
     if (ioCallback)
     {
-        // If the container has an IO callback registered, and the container is exited, wait until the IO callback has processed all IO.
+        // If the container has an IO callback registered, and the container has exited, wait until the IO callback has processed all IO.
         try
         {
             WSLCContainerState state{};
             THROW_IF_FAILED(internalType->container->GetState(&state));
 
-            if (state == WslcContainerStateExited)
+            if (state == WslcContainerStateExited || state == WslcContainerStateDeleted)
             {
                 ioCallback->Complete();
             }
@@ -641,10 +648,18 @@ CATCH_RETURN();
 STDAPI WslcReleaseProcess(_In_ WslcProcess process)
 try
 {
+    // Reject release attempts originating from the process's own IO thread.
+    {
+        auto* peek = CheckAndGetInternalType(process);
+        if (peek->ioCallbacks && peek->ioCallbacks->IsOnIOCallbackThread())
+        {
+            RETURN_HR(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE_STATE));
+        }
+    }
+
     auto internalType = CheckAndGetInternalTypeUniquePointer(process);
     if (internalType->ioCallbacks)
     {
-
         // If the process has an IO callback registered, and the process is exited, wait until the IO callback has processed all IO.
         // If the process is released while still running, cancel the IO callback so we don't get stuck since the process might still be emitting IO.
 

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -616,7 +616,23 @@ CATCH_RETURN();
 STDAPI WslcReleaseContainer(_In_ WslcContainer container)
 try
 {
-    CheckAndGetInternalTypeUniquePointer(container);
+    auto internalType = CheckAndGetInternalTypeUniquePointer(container);
+    auto ioCallback = internalType->ioCallbacks.load();
+    if (ioCallback)
+    {
+        // If the container has an IO callback registered, and the container is exited, wait until the IO callback has processed all IO.
+        try
+        {
+            WSLCContainerState state{};
+            THROW_IF_FAILED(internalType->container->GetState(&state));
+
+            if (state == WslcContainerStateExited)
+            {
+                ioCallback->Complete();
+            }
+        }
+        CATCH_LOG();
+    }
 
     return S_OK;
 }
@@ -625,7 +641,26 @@ CATCH_RETURN();
 STDAPI WslcReleaseProcess(_In_ WslcProcess process)
 try
 {
-    CheckAndGetInternalTypeUniquePointer(process);
+    auto internalType = CheckAndGetInternalTypeUniquePointer(process);
+    if (internalType->ioCallbacks)
+    {
+
+        // If the process has an IO callback registered, and the process is exited, wait until the IO callback has processed all IO.
+        // If the process is released while still running, cancel the IO callback so we don't get stuck since the process might still be emitting IO.
+
+        try
+        {
+            WSLCProcessState state{};
+            int exitCode{};
+            THROW_IF_FAILED(internalType->process->GetState(&state, &exitCode));
+
+            if (state == WslcProcessStateExited || state == WslcProcessStateSignalled)
+            {
+                internalType->ioCallbacks->Complete();
+            }
+        }
+        CATCH_LOG();
+    }
 
     return S_OK;
 }

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -1870,6 +1870,73 @@ class WslcSdkTests
         VERIFY_ARE_EQUAL(stdoutData.size(), c_expectedBytes);
     }
 
+    WSLC_TEST_METHOD(ReleaseFromIOCallbackFails)
+    {
+        struct Context
+        {
+            std::atomic<WslcProcess> process{nullptr};
+            std::atomic<WslcContainer> container{nullptr};
+            std::atomic<HRESULT> releaseProcessHr{S_OK};
+            std::atomic<HRESULT> releaseContainerHr{S_OK};
+            std::atomic<bool> captured{false};
+            wil::unique_event done{wil::EventOptions::ManualReset};
+        } ctx;
+
+        auto ioCb = [](WslcProcessIOHandle, const BYTE*, uint32_t, PVOID c) {
+            auto* cx = static_cast<Context*>(c);
+
+            // Wait until the test thread has published both handles before sampling.
+            auto process = cx->process.load(std::memory_order_acquire);
+            auto container = cx->container.load(std::memory_order_acquire);
+            if (!process || !container)
+            {
+                return;
+            }
+
+            // Only capture on the first eligible callback; later callbacks no-op.
+            bool expected = false;
+            if (!cx->captured.compare_exchange_strong(expected, true))
+            {
+                return;
+            }
+
+            // Both calls should fail with ERROR_INVALID_HANDLE_STATE without consuming the handles.
+            cx->releaseProcessHr.store(WslcReleaseProcess(process));
+            cx->releaseContainerHr.store(WslcReleaseContainer(container));
+            cx->done.SetEvent();
+        };
+
+        // Continuous writer for the init process so onStdOut fires repeatedly.
+        WslcProcessSettings procSettings;
+        VERIFY_SUCCEEDED(WslcInitProcessSettings(&procSettings));
+        const char* argv[] = {"/bin/sh", "-c", "while true; do echo LINE; sleep 0.05; done"};
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCmdLine(&procSettings, argv, ARRAYSIZE(argv)));
+
+        WslcProcessCallbacks callbacks{};
+        callbacks.onStdOut = ioCb;
+        VERIFY_SUCCEEDED(WslcSetProcessSettingsCallbacks(&procSettings, &callbacks, &ctx));
+
+        WslcContainerSettings containerSettings;
+        VERIFY_SUCCEEDED(WslcInitContainerSettings("debian:latest", &containerSettings));
+        VERIFY_SUCCEEDED(WslcSetContainerSettingsInitProcess(&containerSettings, &procSettings));
+
+        UniqueContainer container;
+        VERIFY_SUCCEEDED(WslcCreateContainer(m_defaultSession, &containerSettings, &container, nullptr));
+        VERIFY_SUCCEEDED(WslcStartContainer(container.get(), WSLC_CONTAINER_START_FLAG_ATTACH, nullptr));
+
+        UniqueProcess process;
+        VERIFY_SUCCEEDED(WslcGetContainerInitProcess(container.get(), &process));
+
+        // Publish handles to the callback now that both are valid.
+        ctx.container.store(container.get(), std::memory_order_release);
+        ctx.process.store(process.get(), std::memory_order_release);
+
+        VERIFY_ARE_EQUAL(WaitForSingleObject(ctx.done.get(), 30 * 1000), static_cast<DWORD>(WAIT_OBJECT_0));
+
+        VERIFY_ARE_EQUAL(ctx.releaseProcessHr.load(), HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE_STATE));
+        VERIFY_ARE_EQUAL(ctx.releaseContainerHr.load(), HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE_STATE));
+    }
+
     // -----------------------------------------------------------------------
     // Storage tests
     // -----------------------------------------------------------------------


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a race condition in the SDK IO callback. When the process / container handle is released, the callback is IO is cancelled without waiting for all handles to be fully read, which can lead to data loss.

This change solves the issue by explicitly flushing the IO callback if the process / container has exited. This covers the "expected" usecase of the user waiting for the exited handle to be signaled before releasing the handle. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
