### PR TITLE
Ask for user consent if wsl is active during store updates.

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1054,6 +1054,16 @@ Falling back to NAT networking.</value>
   <data name="MessageUpdate" xml:space="preserve">
     <value>Update</value>
   </data>
+  <data name="MessageUpgradeWhileActiveTitle" xml:space="preserve">
+    <value>WSL Update</value>
+    <comment>{Locked="WSL"}Product names should not be translated</comment>
+  </data>
+  <data name="MessageUpgradeWhileActivePrompt" xml:space="preserve">
+    <value>An update for WSL is ready to install, but it is currently in use.
+
+Select Yes to shutdown WSL and install now. Select No to install on the next reboot.</value>
+    <comment>{Locked="WSL"}Product names should not be translated</comment>
+  </data>
   <data name="MessageViewReleaseNotes" xml:space="preserve">
     <value>See Docs</value>
   </data>

--- a/src/windows/common/CMakeLists.txt
+++ b/src/windows/common/CMakeLists.txt
@@ -53,7 +53,8 @@ set(SOURCES
     wslutil.cpp
     install.cpp
     WSLCUserSettings.cpp
-    notifications.cpp)
+    notifications.cpp
+    WslActivityMarker.cpp)
 
 set(HEADERS
     ../../../generated/Localization.h
@@ -140,6 +141,7 @@ set(HEADERS
     EnumVariantMap.h
     WSLCUserSettings.h
     WSLCSessionDefaults.h
+    WslActivityMarker.h
     )
 
 add_library(common STATIC ${SOURCES} ${HEADERS})

--- a/src/windows/common/WslActivityMarker.cpp
+++ b/src/windows/common/WslActivityMarker.cpp
@@ -1,0 +1,60 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WslActivityMarker.cpp
+
+Abstract:
+
+    This file contains the implementation for tracking whether WSL is in use.
+
+--*/
+
+#include "precomp.h"
+#include "WslActivityMarker.h"
+
+namespace {
+
+constexpr auto c_activityObjectName = L"Global\\WslActive";
+
+wil::srwlock g_activityLock;
+_Guarded_by_(g_activityLock) size_t g_activityCount = 0;
+_Guarded_by_(g_activityLock) wil::unique_handle g_activityEvent;
+
+} // namespace
+
+namespace wsl::windows::common {
+
+WslActivityMarker::WslActivityMarker() noexcept
+{
+    auto lock = g_activityLock.lock_exclusive();
+
+    g_activityCount++;
+
+    if (!g_activityEvent)
+    {
+        g_activityEvent.reset(CreateEventW(nullptr, TRUE, FALSE, c_activityObjectName));
+        LOG_LAST_ERROR_IF_MSG(!g_activityEvent, "Failed to create WSL activity object");
+    }
+}
+
+WslActivityMarker::~WslActivityMarker() noexcept
+{
+    auto lock = g_activityLock.lock_exclusive();
+
+    g_activityCount--;
+    if (g_activityCount == 0)
+    {
+        g_activityEvent.reset();
+    }
+}
+
+bool WslActivityMarker::IsWslActive() noexcept
+{
+    wil::unique_handle event{OpenEventW(SYNCHRONIZE, FALSE, c_activityObjectName)};
+    return event != nullptr;
+}
+
+} // namespace wsl::windows::common

--- a/src/windows/common/WslActivityMarker.h
+++ b/src/windows/common/WslActivityMarker.h
@@ -1,0 +1,31 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WslActivityMarker.h
+
+Abstract:
+
+    This file contains declarations for tracking whether WSL is in use.
+
+--*/
+
+#pragma once
+
+namespace wsl::windows::common {
+
+class WslActivityMarker
+{
+public:
+    WslActivityMarker() noexcept;
+    ~WslActivityMarker() noexcept;
+
+    NON_COPYABLE(WslActivityMarker);
+    NON_MOVABLE(WslActivityMarker);
+
+    static bool IsWslActive() noexcept;
+};
+
+} // namespace wsl::windows::common

--- a/src/windows/service/exe/LxssCreateProcess.h
+++ b/src/windows/service/exe/LxssCreateProcess.h
@@ -16,6 +16,7 @@ Abstract:
 
 #include "SocketChannel.h"
 #include "WslPluginApi.h"
+#include "WslActivityMarker.h"
 
 // Macro to test if Windows interop is enabled.
 #define LXSS_INTEROP_FLAGS (LXSS_DISTRO_FLAGS_ENABLE_DRIVE_MOUNTING | LXSS_DISTRO_FLAGS_ENABLE_INTEROP)
@@ -163,4 +164,6 @@ public:
 
 private:
     int m_idleTimeout;
+
+    wsl::windows::common::WslActivityMarker m_activityMarker;
 };

--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -282,7 +282,17 @@ void WSLCSessionManagerImpl::CreateSession(
 
         // Track the session via its service ref, along with metadata and security info.
         m_sessions.push_back(SessionEntry{
-            std::move(serviceRef), sessionId, creatorPid, resolvedDisplayName, std::move(tokenInfo), notifier, false, sharedToken, std::move(storedSid), std::move(sessionJob)});
+            std::move(serviceRef),
+            sessionId,
+            creatorPid,
+            resolvedDisplayName,
+            std::move(tokenInfo),
+            notifier,
+            false,
+            sharedToken,
+            std::move(storedSid),
+            std::move(sessionJob),
+            std::make_unique<wsl::windows::common::WslActivityMarker>()});
 
         // For persistent sessions, also hold a strong reference to keep them alive.
         const bool persistent = WI_IsFlagSet(Flags, WSLCSessionFlagsPersistent);

--- a/src/windows/service/exe/WSLCSessionManager.h
+++ b/src/windows/service/exe/WSLCSessionManager.h
@@ -34,6 +34,7 @@ Abstract:
 #include "wslc.h"
 #include "COMImplClass.h"
 #include "wslutil.h"
+#include "WslActivityMarker.h"
 #include <atomic>
 #include <algorithm>
 #include <string>
@@ -70,6 +71,8 @@ struct SessionEntry
     std::vector<BYTE> UserSid;
 
     wil::unique_handle JobObject;
+
+    std::unique_ptr<wsl::windows::common::WslActivityMarker> ActivityMarker;
 };
 
 class WSLCSessionManagerImpl

--- a/src/windows/wslinstaller/exe/CMakeLists.txt
+++ b/src/windows/wslinstaller/exe/CMakeLists.txt
@@ -17,6 +17,7 @@ set_target_properties(wslinstaller PROPERTIES LINK_FLAGS "/merge:minATL=.rdata /
 target_link_libraries(wslinstaller
                       ${COMMON_LINK_LIBRARIES}
                       ${MSI_LINK_LIBRARIES}
+                      Wtsapi32.lib
                       common
                       legacy_stdio_definitions)
 

--- a/src/windows/wslinstaller/exe/WslInstaller.cpp
+++ b/src/windows/wslinstaller/exe/WslInstaller.cpp
@@ -15,6 +15,8 @@ Abstract:
 #include "precomp.h"
 #include "install.h"
 #include "WslInstaller.h"
+#include "WslActivityMarker.h"
+#include <wtsapi32.h>
 
 extern wil::unique_event g_stopEvent;
 
@@ -164,6 +166,74 @@ std::pair<bool, std::wstring> IsUpdateNeeded()
     }
 }
 
+static bool DeferUpdatePromptEnabled()
+try
+{
+    const auto key = wsl::windows::common::registry::OpenLxssMachineKey(KEY_READ);
+
+    auto value = wsl::windows::common::registry::ReadDword(key.get(), L"MSI", L"EnableMsixDeferUpdatePrompt", 1);
+
+    return value == 1;
+}
+catch (...)
+{
+    LOG_CAUGHT_EXCEPTION();
+    return true;
+}
+
+static bool PromptUserToUpgradeWhileActive()
+try
+{
+    // For test automation purpose
+    if (!DeferUpdatePromptEnabled())
+    {
+        wsl::windows::common::install::WriteInstallLog("DeferUpdatePrompt is disabled");
+        return false;
+    }
+
+    constexpr DWORD c_upgradePromptTimeoutSeconds = 60;
+
+    const DWORD sessionId = WTSGetActiveConsoleSessionId();
+    if (sessionId == 0xFFFFFFFF)
+    {
+        wsl::windows::common::install::WriteInstallLog("No active console session");
+        return false;
+    }
+
+    auto title = wsl::shared::Localization::MessageUpgradeWhileActiveTitle();
+    auto message = wsl::shared::Localization::MessageUpgradeWhileActivePrompt();
+
+    DWORD response = 0;
+    if (!WTSSendMessageW(
+            WTS_CURRENT_SERVER_HANDLE,
+            sessionId,
+            title.data(),
+            static_cast<DWORD>(title.size() * sizeof(wchar_t)),
+            message.data(),
+            static_cast<DWORD>(message.size() * sizeof(wchar_t)),
+            MB_YESNO | MB_ICONQUESTION | MB_TOPMOST,
+            c_upgradePromptTimeoutSeconds,
+            &response,
+            TRUE))
+    {
+        LOG_LAST_ERROR_MSG("WTSSendMessageW failed");
+        return false;
+    }
+
+    if (response != IDYES)
+    {
+        wsl::windows::common::install::WriteInstallLog(std::format("User declined upgrade prompt (response {})", response));
+        return false;
+    }
+
+    return true;
+}
+catch (...)
+{
+    LOG_CAUGHT_EXCEPTION();
+    return false;
+}
+
 std::shared_ptr<InstallContext> LaunchInstall()
 {
     static wil::srwlock mutex;
@@ -174,6 +244,12 @@ std::shared_ptr<InstallContext> LaunchInstall()
     auto [updateNeeded, existingVersion] = IsUpdateNeeded();
     if (!updateNeeded)
     {
+        return {};
+    }
+
+    if (wsl::windows::common::WslActivityMarker::IsWslActive() && !PromptUserToUpgradeWhileActive())
+    {
+        wsl::windows::common::install::WriteInstallLog("WSL is active; deferring MSI upgrade until WSL is idle.");
         return {};
     }
 

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2476,6 +2476,20 @@ std::optional<GUID> GetDistributionId(LPCWSTR Name)
     return {};
 }
 
+LxssDistributionState GetDistributionState(LPCWSTR Name)
+{
+    wsl::windows::common::SvcComm service;
+    for (const auto& e : service.EnumerateDistributions())
+    {
+        if (wsl::shared::string::IsEqual(e.DistroName, Name))
+        {
+            return e.State;
+        }
+    }
+
+    return LxssDistributionStateInvalid;
+}
+
 wil::unique_hkey OpenDistributionKey(LPCWSTR Name)
 {
     const auto id = GetDistributionId(Name);

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -617,6 +617,7 @@ void StopWslService();
 
 std::optional<GUID> GetDistributionId(LPCWSTR Name);
 wil::unique_hkey OpenDistributionKey(LPCWSTR Name);
+LxssDistributionState GetDistributionState(LPCWSTR Name = LXSS_DISTRO_NAME_TEST_L);
 
 void ValidateOutput(LPCWSTR CommandLine, const std::wstring& ExpectedOutput, const std::wstring& ExpectedWarnings = L"", int ExitCode = -1);
 

--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -206,8 +206,6 @@ class InstallerTests
                 .AddPackageAsync(winrt::Windows::Foundation::Uri{m_msixPackagePath}, nullptr, winrt::Windows::Management::Deployment::DeploymentOptions::None)
                 .get();
 
-        LogInfo("AddPackage result: 0x%08x, %ls", result.ExtendedErrorCode(), result.ErrorText().c_str());
-
         VERIFY_ARE_EQUAL(result.ExtendedErrorCode(), S_OK);
     }
 

--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -119,7 +119,7 @@ class InstallerTests
 
         try
         {
-            wsl::shared::retry::RetryWithTimeout<void>(pred, std::chrono::hours(3), std::chrono::minutes(2));
+            wsl::shared::retry::RetryWithTimeout<void>(pred, std::chrono::seconds(3), std::chrono::minutes(2));
         }
         catch (...)
         {
@@ -205,6 +205,8 @@ class InstallerTests
             m_packageManager
                 .AddPackageAsync(winrt::Windows::Foundation::Uri{m_msixPackagePath}, nullptr, winrt::Windows::Management::Deployment::DeploymentOptions::None)
                 .get();
+
+        LogInfo("AddPackage result: 0x%08x, %ls", result.ExtendedErrorCode(), result.ErrorText().c_str());
 
         VERIFY_ARE_EQUAL(result.ExtendedErrorCode(), S_OK);
     }
@@ -692,6 +694,43 @@ class InstallerTests
             L"Update failed (exit code: 1603).\r\n"
             L"Error code: Wsl/CallMsi/Install/ERROR_INSTALL_FAILURE\r\n",
             output);
+    }
+
+    TEST_METHOD(MsixUpgradeDefer)
+    {
+        InstallMsi();
+        VERIFY_IS_TRUE(IsMsiPackageInstalled());
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { InstallMsi(); });
+
+        RegistryKeyChange<std::wstring> changeVersion(
+            HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows\\CurrentVersion\\Lxss\\MSI", L"Version", L"1.0.0");
+
+        RegistryKeyChange<DWORD> disablePrompt(
+            HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows\\CurrentVersion\\Lxss\\MSI", L"EnableMsixDeferUpdatePrompt", 0);
+
+        const auto commandLine = LxssGenerateWslCommandLine(L"sleep infinity");
+        wsl::windows::common::SubProcess process(nullptr, commandLine.c_str());
+        auto processHandle = process.Start();
+
+        wsl::shared::retry::RetryWithTimeout<void>(
+            []() { THROW_HR_IF(E_ABORT, GetDistributionState() != LxssDistributionStateRunning); },
+            std::chrono::seconds(1),
+            std::chrono::seconds(30));
+
+        // Cannot redeploy directly even with ForceUpdateFromAnyVersion set.
+        UninstallMsix();
+        VERIFY_IS_FALSE(IsMsixInstalled());
+
+        InstallMsix();
+        VERIFY_IS_TRUE(IsMsixInstalled());
+
+        WaitForInstallerServiceStop();
+
+        const auto key = wsl::windows::common::registry::OpenLxssMachineKey();
+        VERIFY_ARE_EQUAL(wsl::windows::common::registry::ReadString(key.get(), L"MSI", L"Version"), L"1.0.0");
+
+        VERIFY_ARE_EQUAL(WaitForSingleObject(processHandle.get(), 0), static_cast<DWORD>(WAIT_TIMEOUT));
     }
 
     TEST_METHOD(WslUpdateNoNewVersion)

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -442,7 +442,9 @@ class UnitTests
 
         // Wait for the distro to exit.
         VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
-            [&]() { THROW_HR_IF(E_ABORT, GetDistroState() == LxssDistributionStateRunning); }, std::chrono::seconds(1), std::chrono::seconds(30)));
+            [&]() { THROW_HR_IF(E_ABORT, GetDistributionState() == LxssDistributionStateRunning); },
+            std::chrono::seconds(1),
+            std::chrono::seconds(30)));
 
         // Verify that a new WSL command succeeds (the distro restarts cleanly).
         auto [out, err] = LxsstuLaunchWslAndCaptureOutput(L"echo hello");
@@ -6363,21 +6365,6 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         }
     }
 
-    static LxssDistributionState GetDistroState()
-    {
-        wsl::windows::common::SvcComm service;
-
-        for (const auto& e : service.EnumerateDistributions())
-        {
-            if (wsl::shared::string::IsEqual(e.DistroName, LXSS_DISTRO_NAME_TEST_L))
-            {
-                return e.State;
-            }
-        }
-
-        return LxssDistributionStateInvalid;
-    }
-
     TEST_METHOD(DistroTimeout)
     {
         WslConfigChange config(LxssGenerateTestConfig() + L"[general]\ninstanceIdleTimeout=-1");
@@ -6388,7 +6375,7 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"echo OK"), 0L);
 
             std::this_thread::sleep_for(std::chrono::seconds(20));
-            VERIFY_ARE_EQUAL(GetDistroState(), LxssDistributionStateRunning);
+            VERIFY_ARE_EQUAL(GetDistributionState(), LxssDistributionStateRunning);
         }
 
         // Validate that distributions time out when timeout value is > 0
@@ -6402,7 +6389,7 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             unsigned long iterations = 0;
             while (std::chrono::steady_clock::now() < deadline)
             {
-                if (GetDistroState() == LxssDistributionStateInstalled)
+                if (GetDistributionState() == LxssDistributionStateInstalled)
                 {
                     LogInfo("Distribution stopped after %lu iterations", iterations);
                     return;
@@ -6412,7 +6399,7 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
                 iterations++;
             }
 
-            LogError("Distribution failed to time out after %lu iterations. State: %i", iterations, GetDistroState());
+            LogError("Distribution failed to time out after %lu iterations. State: %i", iterations, GetDistributionState());
             VERIFY_FAIL();
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Check if WSL is active before installing the msi during a msix installation. If so, ask the user if they would like to shutdown wsl and apply the update. If declined or there is no active user session, the updated will be deferred to the next wslinstaller service start, likely next boot.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/8169 https://github.com/microsoft/WSL/discussions/12675
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Add headless test without the user prompt:
InstallerTests::MsixUpgradeDefer

User prompt manually tested:
<img width="582" height="286" alt="image" src="https://github.com/user-attachments/assets/bfdca916-1548-4536-b418-be8b22973f0e" />
