### PR TITLE
Update Microsoft.WSLg to 1.0.78

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -24,7 +24,7 @@
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
-  <package id="Microsoft.WSLg" version="1.0.77" />
+  <package id="Microsoft.WSLg" version="1.0.78" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="vswhere" version="3.1.7" />
   <package id="WinUIEx" version="2.9.0" />


### PR DESCRIPTION
Bumps the `Microsoft.WSLg` dependency from 1.0.77 to 1.0.78 (tag [v1.0.78](https://github.com/microsoft/WSLg/releases/tag/v1.0.78)).

## Detailed Description

### Source changes (microsoft/wslg [v1.0.77...v1.0.78](https://github.com/microsoft/wslg/compare/v1.0.77...v1.0.78), 19 commits)

This release is almost entirely build/packaging infrastructure with no runtime behavior changes:

- **Versioning:** replace GitVersion with `git describe`; nuspec now records the source SHA via `<repository commit="..."/>`.
- **Dockerfile:** source vendor versions from build-args (fail fast on missing `--build-arg`), extract a debug-strip helper, hoist the Mariner image to an ARG.
- **Packaging metadata:** fix cgmanifest registration and ship `NOTICE.txt` / `LICENSE.txt` in the package (`#1462`, `#1463`).
- **Cleanup:** drop dead `version_functions`/`updateversion` scripts and the legacy `azure-pipelines.yml`; refresh `CONTRIBUTING.md` build instructions.

### Package payload delta

Compared the two NuGet packages and their `system.vhd` payloads directly (attached each via `wsl --mount --vhd --bare` and diffed the rpm DBs):

- **Package files:** 1.0.78 adds `NOTICE.txt` and `LICENSE.txt` (the metadata fix above). `system.vhd` (x64) grew ~2.6 MB (755,360,256 -> 757,993,984 bytes).
- **System distro base:** Azure Linux 3.0 image refreshed `3.0.20260510` -> `3.0.20260602`. Same package count (243), with 18 packages updated by the base servicing refresh:

| Package | 1.0.77 | 1.0.78 |
|---|---|---|
| azurelinux-release | 3.0-43 | 3.0-45 |
| bind-libs / bind-license / bind-utils | 9.20.21-1 | 9.20.23-1 |
| busybox | 1.36.1-23 | 1.36.1-24 |
| containerd2 | 2.1.6-2 | 2.2.4-2 |
| cups-libs | 2.4.18-1 | 2.4.19-1 |
| curl / curl-libs | 8.11.1-6 | 8.11.1-7 |
| docker-buildx | 0.14.0-11 | 0.14.0-13 |
| docker-cli | 25.0.7-2 | 25.0.7-3 |
| glibc | 2.38-19 | 2.38-20 |
| krb5 | 1.21.3-3 | 1.21.3-4 |
| libcap | 2.69-14 | 2.69-15 |
| libpng | 1.6.57-1 | 1.6.58-1 |
| moby-engine | 25.0.3-17 | 25.0.3-18 |
| systemd-libs | 255-27 | 255-30 |
| tini-static | 0.19.0-29 | 0.19.0-30 |

## Validation Steps

- Confirmed the only repo change is the single-line version bump in `packages.config` (no stray BOM/encoding changes).
- Diffed both `system.vhd` payloads by mounting read-only and comparing rpm databases (table above).