### PR TITLE
device host: use a fresh job object per device host process

### DIFF
--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -27,10 +27,6 @@ DeviceHostProxy::DeviceHostProxy(const std::wstring& VmId, const GUID& RuntimeId
 {
     m_devicesShutdown = false;
     m_git = wil::CoCreateInstance<IGlobalInterfaceTable>(CLSID_StdGlobalInterfaceTable, CLSCTX_INPROC_SERVER);
-
-    // Create a job object that will terminate device host processes when this proxy is destroyed
-    // (i.e., when the VM shuts down).
-    m_jobObject = wsl::windows::common::helpers::CreateKillOnCloseJob();
 }
 
 GUID DeviceHostProxy::AddNewDevice(const GUID& Type, const wil::com_ptr<IPlan9FileSystem>& Plan9Fs, const std::wstring& VirtIoTag)
@@ -157,12 +153,29 @@ try
     const wil::com_ptr<IUnknown> unknown = remoteHost.query<IUnknown>();
     THROW_IF_FAILED(proxyDeviceHost(m_system.get(), unknown.get(), ProcessId, IpcSectionHandle));
 
-    // Add the device host process to the job object so it is terminated when the VM shuts down.
-    wil::unique_handle process(OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, ProcessId));
-    LOG_LAST_ERROR_IF_MSG(!process, "Failed to open device host process %u for job assignment", ProcessId);
-    if (process)
+    // Add the device host process to a kill-on-close job so it is terminated when the VM shuts down.
+    // A fresh job is created for each distinct process (see m_processJobs); assigning a process the
+    // system already placed in another job to a job that has already been assigned to a different
+    // process fails with ERROR_ACCESS_DENIED.
     {
-        LOG_IF_WIN32_BOOL_FALSE(AssignProcessToJobObject(m_jobObject.get(), process.get()));
+        auto lock = m_devicesLock.lock_exclusive();
+        if (!m_devicesShutdown && !m_processJobs.contains(ProcessId))
+        {
+            wil::unique_handle process(OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, ProcessId));
+            LOG_LAST_ERROR_IF_MSG(!process, "Failed to open device host process %u for job assignment", ProcessId);
+            if (process)
+            {
+                wil::unique_handle job = wsl::windows::common::helpers::CreateKillOnCloseJob();
+                if (AssignProcessToJobObject(job.get(), process.get()))
+                {
+                    m_processJobs.emplace(ProcessId, std::move(job));
+                }
+                else
+                {
+                    LOG_LAST_ERROR_MSG("Failed to assign device host process %u to job object", ProcessId);
+                }
+            }
+        }
     }
 
     return S_OK;

--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -153,13 +153,12 @@ try
     const wil::com_ptr<IUnknown> unknown = remoteHost.query<IUnknown>();
     THROW_IF_FAILED(proxyDeviceHost(m_system.get(), unknown.get(), ProcessId, IpcSectionHandle));
 
-    // Add the device host process to a kill-on-close job so it is terminated when the VM shuts down.
-    // A fresh job is created for each distinct process (see m_processJobs); assigning a process the
-    // system already placed in another job to a job that has already been assigned to a different
-    // process fails with ERROR_ACCESS_DENIED.
+    // Assign the device host process to a fresh kill-on-close job so it is terminated when the VM
+    // shuts down. Each process needs its own job: a process the system has already placed in a job
+    // cannot be assigned to a job that already owns a different process (ERROR_ACCESS_DENIED).
     {
         auto lock = m_devicesLock.lock_exclusive();
-        if (!m_devicesShutdown && !m_processJobs.contains(ProcessId))
+        if (!m_devicesShutdown)
         {
             wil::unique_handle process(OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, ProcessId));
             LOG_LAST_ERROR_IF_MSG(!process, "Failed to open device host process %u for job assignment", ProcessId);
@@ -168,7 +167,7 @@ try
                 wil::unique_handle job = wsl::windows::common::helpers::CreateKillOnCloseJob();
                 if (AssignProcessToJobObject(job.get(), process.get()))
                 {
-                    m_processJobs.emplace(ProcessId, std::move(job));
+                    m_processJobs.emplace_back(std::move(job));
                 }
                 else
                 {

--- a/src/windows/common/DeviceHostProxy.h
+++ b/src/windows/common/DeviceHostProxy.h
@@ -114,7 +114,13 @@ private:
     std::map<GUID, DeviceHostProxyEntry, wsl::windows::common::helpers::GuidLess> m_devices;
     bool m_devicesShutdown;
 
-    wil::unique_handle m_jobObject;
+    // Per-device-host-process kill-on-close jobs, keyed by process id. A separate job is
+    // created for each distinct device host process rather than sharing one: a process the
+    // system already placed in another job cannot be assigned to a job that has already been
+    // assigned to a different process, which fails intermittently with ERROR_ACCESS_DENIED.
+    // The jobs are held for the proxy's lifetime so the processes are terminated when the VM
+    // shuts down. Guarded by m_devicesLock.
+    std::map<DWORD, wil::unique_handle> m_processJobs;
 
     static constexpr LPCWSTR c_hdvModuleName = L"vmdevicehost.dll";
     static constexpr LPCWSTR c_vmwpctrlModuleName = L"vmwpctrl.dll";

--- a/src/windows/common/DeviceHostProxy.h
+++ b/src/windows/common/DeviceHostProxy.h
@@ -114,13 +114,9 @@ private:
     std::map<GUID, DeviceHostProxyEntry, wsl::windows::common::helpers::GuidLess> m_devices;
     bool m_devicesShutdown;
 
-    // Per-device-host-process kill-on-close jobs, keyed by process id. A separate job is
-    // created for each distinct device host process rather than sharing one: a process the
-    // system already placed in another job cannot be assigned to a job that has already been
-    // assigned to a different process, which fails intermittently with ERROR_ACCESS_DENIED.
-    // The jobs are held for the proxy's lifetime so the processes are terminated when the VM
-    // shuts down. Guarded by m_devicesLock.
-    std::map<DWORD, wil::unique_handle> m_processJobs;
+    // A kill-on-close job per device host process, held for the proxy's lifetime so the
+    // processes are terminated when the VM shuts down. Guarded by m_devicesLock.
+    std::vector<wil::unique_handle> m_processJobs;
 
     static constexpr LPCWSTR c_hdvModuleName = L"vmdevicehost.dll";
     static constexpr LPCWSTR c_vmwpctrlModuleName = L"vmwpctrl.dll";


### PR DESCRIPTION
## Summary

Applies the same fix as #40763 to `DeviceHostProxy`: use a fresh kill-on-close job object per child process instead of one shared job, avoiding an intermittent `ERROR_ACCESS_DENIED` from `AssignProcessToJobObject`.

## PR Checklist

- [x] Found while auditing other job-object assignment sites after #40763
- [x] Built (full x64 Debug build, clean)

## Detailed Description

`DeviceHostProxy` created a single shared kill-on-close job object per VM and assigned every device host process to it in `RegisterDeviceHost`. The system places each newly launched process in its own job; once the shared job had been assigned to one such process, it could no longer accept a process belonging to an unrelated job, so subsequent `AssignProcessToJobObject` calls could fail with `ERROR_ACCESS_DENIED` and leave that device host process out of the kill-on-close job (a potential orphan on VM teardown).

This change creates a fresh kill-on-close job per device host process, keyed by process id (`m_processJobs`), so each assignment targets an empty job and always succeeds. Re-registration by the same process is a no-op (guarded by the process-id lookup). The jobs are held for the proxy's lifetime, so device host processes are still terminated when the VM shuts down.

This is the same root cause and fix shape as #40763 (WSLC session manager), applied to the one other site that shared a job across processes launched by the system. Other job-assignment sites in the tree either assign at process creation (via `PROC_THREAD_ATTRIBUTE_JOB_LIST`) or already tolerate this failure (`install.cpp`), and are not affected.

## Validation Steps

- Full x64 Debug build (`cmake --build .`) — clean.