### PR TITLE
wslcsession: use DuplicateHandle idiom for self-process handle in GetProcessHandle

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -249,12 +249,9 @@ UserCOMCallback::~UserCOMCallback() noexcept
 HRESULT WSLCSession::GetProcessHandle(_Out_ HANDLE* ProcessHandle)
 try
 {
-    RETURN_HR_IF(E_POINTER, ProcessHandle == nullptr);
+    RETURN_HR_IF_NULL(E_POINTER, ProcessHandle);
 
-    wil::unique_handle process{OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, GetCurrentProcessId())};
-    THROW_LAST_ERROR_IF(!process);
-
-    *ProcessHandle = process.release();
+    *ProcessHandle = wslutil::DuplicateHandle(GetCurrentProcess(), PROCESS_SET_QUOTA | PROCESS_TERMINATE);
     return S_OK;
 }
 CATCH_RETURN();

--- a/src/windows/wslcsession/WSLCSessionFactory.cpp
+++ b/src/windows/wslcsession/WSLCSessionFactory.cpp
@@ -76,10 +76,7 @@ try
 {
     RETURN_HR_IF_NULL(E_POINTER, ProcessHandle);
 
-    wil::unique_handle process{OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, GetCurrentProcessId())};
-    RETURN_LAST_ERROR_IF(!process);
-
-    *ProcessHandle = process.release();
+    *ProcessHandle = wslutil::DuplicateHandle(GetCurrentProcess(), PROCESS_SET_QUOTA | PROCESS_TERMINATE);
     return S_OK;
 }
 CATCH_RETURN()


### PR DESCRIPTION
## Summary of the Pull Request

Replace the self-`OpenProcess(GetCurrentProcessId())` calls in `IWSLCSessionFactory::GetProcessHandle` and `IWSLCSession::GetProcessHandle` with a duplicate of the current-process pseudo-handle via the existing `wslutil::DuplicateHandle` helper.

This is a cleanup/hardening change, not a behavioral one. A process should not need to `OpenProcess` itself by PID to obtain a handle to itself — duplicating the `GetCurrentProcess()` pseudo-handle is the canonical idiom. The new call requests the **same** access rights (`PROCESS_SET_QUOTA | PROCESS_TERMINATE`), so the marshaled handle and all downstream usage are unchanged.

> [!NOTE]
> This does **not** fix the reported `0x80070005` (`E_ACCESSDENIED`) seen after hibernate/resume. Debugging shows that failure originates from `AssignProcessToJobObject` in `wslservice.exe` (`WSLCSessionManager::AddSessionProcessToJobObject`, WSLCSessionManager.cpp:454), not from `GetProcessHandle`. Both call sites surface the identical HRESULT, which is why it was initially misattributed. The job-assignment failure is being tracked separately.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already
- [x] **Tests:** N/A — no behavioral change (handle access rights are identical)
- [x] **Localization:** No end-user-facing strings
- [ ] **Dev docs:** N/A

## Detailed Description of the Pull Request / Additional comments

`GetProcessHandle` previously did:

```cpp
wil::unique_handle process{OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, GetCurrentProcessId())};
```

`OpenProcess` performs an access check against the calling **thread's effective token**. Using it to open *your own* process is unnecessary and fragile — there is no reason a process should need an access check to obtain a handle to itself.

The replacement duplicates the current-process pseudo-handle:

```cpp
*ProcessHandle = wslutil::DuplicateHandle(GetCurrentProcess(), PROCESS_SET_QUOTA | PROCESS_TERMINATE);
```

`DuplicateHandle` from the pseudo-handle performs no object DACL access check (it only requires `PROCESS_DUP_HANDLE` on the `GetCurrentProcess()` pseudo-handle, which is always granted), so it is the correct, robust idiom. Because an explicit desired-access mask is passed, the resulting handle carries exactly `PROCESS_SET_QUOTA | PROCESS_TERMINATE` — identical to the previous handle.

## Validation Steps Performed

- Build.
- Verified the duplicated handle carries the same access rights (`PROCESS_SET_QUOTA | PROCESS_TERMINATE`), so `AssignProcessToJobObject` consumption is unchanged.
