### PR TITLE
Map HCS_E_HYPERV_NOT_INSTALLED to an actionable 'install Virtual Machine Platform' error

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2873,7 +2873,26 @@ void LxssUserSessionImpl::_CreateVm()
         m_vmId.store(vmId);
 
         // Create the utility VM and register for callbacks.
-        m_utilityVm = WslCoreVm::Create(m_userToken, std::move(config), vmId);
+        try
+        {
+            m_utilityVm = WslCoreVm::Create(m_userToken, std::move(config), vmId);
+        }
+        catch (...)
+        {
+            // CreateComputeSystem() throws HCS_E_HYPERV_NOT_INSTALLED when the Virtual Machine Platform optional
+            // component is not installed. That HRESULT otherwise maps to a misleading "virtualization is not
+            // enabled" message that points users at their BIOS instead of the missing component. Remap it to an
+            // actionable error covering every path that needs the VM (launch, WSL1->WSL2 conversion, import,
+            // disk mount, ...). Other failures (e.g. the VM starts but networking init fails because VMP is only
+            // partially installed) are left untouched so their existing degraded-mode handling still applies.
+            if (wil::ResultFromCaughtException() == HCS_E_HYPERV_NOT_INSTALLED)
+            {
+                THROW_HR_WITH_USER_ERROR(
+                    WSL_E_VIRTUAL_MACHINE_PLATFORM_REQUIRED, wsl::shared::Localization::MessageVirtualMachinePlatformNotInstalled());
+            }
+
+            throw;
+        }
 
         if (m_httpProxyStateTracker)
         {


### PR DESCRIPTION
### Problem
Any op that needs the WSL2 VM (launch, `--set-version 2`, `--import`, disk mount) goes through `_CreateVm()` -> `WslCoreVm::Create()` -> `hcs::CreateComputeSystem()`. Without the Virtual Machine Platform optional component, HCS throws `HCS_E_HYPERV_NOT_INSTALLED`, which maps to *"virtualization is not enabled on this machine"* — pointing users at their BIOS instead of the real cause (missing optional component). Especially confusing mid `--set-version` conversion (internal Sev1).

### Fix
Catch `HCS_E_HYPERV_NOT_INSTALLED` at the `Create()` call in `_CreateVm()` and remap to `WSL_E_VIRTUAL_MACHINE_PLATFORM_REQUIRED` (already defined + mapped to *"install Virtual Machine Platform via wsl.exe --install --no-distribution"*, just never thrown). One chokepoint fixes every VM-creation path. Keying off the actual failure means the partial-VMP case (`vmcompute` up, `HNS`/`vfpext` missing) still starts with degraded networking as before — no collateral.

### Notes
- Reuses `MessageVirtualMachinePlatformNotInstalled`; its *"Failed to start virtual networking"* prefix is slightly off here — can add a dedicated string if preferred.
- Couldn't build WSL locally; uses only symbols already in this TU, so CI is the real check.
