### PR TITLE
Fix potential init crash by catching exceptions in scope_exit reset()

### DIFF
--- a/src/linux/inc/lxwil.h
+++ b/src/linux/inc/lxwil.h
@@ -128,7 +128,12 @@ namespace details {
             if (m_call)
             {
                 m_call = false;
-                m_lambda();
+
+                try
+                {
+                    m_lambda();
+                }
+                CATCH_LOG();
             }
         }
 

--- a/src/linux/inc/lxwil.h
+++ b/src/linux/inc/lxwil.h
@@ -90,64 +90,6 @@ private:
 };
 
 namespace details {
-    template <typename TLambda>
-    class lambda_call
-    {
-    public:
-        lambda_call(const lambda_call&) = delete;
-        lambda_call& operator=(const lambda_call&) = delete;
-        lambda_call& operator=(lambda_call&& other) = delete;
-
-        explicit lambda_call(TLambda&& lambda) noexcept : m_lambda(std::move(lambda))
-        {
-            static_assert(std::is_same<decltype(lambda()), void>::value, "scope_exit lambdas must not have a return value");
-            static_assert(
-                !std::is_lvalue_reference<TLambda>::value && !std::is_rvalue_reference<TLambda>::value,
-                "scope_exit should only be directly used with a lambda");
-        }
-
-        lambda_call(lambda_call&& other) noexcept : m_lambda(std::move(other.m_lambda)), m_call(other.m_call)
-        {
-            other.m_call = false;
-        }
-
-        ~lambda_call() noexcept
-        {
-            reset();
-        }
-
-        // Ensures the scope_exit lambda will not be called
-        void release() noexcept
-        {
-            m_call = false;
-        }
-
-        // Executes the scope_exit lambda immediately if not yet run; ensures it will not run again
-        void reset() noexcept
-        {
-            if (m_call)
-            {
-                m_call = false;
-
-                try
-                {
-                    m_lambda();
-                }
-                CATCH_LOG();
-            }
-        }
-
-        // Returns true if the scope_exit lambda is still going to be executed
-        explicit operator bool() const noexcept
-        {
-            return m_call;
-        }
-
-    protected:
-        TLambda m_lambda;
-        bool m_call = true;
-    };
-
     inline void ThrowErrorIf(bool condition, int error, FailureInfo info)
     {
         if (condition)
@@ -195,6 +137,68 @@ namespace details {
             LogFailure(message, nullptr);
         }
     }
+
+    template <typename TLambda>
+    class lambda_call
+    {
+    public:
+        lambda_call(const lambda_call&) = delete;
+        lambda_call& operator=(const lambda_call&) = delete;
+        lambda_call& operator=(lambda_call&& other) = delete;
+
+        explicit lambda_call(TLambda&& lambda) noexcept : m_lambda(std::move(lambda))
+        {
+            static_assert(std::is_same<decltype(lambda()), void>::value, "scope_exit lambdas must not have a return value");
+            static_assert(
+                !std::is_lvalue_reference<TLambda>::value && !std::is_rvalue_reference<TLambda>::value,
+                "scope_exit should only be directly used with a lambda");
+        }
+
+        lambda_call(lambda_call&& other) noexcept : m_lambda(std::move(other.m_lambda)), m_call(other.m_call)
+        {
+            other.m_call = false;
+        }
+
+        ~lambda_call() noexcept
+        {
+            reset();
+        }
+
+        // Ensures the scope_exit lambda will not be called
+        void release() noexcept
+        {
+            m_call = false;
+        }
+
+        // Executes the scope_exit lambda immediately if not yet run; ensures it will not run again
+        void reset() noexcept
+        {
+            if (m_call)
+            {
+                m_call = false;
+
+                try
+                {
+                    m_lambda();
+                }
+                catch (...)
+                {
+                    LogCaughtException("Exception thrown from a scope_exit lambda");
+                }
+            }
+        }
+
+        // Returns true if the scope_exit lambda is still going to be executed
+        explicit operator bool() const noexcept
+        {
+            return m_call;
+        }
+
+    protected:
+        TLambda m_lambda;
+        bool m_call = true;
+    };
+
 } // namespace details
 
 inline int ResultFromCaughtException()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This catches exceptions thrown from scope_exit. Because reset() is marked noexcept, an exception thrown from there could crash init. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
