### PR TITLE
Exclude the start menu folder from defender

### DIFF
--- a/tools/test/CloudTest-Setup.bat
+++ b/tools/test/CloudTest-Setup.bat
@@ -8,4 +8,5 @@ mklink /D %1\WexLogFileOutput %2\WexLogFileOutput
 
 rem These need to run before the package is installed
 powershell -NoProfile -Command "Add-MpPreference -ExclusionPath 'C:\Program Files\WSL'"
+powershell -NoProfile -Command "Add-MpPreference -ExclusionPath \"%appdata%\Microsoft\Windows\Start Menu\""
 powershell -NoProfile -Command "Add-MpPreference -ExclusionProcess @('wsl.exe', 'wslg.exe', 'wslconfig.exe', 'wslrelay.exe', 'wslhost.exe', 'msrdc.exe', 'wslservice.exe', 'msal.wsl.proxy.exe', 'te.processhost.exe')"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to exclude the start menu shortcut folder from defender, which should hopefully solve the "ModernInstall" test failures where the service fails to delete the distro shortcut because the file is in use 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
