### PR TITLE
Migrate GuestTelemetryLogger to MultiHandleWait IO infrastructure

### DIFF
--- a/src/windows/service/exe/GuestTelemetryLogger.cpp
+++ b/src/windows/service/exe/GuestTelemetryLogger.cpp
@@ -61,23 +61,28 @@ void GuestTelemetryLogger::Start(const wil::unique_event& ExitEvent)
             const std::vector<HANDLE> exitEvents = {m_threadExit.get(), ExitEvent.get()};
             wsl::windows::common::helpers::ConnectPipe(Pipe.get(), INFINITE, exitEvents);
 
-            std::vector<gsl::byte> buffer(LX_RELAY_BUFFER_SIZE);
-            OVERLAPPED overlapped = {};
-            const wil::unique_event overlappedEvent(wil::EventOptions::ManualReset);
-            overlapped.hEvent = overlappedEvent.get();
-            for (;;)
-            {
-                overlappedEvent.ResetEvent();
-                const auto bytesRead =
-                    wsl::windows::common::relay::InterruptableRead(Pipe.get(), gsl::make_span(buffer), exitEvents, &overlapped);
+            namespace io = wsl::windows::common::io;
+            io::MultiHandleWait ioWait;
+            ioWait.AddHandle(
+                std::make_unique<io::ReadHandle>(
+                    io::HandleWrapper{Pipe.get()},
+                    [this](const gsl::span<char>& buffer) {
+                        if (!buffer.empty())
+                        {
+                            ProcessInput(std::string_view{buffer.data(), static_cast<size_t>(buffer.size())});
+                        }
+                    }),
+                io::MultiHandleWait::IgnoreErrors);
 
-                if (bytesRead == 0)
-                {
-                    break;
-                }
+            ioWait.AddHandle(
+                std::make_unique<io::EventHandle>(io::HandleWrapper{m_threadExit.get()}),
+                io::MultiHandleWait::CancelOnCompleted | io::MultiHandleWait::NeedNotComplete);
 
-                ProcessInput(std::string_view{reinterpret_cast<const char*>(buffer.data()), bytesRead});
-            }
+            ioWait.AddHandle(
+                std::make_unique<io::EventHandle>(io::HandleWrapper{ExitEvent.get()}),
+                io::MultiHandleWait::CancelOnCompleted | io::MultiHandleWait::NeedNotComplete);
+
+            ioWait.Run(std::nullopt);
         }
         CATCH_LOG()
     });


### PR DESCRIPTION
Migrate `GuestTelemetryLogger` from the manual `for(;;) InterruptableRead` loop to the `io::MultiHandleWait` / `ReadHandle` / `EventHandle` model already used by the console relay (#40814), so guest telemetry reads share the unified overlapped-IO wait path.

### Scope

This PR was originally a broad relay-IO migration, but most of that work landed independently on `master` via #40814, #40766, #40658, and #40534. The branch has been rebased and reduced to the one change `master` still lacks: the `GuestTelemetryLogger` conversion. The earlier `relay::` -> `io::` namespace move and `CreateThread` templatization were dropped as unnecessary churn.

### Testing

- Formatted with clang-format 19.1.5 (matches CI).
- Full Debug x64 build passes (`/WX`).