### PR TITLE
Image list/prune filters

### DIFF
--- a/src/windows/wslc/commands/ImageListCommand.cpp
+++ b/src/windows/wslc/commands/ImageListCommand.cpp
@@ -28,6 +28,7 @@ namespace wsl::windows::wslc {
 std::vector<Argument> ImageListCommand::GetArguments() const
 {
     return {
+        Argument::Create(ArgType::Filter, false, NO_LIMIT),
         Argument::Create(ArgType::Format),
         Argument::Create(ArgType::NoTrunc),
         Argument::Create(ArgType::Quiet),

--- a/src/windows/wslc/commands/ImagePruneCommand.cpp
+++ b/src/windows/wslc/commands/ImagePruneCommand.cpp
@@ -29,6 +29,7 @@ std::vector<Argument> ImagePruneCommand::GetArguments() const
 {
     return {
         Argument::Create(ArgType::All, std::nullopt, std::nullopt, Localization::WSLCCLI_ImagePruneAllArgDescription()),
+        Argument::Create(ArgType::Filter, false, NO_LIMIT),
         Argument::Create(ArgType::Session),
     };
 }

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -181,11 +181,24 @@ void ImageService::Build(
     THROW_IF_FAILED(session.Get()->BuildImage(&options, callback, cancelEvent));
 }
 
-std::vector<ImageInformation> ImageService::List(wsl::windows::wslc::models::Session& session)
+std::vector<ImageInformation> ImageService::List(
+    wsl::windows::wslc::models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
 {
+    std::vector<WSLCFilter> filterEntries;
+    filterEntries.reserve(filters.size());
+    for (const auto& [key, value] : filters)
+    {
+        filterEntries.push_back({.Key = key.c_str(), .Value = value.c_str()});
+    }
+
+    WSLCListImagesOptions options{};
+    options.Flags = WSLCListImagesFlagsNone;
+    options.Filters = filterEntries.empty() ? nullptr : filterEntries.data();
+    options.FiltersCount = static_cast<ULONG>(filterEntries.size());
+
     wil::unique_cotaskmem_array_ptr<WSLCImageInformation> images;
     ULONG count = 0;
-    THROW_IF_FAILED(session.Get()->ListImages(nullptr, &images, &count));
+    THROW_IF_FAILED(session.Get()->ListImages(&options, &images, &count));
 
     std::vector<ImageInformation> result;
     for (auto ptr = images.get(), end = images.get() + count; ptr != end; ++ptr)
@@ -297,13 +310,31 @@ void ImageService::Save(wsl::windows::wslc::models::Session& session, const std:
     THROW_IF_FAILED(session.Get()->SaveImage(ToCOMInputHandle(outputHandle), image.c_str(), nullptr, cancelEvent));
 }
 
-wsl::windows::wslc::models::PruneImagesResult ImageService::Prune(wsl::windows::wslc::models::Session& session, bool all)
+wsl::windows::wslc::models::PruneImagesResult ImageService::Prune(
+    wsl::windows::wslc::models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters)
 {
-    WSLCFilter filter{.Key = "dangling", .Value = all ? "false" : "true"};
+    // The --all flag is translated into a `dangling` filter. Skip the implicit
+    // filter if the caller already supplied an explicit `dangling` filter so the
+    // user's value wins (matching docker's behavior).
+    const bool hasExplicitDangling =
+        std::any_of(filters.begin(), filters.end(), [](const auto& f) { return f.first == "dangling"; });
+
+    std::vector<WSLCFilter> filterEntries;
+    filterEntries.reserve(filters.size() + (hasExplicitDangling ? 0 : 1));
+    if (!hasExplicitDangling)
+    {
+        filterEntries.push_back({.Key = "dangling", .Value = all ? "false" : "true"});
+    }
+
+    for (const auto& [key, value] : filters)
+    {
+        filterEntries.push_back({.Key = key.c_str(), .Value = value.c_str()});
+    }
 
     wil::unique_cotaskmem_array_ptr<WSLCDeletedImageInformation> deletedImages;
     ULONGLONG spaceReclaimed = 0;
-    THROW_IF_FAILED(session.Get()->PruneImages(&filter, 1, &deletedImages, deletedImages.size_address<ULONG>(), &spaceReclaimed));
+    THROW_IF_FAILED(session.Get()->PruneImages(
+        filterEntries.data(), static_cast<ULONG>(filterEntries.size()), &deletedImages, deletedImages.size_address<ULONG>(), &spaceReclaimed));
 
     wsl::windows::wslc::models::PruneImagesResult result;
     result.SpaceReclaimed = spaceReclaimed;

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -32,7 +32,8 @@ public:
         IProgressCallback* callback,
         HANDLE cancelEvent = nullptr);
 
-    static std::vector<wsl::windows::wslc::models::ImageInformation> List(wsl::windows::wslc::models::Session& session);
+    static std::vector<wsl::windows::wslc::models::ImageInformation> List(
+        wsl::windows::wslc::models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
     static void Load(wsl::windows::wslc::models::Session& session, const std::wstring& input);
     static void Import(wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName);
     static void Delete(wsl::windows::wslc::models::Session& session, const std::string& image, bool force, bool noPrune);
@@ -42,6 +43,7 @@ public:
     static void Save(wsl::windows::wslc::models::Session& session, const std::string& image, const std::wstring& output, HANDLE cancelEvent = nullptr);
     static void Save(wsl::windows::wslc::models::Session& session, const std::string& image, HANDLE outputHandle, HANDLE cancelEvent = nullptr);
     static void Tag(wsl::windows::wslc::models::Session& session, const std::string& sourceImage, const std::string& targetImage);
-    static wsl::windows::wslc::models::PruneImagesResult Prune(wsl::windows::wslc::models::Session& session, bool all);
+    static wsl::windows::wslc::models::PruneImagesResult Prune(
+        wsl::windows::wslc::models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters = {});
 };
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -92,7 +92,22 @@ void GetImages(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Data.Contains(Data::Session));
     auto& session = context.Data.Get<Data::Session>();
-    auto images = ImageService::List(session);
+
+    // Filter syntax (`key=value`) is enforced upstream; here we just split on the first '='.
+    std::vector<std::pair<std::string, std::string>> filters;
+    if (context.Args.Contains(ArgType::Filter))
+    {
+        for (const auto& wideValue : context.Args.GetAll<ArgType::Filter>())
+        {
+            std::string raw = WideToMultiByte(wideValue);
+            const auto eq = raw.find('=');
+            WI_ASSERT(eq != std::string::npos);
+
+            filters.emplace_back(raw.substr(0, eq), raw.substr(eq + 1));
+        }
+    }
+
+    auto images = ImageService::List(session, filters);
     context.Data.Add<Data::Images>(std::move(images));
 }
 
@@ -290,7 +305,22 @@ void PruneImages(CLIExecutionContext& context)
     auto& session = context.Data.Get<Data::Session>();
 
     bool all = context.Args.Contains(ArgType::All);
-    auto result = ImageService::Prune(session, all);
+
+    // Filter syntax (`key=value`) is enforced upstream; here we just split on the first '='.
+    std::vector<std::pair<std::string, std::string>> filters;
+    if (context.Args.Contains(ArgType::Filter))
+    {
+        for (const auto& wideValue : context.Args.GetAll<ArgType::Filter>())
+        {
+            std::string raw = WideToMultiByte(wideValue);
+            const auto eq = raw.find('=');
+            WI_ASSERT(eq != std::string::npos);
+
+            filters.emplace_back(raw.substr(0, eq), raw.substr(eq + 1));
+        }
+    }
+
+    auto result = ImageService::Prune(session, all, filters);
 
     for (const auto& image : result.UntaggedImages)
     {

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -128,6 +128,120 @@ class WSLCE2EImageListTests
         VERIFY_IS_TRUE(foundHeader, L"Expected table header with REPOSITORY, TAG, IMAGE ID, CREATED, SIZE columns");
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_Filter_MalformedValue)
+    {
+        // Filter values must be of the form key=value; bare keys are rejected by the CLI.
+        const auto result = RunWslc(L"image list --filter dangling");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = Localization::WSLCCLI_InvalidFilterError(L"dangling") + L"\r\n", .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_Filter_InvalidKey)
+    {
+        // Filter keys are validated by the Docker daemon, which rejects unknown keys.
+        const auto result = RunWslc(L"image list --filter color=blue");
+        VERIFY_ARE_EQUAL(1, result.ExitCode);
+        VERIFY_IS_TRUE(result.Stderr.has_value());
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, result.Stderr->find(L"invalid filter"));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_Filter_Reference)
+    {
+        auto listNames = [&](const std::wstring& filterArgs) {
+            auto r = RunWslc(std::format(L"image list --format json {}", filterArgs));
+            r.Verify({.Stderr = L"", .ExitCode = 0});
+            const auto images = wsl::shared::FromJson<std::vector<ImageInformation>>(r.Stdout.value().c_str());
+            std::set<std::wstring> names;
+            for (const auto& image : images)
+            {
+                names.insert(std::format(
+                    L"{}:{}",
+                    wsl::shared::string::MultiByteToWide(image.Repository.value_or("<untagged>")),
+                    wsl::shared::string::MultiByteToWide(image.Tag.value_or("<untagged>"))));
+            }
+            return names;
+        };
+
+        // reference=<name> matches only the matching image.
+        {
+            const auto names = listNames(std::format(L"--filter reference={}", DebianImage.Name));
+            VERIFY_IS_TRUE(names.contains(DebianImage.NameAndTag()));
+            VERIFY_IS_FALSE(names.contains(AlpineImage.NameAndTag()));
+        }
+
+        {
+            const auto names = listNames(std::format(L"--filter reference={}", AlpineImage.Name));
+            VERIFY_IS_FALSE(names.contains(DebianImage.NameAndTag()));
+            VERIFY_IS_TRUE(names.contains(AlpineImage.NameAndTag()));
+        }
+
+        // Multiple --filter reference= values are OR'd: both images should be returned.
+        {
+            const auto names = listNames(std::format(L"--filter reference={} --filter reference={}", DebianImage.Name, AlpineImage.Name));
+            VERIFY_IS_TRUE(names.contains(DebianImage.NameAndTag()));
+            VERIFY_IS_TRUE(names.contains(AlpineImage.NameAndTag()));
+        }
+
+        // A reference that matches nothing returns neither image.
+        {
+            const auto names = listNames(L"--filter reference=wslc-no-such-image-zzz");
+            VERIFY_IS_FALSE(names.contains(DebianImage.NameAndTag()));
+            VERIFY_IS_FALSE(names.contains(AlpineImage.NameAndTag()));
+        }
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_Filter_Dangling)
+    {
+        // dangling=false should include normal (tagged) images.
+        auto result = RunWslc(L"image list --format json --filter dangling=false");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto images = wsl::shared::FromJson<std::vector<ImageInformation>>(result.Stdout.value().c_str());
+        bool foundDebian = false;
+        for (const auto& image : images)
+        {
+            if (image.Repository == wsl::shared::string::WideToMultiByte(DebianImage.Name))
+            {
+                foundDebian = true;
+                break;
+            }
+        }
+        VERIFY_IS_TRUE(foundDebian, L"Expected debian image to appear in dangling=false image list");
+
+        // dangling=true should exclude all tagged images.
+        result = RunWslc(L"image list --format json --filter dangling=true");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        images = wsl::shared::FromJson<std::vector<ImageInformation>>(result.Stdout.value().c_str());
+        for (const auto& image : images)
+        {
+            VERIFY_IS_FALSE(
+                image.Repository.has_value() && image.Repository.value() != "<none>",
+                L"dangling=true list should not contain tagged images");
+        }
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_Filter_MultipleKinds)
+    {
+        // Mixing different filter kinds should AND: reference=<debian> AND dangling=false
+        // narrows to just debian (alpine is excluded by the reference filter).
+        const auto result =
+            RunWslc(std::format(L"image list --format json --filter reference={} --filter dangling=false", DebianImage.Name));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto images = wsl::shared::FromJson<std::vector<ImageInformation>>(result.Stdout.value().c_str());
+        bool foundDebian = false;
+        for (const auto& image : images)
+        {
+            const auto repo = wsl::shared::string::MultiByteToWide(image.Repository.value_or(""));
+            VERIFY_ARE_NOT_EQUAL(AlpineImage.Name, repo, L"alpine should not appear when filtering by reference=debian");
+            if (repo == DebianImage.Name)
+            {
+                foundDebian = true;
+            }
+        }
+        VERIFY_IS_TRUE(foundDebian, L"Expected debian image when combining reference and dangling filters");
+    }
+
 private:
     const TestImage& DebianImage = DebianTestImage();
     const TestImage& AlpineImage = AlpineTestImage();
@@ -162,12 +276,13 @@ private:
     {
         std::wstringstream options;
         options << L"The following options are available:\r\n"
-                << L"  --format    " << Localization::WSLCCLI_FormatArgDescription() << L"\r\n"
-                << L"  --no-trunc  Do not truncate output\r\n"
-                << L"  -q,--quiet  Outputs the container IDs only\r\n"
-                << L"  --session   Specify the session to use\r\n"
-                << L"  --verbose   Output verbose details\r\n"
-                << L"  -?,--help   Shows help about the selected command\r\n"
+                << L"  -f,--filter  " << Localization::WSLCCLI_FilterArgDescription() << L"\r\n"
+                << L"  --format     " << Localization::WSLCCLI_FormatArgDescription() << L"\r\n"
+                << L"  --no-trunc   Do not truncate output\r\n"
+                << L"  -q,--quiet   Outputs the container IDs only\r\n"
+                << L"  --session    Specify the session to use\r\n"
+                << L"  --verbose    Output verbose details\r\n"
+                << L"  -?,--help    Shows help about the selected command\r\n"
                 << L"\r\n";
         return options.str();
     }

--- a/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
@@ -110,6 +110,67 @@ class WSLCE2EImagePruneTests
         }
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Image_Prune_Filter_MalformedValue)
+    {
+        // Filter values must be of the form key=value; bare keys are rejected by the CLI.
+        const auto result = RunWslc(L"image prune --filter label");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = Localization::WSLCCLI_InvalidFilterError(L"label") + L"\r\n", .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Prune_Filter_InvalidKey)
+    {
+        // Filter keys are validated by the Docker daemon, which rejects unknown keys.
+        const auto result = RunWslc(L"image prune --filter color=blue");
+        VERIFY_ARE_EQUAL(1, result.ExitCode);
+        VERIFY_IS_TRUE(result.Stderr.has_value());
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, result.Stderr->find(L"invalid filter"));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Prune_Filter_LabelPreservesDangling)
+    {
+        // Create a dangling debian image (same trick as WSLCE2E_Image_Prune_DanglingImage).
+        EnsureImageIsLoaded(AlpineImage);
+        auto cleanup = wil::scope_exit([&]() {
+            RunWslc(L"image prune");
+            RunWslc(L"image delete prune-target:v1");
+            EnsureImageIsDeleted(AlpineImage);
+            EnsureImageIsLoaded(DebianImage);
+        });
+
+        RunWslc(std::format(L"image tag {} prune-target:v1", DebianImage.NameAndTag())).Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"image delete {}", DebianImage.NameAndTag())).Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"image tag {} prune-target:v1", AlpineImage.NameAndTag())).Verify({.Stderr = L"", .ExitCode = 0});
+
+        // Prune only dangling images carrying a label the dangling image does NOT have.
+        // Multiple --filter label= values are AND'd by the daemon; the dangling image
+        // matches neither, so it must survive this prune.
+        auto filteredPrune = RunWslc(L"image prune --filter label=wslc.test.never=present --filter label=wslc.test.also=missing");
+        filteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
+        for (const auto& line : filteredPrune.GetStdoutLines())
+        {
+            VERIFY_IS_FALSE(
+                line.find(L"Deleted:") != std::wstring::npos, L"Filtered prune should not have deleted the dangling image");
+            VERIFY_IS_FALSE(
+                line.find(L"Untagged:") != std::wstring::npos, L"Filtered prune should not have untagged the dangling image");
+        }
+
+        // A subsequent unfiltered prune should still find and remove the dangling image,
+        // proving the filter — not the absence of dangling images — was the reason nothing
+        // was pruned above.
+        auto unfilteredPrune = RunWslc(L"image prune");
+        unfilteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
+        bool foundDeleted = false;
+        for (const auto& line : unfilteredPrune.GetStdoutLines())
+        {
+            if (line.find(L"Deleted:") != std::wstring::npos || line.find(L"Untagged:") != std::wstring::npos)
+            {
+                foundDeleted = true;
+                break;
+            }
+        }
+        VERIFY_IS_TRUE(foundDeleted, L"Expected the dangling image to be pruned by the unfiltered call");
+    }
+
 private:
     const TestImage& DebianImage = DebianTestImage();
     const TestImage& AlpineImage = AlpineTestImage();
@@ -151,9 +212,10 @@ private:
     {
         std::wstringstream options;
         options << L"The following options are available:\r\n"
-                << L"  -a,--all   " << Localization::WSLCCLI_ImagePruneAllArgDescription() << L"\r\n"
-                << L"  --session  " << Localization::WSLCCLI_SessionIdArgDescription() << L"\r\n"
-                << L"  -?,--help  " << Localization::WSLCCLI_HelpArgDescription() << L"\r\n"
+                << L"  -a,--all     " << Localization::WSLCCLI_ImagePruneAllArgDescription() << L"\r\n"
+                << L"  -f,--filter  " << Localization::WSLCCLI_FilterArgDescription() << L"\r\n"
+                << L"  --session    " << Localization::WSLCCLI_SessionIdArgDescription() << L"\r\n"
+                << L"  -?,--help    " << Localization::WSLCCLI_HelpArgDescription() << L"\r\n"
                 << L"\r\n";
         return options.str();
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Exposes the `--filter` flag on the `wslc image list` and `wslc image prune` CLI commands.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Added -f,--filter <key=value> to wslc image list (alias wslc image ls) and wslc image prune. The flag is repeatable and follows the same syntax/validation as wslc container list --filter (CLI rejects entries without =; key/value validity is left to the Docker daemon, matching docker's behavior and aligning with the model adopted across the rest of the CLI).
- `wslc image prune --all` continues to map to dangling=false under the hood, but a user-supplied --filter dangling=… now takes precedence so explicit user input always wins (also matching docker).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Added e2e tests covering the new flag.