### PR TITLE
Add telemetry event on container creation

### DIFF
--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -270,7 +270,7 @@ void WSLCSessionManagerImpl::CreateSession(
         auto factory = wslutil::CreateComServerAsUser<IWSLCSessionFactory>(__uuidof(WSLCSessionFactory), userToken.get());
         AddSessionProcessToJobObject(factory.get());
 
-        const auto sessionSettings = CreateSessionSettings(sessionId, creatorPid, Settings, resolvedDisplayName.c_str());
+        const auto sessionSettings = CreateSessionSettings(sessionId, callerFileName.c_str(), Settings, resolvedDisplayName.c_str());
         wil::com_ptr<IWSLCSession> session;
         wil::com_ptr<IWSLCSessionReference> serviceRef;
         THROW_IF_FAILED(factory->CreateSession(&sessionSettings, vm.Get(), notifier.Get(), WarningCallback, &session, &serviceRef));
@@ -415,11 +415,11 @@ void WSLCSessionManagerImpl::EnterSession(
 }
 
 WSLCSessionInitSettings WSLCSessionManagerImpl::CreateSessionSettings(
-    _In_ ULONG SessionId, _In_ DWORD CreatorPid, _In_ const WSLCSessionSettings* Settings, _In_ LPCWSTR ResolvedDisplayName)
+    _In_ ULONG SessionId, _In_ LPCWSTR CreatorProcessName, _In_ const WSLCSessionSettings* Settings, _In_ LPCWSTR ResolvedDisplayName)
 {
     WSLCSessionInitSettings sessionSettings{};
     sessionSettings.SessionId = SessionId;
-    sessionSettings.CreatorPid = CreatorPid;
+    sessionSettings.CreatorProcessName = CreatorProcessName;
     sessionSettings.DisplayName = ResolvedDisplayName;
     sessionSettings.StoragePath = Settings->StoragePath;
     sessionSettings.MaximumStorageSizeMb = Settings->MaximumStorageSizeMb;

--- a/src/windows/service/exe/WSLCSessionManager.h
+++ b/src/windows/service/exe/WSLCSessionManager.h
@@ -165,7 +165,7 @@ private:
 
     void AddSessionProcessToJobObject(_In_ IWSLCSessionFactory* Factory);
     WSLCSessionInitSettings CreateSessionSettings(
-        _In_ ULONG SessionId, _In_ DWORD CreatorPid, _In_ const WSLCSessionSettings* Settings, _In_ LPCWSTR ResolvedDisplayName);
+        _In_ ULONG SessionId, _In_ LPCWSTR CreatorProcessName, _In_ const WSLCSessionSettings* Settings, _In_ LPCWSTR ResolvedDisplayName);
     void EnsureJobObjectCreated();
     static CallingProcessTokenInfo GetCallingProcessTokenInfo();
     static HRESULT CheckTokenAccess(const SessionEntry& Entry, const CallingProcessTokenInfo& TokenInfo);

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -711,7 +711,7 @@ typedef enum _WSLCSessionState
 typedef struct _WSLCSessionInitSettings
 {
     ULONG SessionId;
-    ULONG CreatorPid;
+    [unique] LPCWSTR CreatorProcessName;
     LPCWSTR DisplayName;
     LPCWSTR StoragePath;
     WSLCSessionStorageFlags StorageFlags;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -284,7 +284,7 @@ try
         "SessionInitialized",
         TraceLoggingValue(m_id, "SessionId"),
         TraceLoggingValue(m_displayName.c_str(), "DisplayName"),
-        TraceLoggingValue(Settings->CreatorProcessName, "CreatorProcess"));
+        TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess"));
 
     // Create the VM.
     m_virtualMachine.emplace(Vm, Settings, m_sessionTerminatingEvent.get());
@@ -1637,6 +1637,10 @@ HRESULT WSLCSession::CreateContainer(const WSLCContainerOptions* containerOption
 try
 {
     WSLCExecutionContext context(this, WarningCallback);
+    THROW_HR_IF_NULL(E_POINTER, containerOptions);
+    THROW_HR_IF_NULL(E_POINTER, Container);
+    THROW_HR_IF(E_POINTER, containerOptions->Image == nullptr);
+
     auto lock = m_lock.lock_shared();
 
     auto result = wil::ResultFromException([&]() { CreateContainerImpl(containerOptions, Container); });
@@ -1647,7 +1651,7 @@ try
         PDT_ProductAndServicePerformance,
         TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA),
         TraceLoggingValue(result, "Result"),
-        TraceLoggingValue(containerOptions->Image ? containerOptions->Image : "<null>", "Image"),
+        TraceLoggingValue(containerOptions->Image, "Image"),
         TraceLoggingValue(m_displayName.c_str(), "SessionName"),
         TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess"));
 
@@ -1657,9 +1661,6 @@ CATCH_RETURN();
 
 void WSLCSession::CreateContainerImpl(const WSLCContainerOptions* containerOptions, IWSLCContainer** Container)
 {
-    THROW_HR_IF_NULL(E_POINTER, containerOptions);
-    THROW_HR_IF(E_POINTER, containerOptions->Image == nullptr);
-
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_eventTracker);
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -273,6 +273,7 @@ try
     // N.B. No locking is required because Initialize() is always called before the session is returned to the caller.
     m_id = Settings->SessionId;
     m_displayName = Settings->DisplayName ? Settings->DisplayName : L"";
+    m_creatorProcessName = Settings->CreatorProcessName ? Settings->CreatorProcessName : L"";
     m_featureFlags = Settings->FeatureFlags;
     m_pluginNotifier = PluginNotifier;
 
@@ -283,7 +284,7 @@ try
         "SessionInitialized",
         TraceLoggingValue(m_id, "SessionId"),
         TraceLoggingValue(m_displayName.c_str(), "DisplayName"),
-        TraceLoggingValue(Settings->CreatorPid, "CreatorPid"));
+        TraceLoggingValue(Settings->CreatorProcessName, "CreatorProcess"));
 
     // Create the VM.
     m_virtualMachine.emplace(Vm, Settings, m_sessionTerminatingEvent.get());
@@ -1636,17 +1637,32 @@ HRESULT WSLCSession::CreateContainer(const WSLCContainerOptions* containerOption
 try
 {
     WSLCExecutionContext context(this, WarningCallback);
-
-    RETURN_HR_IF_NULL(E_POINTER, containerOptions);
-
-    // Validate that Image is not null.
-    RETURN_HR_IF(E_INVALIDARG, containerOptions->Image == nullptr);
-
     auto lock = m_lock.lock_shared();
 
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_eventTracker);
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);
+    auto result = wil::ResultFromException([&]() { CreateContainerImpl(containerOptions, Container); });
+
+    // This telemetry event is used to keep track of the container creation failure rate and surface unexpected errors.
+    WSL_LOG_TELEMETRY(
+        "WSLCCreateContainer",
+        PDT_ProductAndServicePerformance,
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA),
+        TraceLoggingValue(result, "Result"),
+        TraceLoggingValue(containerOptions->Image ? containerOptions->Image : "<null>", "Image"),
+        TraceLoggingValue(m_displayName.c_str(), "SessionName"),
+        TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess"));
+
+    return result;
+}
+CATCH_RETURN();
+
+void WSLCSession::CreateContainerImpl(const WSLCContainerOptions* containerOptions, IWSLCContainer** Container)
+{
+    THROW_HR_IF_NULL(E_POINTER, containerOptions);
+    THROW_HR_IF(E_POINTER, containerOptions->Image == nullptr);
+
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_eventTracker);
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);
 
     // Validate that name & images are valid.
     if (containerOptions->Name != nullptr && containerOptions->Name[0] != '\0')
@@ -1654,9 +1670,7 @@ try
         ValidateName(containerOptions->Name, WSLC_MAX_CONTAINER_NAME_LENGTH);
     }
 
-    RETURN_HR_IF(E_INVALIDARG, strlen(containerOptions->Image) > WSLC_MAX_IMAGE_NAME_LENGTH);
-
-    // TODO: Log entrance into the function.
+    THROW_HR_IF(E_INVALIDARG, strlen(containerOptions->Image) > WSLC_MAX_IMAGE_NAME_LENGTH);
 
     try
     {
@@ -1708,8 +1722,6 @@ try
         WI_ASSERT(inserted);
 
         it->second->CopyTo(Container);
-
-        return S_OK;
     }
     catch (const DockerHTTPException& e)
     {
@@ -1724,7 +1736,6 @@ try
         THROW_HR_WITH_USER_ERROR(E_FAIL, errorMessage);
     }
 }
-CATCH_RETURN();
 
 HRESULT WSLCSession::OpenContainer(LPCSTR Id, IWSLCContainer** Container)
 try

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -201,6 +201,8 @@ private:
 
     __requires_lock_held(m_userHandlesLock) void CancelUserHandleIO();
     __requires_lock_held(m_userCOMCallbacksLock) void CancelUserCOMCallbacks();
+
+    __requires_lock_held(m_lock) void CreateContainerImpl(const WSLCContainerOptions* Options, IWSLCContainer** Container);
     void ConfigureStorage(const WSLCSessionInitSettings& Settings, PSID UserSid);
     void Ext4Format(const std::string& Device);
     _Requires_shared_lock_held_(m_lock)
@@ -234,6 +236,7 @@ private:
     std::optional<DockerEventTracker> m_eventTracker;
     wil::unique_event m_dockerdReadyEvent{wil::EventOptions::ManualReset};
     std::wstring m_displayName;
+    std::wstring m_creatorProcessName;
     std::filesystem::path m_storageVhdPath;
     std::filesystem::path m_swapVhdPath;
 

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -202,7 +202,9 @@ private:
     __requires_lock_held(m_userHandlesLock) void CancelUserHandleIO();
     __requires_lock_held(m_userCOMCallbacksLock) void CancelUserCOMCallbacks();
 
-    __requires_lock_held(m_lock) void CreateContainerImpl(const WSLCContainerOptions* Options, IWSLCContainer** Container);
+    _Requires_shared_lock_held_(m_lock)
+    void CreateContainerImpl(const WSLCContainerOptions* Options, IWSLCContainer** Container);
+
     void ConfigureStorage(const WSLCSessionInitSettings& Settings, PSID UserSid);
     void Ext4Format(const std::string& Device);
     _Requires_shared_lock_held_(m_lock)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5290,7 +5290,7 @@ class WSLCTests
 
             wil::com_ptr<IWSLCContainer> container;
             auto hr = m_defaultSession->CreateContainer(&options, nullptr, &container);
-            VERIFY_ARE_EQUAL(hr, E_INVALIDARG);
+            VERIFY_ARE_EQUAL(hr, E_POINTER);
         }
 
         // Test null container name


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds a telemetry event on container creation.

Sample event: 

```
Microsoft.Windows.Wslc	WSLCCreateContainer	06-03-2026 15:27:21.858	"CreatorProcess: 	wslc.exe
Image: 	debian:latest
Result: 	0
SessionName: 	wslc-cli-admin-oneblue
wslVersion: 	2.8.11.11"				3128	5048	5		4dad646b-fbd7-4924-ad24-b166bd8c2a49		
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
