### PR TITLE
Publish PDBs for the third-party binaries we ship

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,8 +230,18 @@ if (DEFINED PIPELINE_BUILD_ID)
 endif()
 
 set(PACKAGE_CERTIFICATE ${GENERATED_DIR}/dev-cert.pfx)
+
+# Link the third-party binaries we ship (and their PDBs) into bin so packaging
+# and the pipeline's symbol publishing step find them. Without the PDBs here,
+# Watson can't resolve function names in their crash frames.
+string(REPLACE ".dll" ".pdb" WSLG_TS_PLUGIN_PDB ${WSLG_TS_PLUGIN_DLL})
 file(CREATE_LINK ${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_DLL} ${BIN}/${WSLG_TS_PLUGIN_DLL})
+file(CREATE_LINK ${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_PDB} ${BIN}/${WSLG_TS_PLUGIN_PDB})
 file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.dll ${BIN}/wsldeps.dll)
+file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.pdb ${BIN}/wsldeps.pdb)
+# wsldevicehost.dll is packaged directly from its NuGet package, so only its PDB
+# needs linking into bin for symbol publishing.
+file(CREATE_LINK ${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.pdb ${BIN}/wsldevicehost.pdb)
 
 if (${SKIP_PACKAGE_SIGNING})
     set(PACKAGE_SIGN_COMMAND echo Skipped package signing for:)


### PR DESCRIPTION
## What

Stage the PDBs for the third-party binaries we ship (`wsldevicehost.dll`, `wsldeps.dll`, `WSLDVCPlugin.dll`) into `bin` so the pipeline actually publishes them.

## Why

While digging into Watson, I found a big crash family for `wsldevicehost.dll` (~24k cabs) that buckets as `breakpoint_80000003_wsldevicehost.dll!unknown`. Watson can see the module but never the function, so the crashes aren't actionable.

The root cause is on our side: the `Collect symbols` step only scans `bin\<platform>\Release` for PDBs, but these three binaries come from NuGet packages and their PDBs land under `packages\` â€” they never make it into `bin`. So we ship the DLLs but never publish matching symbols. `wsldeps` and `WSLDVCPlugin` have the same gap, just less crash volume.

## Change

For each shipped binary, link its PDB into `bin` next to the DLL (same `file(CREATE_LINK ...)` pattern we already use for the DLLs). `wsldevicehost.dll` is packaged directly from its NuGet package rather than from `bin`, so only its PDB needs linking.

No effect on signing â€” PDBs aren't in the signing allow-list, and these DLLs are unchanged.

## Notes

I haven't independently confirmed the symbols land in the store Watson reads (vs. the ADO symbol service) â€” worth a sanity check once a build flows through, but this is a necessary first step regardless.
