### PR TITLE
Fix wsl.wprp specialized log profiles to actually extend the default profile instead of replacing it

### DIFF
--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -331,7 +331,7 @@
             <EventProviderId Value="vmwp"/>
             <EventProviderId Value="wsl_devicehost"/>
             <EventProviderId Value="wslapi"/>
-            <EventProviderId Value="wslaservice"/>
+            <EventProviderId Value="wslc"/>
             <EventProviderId Value="wslclient"/>
           </EventProviders>
         </EventCollectorId>

--- a/diagnostics/wsl.wprp
+++ b/diagnostics/wsl.wprp
@@ -15,6 +15,15 @@
       <BufferSize Value="512"/>
       <Buffers Value="4096"/>
     </EventCollector>
+
+    <!--
+      Separate collector used by sub-profiles. Using the same provider in a sub-profile
+      would replace the base provider instead of extending it.
+    -->
+    <EventCollector Id="Collector_extra" Name="Collector_extra">
+      <BufferSize Value="512"/>
+      <Buffers Value="4096"/>
+    </EventCollector>
    
     <!-- Event Providers -->
     <EventProvider Id="9p" Name="e13c8d52-b153-571f-78c5-1d4098af2a1e"/>
@@ -322,7 +331,7 @@
             <EventProviderId Value="vmwp"/>
             <EventProviderId Value="wsl_devicehost"/>
             <EventProviderId Value="wslapi"/>
-            <EventProviderId Value="wslc"/>
+            <EventProviderId Value="wslaservice"/>
             <EventProviderId Value="wslclient"/>
           </EventProviders>
         </EventCollectorId>
@@ -339,7 +348,7 @@
       Base="WSL.Verbose.File"
       >
       <Collectors>
-        <EventCollectorId Value="Collector">
+        <EventCollectorId Value="Collector_extra">
           <EventProviders>
             <!-- Additional storage-specific providers -->
             <EventProviderId Value="storvsp_io"/>
@@ -359,7 +368,7 @@
       Base="WSL.Verbose.File"
       >
       <Collectors>
-        <EventCollectorId Value="Collector">
+        <EventCollectorId Value="Collector_extra">
           <EventProviders>
             <!-- Additional networking-specific providers -->
             <EventProviderId Value="aad_WPP"/>
@@ -521,7 +530,7 @@
       Base="WSL.Verbose.File"
       >
       <Collectors>
-        <EventCollectorId Value="Collector">
+        <EventCollectorId Value="Collector_extra">
           <EventProviders>
             <!-- Additional providers specific to HvSocket profile -->
             <EventProviderId Value="EventProvider_HvSocketTraceProvider"/>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes `wsl.wprp` to always collect logs from the default provider when using a specialized collection profile 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
