### PR TITLE
wslc: introduce IWSLCVirtualMachineFactory for session VM creation

### DIFF
--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -370,6 +370,14 @@
                     </RegistryKey>
                 </RegistryKey>
 
+                <!-- IWSLCVirtualMachineFactory-->
+                <RegistryKey Root="HKCR" Key="Interface\{2E3C9A41-7D58-4B6E-9F12-6C4A2E9B6D3B}">
+                    <RegistryValue Value="IWSLCVirtualMachineFactory" Type="string" />
+                    <RegistryKey Key="ProxyStubClsid32">
+                        <RegistryValue Value="{4EA0C6DD-E9FF-48E7-994E-13A31D10DC60}" Type="string" />
+                    </RegistryKey>
+                </RegistryKey>
+
                 <!-- IWSLCPluginNotifier-->
                 <RegistryKey Root="HKCR" Key="Interface\{F3E6D5B2-1D40-4E8B-9C39-7A45D1C0F8A2}">
                     <RegistryValue Value="IWSLCPluginNotifier" Type="string" />

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -837,3 +837,79 @@ void HcsVirtualMachine::FreeLun(ULONG Lun)
 
     m_lunBitmap[Lun] = false;
 }
+
+namespace wsl::windows::service::wslc {
+
+WSLCVirtualMachineFactory::WSLCVirtualMachineFactory(_In_ const WSLCSessionSettings* Settings)
+{
+    THROW_HR_IF(E_POINTER, Settings == nullptr);
+
+    m_displayName = Settings->DisplayName ? Settings->DisplayName : L"";
+    m_storagePath = Settings->StoragePath ? Settings->StoragePath : L"";
+
+    if (Settings->RootVhdOverride != nullptr)
+    {
+        m_rootVhdOverride.emplace(Settings->RootVhdOverride);
+    }
+
+    if (Settings->RootVhdTypeOverride != nullptr)
+    {
+        m_rootVhdTypeOverride.emplace(Settings->RootVhdTypeOverride);
+    }
+
+    // Keep our own duplicate of the dmesg sink so recreated VMs can reuse it.
+    if (Settings->DmesgOutput.Handle.File != nullptr && Settings->DmesgOutput.Handle.File != INVALID_HANDLE_VALUE)
+    {
+        m_dmesgOutput.reset(wslutil::DuplicateHandle(wslutil::FromCOMInputHandle(Settings->DmesgOutput), GENERIC_WRITE | SYNCHRONIZE));
+    }
+
+    m_terminationCallback = Settings->TerminationCallback;
+    m_maximumStorageSizeMb = Settings->MaximumStorageSizeMb;
+    m_cpuCount = Settings->CpuCount;
+    m_memoryMb = Settings->MemoryMb;
+    m_bootTimeoutMs = Settings->BootTimeoutMs;
+    m_networkingMode = Settings->NetworkingMode;
+    m_featureFlags = Settings->FeatureFlags;
+    m_storageFlags = Settings->StorageFlags;
+}
+
+WSLCSessionSettings WSLCVirtualMachineFactory::BuildSettings()
+{
+    WSLCSessionSettings settings{};
+    settings.DisplayName = m_displayName.c_str();
+    settings.StoragePath = m_storagePath.empty() ? nullptr : m_storagePath.c_str();
+    settings.MaximumStorageSizeMb = m_maximumStorageSizeMb;
+    settings.CpuCount = m_cpuCount;
+    settings.MemoryMb = m_memoryMb;
+    settings.BootTimeoutMs = m_bootTimeoutMs;
+    settings.NetworkingMode = m_networkingMode;
+    settings.TerminationCallback = m_terminationCallback.get();
+    settings.FeatureFlags = m_featureFlags;
+    settings.StorageFlags = m_storageFlags;
+    settings.RootVhdOverride = m_rootVhdOverride ? m_rootVhdOverride->c_str() : nullptr;
+    settings.RootVhdTypeOverride = m_rootVhdTypeOverride ? m_rootVhdTypeOverride->c_str() : nullptr;
+
+    if (m_dmesgOutput)
+    {
+        settings.DmesgOutput = wslutil::ToCOMInputHandle(m_dmesgOutput.get());
+    }
+
+    return settings;
+}
+
+HRESULT WSLCVirtualMachineFactory::CreateVirtualMachine(_Out_ IWSLCVirtualMachine** Vm)
+try
+{
+    RETURN_HR_IF(E_POINTER, Vm == nullptr);
+    *Vm = nullptr;
+
+    const auto settings = BuildSettings();
+    auto vm = Microsoft::WRL::Make<HcsVirtualMachine>(&settings);
+    THROW_IF_NULL_ALLOC(vm);
+
+    *Vm = vm.Detach();
+    return S_OK;
+}
+CATCH_RETURN()
+
+} // namespace wsl::windows::service::wslc

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -24,6 +24,8 @@ Abstract:
 #include "WslCoreConfig.h"
 #include <filesystem>
 #include <map>
+#include <optional>
+#include <string>
 
 #define MAX_VHD_COUNT 254
 
@@ -103,6 +105,46 @@ private:
     std::atomic<bool> m_crashLogCaptured = false;
 
     wil::com_ptr<ITerminationCallback> m_terminationCallback;
+};
+
+//
+// WSLCVirtualMachineFactory - Implements IWSLCVirtualMachineFactory.
+//
+// Owns a deep copy of the WSLCSessionSettings needed to construct a VM and creates a
+// fresh HcsVirtualMachine on demand. This lets the per-user session recreate a VM that
+// was idle-terminated, without the SYSTEM service holding a VM up front.
+//
+class WSLCVirtualMachineFactory
+    : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IWSLCVirtualMachineFactory, IFastRundown>
+{
+public:
+    explicit WSLCVirtualMachineFactory(_In_ const WSLCSessionSettings* Settings);
+
+    IFACEMETHOD(CreateVirtualMachine)(_Out_ IWSLCVirtualMachine** Vm) override;
+
+private:
+    // Rebuilds a WSLCSessionSettings that points at this factory's owned storage.
+    // The returned struct is only valid while this factory is alive.
+    WSLCSessionSettings BuildSettings();
+
+    std::wstring m_displayName;
+    std::wstring m_storagePath;
+    std::optional<std::wstring> m_rootVhdOverride;
+    std::optional<std::string> m_rootVhdTypeOverride;
+
+    // Duplicated dmesg sink (best-effort): only the first VM is guaranteed a live sink;
+    // subsequent VMs reuse this duplicate, whose writes simply fail if the sink is gone.
+    wil::unique_handle m_dmesgOutput;
+
+    wil::com_ptr<ITerminationCallback> m_terminationCallback;
+
+    ULONGLONG m_maximumStorageSizeMb{};
+    ULONG m_cpuCount{};
+    ULONG m_memoryMb{};
+    ULONG m_bootTimeoutMs{};
+    WSLCNetworkingMode m_networkingMode{};
+    WSLCFeatureFlags m_featureFlags{};
+    WSLCSessionStorageFlags m_storageFlags{};
 };
 
 } // namespace wsl::windows::service::wslc

--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -45,6 +45,7 @@ using wsl::windows::service::wslc::CallingProcessTokenInfo;
 using wsl::windows::service::wslc::HcsVirtualMachine;
 using wsl::windows::service::wslc::WSLCPluginNotifier;
 using wsl::windows::service::wslc::WSLCSessionManagerImpl;
+using wsl::windows::service::wslc::WSLCVirtualMachineFactory;
 namespace wslutil = wsl::windows::common::wslutil;
 namespace settings = wsl::windows::wslc::settings;
 
@@ -268,8 +269,10 @@ void WSLCSessionManagerImpl::CreateSession(
         notifier = wil::MakeOrThrow<WSLCPluginNotifier>(
             g_pluginManager, sessionId, creatorPid, std::wstring(resolvedDisplayName), wil::shared_handle(sharedToken), std::vector<BYTE>(storedSid));
 
-        // Create the VM in the SYSTEM service (privileged).
-        auto vm = Microsoft::WRL::Make<HcsVirtualMachine>(Settings);
+        // Create the VM factory in the SYSTEM service (privileged). The per-user session
+        // uses it to create the VM. Funneling VM creation through a factory lets the session
+        // own when VMs are created, rather than having one handed to it up front.
+        auto vmFactory = Microsoft::WRL::Make<WSLCVirtualMachineFactory>(Settings);
 
         // Launch per-user COM server factory and add it to a fresh per-session job object for crash cleanup.
         auto factory = wslutil::CreateComServerAsUser<IWSLCSessionFactory>(__uuidof(WSLCSessionFactory), userToken.get());
@@ -278,7 +281,7 @@ void WSLCSessionManagerImpl::CreateSession(
         const auto sessionSettings = CreateSessionSettings(sessionId, callerFileName.c_str(), Settings, resolvedDisplayName.c_str());
         wil::com_ptr<IWSLCSession> session;
         wil::com_ptr<IWSLCSessionReference> serviceRef;
-        THROW_IF_FAILED(factory->CreateSession(&sessionSettings, vm.Get(), notifier.Get(), WarningCallback, &session, &serviceRef));
+        THROW_IF_FAILED(factory->CreateSession(&sessionSettings, vmFactory.Get(), notifier.Get(), WarningCallback, &session, &serviceRef));
 
         // Track the session via its service ref, along with metadata and security info.
         m_sessions.push_back(SessionEntry{

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -533,6 +533,26 @@ interface IWSLCVirtualMachine : IUnknown
     HRESULT GetTerminationEvent([out, system_handle(sh_event)] HANDLE* Event);
 }
 
+//
+// IWSLCVirtualMachineFactory - Creates VMs on demand for a session.
+//
+// Held by the per-user session process and implemented by the SYSTEM service.
+// This lets the session create a fresh VM at any time (e.g. to recreate a VM that
+// was idle-terminated when it had no running containers), instead of the service
+// eagerly creating a single VM up front. Each successful call returns a new VM whose
+// lifetime is owned by the caller: releasing the IWSLCVirtualMachine tears it down.
+//
+[
+    uuid(2E3C9A41-7D58-4B6E-9F12-6C4A2E9B6D3B),
+    pointer_default(unique),
+    object
+]
+interface IWSLCVirtualMachineFactory : IUnknown
+{
+    // Creates a new VM using the settings captured at session creation time.
+    HRESULT CreateVirtualMachine([out] IWSLCVirtualMachine** Vm);
+}
+
 typedef enum _WSLCSessionStorageFlags
 {
     WSLCSessionStorageFlagsNone = 0,
@@ -803,10 +823,10 @@ interface IWSLCSession : IUnknown
     // Returns a handle to this COM server process (used to add to job object).
     HRESULT GetProcessHandle([out, system_handle(sh_process)] HANDLE* ProcessHandle);
 
-    // Initializes the session with a pre-created VM.
+    // Initializes the session with a VM factory. VMs are created through the factory.
     HRESULT Initialize(
         [in] const WSLCSessionInitSettings* Settings,
-        [in] IWSLCVirtualMachine* Vm,
+        [in] IWSLCVirtualMachineFactory* VmFactory,
         [in] IWSLCPluginNotifier* PluginNotifier,
         [in, unique] IWarningCallback* WarningCallback);
 
@@ -863,7 +883,7 @@ interface IWSLCSessionFactory : IUnknown
     // Creates a new session and returns both the session interface and a service reference.
     HRESULT CreateSession(
         [in] const WSLCSessionInitSettings* Settings,
-        [in] IWSLCVirtualMachine* Vm,
+        [in] IWSLCVirtualMachineFactory* VmFactory,
         [in] IWSLCPluginNotifier* PluginNotifier,
         [in, unique] IWarningCallback* WarningCallback,
         [out] IWSLCSession** Session,

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -292,10 +292,13 @@ try
 CATCH_RETURN();
 
 HRESULT WSLCSession::Initialize(
-    _In_ const WSLCSessionInitSettings* Settings, _In_ IWSLCVirtualMachine* Vm, _In_ IWSLCPluginNotifier* PluginNotifier, _In_opt_ IWarningCallback* WarningCallback)
+    _In_ const WSLCSessionInitSettings* Settings,
+    _In_ IWSLCVirtualMachineFactory* VmFactory,
+    _In_ IWSLCPluginNotifier* PluginNotifier,
+    _In_opt_ IWarningCallback* WarningCallback)
 try
 {
-    RETURN_HR_IF(E_POINTER, Settings == nullptr || Vm == nullptr);
+    RETURN_HR_IF(E_POINTER, Settings == nullptr || VmFactory == nullptr);
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_INITIALIZED), m_virtualMachine.has_value());
 
     THROW_HR_IF_MSG(
@@ -326,10 +329,13 @@ try
         TraceLoggingValue(m_displayName.c_str(), "DisplayName"),
         TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess"));
 
-    // Create the VM. The VM produces crash events; the session multiplexes them out to any
-    // registered ICrashDumpCallback subscribers via OnCrashDumpWritten.
+    // Create the VM through the factory. The VM produces crash events; the session multiplexes
+    // them out to any registered ICrashDumpCallback subscribers via OnCrashDumpWritten.
+    wil::com_ptr<IWSLCVirtualMachine> vm;
+    THROW_IF_FAILED(VmFactory->CreateVirtualMachine(&vm));
+
     m_virtualMachine.emplace(
-        Vm,
+        vm.get(),
         Settings,
         m_sessionTerminatingEvent.get(),
         std::bind(&WSLCSession::OnCrashDumpWritten, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
@@ -340,7 +346,7 @@ try
     m_virtualMachine->Initialize();
 
     // Get an event from the service that is signaled when the VM exits.
-    THROW_IF_FAILED(Vm->GetTerminationEvent(&m_vmExitedEvent));
+    THROW_IF_FAILED(vm->GetTerminationEvent(&m_vmExitedEvent));
 
     // Configure storage.
     ConfigureStorage(*Settings, tokenInfo->User.Sid);

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -92,7 +92,7 @@ public:
     IFACEMETHOD(GetProcessHandle)(_Out_ HANDLE* ProcessHandle) override;
     IFACEMETHOD(Initialize)(
         _In_ const WSLCSessionInitSettings* Settings,
-        _In_ IWSLCVirtualMachine* Vm,
+        _In_ IWSLCVirtualMachineFactory* VmFactory,
         _In_ IWSLCPluginNotifier* PluginNotifier,
         _In_opt_ IWarningCallback* WarningCallback) override;
 

--- a/src/windows/wslcsession/WSLCSessionFactory.cpp
+++ b/src/windows/wslcsession/WSLCSessionFactory.cpp
@@ -31,7 +31,7 @@ void wslc::WSLCSessionFactory::SetDestructionCallback(std::function<void()>&& ca
 
 HRESULT wslc::WSLCSessionFactory::CreateSession(
     _In_ const WSLCSessionInitSettings* Settings,
-    _In_ IWSLCVirtualMachine* Vm,
+    _In_ IWSLCVirtualMachineFactory* VmFactory,
     _In_ IWSLCPluginNotifier* PluginNotifier,
     _In_opt_ IWarningCallback* WarningCallback,
     _Out_ IWSLCSession** Session,
@@ -51,8 +51,8 @@ try
     // One session per process, so when it's destroyed, exit.
     session->SetDestructionCallback(std::move(m_destructionCallback));
 
-    // Initialize the session with the VM.
-    RETURN_IF_FAILED(session->Initialize(Settings, Vm, PluginNotifier, WarningCallback));
+    // Initialize the session with the VM factory (VMs are created on demand).
+    RETURN_IF_FAILED(session->Initialize(Settings, VmFactory, PluginNotifier, WarningCallback));
 
     // Create the service session ref. It extracts metadata and a weak reference from the session.
     auto serviceRef = Microsoft::WRL::Make<wslc::WSLCSessionReference>(session.Get());

--- a/src/windows/wslcsession/WSLCSessionFactory.h
+++ b/src/windows/wslcsession/WSLCSessionFactory.h
@@ -45,7 +45,7 @@ public:
     // IWSLCSessionFactory
     IFACEMETHOD(CreateSession)
     (_In_ const WSLCSessionInitSettings* Settings,
-     _In_ IWSLCVirtualMachine* Vm,
+     _In_ IWSLCVirtualMachineFactory* VmFactory,
      _In_ IWSLCPluginNotifier* PluginNotifier,
      _In_opt_ IWarningCallback* WarningCallback,
      _Out_ IWSLCSession** Session,


### PR DESCRIPTION
## Summary of the Pull Request

Introduces `IWSLCVirtualMachineFactory` as the abstraction the per-user `wslcsession.exe` uses to create its VM, replacing the previous model where the SYSTEM service created the VM up front and handed the pre-created `IWSLCVirtualMachine` to the session.

This is **behavior-preserving**: the session still creates exactly one VM eagerly during `Initialize`. The change simply funnels VM creation through a factory so the session owns *when* the VM is created. This is groundwork for a follow-up change that lets a session tear down its VM when idle and recreate it on demand.

## PR Checklist

- [ ] **Closes:** N/A (refactor / groundwork)
- [x] **Communication:** Foundational refactor split out of a larger idle-VM feature branch
- [x] **Tests:** No new tests; behavior-preserving. Existing WSLC container E2E suite passes.
- [x] **Localization:** No new end-user-facing strings
- [x] **Dev docs:** N/A

## Detailed Description of the Pull Request / Additional comments

- `wslc.idl`: add `IWSLCVirtualMachineFactory` (single method `CreateVirtualMachine`); change `IWSLCSession::Initialize` and `IWSLCSessionFactory::CreateSession` to take `IWSLCVirtualMachineFactory*` instead of `IWSLCVirtualMachine*`.
- `HcsVirtualMachine.{h,cpp}`: implement `WSLCVirtualMachineFactory`, a `RuntimeClass<ClassicCom, IWSLCVirtualMachineFactory, IFastRundown>` that owns a deep copy of the VM settings (including a duplicated dmesg sink) and constructs a fresh `HcsVirtualMachine` per call.
- `WSLCSessionManager.cpp`: the SYSTEM service now creates the factory (`Make<WSLCVirtualMachineFactory>(Settings)`) and passes it through `CreateSession`.
- `WSLCSession.cpp` / `WSLCSessionFactory.cpp`: the session creates the VM via `VmFactory->CreateVirtualMachine()` during `Initialize`, then proceeds exactly as before.
- `msipackage/package.wix.in`: register the new interface IID for COM marshaling (proxy/stub), matching every other cross-process WSLC interface. Omitting this fails session `Initialize` with `REGDB_E_INTERFACENOTREG` (0x80040155).

## Validation Steps Performed

- Full `cmake --build . -- -m` (x64 Debug) clean.
- `WSLCE2ETests::WSLCE2EContainerCreateTests::*` — **45/45 pass** (exercises real VM bring-up plus container create/start/attach).
- Confirmed the new interface marshals across the service↔session process boundary after registering the proxy-stub IID.