### PR TITLE
wslc: use a fresh job object per session to avoid intermittent ERROR_ACCESS_DENIED

### DIFF
--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -271,9 +271,9 @@ void WSLCSessionManagerImpl::CreateSession(
         // Create the VM in the SYSTEM service (privileged).
         auto vm = Microsoft::WRL::Make<HcsVirtualMachine>(Settings);
 
-        // Launch per-user COM server factory and add it to our job object for crash cleanup.
+        // Launch per-user COM server factory and add it to a fresh per-session job object for crash cleanup.
         auto factory = wslutil::CreateComServerAsUser<IWSLCSessionFactory>(__uuidof(WSLCSessionFactory), userToken.get());
-        AddSessionProcessToJobObject(factory.get());
+        wil::unique_handle sessionJob = AddSessionProcessToJobObject(factory.get());
 
         const auto sessionSettings = CreateSessionSettings(sessionId, callerFileName.c_str(), Settings, resolvedDisplayName.c_str());
         wil::com_ptr<IWSLCSession> session;
@@ -282,7 +282,7 @@ void WSLCSessionManagerImpl::CreateSession(
 
         // Track the session via its service ref, along with metadata and security info.
         m_sessions.push_back(SessionEntry{
-            std::move(serviceRef), sessionId, creatorPid, resolvedDisplayName, std::move(tokenInfo), notifier, false, sharedToken, std::move(storedSid)});
+            std::move(serviceRef), sessionId, creatorPid, resolvedDisplayName, std::move(tokenInfo), notifier, false, sharedToken, std::move(storedSid), std::move(sessionJob)});
 
         // For persistent sessions, also hold a strong reference to keep them alive.
         const bool persistent = WI_IsFlagSet(Flags, WSLCSessionFlagsPersistent);
@@ -445,24 +445,18 @@ WSLCSessionInitSettings WSLCSessionManagerImpl::CreateSessionSettings(
     return sessionSettings;
 }
 
-void WSLCSessionManagerImpl::AddSessionProcessToJobObject(_In_ IWSLCSessionFactory* Factory)
+wil::unique_handle WSLCSessionManagerImpl::AddSessionProcessToJobObject(_In_ IWSLCSessionFactory* Factory)
 {
-    EnsureJobObjectCreated();
+    // Use a fresh job per session; reusing one fails intermittently with
+    // ERROR_ACCESS_DENIED once it's assigned to a process the system put in another job.
+    wil::unique_handle jobObject = wsl::windows::common::helpers::CreateKillOnCloseJob();
 
     wil::unique_handle process;
     THROW_IF_FAILED(Factory->GetProcessHandle(process.put()));
 
-    THROW_IF_WIN32_BOOL_FALSE(AssignProcessToJobObject(m_sessionJobObject.get(), process.get()));
-}
+    THROW_IF_WIN32_BOOL_FALSE(AssignProcessToJobObject(jobObject.get(), process.get()));
 
-void WSLCSessionManagerImpl::EnsureJobObjectCreated()
-{
-    // Create a job object that will automatically terminate all child processes
-    // when the job handle is closed (i.e., when wslservice exits or crashes).
-    std::call_once(m_jobObjectInitFlag, [this] {
-        m_sessionJobObject = wsl::windows::common::helpers::CreateKillOnCloseJob();
-        WSL_LOG("SessionManagerJobObjectCreated", TraceLoggingLevel(WINEVENT_LEVEL_INFO));
-    });
+    return jobObject;
 }
 
 CallingProcessTokenInfo WSLCSessionManagerImpl::GetCallingProcessTokenInfo()

--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -273,7 +273,7 @@ void WSLCSessionManagerImpl::CreateSession(
 
         // Launch per-user COM server factory and add it to a fresh per-session job object for crash cleanup.
         auto factory = wslutil::CreateComServerAsUser<IWSLCSessionFactory>(__uuidof(WSLCSessionFactory), userToken.get());
-        wil::unique_handle sessionJob = AddSessionProcessToJobObject(factory.get());
+        wil::unique_handle sessionJob = CreateSessionProcessJob(factory.get());
 
         const auto sessionSettings = CreateSessionSettings(sessionId, callerFileName.c_str(), Settings, resolvedDisplayName.c_str());
         wil::com_ptr<IWSLCSession> session;
@@ -445,7 +445,7 @@ WSLCSessionInitSettings WSLCSessionManagerImpl::CreateSessionSettings(
     return sessionSettings;
 }
 
-wil::unique_handle WSLCSessionManagerImpl::AddSessionProcessToJobObject(_In_ IWSLCSessionFactory* Factory)
+wil::unique_handle WSLCSessionManagerImpl::CreateSessionProcessJob(_In_ IWSLCSessionFactory* Factory)
 {
     // Use a fresh job per session; reusing one fails intermittently with
     // ERROR_ACCESS_DENIED once it's assigned to a process the system put in another job.

--- a/src/windows/service/exe/WSLCSessionManager.h
+++ b/src/windows/service/exe/WSLCSessionManager.h
@@ -68,6 +68,8 @@ struct SessionEntry
 
     wil::shared_handle UserToken;
     std::vector<BYTE> UserSid;
+
+    wil::unique_handle JobObject;
 };
 
 class WSLCSessionManagerImpl
@@ -163,10 +165,9 @@ private:
         }
     }
 
-    void AddSessionProcessToJobObject(_In_ IWSLCSessionFactory* Factory);
+    [[nodiscard]] wil::unique_handle AddSessionProcessToJobObject(_In_ IWSLCSessionFactory* Factory);
     WSLCSessionInitSettings CreateSessionSettings(
         _In_ ULONG SessionId, _In_ LPCWSTR CreatorProcessName, _In_ const WSLCSessionSettings* Settings, _In_ LPCWSTR ResolvedDisplayName);
-    void EnsureJobObjectCreated();
     static CallingProcessTokenInfo GetCallingProcessTokenInfo();
     static HRESULT CheckTokenAccess(const SessionEntry& Entry, const CallingProcessTokenInfo& TokenInfo);
 
@@ -174,11 +175,6 @@ private:
 
     std::atomic<ULONG> m_nextSessionId{1};
     std::recursive_mutex m_wslcSessionsLock;
-
-    // Job object that automatically terminates all child COM server processes
-    // when this service exits or crashes (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE).
-    std::once_flag m_jobObjectInitFlag;
-    wil::unique_handle m_sessionJobObject;
 
     // All sessions tracked via SessionEntry (which holds weak refs and service-side security info).
     // Sessions are automatically cleaned up when the underlying session is released.

--- a/src/windows/service/exe/WSLCSessionManager.h
+++ b/src/windows/service/exe/WSLCSessionManager.h
@@ -165,7 +165,7 @@ private:
         }
     }
 
-    [[nodiscard]] wil::unique_handle AddSessionProcessToJobObject(_In_ IWSLCSessionFactory* Factory);
+    [[nodiscard]] wil::unique_handle CreateSessionProcessJob(_In_ IWSLCSessionFactory* Factory);
     WSLCSessionInitSettings CreateSessionSettings(
         _In_ ULONG SessionId, _In_ LPCWSTR CreatorProcessName, _In_ const WSLCSessionSettings* Settings, _In_ LPCWSTR ResolvedDisplayName);
     static CallingProcessTokenInfo GetCallingProcessTokenInfo();


### PR DESCRIPTION
## Summary

Fixes an intermittent `ERROR_ACCESS_DENIED` (`0x80070005`) from `AssignProcessToJobObject` when creating a WSLC session, most often seen after hibernate / modern-standby resume.

## PR Checklist

- [x] Found an issue and discussed in a separate thread (review feedback on #40748)
- [x] Built and ran the relevant tests (see Validation Steps)

## Detailed Description

`WSLCSessionManagerImpl` assigned every per-session `wslcsession.exe` COM-server process to a single shared kill-on-close job object. The system places each newly launched process in its own job; once the shared job had been assigned to one such process, it could no longer accept a process belonging to an unrelated job, so subsequent `AssignProcessToJobObject` calls intermittently failed with `ERROR_ACCESS_DENIED`. Resume from hibernate/modern-standby widens the window because the system actively re-assigns processes to jobs.

This change creates a fresh kill-on-close job per session and stores the handle in that session's `SessionEntry` for its lifetime, replacing the shared `m_sessionJobObject` (and the associated `EnsureJobObjectCreated` / `std::call_once` bookkeeping). A freshly created job is always assigned exactly once, so it never lands in the state that triggers the failure.

Crash-cleanup behavior is unchanged: `wslservice.exe` owns every job handle, so if it exits or crashes all jobs close and every session process is terminated.

## Validation Steps

- Full x64 Debug build (`cmake --build .`) — clean.
- `WSLCE2ESessionEnterTests` (creates, lists, and exits multiple sequential sessions): Total=3, Passed=3, Failed=0.