### PR TITLE
Disable warnings notifications in WSLC

### DIFF
--- a/src/windows/common/ExecutionContext.cpp
+++ b/src/windows/common/ExecutionContext.cpp
@@ -15,14 +15,16 @@ thread_local ExecutionContext* g_currentContext = nullptr;
 static bool g_enabled = false;
 bool g_runningInService = false;
 bool g_useComErrors = false;
+bool g_enableNotifications = false;
 static HANDLE g_eventLog = nullptr;
 
-void wsl::windows::common::EnableContextualizedErrors(bool service, bool useComErrors)
+void wsl::windows::common::EnableContextualizedErrors(bool service, bool useComErrors, bool enableNotifications)
 {
     WI_ASSERT(!g_enabled);
     g_enabled = true;
     g_runningInService = service;
     g_useComErrors = useComErrors;
+    g_enableNotifications = enableNotifications;
 }
 
 ExecutionContext::ExecutionContext(Context context, FILE* warningsFile) noexcept :
@@ -169,7 +171,7 @@ void ExecutionContext::EmitUserWarning(const std::wstring& warning, const std::s
         return;
     }
 
-    if (!CollectUserWarning(std::format(L"wsl: {}\n", warning)))
+    if (!CollectUserWarning(std::format(L"wsl: {}\n", warning)) && g_enableNotifications)
     {
         static std::atomic<bool> displayed = false;
         if (!displayed.exchange(true))

--- a/src/windows/common/ExecutionContext.h
+++ b/src/windows/common/ExecutionContext.h
@@ -217,7 +217,7 @@ public:
     bool CanCollectUserErrorMessage() override;
 };
 
-void EnableContextualizedErrors(bool service, bool useComErrors = false);
+void EnableContextualizedErrors(bool service, bool useComErrors = false, bool enableNotifications = false);
 
 void SetErrorMessage(std::wstring&& message, const std::source_location& source = std::source_location::current());
 void SetErrorMessage(std::string&& message, const std::source_location& source = std::source_location::current());

--- a/src/windows/service/exe/ServiceMain.cpp
+++ b/src/windows/service/exe/ServiceMain.cpp
@@ -164,7 +164,7 @@ try
     ConfigureCrt();
 
     // Enable contextualized errors
-    wsl::windows::common::EnableContextualizedErrors(true);
+    wsl::windows::common::EnableContextualizedErrors(true, false, true);
 
     // Initialize telemetry.
     WslTraceLoggingInitialize(WslServiceTelemetryProvider, !wsl::shared::OfficialBuild);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

WSLC currently displays a Windows notification if a warning is emitted during startup. The warning says "Errors during WSL startup", which is misleading. 

For now, this change disables the Windows notification logic when a warning is emitted, but couldn't be printed on stderr.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
