### PR TITLE
Fix CreateInstance failure when Windows hosts file exceeds message size cap (2.7 backport)

### DIFF
--- a/src/shared/inc/socketshared.h
+++ b/src/shared/inc/socketshared.h
@@ -64,7 +64,7 @@ try
 #endif
     }
 
-    if (MessageSize > 4 * 1024 * 1024) // 4 MiB
+    if (MessageSize > 16 * 1024 * 1024) // 16 MiB
     {
 #if defined(_MSC_VER)
         THROW_HR_MSG(E_UNEXPECTED, "Message size too large: %llu", MessageSize);

--- a/src/windows/common/filesystem.cpp
+++ b/src/windows/common/filesystem.cpp
@@ -930,6 +930,12 @@ std::string wsl::windows::common::filesystem::GetWindowsHosts(const std::filesys
                 WindowsHosts.append(CurrentEntry);
             }
         }
+
+        if (WindowsHosts.size() > 8 * _1MB)
+        {
+            LOG_HR_MSG(HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE), "Windows hosts file too large");
+            return {};
+        }
     }
 
     WI_ASSERT(Stream.eof());


### PR DESCRIPTION
Cherry-pick of #40718 for the 2.7 release branch.

Changes from master:
- Replaced EMIT_USER_WARNING with LOG_HR_MSG (trace-only, no user-facing message)
- Removed MessageHostsFileTooLarge localization string

Fixes #40696
Fixes #40700
Fixes #40699