### PR TITLE
Fix stress test with name deduping.

### DIFF
--- a/src/windows/wslcsession/WSLCVolumes.cpp
+++ b/src/windows/wslcsession/WSLCVolumes.cpp
@@ -118,9 +118,6 @@ WSLCVolumeInformation WSLCVolumes::CreateVolume(
     auto [it, inserted] = m_volumes.insert({name, std::move(volume)});
     WI_VERIFY(inserted);
 
-    // Record that we initiated this create so OnVolumeEvent ignores the matching docker event.
-    m_expectedEvents.emplace_back(name, VolumeEvent::Create);
-
     return info;
 }
 
@@ -260,6 +257,16 @@ __requires_lock_held(m_lock) void WSLCVolumes::OpenVolumeExclusiveLockHeld(const
     try
     {
         OpenVolumeExclusiveLockHeld(m_dockerClient.InspectVolume(volumeName));
+    }
+    catch (const DockerHTTPException& e)
+    {
+        // A 404 here is expected when a late `create` event arrives after the volume has already
+        // been deleted (e.g. user calls CreateVolume then DeleteVolume; the create event from
+        // docker can race in after the delete has been processed).
+        if (e.StatusCode() != 404)
+        {
+            LOG_CAUGHT_EXCEPTION_MSG("Failed to open volume: %hs", volumeName.c_str());
+        }
     }
     CATCH_LOG_MSG("Failed to open volume: %hs", volumeName.c_str());
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes flakiness in `WSLCTests::NamedVolumesStress` where the post-stress invariant (`InspectVolume` returns `WSLC_E_VOLUME_NOT_FOUND` after all threads end on a `Delete`) intermittently failed because the WSLC volume cache drifted out of sync with docker. Root cause: docker's `POST /volumes/create` is idempotent. When a matching volume already exists it returns 201 but emits no create event, which left ghost entries permanently stuck at the front of our `m_expectedEvents` FIFO, causing later real events to be silently absorbed against the wrong slot. Fix: stop enqueueing self-initiated Create operations; only Destroy operations are tracked. 404s from `InspectVolume` (late-create-after-delete race) are now suppressed silently instead of logged.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
