### PR TITLE
Update Microsoft.WSL.Kernel version to 6.18.33.1-1

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -20,7 +20,7 @@
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.DeviceHost" version="1.2.29-0" />
-  <package id="Microsoft.WSL.Kernel" version="6.18.26.3-1" targetFramework="native" />
+  <package id="Microsoft.WSL.Kernel" version="6.18.33.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />


### PR DESCRIPTION
Update to 6.18.33.1. See  https://github.com/microsoft/WSL2-Linux-Kernel/releases/tag/linux-msft-wsl-6.18.33.1