### PR TITLE
Fix disk-attach restore TOCTOU by impersonating the mounting user on VHD restore

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -3210,10 +3210,20 @@ try
 
     // Attach the disk to the VM, reusing the same LUN if possible.
     //
-    // N.B. The user token is not provided because the key that holds the disk
-    // state can only be written by elevated users.
+    // N.B. The disk-mount state is stored under the user's SID in a volatile (per-boot)
+    // registry key, so the disk being restored here was mounted earlier in this same boot
+    // by this same user. For a VHD we therefore pass the user token so the access grant and
+    // the path resolution run under the mounting user's identity: a privileged operation can
+    // only ever touch a file that user can already reach, which closes the restore-time
+    // junction/symlink swap (TOCTOU) without re-resolving the path as SYSTEM.
+    //
+    // A pass-through (raw block device) attach is elevation-gated and the reconnecting user
+    // may no longer be elevated, so it is restored as SYSTEM (no token). Block-device paths
+    // (\\.\PhysicalDriveN) have no reparse-point surface, so there is no swap to defend
+    // against.
     auto lun = std::stoul(LunStr);
-    m_utilityVm->AttachDisk(path.c_str(), diskType, lun, true, nullptr);
+    const HANDLE userToken = (diskType == WslCoreVm::DiskType::VHD) ? m_userToken.get() : nullptr;
+    m_utilityVm->AttachDisk(path.c_str(), diskType, lun, true, userToken);
 
     // Restore each mount point.
     for (const auto& e : wsl::windows::common::registry::EnumKeys(Key, KEY_READ))

--- a/test/windows/MountTests.cpp
+++ b/test/windows/MountTests.cpp
@@ -460,6 +460,72 @@ class MountTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + absolutePath.wstring()), (DWORD)0);
     }
 
+    // A VHD whose path is a symbolic link is a legitimate, supported scenario: the link is
+    // followed and the real VHD is attached. Access is granted while impersonating the user,
+    // so the user can only ever attach a file they can already reach; there is no need to
+    // reject reparse points in the path.
+    WSL2_TEST_METHOD(MountVhdThroughSymlinkSucceeds)
+    {
+        SKIP_UNSUPPORTED_ARM64_MOUNT_TEST();
+
+        const auto symlink = std::filesystem::absolute(L"TestVhdSymlink.vhd");
+        DeleteFileW(symlink.c_str());
+
+        const auto absoluteTarget = std::filesystem::absolute(TEST_MOUNT_VHD);
+
+        // Create a file symbolic link pointing at the real VHD.
+        if (!CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
+        {
+            // Creating symlinks requires Developer Mode or SeCreateSymbolicLinkPrivilege; skip if unavailable.
+            LogSkipped("Unable to create a symbolic link (error %d); skipping", GetLastError());
+            return;
+        }
+
+        auto cleanup = wil::scope_exit([&]() { DeleteFileW(symlink.c_str()); });
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--mount " + symlink.wstring() + L" --vhd --bare"), (DWORD)0);
+
+        const auto disk = GetBlockDeviceInWsl();
+        VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + symlink.wstring()), (DWORD)0);
+    }
+
+    // A symlinked VHD must still be restored after the VM is torn down on idle. Restore runs
+    // under the mounting user's identity (the disk-mount state is stored per-SID for the
+    // current boot), so the same access check applies and the symlinked VHD re-attaches.
+    WSL2_TEST_METHOD(MountVhdThroughSymlinkSurvivesVmTimeout)
+    {
+        SKIP_UNSUPPORTED_ARM64_MOUNT_TEST();
+
+        const auto symlink = std::filesystem::absolute(L"TestVhdSymlinkRestore.vhd");
+        DeleteFileW(symlink.c_str());
+
+        const auto absoluteTarget = std::filesystem::absolute(TEST_MOUNT_VHD);
+
+        if (!CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
+        {
+            LogSkipped("Unable to create a symbolic link (error %d); skipping", GetLastError());
+            return;
+        }
+
+        auto cleanup = wil::scope_exit([&]() { DeleteFileW(symlink.c_str()); });
+
+        WslKeepAlive keepAlive;
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--mount " + symlink.wstring() + L" --vhd --bare"), (DWORD)0);
+
+        const auto disk = GetBlockDeviceInWsl();
+        VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
+
+        WaitForVmTimeout(keepAlive);
+
+        // Recreating the VM restores the persisted disk mount; the symlinked VHD must re-attach.
+        VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + symlink.wstring()), (DWORD)0);
+    }
+
     // Attach a disk, but don't mount it
     WSL2_TEST_METHOD(TestBareMount)
     {

--- a/test/windows/MountTests.cpp
+++ b/test/windows/MountTests.cpp
@@ -474,12 +474,7 @@ class MountTests
         const auto absoluteTarget = std::filesystem::absolute(TEST_MOUNT_VHD);
 
         // Create a file symbolic link pointing at the real VHD.
-        if (!CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
-        {
-            // Creating symlinks requires Developer Mode or SeCreateSymbolicLinkPrivilege; skip if unavailable.
-            LogSkipped("Unable to create a symbolic link (error %d); skipping", GetLastError());
-            return;
-        }
+        VERIFY_IS_TRUE(CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE));
 
         auto cleanup = wil::scope_exit([&]() { DeleteFileW(symlink.c_str()); });
 
@@ -503,11 +498,7 @@ class MountTests
 
         const auto absoluteTarget = std::filesystem::absolute(TEST_MOUNT_VHD);
 
-        if (!CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
-        {
-            LogSkipped("Unable to create a symbolic link (error %d); skipping", GetLastError());
-            return;
-        }
+        VERIFY_IS_TRUE(CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE));
 
         auto cleanup = wil::scope_exit([&]() { DeleteFileW(symlink.c_str()); });
 
@@ -515,12 +506,14 @@ class MountTests
 
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--mount " + symlink.wstring() + L" --vhd --bare"), (DWORD)0);
 
-        const auto disk = GetBlockDeviceInWsl();
+        auto disk = GetBlockDeviceInWsl();
         VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
 
         WaitForVmTimeout(keepAlive);
 
-        // Recreating the VM restores the persisted disk mount; the symlinked VHD must re-attach.
+        // Recreating the VM restores the persisted disk mount; the symlinked VHD must re-attach. The
+        // block device name is not guaranteed to be stable across the VM teardown, so re-query it.
+        disk = GetBlockDeviceInWsl();
         VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
 
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + symlink.wstring()), (DWORD)0);


### PR DESCRIPTION
## Summary

Closes a time-of-check/time-of-use (TOCTOU) gap in disk attach where the **restore** path re-resolved a user-controllable VHD path as **SYSTEM** after the VM was recreated.

## Background

For a live `wsl --mount --vhd`, a junction/symlink swap is already harmless: the VM access grant runs while **impersonating the user** (`GrantVmAccess`), and the SYSTEM-side `AddVhd` only succeeds on a file the VM was granted access to. A swap therefore yields `ACCESS_DENIED`, not disclosure.

The real gap was **disk restore**: when the utility VM is torn down on idle and later recreated, `LxssUserSession::_LoadDiskMount` re-attached persisted VHDs with **no user token** (as SYSTEM), re-resolving the user-supplied path and reopening the swap window.

## Fix

Disk-mount state is stored under the user's SID in a **volatile (per-boot)** registry key, so the disk being restored was mounted earlier in the same boot by the **same user**, and that user's token is already available at VM-create time. So restore simply passes the user token for VHDs and lets the existing impersonated grant close the window:

- **VHD restore** now runs under the mounting user's identity — a privileged operation can only ever touch a file that user can already reach.
- **Pass-through** (raw block device) restore stays SYSTEM: it is elevation-gated and `\\.\PhysicalDriveN` paths have no reparse-point surface, so there is nothing to swap.

This replaces the earlier handle-pinning / reparse-point-rejection approach (per review feedback), which also regressed legitimate symlinked VHDs.

## Tests

- `MountVhdThroughSymlinkSucceeds` — a symlinked VHD mounts (regression guard).
- `MountVhdThroughSymlinkSurvivesVmTimeout` — a symlinked VHD re-attaches after a VM idle-timeout restore.