### PR TITLE
Fix potential hang when DockerIORelayHandle completes a write asynchronously 

### DIFF
--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -896,6 +896,8 @@ void DockerIORelayHandle::Collect()
             if (ActiveHandle->GetState() == IOHandleStatus::Completed)
             {
                 ActiveHandle = nullptr;
+
+                ProcessNextHeader();
             }
         }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8243,6 +8243,52 @@ class WSLCTests
 
             runTest(input, largeStdout + "regularStdout", largeStderr);
         }
+
+        // Validate that behavior is correct with various input sizes.
+        {
+            const std::string marker1 = "--start--";
+            const std::string marker2 = "--end--";
+
+            auto runTest = [&](size_t payloadSize) {
+                std::vector<char> input;
+                insert(input, 1, marker1);
+                insert(input, 1, std::string(payloadSize, 'A'));
+                insert(input, 1, marker2);
+                const std::string expected = marker1 + std::string(payloadSize, 'A') + marker2;
+
+                auto [inputRead, inputWrite] =
+                    wsl::windows::common::wslutil::OpenAnonymousPipe(static_cast<DWORD>(input.size() + 1), true, false);
+                auto [stdoutRead, stdoutWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(4096, true, true);
+                auto [stderrRead, stderrWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(4096, true, true);
+
+                DWORD written = 0;
+                THROW_IF_WIN32_BOOL_FALSE(WriteFile(inputWrite.get(), input.data(), static_cast<DWORD>(input.size()), &written, nullptr));
+                VERIFY_ARE_EQUAL(written, static_cast<DWORD>(input.size()));
+
+                std::string output;
+                MultiHandleWait io;
+
+                io.AddHandle(std::make_unique<DockerIORelayHandle>(
+                    std::move(inputRead), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
+
+                io.AddHandle(std::make_unique<ReadHandle>(std::move(stdoutRead), [&](const auto& buffer) {
+                    output.append(buffer.data(), buffer.size());
+                    if (output.find(marker2) != std::string::npos)
+                    {
+                        io.Cancel();
+                    }
+                }));
+
+                io.Run(std::chrono::seconds(60));
+
+                VERIFY_ARE_EQUAL(expected, output);
+            };
+
+            for (const size_t payloadSize : {1, 100, 4096, 8192, 32768, 64036, 65535, 65536, 65537, 65556, 65571, 65572, 65576, 130000})
+            {
+                runTest(payloadSize);
+            }
+        }
     }
 
     WSLC_TEST_METHOD(ContainerRecoveryFromStorage)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a hang that can happen if `DockerIORelayHandle` completes a write call in `Collect()`. In that code path, `ProcessNextHeader` is not called so `ActiveHandle` is not set if we already have a header in buffer, which causes the relay to get stuck.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
