### PR TITLE
Pipelines: fix nuget stage CodeSign failure on in-repo .ps1 scripts

### DIFF
--- a/.pipelines/nuget-stage.yml
+++ b/.pipelines/nuget-stage.yml
@@ -28,6 +28,10 @@ stages:
       ob_outputDirectory: '$(Build.SourcesDirectory)\out'
       ob_artifactBaseName: 'drop_wsl'
       ob_artifactSuffix: '_nuget'
+      # The per-stage SDL CodeSign post-analysis scans the checked-out repo, which contains unsigned
+      # helper .ps1 scripts. The pipeline-level exclude does not flow into per-stage SDL, so it must be
+      # set on this job as well (mirrors build-job.yml). The published .nupkg files remain validated.
+      ob_sdl_codeSignValidation_excludes: -|**\*.ps1
 
     steps:
 

--- a/.pipelines/wsl-build-nightly-onebranch.yml
+++ b/.pipelines/wsl-build-nightly-onebranch.yml
@@ -11,7 +11,6 @@ schedules:
 variables:
   WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest"
   WindowsHostVersion: '1ESWindows2022'
-  ob_sdl_codeSignValidation_excludes: -|**\*.ps1
 
 resources:
   repositories:

--- a/.pipelines/wsl-build-pr-onebranch.yml
+++ b/.pipelines/wsl-build-pr-onebranch.yml
@@ -7,7 +7,6 @@ trigger:
 variables:
   WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest"
   WindowsHostVersion: '1ESWindows2022'
-  ob_sdl_codeSignValidation_excludes: -|**\*.ps1
 
 resources:
   repositories:

--- a/.pipelines/wsl-build-release-onebranch.yml
+++ b/.pipelines/wsl-build-release-onebranch.yml
@@ -21,7 +21,6 @@ trigger:
 variables:
   WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest"
   WindowsHostVersion: '1ESWindows2022'
-  ob_sdl_codeSignValidation_excludes: -|**\*.ps1
 
 resources:
   repositories:


### PR DESCRIPTION
## Please briefly describe your changes
Fixes the release build''s **nuget** stage (`Publish nuget packages`) failing in the Guardian **CodeSign post-analysis** with 10 `CodeSign.MissingSigningCert` errors on unsigned in-repo dev/diagnostic/test `.ps1` helper scripts (e.g. `diagnostics/collect-wsl-logs.ps1`, `tools/deploy/deploy-to-host.ps1`, `triage/install-latest-wsl.ps1`).

Observed in build [148184293](https://dev.azure.com/microsoft/Microsoft.WSL/_build/results?buildId=148184293&view=results) (tag `2.8.10`).

## Root cause
OneBranch''s per-stage SDL CodeSign validation is **job-scoped**. The pipeline-level `ob_sdl_codeSignValidation_excludes` variable (added in #40541) does **not** flow into the auto-injected per-stage analysis, so it never suppressed anything. Proof from the failing build: the `Formatting & localization checks` and flight stages have no job-level exclude yet **passed** (protected by the binaries-only `globalSdl.codesign.targetGlob`), while the nuget job — which has neither a job-level exclude nor effective `targetGlob` coverage for its scan — **failed** despite the same pipeline-level variable being present.

## Changes
- **`.pipelines/nuget-stage.yml`**: set `ob_sdl_codeSignValidation_excludes: -|**\*.ps1` on the `nuget` job (mirrors `build-job.yml`). Published `.nupkg` files remain CodeSign-validated.
- **Remove the ineffective pipeline-level `ob_sdl_codeSignValidation_excludes`** from the release/nightly/PR OneBranch ymls. It never worked: the release pipeline is covered by the binaries-only `targetGlob` + per-job excludes, and the nightly/PR pipelines use the NonOfficial template with no breaking codesign.

## PR Checklist
- [x] Changes are limited to pipeline YAML; no product code affected
- [x] All four edited YAML files validated as well-formed
- [ ] Confirmed green by re-running the release pipeline (requires maintainer)

## Validation
- `python -c "import yaml; yaml.safe_load(...)"` on all four edited files — OK.
- A/B analysis of the failing build''s timeline confirms `targetGlob` (not the pipeline-level variable) is what protects passing stages, and that job-level excludes are the proven mechanism (`build-job.yml`, `package-stage.yml`).
- Final confirmation: re-run `wsl-github-release` and verify the nuget stage CodeSign post-analysis passes.
