### PR TITLE
Force virtiofs devices to a single virtio queue (vcpus=1)

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.29-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.34-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />

--- a/src/windows/common/GuestDeviceManager.h
+++ b/src/windows/common/GuestDeviceManager.h
@@ -10,6 +10,11 @@
 
 inline const std::wstring c_defaultDeviceTag = L"default";
 
+// Use vcpus=1 so the device exposes a single virtio queue, bounding concurrent
+// guest-memory apertures to avoid hitting the host VID's 512-aperture quota.
+// TODO: revisit when the devicehost supports multiple shares per device.
+inline const std::wstring c_vcpusOption = L"vcpus=1";
+
 // These device types and class IDs are implemented by the external wsldevicehost vdev.
 DEFINE_GUID(VIRTIO_FS_DEVICE_ID, 0x872270E1, 0xA899, 0x4AF6, 0xB4, 0x54, 0x71, 0x93, 0x63, 0x44, 0x35, 0xAD); // {872270E1-A899-4AF6-B454-7193634435AD}
 DEFINE_GUID(VIRTIO_FS_ADMIN_CLASS_ID, 0x7E6AD219, 0xD1B3, 0x42D5, 0xB8, 0xEE, 0xD9, 0x63, 0x24, 0xE6, 0x4F, 0xF6); // {7E6AD219-D1B3-42D5-B8EE-D96324E64FF6}

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -587,15 +587,22 @@ try
     else
     {
         std::wstring options = ReadOnly ? L"ro" : L"";
-        if (!m_swiotlbOption.empty())
-        {
+        auto appendOption = [&options](const std::wstring& option) {
+            if (option.empty())
+            {
+                return;
+            }
+
             if (!options.empty())
             {
                 options += L";";
             }
 
-            options += m_swiotlbOption;
-        }
+            options += option;
+        };
+
+        appendOption(m_swiotlbOption);
+        appendOption(c_vcpusOption);
 
         it->second = m_guestDeviceManager->AddGuestDevice(
             VIRTIO_FS_DEVICE_ID,

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2195,18 +2195,25 @@ std::pair<std::wstring, std::wstring> WslCoreVm::AddVirtioFsShare(_In_ bool Admi
 
     sharePath = std::filesystem::weakly_canonical(sharePath).wstring();
 
-    // Append the swiotlb token here so it covers fixed-drive, dynamic add, and remount paths.
-    // Duplicate swiotlb tokens are harmless: VirtioFsShare parses options into a map.
+    // Append swiotlb and vcpus here to cover the fixed-drive, dynamic add, and remount paths.
+    // Safe to duplicate: both tokens are constant per VM, and VirtioFsShare collapses repeats into one map entry.
     std::wstring effectiveOptions(Options);
-    if (!m_swiotlbOption.empty())
-    {
+    auto appendOption = [&effectiveOptions](const std::wstring& option) {
+        if (option.empty())
+        {
+            return;
+        }
+
         if (!effectiveOptions.empty())
         {
             effectiveOptions += L';';
         }
 
-        effectiveOptions += m_swiotlbOption;
-    }
+        effectiveOptions += option;
+    };
+
+    appendOption(m_swiotlbOption);
+    appendOption(c_vcpusOption);
 
     // Check if a matching share already exists.
     bool created = false;


### PR DESCRIPTION
## Summary of the Pull Request

Force each virtiofs device to a single virtio queue by adding a `vcpus=1` token to the virtiofs device-options string. This bounds the number of concurrent guest-memory apertures a device can request, avoiding the host VID's 512-aperture quota that `wsldevicehost` otherwise livelocks against when servicing many parallel requests.

The token reuses the existing device-options channel already used to pass the `swiotlb` information, so no new IPC path or message format is introduced.

## Detailed Description of the Pull Request / Additional comments

- Defines a shared `c_vcpusOption` (`"vcpus=1"`) constant in `GuestDeviceManager.h`, with a TODO to revisit once the devicehost supports multiple shares per device.
- `HcsVirtualMachine::AddShare` (wslc) and `WslCoreVm::AddVirtioFsShare` (wsl) append the `swiotlb` and `vcpus` tokens via a small `appendOption` lambda, covering the fixed-drive, dynamic-add, and remount paths.
- Both tokens are constant for the VM's lifetime, so duplicates collapse to a single entry when `VirtioFsShare` parses the options into a map.
- Bumps `Microsoft.WSL.DeviceHost` to `1.2.34-0`.

> Note: this supersedes the earlier approach of passing the VM's dynamic vCPU count. A single queue (`vcpus=1`) is what's needed to keep aperture usage under the host quota.
