### PR TITLE
Back system distro overlay with a per-instance scratch vhd

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -121,9 +121,9 @@ std::optional<bool> g_EnableSocketLogging;
 
 int Chroot(const char* Target);
 
-void CreateSwap(unsigned int Lun);
+std::optional<std::string> FormatScratchDevice(unsigned int Lun);
 
-int CreateTempDirectory(const char* ParentPath, std::string& Path);
+void CreateSwap(unsigned int Lun);
 
 int DetachScsiDisk(unsigned int Lun);
 
@@ -170,7 +170,8 @@ void LaunchSystemDistro(
     const char* SharedMemoryRoot,
     const char* InstallPath,
     const char* UserProfile,
-    pid_t DistroInitPid);
+    pid_t DistroInitPid,
+    unsigned int ScratchLun);
 
 std::map<unsigned long, std::string> ListDiskPartitions(const std::string& DeviceName, std::optional<unsigned long> WaitForIndex = {});
 
@@ -295,6 +296,59 @@ Return Value:
     return Fd;
 }
 
+std::optional<std::string> FormatScratchDevice(unsigned int Lun)
+
+/*++
+
+Routine Description:
+
+    This routine formats the scratch vhd used to back the system distro overlay's
+    read/write layer.
+
+    N.B. This must run after the scratch device LUN is attached, but before the
+         overlay is created so the overlay can mount the device as its rw layer.
+
+Arguments:
+
+    Lun - Supplies the LUN of the scratch device, or UINT_MAX if none.
+
+Return Value:
+
+    The scratch device path on success, std::nullopt on failure.
+
+--*/
+
+try
+{
+    if (Lun == UINT_MAX)
+    {
+        return std::nullopt;
+    }
+
+    const std::string DevicePath = GetLunDevicePath(Lun);
+    WaitForBlockDevice(DevicePath.c_str());
+
+    //
+    // Format the scratch device with ext4.
+    //
+    // N.B. This runs with the system distro as the root filesystem, so mkfs.ext4
+    //      and the scratch device node are directly reachable.
+    //
+    // N.B. The journal is omitted (the data is disposable) and the inode table is
+    //      lazily initialized to keep formatting off the boot critical path.
+    //
+
+    const std::string CommandLine = std::format("/usr/sbin/mkfs.ext4 -q -m 0 -O ^has_journal -E lazy_itable_init=1 '{}'", DevicePath);
+    THROW_LAST_ERROR_IF(UtilExecCommandLine(CommandLine.c_str(), nullptr) < 0);
+
+    return DevicePath;
+}
+catch (...)
+{
+    LOG_CAUGHT_EXCEPTION();
+    return std::nullopt;
+}
+
 void CreateSwap(unsigned int Lun)
 
 /*++
@@ -332,50 +386,6 @@ Return Value:
         CommandLine = std::format("/usr/sbin/swapon '{}'", DevicePath);
         UtilExecCommandLine(CommandLine.c_str(), nullptr);
     });
-}
-
-int CreateTempDirectory(const char* ParentPath, std::string& Path)
-
-/*++
-
-Routine Description:
-
-    This routine creates a unique directory under the specified parent path.
-
-Arguments:
-
-    ParentPath - Supplies the path of the parent directory.
-
-    Path - Supplies a buffer to receive the path of the child directory that was
-        created.
-
-Return Value:
-
-    0 on success, -1 on failure.
-
---*/
-
-{
-    if (ParentPath)
-    {
-        Path = ParentPath;
-    }
-
-    //
-    // Generate a random name for the directory.
-    //
-    // N.B. mkdtemp requires a template string that ends in "XXXXXX".
-    //
-
-    Path += "/wslXXXXXX";
-
-    if (mkdtemp(Path.data()) == NULL)
-    {
-        LOG_ERROR("mkdtemp({}) failed {}", Path.c_str(), errno);
-        return -1;
-    }
-
-    return 0;
 }
 
 dev_t GetBlockDeviceNumber(const std::string& BlockDeviceName)
@@ -1477,7 +1487,7 @@ try
     size_t TargetPathLength = strlen(Target);
     auto AddTemporaryMount = [&](const char* Name, const char* Source, unsigned long MountFlags) {
         std::string Path;
-        THROW_LAST_ERROR_IF(CreateTempDirectory(Target, Path) < 0);
+        THROW_LAST_ERROR_IF(UtilCreateTempDirectory(Target, Path) < 0);
         THROW_LAST_ERROR_IF(mount(Source, Path.c_str(), nullptr, MountFlags, nullptr) < 0);
         AddEnvironmentVariable(Name, Path.substr(TargetPathLength).data());
     };
@@ -1665,7 +1675,8 @@ void LaunchSystemDistro(
     const char* SharedMemoryRoot,
     const char* InstallPath,
     const char* UserProfile,
-    pid_t DistroInitPid)
+    pid_t DistroInitPid,
+    unsigned int ScratchLun)
 
 /*++
 
@@ -1702,6 +1713,10 @@ Arguments:
 
     DistroInitPid - Supplies the pid of the user distribution's init process.
 
+    ScratchLun - Supplies the SCSI LUN of the scratch device used to back the
+        overlay read/write layer, or UINT_MAX if none. When unavailable, the
+        overlay falls back to a tmpfs read/write layer.
+
 Return Value:
 
     None. This method does not return.
@@ -1711,10 +1726,26 @@ Return Value:
 try
 {
     //
-    // Create a writable layer on top of the read-only vhd.
+    // Format the scratch device (backed by a vhd) used to back the overlay
+    // read/write layer so it is disk-backed instead of consuming guest memory.
+    // On failure, the overlay transparently falls back to tmpfs.
     //
 
-    THROW_LAST_ERROR_IF(UtilMountOverlayFs(Target, SYSTEM_DISTRO_VHD_PATH) < 0);
+    const std::optional<std::string> ScratchDevice = FormatScratchDevice(ScratchLun);
+
+    //
+    // Create a writable layer on top of the read-only vhd. If the scratch-backed
+    // overlay fails to mount (e.g. the backing vhd is full or the rw layer setup
+    // fails), fall back to a tmpfs-backed overlay so the system distro can still
+    // launch.
+    //
+
+    if (UtilMountOverlayFs(Target, SYSTEM_DISTRO_VHD_PATH, 0, {}, ScratchDevice) < 0)
+    {
+        THROW_LAST_ERROR_IF(!ScratchDevice.has_value());
+        LOG_ERROR("scratch-backed overlay mount failed, falling back to tmpfs");
+        THROW_LAST_ERROR_IF(UtilMountOverlayFs(Target, SYSTEM_DISTRO_VHD_PATH, 0, {}, std::nullopt) < 0);
+    }
 
     //
     // Launch the init daemon, this method does not return.
@@ -1852,7 +1883,7 @@ try
     std::string MountPoint;
     if (Flags & LxMiniInitMessageFlagCreateOverlayFs)
     {
-        if (CreateTempDirectory(Target, MountPoint) < 0)
+        if (UtilCreateTempDirectory(Target, MountPoint) < 0)
         {
             return -1;
         }
@@ -1940,7 +1971,7 @@ int MountSystemDistro(LX_MINI_INIT_MOUNT_DEVICE_TYPE DeviceType, unsigned int De
 Routine Description:
 
     This routine mounts the system distro as read-only, creates a writable
-    tmpfs layer using overlayfs, and chroots to the mount point.
+    overlayfs layer, and chroots to the mount point.
 
 Arguments:
 
@@ -2301,7 +2332,8 @@ void ProcessLaunchInitMessage(
                         wsl::shared::string::FromSpan(Buffer, Message->SharedMemoryRootOffset),
                         wsl::shared::string::FromSpan(Buffer, Message->InstallPathOffset),
                         wsl::shared::string::FromSpan(Buffer, Message->UserProfileOffset),
-                        ChildPid);
+                        ChildPid,
+                        Message->ScratchLun);
                 }
             }
 

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -1861,10 +1861,12 @@ Return Value:
 --*/
 
 {
-    if (ParentPath)
-    {
-        Path = ParentPath;
-    }
+    //
+    // Set the parent path explicitly so the result does not depend on any prior contents of the
+    // caller's buffer when ParentPath is null.
+    //
+
+    Path = ParentPath != nullptr ? ParentPath : "";
 
     //
     // Generate a random name for the directory.
@@ -2003,13 +2005,27 @@ try
     if (ScratchDevice.has_value())
     {
         const auto VolatileOptions = MountOptions + ",volatile";
-        if (UtilMount(nullptr, Target, "overlay", MountFlags, VolatileOptions.c_str(), TimeoutSeconds) >= 0)
+        const int VolatileResult = UtilMount(nullptr, Target, "overlay", MountFlags, VolatileOptions.c_str(), TimeoutSeconds);
+        if (VolatileResult >= 0)
         {
             cleanupRwLayer.release();
             return 0;
         }
 
-        LOG_ERROR("volatile overlay mount failed, retrying without volatile");
+        //
+        // A kernel that does not understand the "volatile" option fails the mount with EINVAL;
+        // only that warrants retrying without it. Any other failure (e.g. ENOSPC, EBUSY) would
+        // recur, so surface it to the caller, which falls back to a tmpfs read/write layer.
+        //
+        // N.B. UtilMount returns the negated errno on failure.
+        //
+
+        if (VolatileResult != -EINVAL)
+        {
+            return -1;
+        }
+
+        LOG_ERROR("volatile overlay mount unsupported (errno {}), retrying without volatile", -VolatileResult);
     }
 
     if (UtilMount(nullptr, Target, "overlay", MountFlags, MountOptions.c_str(), TimeoutSeconds) < 0)

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -1985,6 +1985,33 @@ try
     }
 
     MountOptions += std::format("workdir={}", Path);
+
+    //
+    // The scratch-backed read/write layer is reformatted on every launch and discarded on
+    // teardown, so the overlay upper dir is disposable. Mount it "volatile" to skip syncs to the
+    // upper filesystem (supported since overlayfs 5.10), avoiding writeback stalls on a layer
+    // whose contents never need to survive a crash. overlayfs refuses to reuse a volatile upper
+    // dir after an unclean shutdown, but that is moot here because the upper dir is always freshly
+    // created above. A tmpfs read/write layer gains nothing from volatile, so it is only used for
+    // the scratch-backed layer.
+    //
+    // N.B. If the running kernel does not support the volatile option the mount fails with EINVAL;
+    //      retry without it so a disk-backed overlay is still used rather than falling all the way
+    //      back to a tmpfs layer.
+    //
+
+    if (ScratchDevice.has_value())
+    {
+        const auto VolatileOptions = MountOptions + ",volatile";
+        if (UtilMount(nullptr, Target, "overlay", MountFlags, VolatileOptions.c_str(), TimeoutSeconds) >= 0)
+        {
+            cleanupRwLayer.release();
+            return 0;
+        }
+
+        LOG_ERROR("volatile overlay mount failed, retrying without volatile");
+    }
+
     if (UtilMount(nullptr, Target, "overlay", MountFlags, MountOptions.c_str(), TimeoutSeconds) < 0)
     {
         return -1;

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -30,6 +30,7 @@ Abstract:
 #include <thread>
 #include <chrono>
 #include <climits>
+#include <cstdlib>
 #include <pthread.h>
 #include "common.h"
 #include "wslpath.h"
@@ -1838,7 +1839,56 @@ Return Value:
     return 0;
 }
 
-int UtilMountOverlayFs(const char* Target, const char* Lower, unsigned long MountFlags, std::optional<std::chrono::seconds> TimeoutSeconds)
+int UtilCreateTempDirectory(const char* ParentPath, std::string& Path)
+
+/*++
+
+Routine Description:
+
+    This routine creates a unique directory under the specified parent path.
+
+Arguments:
+
+    ParentPath - Supplies the path of the parent directory.
+
+    Path - Supplies a buffer to receive the path of the child directory that was
+        created.
+
+Return Value:
+
+    0 on success, -1 on failure.
+
+--*/
+
+{
+    if (ParentPath)
+    {
+        Path = ParentPath;
+    }
+
+    //
+    // Generate a random name for the directory.
+    //
+    // N.B. mkdtemp requires a template string that ends in "XXXXXX".
+    //
+
+    Path += "/wslXXXXXX";
+
+    if (mkdtemp(Path.data()) == NULL)
+    {
+        LOG_ERROR("mkdtemp({}) failed {}", Path.c_str(), errno);
+        return -1;
+    }
+
+    return 0;
+}
+
+int UtilMountOverlayFs(
+    const char* Target,
+    const char* Lower,
+    unsigned long MountFlags,
+    std::optional<std::chrono::seconds> TimeoutSeconds,
+    const std::optional<std::string>& ScratchDevice)
 
 /*++
 
@@ -1857,6 +1907,9 @@ Arguments:
 
     TimeoutSeconds - Supplies an optional timeout if the mount should be retried.
 
+    ScratchDevice - Supplies an optional ext4 scratch block device used to back the
+        read/write layer. When empty, the read/write layer is backed by a tmpfs.
+
 Return Value:
 
     0 on success, < 0 on failure.
@@ -1869,7 +1922,7 @@ try
     // Set up the state required for overlayfs mount:
     //
     // <Target> - mount point for read/write overlayfs (this happens last)
-    // <Target>/rw - tmpfs mount for upper and work dirs
+    // <Target>/rw - read/write layer (scratch device or tmpfs) for upper and work dirs
     // <Target>/rw/upper - upper dir
     // <Target>/rw/work - work dir
     //
@@ -1882,13 +1935,37 @@ try
     auto Path = std::format("{}/rw", Target);
 
     //
-    // Create a tmpfs mount for the read/write layer
+    // Mount the read/write layer at <Target>/rw, backed either by the scratch
+    // device (disk-backed, reclaimable) or, when no scratch device is available,
+    // by a tmpfs (pinned guest memory). It is unwound on a later failure so the
+    // caller is not left with a half-constructed overlay.
     //
 
-    if (UtilMount(nullptr, Path.c_str(), "tmpfs", 0, nullptr) < 0)
+    const std::string rwPath = Path;
+    bool rwMounted = false;
+    auto cleanupRwLayer = wil::scope_exit([&]() {
+        if (rwMounted)
+        {
+            umount2(rwPath.c_str(), MNT_DETACH);
+        }
+    });
+
+    if (ScratchDevice.has_value())
     {
-        return -1;
+        if (UtilMount(ScratchDevice->c_str(), Path.c_str(), "ext4", MS_NOATIME, nullptr) < 0)
+        {
+            return -1;
+        }
     }
+    else
+    {
+        if (UtilMount(nullptr, Path.c_str(), "tmpfs", 0, nullptr) < 0)
+        {
+            return -1;
+        }
+    }
+
+    rwMounted = true;
 
     //
     // Create upper and work directories.
@@ -1913,6 +1990,7 @@ try
         return -1;
     }
 
+    cleanupRwLayer.release();
     return 0;
 }
 CATCH_RETURN_ERRNO()

--- a/src/linux/init/util.h
+++ b/src/linux/init/util.h
@@ -251,11 +251,19 @@ int UtilMkdir(const char* Path, mode_t Mode);
 
 int UtilMkdirPath(const char* Path, mode_t Mode, bool SkipLast = false);
 
+// Creates a uniquely-named directory under ParentPath, returning its path in Path.
+int UtilCreateTempDirectory(const char* ParentPath, std::string& Path);
+
 int UtilMountFile(const char* Source, const char* Destination);
 
 int UtilMount(const char* Source, const char* Target, const char* Type, unsigned long MountFlags, const char* Options, std::optional<std::chrono::seconds> TimeoutSeconds = {});
 
-int UtilMountOverlayFs(const char* Target, const char* Lower, unsigned long MountFlags = 0, std::optional<std::chrono::seconds> TimeoutSeconds = {});
+int UtilMountOverlayFs(
+    const char* Target,
+    const char* Lower,
+    unsigned long MountFlags = 0,
+    std::optional<std::chrono::seconds> TimeoutSeconds = {},
+    const std::optional<std::string>& ScratchDevice = {});
 
 int UtilOpenMountNamespace(void);
 

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1228,6 +1228,7 @@ typedef struct _LX_MINI_INIT_MESSAGE
     unsigned int UserProfileOffset;
     unsigned int Flags;
     unsigned int ConnectPort;
+    unsigned int ScratchLun;
     char Buffer[];
 
     PRETTY_PRINT(
@@ -1241,7 +1242,8 @@ typedef struct _LX_MINI_INIT_MESSAGE
         STRING_FIELD(InstallPathOffset),
         STRING_FIELD(UserProfileOffset),
         FIELD(Flags),
-        FIELD(ConnectPort));
+        FIELD(ConnectPort),
+        FIELD(ScratchLun));
 
 } LX_MINI_INIT_MESSAGE, *PLX_MINI_INIT_MESSAGE;
 

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2591,6 +2591,16 @@ std::shared_ptr<LxssRunningInstance> LxssUserSessionImpl::_CreateInstance(_In_op
                         instanceId, configuration, LxMiniInitMessageLaunchInit, m_utilityVm->GetConfig().KernelBootTimeout, defaultUid, clientKey);
                 }
 
+                // If instance startup fails after this point, ensure the per-instance overlay
+                // scratch vhd created in CreateInstance is ejected and deleted (the normal
+                // terminate path is not reached for an instance that never finishes starting).
+                auto scratchCleanupOnFailure = wil::scope_exit([&]() {
+                    if (m_utilityVm)
+                    {
+                        m_utilityVm->CleanupInstanceScratch(instanceId);
+                    }
+                });
+
                 // Log telemetry to determine how long initialization takes.
                 WSL_LOG(
                     "InitializeInstanceBegin",
@@ -2645,6 +2655,8 @@ std::shared_ptr<LxssRunningInstance> LxssUserSessionImpl::_CreateInstance(_In_op
                     m_pluginManager.OnDistributionStarted(&m_session, instance->DistributionInformation());
                     cleanupOnFailure.release();
                 }
+
+                scratchCleanupOnFailure.release();
 
                 result = S_OK;
             }
@@ -3613,9 +3625,11 @@ bool LxssUserSessionImpl::_TerminateInstanceInternal(_In_ LPCGUID DistroGuid, _I
             success = (success || force);
             if (success)
             {
+                std::optional<GUID> scratchInstanceId;
                 if (const auto* wslcoreInstance = dynamic_cast<WslCoreInstance*>(instance->second.get()); wslcoreInstance != nullptr)
                 {
                     m_pluginManager.OnDistributionStopping(&m_session, wslcoreInstance->DistributionInformation());
+                    scratchInstanceId = wslcoreInstance->GetInstanceId();
                 }
 
                 instance->second->Stop();
@@ -3629,6 +3643,12 @@ bool LxssUserSessionImpl::_TerminateInstanceInternal(_In_ LPCGUID DistroGuid, _I
                 m_lifetimeManager.RemoveCallback(clientKey);
 
                 m_runningInstances.erase(instance);
+
+                // Eject and delete the per-instance overlay scratch vhd, if one was created.
+                if (scratchInstanceId.has_value() && m_utilityVm)
+                {
+                    m_utilityVm->CleanupInstanceScratch(scratchInstanceId.value());
+                }
 
                 // If the instance that was terminated was a WSL2 instance,
                 // check if the VM is now idle.

--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -329,6 +329,11 @@ GUID WslCoreInstance::GetDistributionId() const
     return m_configuration.DistroId;
 }
 
+GUID WslCoreInstance::GetInstanceId() const
+{
+    return m_instanceId;
+}
+
 std::shared_ptr<LxssPort> WslCoreInstance::GetInitPort()
 {
     THROW_HR_IF(HCS_E_TERMINATED, !m_initChannel);

--- a/src/windows/service/exe/WslCoreInstance.h
+++ b/src/windows/service/exe/WslCoreInstance.h
@@ -92,6 +92,8 @@ public:
 
     GUID GetDistributionId() const override;
 
+    GUID GetInstanceId() const;
+
     std::shared_ptr<LxssPort> GetInitPort() override;
 
     std::shared_ptr<LxssRunningInstance> GetSystemDistro();

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -45,6 +45,10 @@ using namespace std::string_literals;
 static constexpr size_t c_bootEntropy = 0x1000;
 static constexpr auto c_localDevicesKey = L"SOFTWARE\\Microsoft\\Terminal Server Client\\LocalDevices";
 
+// Virtual size of the dynamically-expanding scratch vhd that backs overlay
+// read/write layers. The vhd grows on demand, so this is only an upper bound.
+static constexpr ULONGLONG c_scratchVhdSizeBytes = 64ull * _1GB;
+
 #define LXSS_ENABLE_GUI_APPS() (m_vmConfig.EnableGuiApps && (m_systemDistroDeviceId != ULONG_MAX))
 
 using namespace wsl::windows::common;
@@ -1205,12 +1209,55 @@ std::shared_ptr<LxssRunningInstance> WslCoreVm::CreateInstance(
 #endif
 
     std::wstring userProfile{};
+    ULONG scratchLun = ULONG_MAX;
+    auto scratchCleanup = wil::scope_exit([&]() { CleanupInstanceScratchLockHeld(InstanceId); });
     if (LXSS_ENABLE_GUI_APPS() && (MessageType == LxMiniInitMessageLaunchInit))
     {
         WI_SetFlag(flags, LxMiniInitMessageFlagLaunchSystemDistro);
         sharedMemoryRoot = m_sharedMemoryRoot;
 
         userProfile = m_userProfile;
+
+        // Create and attach a per-instance scratch vhd to back the system distro overlay's
+        // read/write layer, so heavy writes land on reclaimable disk instead of guest memory.
+        //
+        // N.B. This can fail if the target directory is compressed, encrypted, or if the user
+        //      does not have write access. On failure the guest falls back to a tmpfs overlay.
+        try
+        {
+            auto scratchPath = m_tempPath / std::format(L"scratch-{}.vhdx", wsl::shared::string::GuidToString<wchar_t>(InstanceId));
+
+            // Eject and delete the scratch vhd if creation/attach succeeds but it is never
+            // successfully tracked (otherwise CleanupInstanceScratch / the temp dir teardown
+            // owns it). Released only once the vhd is recorded in m_instanceScratchVhds.
+            auto cleanupScratch = wil::scope_exit([&]() {
+                // Avoid advertising a lun that was torn down or never tracked.
+                scratchLun = ULONG_MAX;
+
+                try
+                {
+                    EjectVhdLockHeld(scratchPath.c_str());
+                }
+                CATCH_LOG()
+
+                try
+                {
+                    const auto runAsUser = wil::impersonate_token(m_userToken.get());
+                    LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(scratchPath.c_str()));
+                }
+                CATCH_LOG()
+            });
+
+            {
+                const auto runAsUser = wil::impersonate_token(m_userToken.get());
+                wsl::core::filesystem::CreateVhd(scratchPath.c_str(), c_scratchVhdSizeBytes, &m_userSid.Sid, false, false);
+            }
+
+            scratchLun = AttachDiskLockHeld(scratchPath.c_str(), DiskType::VHD, MountFlags::None, {}, false, m_userToken.get());
+            m_instanceScratchVhds.emplace(InstanceId, scratchPath);
+            cleanupScratch.release();
+        }
+        CATCH_LOG()
     }
 
     WI_SetFlagIf(flags, LxMiniInitMessageFlagExportCompressGzip, WI_IsFlagSet(ExportFlags, LXSS_EXPORT_DISTRO_FLAGS_GZIP));
@@ -1228,11 +1275,15 @@ std::shared_ptr<LxssRunningInstance> WslCoreVm::CreateInstance(
     message.WriteString(message->SharedMemoryRootOffset, sharedMemoryRoot);
     message.WriteString(message->InstallPathOffset, installPath);
     message.WriteString(message->UserProfileOffset, userProfile);
+    message->ScratchLun = scratchLun;
     auto transaction = m_miniInitChannel.StartTransaction();
     transaction.Send<LX_MINI_INIT_MESSAGE>(message.Span());
 
-    return CreateInstanceInternal(
+    auto instance = CreateInstanceInternal(
         InstanceId, Configuration, ReceiveTimeout, DefaultUid, ClientLifetimeId, WI_IsFlagSet(flags, LxMiniInitMessageFlagLaunchSystemDistro), ConnectPort);
+
+    scratchCleanup.release();
+    return instance;
 }
 
 std::shared_ptr<LxssRunningInstance> WslCoreVm::CreateInstanceInternal(
@@ -1396,6 +1447,44 @@ void WslCoreVm::EjectVhdLockHeld(_In_ PCWSTR VhdPath)
         m_attachedDisks.erase(search);
         FreeLun(message.Lun);
     }
+}
+
+void WslCoreVm::CleanupInstanceScratch(_In_ const GUID& InstanceId)
+{
+    auto lock = m_lock.lock_exclusive();
+    CleanupInstanceScratchLockHeld(InstanceId);
+}
+
+_Requires_lock_held_(m_lock)
+void WslCoreVm::CleanupInstanceScratchLockHeld(_In_ const GUID& InstanceId)
+{
+    const auto search = m_instanceScratchVhds.find(InstanceId);
+    if (search == m_instanceScratchVhds.end())
+    {
+        return;
+    }
+
+    const auto scratchPath = std::move(search->second);
+    m_instanceScratchVhds.erase(search);
+
+    // Eject and delete the scratch vhd.
+    //
+    // N.B. The scratch device is only ever mounted inside the per-instance overlay mount
+    //      namespace, which is destroyed when the instance terminates, so by this point no
+    //      mount pins the device. Both steps are best-effort: any leftover is reclaimed when
+    //      the per-VM temp directory is deleted on VM teardown.
+    try
+    {
+        EjectVhdLockHeld(scratchPath.c_str());
+    }
+    CATCH_LOG()
+
+    try
+    {
+        const auto runAsUser = wil::impersonate_token(m_userToken.get());
+        LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(scratchPath.c_str()));
+    }
+    CATCH_LOG()
 }
 
 _Requires_lock_held_(m_guestDeviceLock)

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1221,32 +1221,14 @@ std::shared_ptr<LxssRunningInstance> WslCoreVm::CreateInstance(
         // Create and attach a per-instance scratch vhd to back the system distro overlay's
         // read/write layer, so heavy writes land on reclaimable disk instead of guest memory.
         //
-        // N.B. This can fail if the target directory is compressed, encrypted, or if the user
-        //      does not have write access. On failure the guest falls back to a tmpfs overlay.
+        // N.B. The vhd path is derived from the instance id (GetInstanceScratchPath) and is not
+        //      tracked: cleanup on failure here, on a later startup failure (scratchCleanup), and
+        //      on terminate all recompute it. Creation can fail if the target directory is
+        //      compressed, encrypted, or not writable by the user; on any failure the scratch is
+        //      torn down and the guest falls back to a tmpfs overlay.
         try
         {
-            auto scratchPath = m_tempPath / std::format(L"scratch-{}.vhdx", wsl::shared::string::GuidToString<wchar_t>(InstanceId));
-
-            // Eject and delete the scratch vhd if creation/attach succeeds but it is never
-            // successfully tracked (otherwise CleanupInstanceScratch / the temp dir teardown
-            // owns it). Released only once the vhd is recorded in m_instanceScratchVhds.
-            auto cleanupScratch = wil::scope_exit([&]() {
-                // Avoid advertising a lun that was torn down or never tracked.
-                scratchLun = ULONG_MAX;
-
-                try
-                {
-                    EjectVhdLockHeld(scratchPath.c_str());
-                }
-                CATCH_LOG()
-
-                try
-                {
-                    const auto runAsUser = wil::impersonate_token(m_userToken.get());
-                    LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(scratchPath.c_str()));
-                }
-                CATCH_LOG()
-            });
+            const auto scratchPath = GetInstanceScratchPath(InstanceId);
 
             {
                 const auto runAsUser = wil::impersonate_token(m_userToken.get());
@@ -1254,10 +1236,16 @@ std::shared_ptr<LxssRunningInstance> WslCoreVm::CreateInstance(
             }
 
             scratchLun = AttachDiskLockHeld(scratchPath.c_str(), DiskType::VHD, MountFlags::None, {}, false, m_userToken.get());
-            m_instanceScratchVhds.emplace(InstanceId, scratchPath);
-            cleanupScratch.release();
         }
-        CATCH_LOG()
+        catch (...)
+        {
+            LOG_CAUGHT_EXCEPTION();
+
+            // Tear down any partially-created scratch and avoid advertising a torn-down lun; the
+            // guest falls back to a tmpfs overlay.
+            scratchLun = ULONG_MAX;
+            CleanupInstanceScratchLockHeld(InstanceId);
+        }
     }
 
     WI_SetFlagIf(flags, LxMiniInitMessageFlagExportCompressGzip, WI_IsFlagSet(ExportFlags, LXSS_EXPORT_DISTRO_FLAGS_GZIP));
@@ -1455,24 +1443,25 @@ void WslCoreVm::CleanupInstanceScratch(_In_ const GUID& InstanceId)
     CleanupInstanceScratchLockHeld(InstanceId);
 }
 
+std::filesystem::path WslCoreVm::GetInstanceScratchPath(_In_ const GUID& InstanceId) const
+{
+    return m_tempPath / std::format(L"scratch-{}.vhdx", wsl::shared::string::GuidToString<wchar_t>(InstanceId));
+}
+
 _Requires_lock_held_(m_lock)
 void WslCoreVm::CleanupInstanceScratchLockHeld(_In_ const GUID& InstanceId)
 {
-    const auto search = m_instanceScratchVhds.find(InstanceId);
-    if (search == m_instanceScratchVhds.end())
-    {
-        return;
-    }
-
-    const auto scratchPath = std::move(search->second);
-    m_instanceScratchVhds.erase(search);
-
-    // Eject and delete the scratch vhd.
+    // Eject and delete the per-instance overlay scratch vhd. The path is derived from the
+    // instance id, so this is idempotent and safe to call on any failure path and on terminate:
+    // ejecting a device that was never attached is a no-op, and deleting a file that was never
+    // created is ignored.
     //
     // N.B. The scratch device is only ever mounted inside the per-instance overlay mount
     //      namespace, which is destroyed when the instance terminates, so by this point no
-    //      mount pins the device. Both steps are best-effort: any leftover is reclaimed when
-    //      the per-VM temp directory is deleted on VM teardown.
+    //      mount pins the device. Any leftover is also reclaimed when the per-VM temp directory
+    //      is deleted on VM teardown.
+    const auto scratchPath = GetInstanceScratchPath(InstanceId);
+
     try
     {
         EjectVhdLockHeld(scratchPath.c_str());
@@ -1482,7 +1471,10 @@ void WslCoreVm::CleanupInstanceScratchLockHeld(_In_ const GUID& InstanceId)
     try
     {
         const auto runAsUser = wil::impersonate_token(m_userToken.get());
-        LOG_IF_WIN32_BOOL_FALSE(DeleteFileW(scratchPath.c_str()));
+        if (!DeleteFileW(scratchPath.c_str()) && (GetLastError() != ERROR_FILE_NOT_FOUND))
+        {
+            LOG_LAST_ERROR();
+        }
     }
     CATCH_LOG()
 }

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -91,6 +91,10 @@ public:
 
     void EjectVhd(_In_ PCWSTR VhdPath);
 
+    // Ejects and deletes the per-instance overlay scratch vhd (if any) that was
+    // created for the instance with the specified id.
+    void CleanupInstanceScratch(_In_ const GUID& InstanceId);
+
     const wsl::core::Config& GetConfig() const noexcept;
 
     GUID GetRuntimeId() const;
@@ -202,6 +206,9 @@ private:
     _Requires_lock_held_(m_lock)
     void EjectVhdLockHeld(_In_ PCWSTR VhdPath);
 
+    _Requires_lock_held_(m_lock)
+    void CleanupInstanceScratchLockHeld(_In_ const GUID& InstanceId);
+
     _Requires_lock_held_(m_guestDeviceLock)
     std::optional<VirtioFsShare> FindVirtioFsShare(_In_ PCWSTR tag, _In_ std::optional<bool> Admin = {}) const;
 
@@ -303,6 +310,7 @@ private:
     std::shared_ptr<LxssRunningInstance> m_systemDistro;
     _Guarded_by_(m_lock) std::bitset<MAX_VHD_COUNT> m_lunBitmap;
     _Guarded_by_(m_lock) std::map<AttachedDisk, DiskState> m_attachedDisks;
+    _Guarded_by_(m_lock) std::map<GUID, std::filesystem::path, wsl::windows::common::helpers::GuidLess> m_instanceScratchVhds;
     std::tuple<std::uint32_t, std::uint32_t, std::uint32_t> m_kernelVersion;
     std::wstring m_kernelVersionString;
     bool m_seccompAvailable;

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -209,6 +209,11 @@ private:
     _Requires_lock_held_(m_lock)
     void CleanupInstanceScratchLockHeld(_In_ const GUID& InstanceId);
 
+    // Returns the per-instance overlay scratch vhd path, derived from the instance id. The path
+    // is deterministic so the scratch vhd does not need to be tracked: every cleanup path
+    // recomputes it.
+    std::filesystem::path GetInstanceScratchPath(_In_ const GUID& InstanceId) const;
+
     _Requires_lock_held_(m_guestDeviceLock)
     std::optional<VirtioFsShare> FindVirtioFsShare(_In_ PCWSTR tag, _In_ std::optional<bool> Admin = {}) const;
 
@@ -310,7 +315,6 @@ private:
     std::shared_ptr<LxssRunningInstance> m_systemDistro;
     _Guarded_by_(m_lock) std::bitset<MAX_VHD_COUNT> m_lunBitmap;
     _Guarded_by_(m_lock) std::map<AttachedDisk, DiskState> m_attachedDisks;
-    _Guarded_by_(m_lock) std::map<GUID, std::filesystem::path, wsl::windows::common::helpers::GuidLess> m_instanceScratchVhds;
     std::tuple<std::uint32_t, std::uint32_t, std::uint32_t> m_kernelVersion;
     std::wstring m_kernelVersionString;
     bool m_seccompAvailable;

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -21,6 +21,7 @@ Abstract:
 #include <werapi.h>
 #include <Dbghelp.h>
 #include <winsafer.h>
+#include <thread>
 
 using namespace WEX::Logging;
 using namespace WEX::Common;
@@ -2552,6 +2553,12 @@ std::wstring GetBlockDeviceInWsl()
         }
 
         done = std::chrono::steady_clock::now() > timeout;
+        if (!done)
+        {
+            // Wait briefly before rescanning so the helper does not spin launching wsl.exe in a
+            // tight loop (burning CPU and spawning a burst of subprocesses) while the disk attaches.
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        }
     }
 
     VERIFY_FAIL(L"Failed to find the block device in WSL");

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2517,6 +2517,49 @@ void Trim(std::wstring& string)
     std::erase_if(string, [](auto c) { return !isalnum(c); });
 }
 
+std::wstring GetBlockDeviceInWsl()
+{
+    // Wait for the disk to be attached
+    const auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+
+    bool done = false;
+    while (true)
+    {
+        for (wchar_t name = 'a'; name < 'z'; name++)
+        {
+            std::wstring cmd = L"-u root blockdev --getsize64 /dev/sd";
+            cmd += name;
+
+            std::wstring out;
+            try
+            {
+                out = LxsstuLaunchWslAndCaptureOutput(cmd.data()).first;
+            }
+            CATCH_LOG()
+
+            Trim(out);
+
+            // Disk size is 20MB, so 20 * 1024 * 1024 bytes
+            if (out == L"20971520")
+            {
+                return std::wstring(L"/dev/sd") + name;
+            }
+        }
+
+        if (done)
+        {
+            break;
+        }
+
+        done = std::chrono::steady_clock::now() > timeout;
+    }
+
+    VERIFY_FAIL(L"Failed to find the block device in WSL");
+
+    // Unreachable.
+    return {};
+}
+
 static std::optional<std::wstring> CaptureEnvValue(const std::wstring& Name)
 {
     std::wstring value;

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2525,7 +2525,7 @@ std::wstring GetBlockDeviceInWsl()
     bool done = false;
     while (true)
     {
-        for (wchar_t name = 'a'; name < 'z'; name++)
+        for (wchar_t name = 'a'; name <= 'z'; name++)
         {
             std::wstring cmd = L"-u root blockdev --getsize64 /dev/sd";
             cmd += name;

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -611,6 +611,11 @@ void TerminateDistribution(LPCWSTR DistributionName = LXSS_DISTRO_NAME_TEST_L);
 
 void Trim(std::wstring& string);
 
+// Returns the /dev/sd* node of the 20MB test block device attached to the WSL VM, waiting up
+// to 30s for it to appear. The device letter is not stable across runs (it shifts with the
+// number of VHDs attached to the VM), so callers must look it up rather than hard-coding it.
+std::wstring GetBlockDeviceInWsl();
+
 inline auto EnableSystemd(const std::string& extraConfig = "")
 {
     // enable systemd on the test distro by editing /etc/wsl.conf

--- a/test/windows/MountTests.cpp
+++ b/test/windows/MountTests.cpp
@@ -1002,49 +1002,6 @@ class MountTests
         VERIFY_ARE_EQUAL(!offline, wsl::windows::common::disk::IsDiskOnline(disk.get()));
     }
 
-    static std::wstring GetBlockDeviceInWsl()
-    {
-        // Wait for the disk to be attached
-        const auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(30);
-
-        bool done = false;
-        while (true)
-        {
-            for (wchar_t name = 'a'; name < 'z'; name++)
-            {
-                std::wstring cmd = L"-u root blockdev --getsize64 /dev/sd";
-                cmd += name;
-
-                std::wstring out;
-                try
-                {
-                    out = LxsstuLaunchWslAndCaptureOutput(cmd.data()).first;
-                }
-                CATCH_LOG()
-
-                Trim(out);
-
-                // Disk size is 20MB, so 20 * 1024 * 1024 bytes
-                if (out == L"20971520")
-                {
-                    return std::wstring(L"/dev/sd") + name;
-                }
-            }
-
-            if (done)
-            {
-                break;
-            }
-
-            done = std::chrono::steady_clock::now() > timeout;
-        }
-
-        VERIFY_FAIL(L"Failed to find the block device in WSL");
-
-        // Unreachable.
-        return {};
-    }
-
     static bool IsBlockDevicePresent(const std::wstring& Device)
     {
         const auto Cmd = L"test -e " + Device;

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -6657,7 +6657,12 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             LxsstuLaunchPowershellAndCaptureOutput(std::format(L"New-Vhd {}  -SizeBytes 20MB", testVhd));
 
             VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--mount {} --vhd --bare", testVhd)), 0L);
-            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"mkfs.ext4 /dev/sde"), 0L);
+
+            // Locate the bare-mounted disk by its size rather than hard-coding a device node.
+            // The /dev/sd* letter depends on how many other VHDs are attached to the VM (e.g.
+            // the per-instance system distro overlay scratch vhd), which shifts the bare disk.
+            const auto bareDevice = GetBlockDeviceInWsl();
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl((L"-u root mkfs.ext4 " + bareDevice).c_str()), 0L);
             VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount"), 0L);
 
             auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"--import-in-place broken-test-distro {}", testVhd), -1);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The WSLg system distro runs from a read-only VHD with a writable overlay on top. That overlay's read/write layer was backed by **tmpfs**, so everything written into it (logs, temp files, copied-up files, build output) consumed **guest memory** and could spill into swap. Heavy writes ΓÇö e.g. compiling the Linux kernel inside the system distro ΓÇö could exhaust RAM *and* swap and trigger the OOM killer VM-wide.

This change backs the overlay read/write layer with a **per-instance temporary ext4 "scratch" VHD** (dynamically expanding, 64 GB cap) instead, mirroring the existing swap VHD. Overlay writes now land on **reclaimable disk page cache** rather than pinned guest memory, and a runaway write gets a clean `ENOSPC` instead of an OOM kill.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass <!-- manual validation only; see below -->
- [x] **Localization:** All end user facing strings can be localized <!-- no new user-facing strings -->
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

**Host (`src/windows/service/exe/`)**
- When GUI apps are enabled (`LaunchInit` message), `WslCoreVm::CreateInstance` creates a sparse, dynamically-expanding `scratch-<InstanceId>.vhdx` (`c_scratchVhdSizeBytes` = 64 GB) under user impersonation, attaches it via `AttachDiskLockHeld` to get a SCSI LUN, derives the VHD path deterministically from the runtime instance GUID (`GetInstanceScratchPath`; no tracking map is kept), and passes the LUN to the guest in `LX_MINI_INIT_MESSAGE.ScratchLun` (default `ULONG_MAX` = none).
- On terminate, `LxssUserSession::_TerminateInstanceInternal` captures the instance id and calls `WslCoreVm::CleanupInstanceScratch`, which recomputes the deterministic path, ejects the disk, and deletes the VHDX (idempotent; nothing is tracked). The per-VM temp directory teardown on VM shutdown is the backstop for any leak.
- `scope_exit` guards cover every failure path (create-but-attach-fails, attach-but-track-fails, and post-registration startup failures), so a failed launch never leaks an attached disk, LUN, or file, and never advertises a torn-down LUN to the guest.

**Message (`src/shared/inc/lxinitshared.h`)**
- `ScratchLun` moved from `LX_MINI_INIT_EARLY_CONFIG_MESSAGE` to `LX_MINI_INIT_MESSAGE` (it is now per-instance, not per-VM).

**Guest (`src/linux/init/`)**
- `CreateOverlayScratch(Lun)` formats the scratch device as ext4 (no journal, lazy inode init ΓÇö the data is disposable) and mounts it at `/scratch`.
- `UtilMountOverlayFs` gained an optional scratch-root parameter: when present, the overlay rw layer is a unique subdirectory bind-mounted from `/scratch` (disk-backed, reclaimable); otherwise it falls back to tmpfs. The scratch-backed rw layer is mounted with the overlayfs `volatile` option (skipping upper-fs syncs, since the data is disposable); a kernel that rejects `volatile` with `EINVAL` is retried without it.
- If the scratch VHD cannot be created, attached, formatted, or mounted ΓÇö or the overlay rw setup fails (e.g. backing disk full) ΓÇö the overlay **transparently falls back to the previous tmpfs behavior** so the distro still launches.
- Each instance runs in a private mount namespace, so the `/scratch` mount and the overlay are torn down automatically when the instance exits.

No new user-facing strings; no IDL/ABI changes (the `ScratchLun` field moved within the internal mini_init wire protocol, which is versioned together).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Built, deployed to host, and validated end-to-end inside the system distro (`wsl --system -d <distro>`):

- **ext4-backed overlay:** root overlay (`df -h /`) reports 64 GB (the scratch size); `mount` shows `upperdir=/system/rw/upper` on the bind-mounted ext4 scratch.
- **RAM not pinned:** a 4 GiB write lands in reclaimable `buff/cache` (freed by `echo 3 > /proc/sys/vm/drop_caches`) and **not** in `shared`/shmem, unlike the previous tmpfs behavior.
- **Host disk grows on demand:** an 8 GiB random write grows the host `scratch-<id>.vhdx` from ~0.07 GB to ~8.07 GB; only the VHD for the instance written to grows (per-instance isolation confirmed with two running distros).
- **Cleanup:** `wsl --terminate <distro>` ejects and deletes that instance's `scratch-*.vhdx` while the VM stays running; the per-VM temp directory is removed on `wsl --shutdown`.
- **Fallback:** verified the overlay still launches via tmpfs when no scratch device is available.

**Constrained-memory OOM A/B (the headline win):** capped the VM at `memory=4GB, swap=0` and wrote 6 GiB into the system-distro overlay on the same build, comparing the ext4 scratch against the old tmpfs behavior (`mount -t tmpfs`):

| | ext4 scratch (this change) | tmpfs (old behavior) |
|---|---|---|
| 6 GiB overlay write | **succeeds** (`/` 10% used, data on disk) | **fails** |
| Global OOM killer | none | fires repeatedly |
| Processes killed | none | `Xwayland`, `WSLGd`/`init()`, `pulseaudio`, `GnsEngine`, ΓÇª |
| `vmmemWSL` (host) | bounded under the 4 GB cap | pinned at the cap, then OOM |

With ext4 the kernel writes overlay data back to the scratch VHD and frees the pages, so 6 GiB fits in a 4 GiB VM. With tmpfs every byte is unevictable shmem, so at the memory ceiling the kernel OOM-kills the WSLg stack and the write never completes ΓÇö the exact failure this change eliminates.

**Memory reclaimability A/B (unconstrained VM):** same 8 GiB write ΓÇö ext4 keeps guest `Shmem` flat and `buff/cache` fully reclaimable (host `vmmemWSL` working set drops ~9.7 GB ΓåÆ ~5.4 GB after `drop_caches`), whereas tmpfs parks the full 8 GiB in `Shmem` that `drop_caches` cannot reclaim (working set stays pinned at ~9.5 GB).

The change was additionally reviewed across several rounds of multi-model code review; all findings were addressed.

