### PR TITLE
CLI: Add multiple image support to image delete

### DIFF
--- a/src/windows/wslc/commands/ImageRemoveCommand.cpp
+++ b/src/windows/wslc/commands/ImageRemoveCommand.cpp
@@ -28,7 +28,7 @@ namespace wsl::windows::wslc {
 std::vector<Argument> ImageRemoveCommand::GetArguments() const
 {
     return {
-        Argument::Create(ArgType::ImageId, true),
+        Argument::Create(ArgType::ImageId, true, NO_LIMIT),
         Argument::Create(ArgType::ImageForce),
         Argument::Create(ArgType::NoPrune),
         Argument::Create(ArgType::Session),

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -201,7 +201,7 @@ void DeleteImage(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Data.Contains(Data::Session));
     auto& session = context.Data.Get<Data::Session>();
-    auto imageIds = context.Args.GetAll<ArgType::ImageId>();
+    const auto& imageIds = context.Args.GetAll<ArgType::ImageId>();
     bool force = context.Args.Contains(ArgType::ImageForce);
     bool noPrune = context.Args.Contains(ArgType::NoPrune);
     for (const auto& id : imageIds)

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -200,13 +200,14 @@ void PushImage(CLIExecutionContext& context)
 void DeleteImage(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Data.Contains(Data::Session));
-    WI_ASSERT(context.Args.Contains(ArgType::ImageId));
     auto& session = context.Data.Get<Data::Session>();
-    auto& imageId = context.Args.Get<ArgType::ImageId>();
-
+    auto imageIds = context.Args.GetAll<ArgType::ImageId>();
     bool force = context.Args.Contains(ArgType::ImageForce);
     bool noPrune = context.Args.Contains(ArgType::NoPrune);
-    services::ImageService::Delete(session, WideToMultiByte(imageId), force, noPrune);
+    for (const auto& id : imageIds)
+    {
+        services::ImageService::Delete(session, WideToMultiByte(id), force, noPrune);
+    }
 }
 
 void LoadImage(CLIExecutionContext& context)

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -214,6 +214,8 @@ COMMAND_LINE_TEST_CASE(L"image list --verbose", L"list", true)
 COMMAND_LINE_TEST_CASE(L"image list -q", L"list", true)
 COMMAND_LINE_TEST_CASE(L"image pull ubuntu", L"pull", true)
 COMMAND_LINE_TEST_CASE(L"pull ubuntu", L"pull", true)
+COMMAND_LINE_TEST_CASE(L"image rm cont1 --force --no-prune", L"remove", true)
+COMMAND_LINE_TEST_CASE(L"image rm cont1 cont2 cont3 --force --no-prune", L"remove", true)
 
 // Version command tests
 COMMAND_LINE_TEST_CASE(L"version", L"version", true)

--- a/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
@@ -27,6 +27,7 @@ class WSLCE2EImageDeleteTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureImageIsDeleted(DebianImage);
+        EnsureImageIsDeleted(AlpineImage);
         return true;
     }
 
@@ -34,6 +35,7 @@ class WSLCE2EImageDeleteTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureImageIsDeleted(DebianImage);
+        EnsureImageIsDeleted(AlpineImage);
         return true;
     }
 
@@ -62,6 +64,17 @@ class WSLCE2EImageDeleteTests
         VerifyImageIsNotUsed(DebianImage);
 
         auto result = RunWslc(std::format(L"image delete {}", DebianImage.Name));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Delete_MultipleUnusedImages_Success)
+    {
+        EnsureImageIsLoaded(DebianImage);
+        EnsureImageIsLoaded(AlpineImage);
+        VerifyImageIsNotUsed(DebianImage);
+        VerifyImageIsNotUsed(AlpineImage);
+
+        auto result = RunWslc(std::format(L"image delete {} {}", DebianImage.Name, AlpineImage.Name));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
     }
 
@@ -113,6 +126,7 @@ class WSLCE2EImageDeleteTests
 private:
     const std::wstring WslcContainerName = L"wslc-test-container";
     const TestImage& DebianImage = DebianTestImage();
+    const TestImage& AlpineImage = AlpineTestImage();
     const TestImage& InvalidImage = InvalidTestImage();
 
     std::wstring GetHelpMessage() const


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Image remove / delete only supported one image. This PR enables multiple images to be specified on the command line.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Updates image argument to be multiple.
* Updates image tasks to process multiple images.
* Adds command line unit tests for image delete.
* Adds E2E test for multiple image delete.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
New tests pass