### PR TITLE
Fix wslc image pull command when invoked in network logon session

### DIFF
--- a/src/windows/wslc/services/WinCredStorage.cpp
+++ b/src/windows/wslc/services/WinCredStorage.cpp
@@ -53,7 +53,11 @@ std::pair<std::string, std::string> WinCredStorage::Get(const std::string& serve
     unique_credential cred;
     if (!CredReadW(targetName.c_str(), CRED_TYPE_GENERIC, 0, &cred))
     {
-        THROW_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
+        auto error = GetLastError();
+
+        // Credential Manager is unavailable under network logon session (e.g. an SSH network logon),
+        // Treat it like "no credential found" so anonymous pull/push can proceed.
+        THROW_LAST_ERROR_IF(error != ERROR_NOT_FOUND && error != ERROR_NO_SUCH_LOGON_SESSION);
         return {};
     }
 
@@ -94,7 +98,11 @@ std::vector<std::wstring> WinCredStorage::List()
     unique_credential_array creds;
     if (!CredEnumerateW(filter.c_str(), 0, &count, &creds))
     {
-        THROW_LAST_ERROR_IF(GetLastError() != ERROR_NOT_FOUND);
+        auto error = GetLastError();
+
+        // Credential Manager is unavailable under network logon session (e.g. an SSH network logon),
+        // Treat it like "no credential found" so anonymous pull/push can proceed.
+        THROW_LAST_ERROR_IF(error != ERROR_NOT_FOUND && error != ERROR_NO_SUCH_LOGON_SESSION);
         return {};
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In network logon session, wincred store is not available. Treat it as "credential not exist" for anonymous pull operation to work. For write and delete operations, keep it as failed.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated manually with 2 VMs setup, one invoking other via ssh, issue repros before this change and issue fixed after this change. It's quite complex to write an e2e test (start up 2 vm, setup ssh service and ssh client, create net login, etc) for it so I did not add test with this change. 