### PR TITLE
Fix wslc push/pull progress display glitches

### DIFF
--- a/src/windows/wslc/services/ImageProgressCallback.cpp
+++ b/src/windows/wslc/services/ImageProgressCallback.cpp
@@ -105,12 +105,20 @@ std::wstring ImageProgressCallback::GenerateStatusLine(LPCSTR status, LPCSTR id,
         bar.append(L">");
         bar.resize(c_progressBarWidth, L' ');
 
-        line = std::format(
-            L"{}: {} [{}] {}/{}", id, status, bar, wsl::shared::string::FormatBytes(current), wsl::shared::string::FormatBytes(total));
+        // Docker's reported total is an estimate of the compressed layer size, so the actual bytes
+        // transferred can exceed it. Drop the total in that case to avoid displaying a count over 100%.
+        auto progress = wsl::shared::string::FormatBytes(current);
+
+        if (current <= total)
+        {
+            progress += std::format(L"/{}", wsl::shared::string::FormatBytes(total));
+        }
+
+        line = std::format(L"{}: {} [{}] {}", id, status, bar, progress);
     }
     else if (current != 0)
     {
-        line = std::format(L"{}: {} {}s", id, status, current);
+        line = std::format(L"{}: {} {}", id, status, wsl::shared::string::FormatBytes(current));
     }
     else
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes two display glitches in wslc push/wslc pull per-layer progress output produced by ImageProgressCallback::GenerateStatusLine: a byte count rendered with a bogus s suffix (e.g. 1536s), and a current/total count that could exceed 100% because Docker's reported total is only an estimate. The over-100% handling mirrors the Docker CLI, which drops the total when the streamed byte count surpasses it.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
