### PR TITLE
Fix CreateRootNamespaceProcess test call to match updated IDL signature

### DIFF
--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3624,7 +3624,7 @@ class WSLCTests
             options.Flags = static_cast<WSLCProcessFlags>(0x4);
             wil::com_ptr<IWSLCProcess> process;
             int err = 0;
-            VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateRootNamespaceProcess("/bin/true", &options, &process, &err));
+            VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateRootNamespaceProcess("/bin/true", &options, 0, 0, &process, &err));
         }
 
         // Simple case

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3624,7 +3624,7 @@ class WSLCTests
             options.Flags = static_cast<WSLCProcessFlags>(0x4);
             wil::com_ptr<IWSLCProcess> process;
             int err = 0;
-            VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateRootNamespaceProcess("/bin/true", &options, 0, 0, &process, &err));
+            VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateRootNamespaceProcess("/bin/true", &options, {}, {}, &process, &err));
         }
 
         // Simple case


### PR DESCRIPTION
## Summary of the Pull Request

Fixes a clean-build compile error in `WSLCTests::CreateRootNamespaceProcess`: the test still called `IWSLCSession::CreateRootNamespaceProcess` with 4 arguments after commit 31331371 added the `TtyRows`/`TtyColumns` parameters to the IDL.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I''ve discussed this with core contributors already. If work hasn''t been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

**Problem.** Commit 31331371 ("Fix various issues around initial tty sizes + add test coverage") changed `IWSLCSession::CreateRootNamespaceProcess` in `wslc.idl` to take `TtyRows` and `TtyColumns`, and updated the `WSLCProcessLauncher` caller, but left the one direct call site in `WSLCTests::CreateRootNamespaceProcess` (the reject-invalid-flags block) passing only 4 arguments. The generated `wslc.h` is an untracked MIDL build artifact that is not part of the build''s up-to-date check, so incremental builds kept compiling the test against the stale 4-argument header and never surfaced the mismatch. A clean MIDL regen produces the 6-argument header and the test fails with `C2660: function does not take 4 arguments`.

**Change.** Pass `0, 0` for the `TtyRows`/`TtyColumns` arguments in the test call, matching the existing usage in `PluginManager.cpp`.

## Validation Steps Performed

- Built `wsltests` from a clean MIDL regen; `WSLCTests.cpp` now compiles.