### PR TITLE
Fix use-after-free in virtiofs request worker thread

### DIFF
--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -393,7 +393,6 @@ void AcceptHandle::CreateAcceptSocket()
     AcceptedSocket.reset(WSASocketW(AddressFamily, SocketType, Protocol, nullptr, 0, WSA_FLAG_OVERLAPPED));
     THROW_LAST_ERROR_IF(!AcceptedSocket);
 
-    // Configure the socket like hvsocket::Create() does so Hyper-V connections survive VM suspend.
     if (AddressFamily == AF_HYPERV)
     {
         ULONG enable = 1;

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -403,11 +403,7 @@ void AcceptHandle::CreateAcceptSocket()
 
 void AcceptHandle::OnComplete()
 {
-    // Mark the accepted socket as connected (this also updates its context from the listen socket).
-    const auto listenSocket = reinterpret_cast<SOCKET>(ListenSocket.Get());
-    THROW_LAST_ERROR_IF(
-        setsockopt(AcceptedSocket.get(), SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, reinterpret_cast<const char*>(&listenSocket), sizeof(listenSocket)) ==
-        SOCKET_ERROR);
+    wsl::windows::common::socket::SetAcceptContext(AcceptedSocket.get(), reinterpret_cast<SOCKET>(ListenSocket.Get()));
 
     OnAccepted(std::move(AcceptedSocket));
 

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -377,8 +377,6 @@ AcceptHandle::AcceptHandle(HandleWrapper&& ListenSocket, bool AcceptOnce, std::f
     AddressFamily = protocolInfo.iAddressFamily;
     SocketType = protocolInfo.iSocketType;
     Protocol = protocolInfo.iProtocol;
-
-    CreateAcceptSocket();
 }
 
 AcceptHandle::~AcceptHandle()
@@ -419,8 +417,6 @@ void AcceptHandle::OnComplete()
     }
     else
     {
-        // Prepare a fresh socket for the next accept and return to standby so the loop reschedules.
-        CreateAcceptSocket();
         State = IOHandleStatus::Standby;
     }
 }
@@ -428,6 +424,8 @@ void AcceptHandle::OnComplete()
 void AcceptHandle::Schedule()
 {
     WI_ASSERT(State == IOHandleStatus::Standby);
+
+    CreateAcceptSocket();
 
     Event.ResetEvent();
 

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -371,7 +371,8 @@ AcceptHandle::AcceptHandle(HandleWrapper&& ListenSocket, bool AcceptOnce, std::f
     WSAPROTOCOL_INFOW protocolInfo{};
     int length = sizeof(protocolInfo);
     THROW_LAST_ERROR_IF(
-        getsockopt(reinterpret_cast<SOCKET>(this->ListenSocket.Get()), SOL_SOCKET, SO_PROTOCOL_INFOW, reinterpret_cast<char*>(&protocolInfo), &length) == SOCKET_ERROR);
+        getsockopt(reinterpret_cast<SOCKET>(this->ListenSocket.Get()), SOL_SOCKET, SO_PROTOCOL_INFOW, reinterpret_cast<char*>(&protocolInfo), &length) ==
+        SOCKET_ERROR);
 
     AddressFamily = protocolInfo.iAddressFamily;
     SocketType = protocolInfo.iSocketType;
@@ -397,7 +398,8 @@ void AcceptHandle::CreateAcceptSocket()
     {
         ULONG enable = 1;
         THROW_LAST_ERROR_IF(
-            setsockopt(AcceptedSocket.get(), HV_PROTOCOL_RAW, HVSOCKET_CONNECTED_SUSPEND, reinterpret_cast<char*>(&enable), sizeof(enable)) == SOCKET_ERROR);
+            setsockopt(AcceptedSocket.get(), HV_PROTOCOL_RAW, HVSOCKET_CONNECTED_SUSPEND, reinterpret_cast<char*>(&enable), sizeof(enable)) ==
+            SOCKET_ERROR);
     }
 }
 
@@ -406,7 +408,8 @@ void AcceptHandle::OnComplete()
     // Mark the accepted socket as connected (this also updates its context from the listen socket).
     const auto listenSocket = reinterpret_cast<SOCKET>(ListenSocket.Get());
     THROW_LAST_ERROR_IF(
-        setsockopt(AcceptedSocket.get(), SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, reinterpret_cast<const char*>(&listenSocket), sizeof(listenSocket)) == SOCKET_ERROR);
+        setsockopt(AcceptedSocket.get(), SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, reinterpret_cast<const char*>(&listenSocket), sizeof(listenSocket)) ==
+        SOCKET_ERROR);
 
     OnAccepted(std::move(AcceptedSocket));
 

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -4,6 +4,7 @@
 #include "HandleIO.h"
 #pragma hdrstop
 
+using wsl::windows::common::io::AcceptHandle;
 using wsl::windows::common::io::BufferWrapper;
 using wsl::windows::common::io::DockerIORelayHandle;
 using wsl::windows::common::io::EventHandle;
@@ -16,7 +17,6 @@ using wsl::windows::common::io::OverlappedIOHandle;
 using wsl::windows::common::io::ReadHandle;
 using wsl::windows::common::io::ReadNamedPipe;
 using wsl::windows::common::io::ReadSocketMessageHandle;
-using wsl::windows::common::io::SingleAcceptHandle;
 using wsl::windows::common::io::WriteHandle;
 using wsl::windows::common::io::WriteNamedPipe;
 
@@ -360,41 +360,81 @@ void ReadNamedPipe::Collect()
     ReadHandle::Collect();
 }
 
-// SingleAcceptHandle
+// AcceptHandle
 
-SingleAcceptHandle::SingleAcceptHandle(HandleWrapper&& ListenSocket, HandleWrapper&& AcceptedSocket, std::function<void()>&& OnAccepted) :
-    ListenSocket(std::move(ListenSocket)), AcceptedSocket(std::move(AcceptedSocket)), OnAccepted(std::move(OnAccepted))
+AcceptHandle::AcceptHandle(HandleWrapper&& ListenSocket, bool AcceptOnce, std::function<void(wil::unique_socket&&)>&& OnAccepted) :
+    ListenSocket(std::move(ListenSocket)), AcceptOnce(AcceptOnce), OnAccepted(std::move(OnAccepted))
 {
     Overlapped.hEvent = Event.get();
+
+    // Query the listen socket so accepted sockets can be created with a matching address family, type, and protocol.
+    WSAPROTOCOL_INFOW protocolInfo{};
+    int length = sizeof(protocolInfo);
+    THROW_LAST_ERROR_IF(
+        getsockopt(reinterpret_cast<SOCKET>(this->ListenSocket.Get()), SOL_SOCKET, SO_PROTOCOL_INFOW, reinterpret_cast<char*>(&protocolInfo), &length) == SOCKET_ERROR);
+
+    AddressFamily = protocolInfo.iAddressFamily;
+    SocketType = protocolInfo.iSocketType;
+    Protocol = protocolInfo.iProtocol;
+
+    CreateAcceptSocket();
 }
 
-SingleAcceptHandle::~SingleAcceptHandle()
+AcceptHandle::~AcceptHandle()
 {
     if (State == IOHandleStatus::Pending)
     {
-        LOG_IF_WIN32_BOOL_FALSE(CancelIoEx(ListenSocket.Get(), &Overlapped));
-
-        DWORD bytesProcessed{};
-        DWORD flagsReturned{};
-        if (!WSAGetOverlappedResult((SOCKET)ListenSocket.Get(), &Overlapped, &bytesProcessed, TRUE, &flagsReturned))
-        {
-            auto error = GetLastError();
-            LOG_LAST_ERROR_IF(error != ERROR_CONNECTION_ABORTED && error != ERROR_OPERATION_ABORTED);
-        }
+        CancelPendingIo(reinterpret_cast<SOCKET>(ListenSocket.Get()), Overlapped);
     }
 }
 
-void SingleAcceptHandle::Schedule()
+void AcceptHandle::CreateAcceptSocket()
+{
+    AcceptedSocket.reset(WSASocketW(AddressFamily, SocketType, Protocol, nullptr, 0, WSA_FLAG_OVERLAPPED));
+    THROW_LAST_ERROR_IF(!AcceptedSocket);
+
+    // Configure the socket like hvsocket::Create() does so Hyper-V connections survive VM suspend.
+    if (AddressFamily == AF_HYPERV)
+    {
+        ULONG enable = 1;
+        THROW_LAST_ERROR_IF(
+            setsockopt(AcceptedSocket.get(), HV_PROTOCOL_RAW, HVSOCKET_CONNECTED_SUSPEND, reinterpret_cast<char*>(&enable), sizeof(enable)) == SOCKET_ERROR);
+    }
+}
+
+void AcceptHandle::OnComplete()
+{
+    // Mark the accepted socket as connected (this also updates its context from the listen socket).
+    const auto listenSocket = reinterpret_cast<SOCKET>(ListenSocket.Get());
+    THROW_LAST_ERROR_IF(
+        setsockopt(AcceptedSocket.get(), SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, reinterpret_cast<const char*>(&listenSocket), sizeof(listenSocket)) == SOCKET_ERROR);
+
+    OnAccepted(std::move(AcceptedSocket));
+
+    if (AcceptOnce)
+    {
+        State = IOHandleStatus::Completed;
+    }
+    else
+    {
+        // Prepare a fresh socket for the next accept and return to standby so the loop reschedules.
+        CreateAcceptSocket();
+        State = IOHandleStatus::Standby;
+    }
+}
+
+void AcceptHandle::Schedule()
 {
     WI_ASSERT(State == IOHandleStatus::Standby);
 
+    Event.ResetEvent();
+
     // Schedule the accept.
     DWORD bytesReturned{};
-    if (AcceptEx((SOCKET)ListenSocket.Get(), (SOCKET)AcceptedSocket.Get(), &AcceptBuffer, 0, sizeof(SOCKADDR_STORAGE), sizeof(SOCKADDR_STORAGE), &bytesReturned, &Overlapped))
+    if (AcceptEx((SOCKET)ListenSocket.Get(), AcceptedSocket.get(), &AcceptBuffer, 0, sizeof(SOCKADDR_STORAGE), sizeof(SOCKADDR_STORAGE), &bytesReturned, &Overlapped))
     {
         // Accept completed immediately.
-        State = IOHandleStatus::Completed;
-        OnAccepted();
+        OnComplete();
     }
     else
     {
@@ -405,7 +445,7 @@ void SingleAcceptHandle::Schedule()
     }
 }
 
-void SingleAcceptHandle::Collect()
+void AcceptHandle::Collect()
 {
     WI_ASSERT(State == IOHandleStatus::Pending);
 
@@ -414,11 +454,10 @@ void SingleAcceptHandle::Collect()
 
     THROW_IF_WIN32_BOOL_FALSE(WSAGetOverlappedResult((SOCKET)ListenSocket.Get(), &Overlapped, &bytesReceived, false, &flagsReturned));
 
-    State = IOHandleStatus::Completed;
-    OnAccepted();
+    OnComplete();
 }
 
-HANDLE SingleAcceptHandle::GetHandle() const
+HANDLE AcceptHandle::GetHandle() const
 {
     return Event.get();
 }

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -139,25 +139,37 @@ private:
     bool m_connected = false;
 };
 
-class SingleAcceptHandle : public OverlappedIOHandle
+// Accepts connections on a listen socket using overlapped IO. The accepted sockets are created internally to
+// match the address family, type, and protocol of the listen socket, so callers no longer need to pre-create them.
+// Hyper-V sockets are additionally configured to match hvsocket::Create() (HVSOCKET_CONNECTED_SUSPEND). When
+// AcceptOnce is true the handle completes after a single accept; otherwise it keeps accepting until the loop is
+// cancelled. OnAccepted is invoked with ownership of each accepted socket.
+class AcceptHandle : public OverlappedIOHandle
 {
 public:
-    NON_COPYABLE(SingleAcceptHandle)
-    NON_MOVABLE(SingleAcceptHandle)
+    NON_COPYABLE(AcceptHandle)
+    NON_MOVABLE(AcceptHandle)
 
-    SingleAcceptHandle(HandleWrapper&& ListenSocket, HandleWrapper&& AcceptedSocket, std::function<void()>&& OnAccepted);
-    ~SingleAcceptHandle();
+    AcceptHandle(HandleWrapper&& ListenSocket, bool AcceptOnce, std::function<void(wil::unique_socket&&)>&& OnAccepted);
+    ~AcceptHandle();
 
     void Schedule() override;
     void Collect() override;
     HANDLE GetHandle() const override;
 
 private:
+    void CreateAcceptSocket();
+    void OnComplete();
+
     HandleWrapper ListenSocket;
-    HandleWrapper AcceptedSocket;
+    wil::unique_socket AcceptedSocket;
+    int AddressFamily{};
+    int SocketType{};
+    int Protocol{};
+    bool AcceptOnce{};
     wil::unique_event Event{wil::EventOptions::ManualReset};
     OVERLAPPED Overlapped{};
-    std::function<void()> OnAccepted;
+    std::function<void(wil::unique_socket&&)> OnAccepted;
     char AcceptBuffer[2 * sizeof(SOCKADDR_STORAGE)];
 };
 

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -139,11 +139,6 @@ private:
     bool m_connected = false;
 };
 
-// Accepts connections on a listen socket using overlapped IO. The accepted sockets are created internally to
-// match the address family, type, and protocol of the listen socket, so callers no longer need to pre-create them.
-// Hyper-V sockets are additionally configured to match hvsocket::Create() (HVSOCKET_CONNECTED_SUSPEND). When
-// AcceptOnce is true the handle completes after a single accept; otherwise it keeps accepting until the loop is
-// cancelled. OnAccepted is invoked with ownership of each accepted socket.
 class AcceptHandle : public OverlappedIOHandle
 {
 public:

--- a/src/windows/common/hvsocket.cpp
+++ b/src/windows/common/hvsocket.cpp
@@ -40,13 +40,9 @@ void InitializeWildcardSocketAddress(_Out_ PSOCKADDR_HV Address)
 std::optional<wil::unique_socket> wsl::windows::common::hvsocket::CancellableAccept(
     _In_ SOCKET ListenSocket, _In_ DWORD Timeout, _In_opt_ HANDLE ExitHandle, _In_ const std::source_location& Location)
 {
-    wil::unique_socket Socket = Create();
-    if (!socket::CancellableAccept(ListenSocket, Socket.get(), Timeout, ExitHandle, Location))
-    {
-        return {};
-    }
-
-    return Socket;
+    // AcceptHandle creates the accepted socket from the listen socket's protocol info and, because the listen socket
+    // is a Hyper-V socket, configures it with HVSOCKET_CONNECTED_SUSPEND to match Create().
+    return socket::CancellableAccept(ListenSocket, Timeout, ExitHandle, Location);
 }
 
 wil::unique_socket wsl::windows::common::hvsocket::Connect(

--- a/src/windows/common/hvsocket.cpp
+++ b/src/windows/common/hvsocket.cpp
@@ -37,12 +37,6 @@ void InitializeWildcardSocketAddress(_Out_ PSOCKADDR_HV Address)
 }
 } // namespace
 
-std::optional<wil::unique_socket> wsl::windows::common::hvsocket::CancellableAccept(
-    _In_ SOCKET ListenSocket, _In_ DWORD Timeout, _In_opt_ HANDLE ExitHandle, _In_ const std::source_location& Location)
-{
-    return socket::CancellableAccept(ListenSocket, Timeout, ExitHandle, Location);
-}
-
 wil::unique_socket wsl::windows::common::hvsocket::Connect(
     _In_ const GUID& VmId, _In_ unsigned long Port, _In_opt_ HANDLE ExitHandle, _In_opt_ ULONG Timeout, _In_ const std::source_location& Location)
 {

--- a/src/windows/common/hvsocket.cpp
+++ b/src/windows/common/hvsocket.cpp
@@ -40,8 +40,6 @@ void InitializeWildcardSocketAddress(_Out_ PSOCKADDR_HV Address)
 std::optional<wil::unique_socket> wsl::windows::common::hvsocket::CancellableAccept(
     _In_ SOCKET ListenSocket, _In_ DWORD Timeout, _In_opt_ HANDLE ExitHandle, _In_ const std::source_location& Location)
 {
-    // AcceptHandle creates the accepted socket from the listen socket's protocol info and, because the listen socket
-    // is a Hyper-V socket, configures it with HVSOCKET_CONNECTED_SUSPEND to match Create().
     return socket::CancellableAccept(ListenSocket, Timeout, ExitHandle, Location);
 }
 

--- a/src/windows/common/hvsocket.hpp
+++ b/src/windows/common/hvsocket.hpp
@@ -19,12 +19,6 @@ Abstract:
 
 namespace wsl::windows::common::hvsocket {
 
-std::optional<wil::unique_socket> CancellableAccept(
-    _In_ SOCKET ListenSocket,
-    _In_ DWORD Timeout,
-    _In_opt_ HANDLE ExitHandle = nullptr,
-    const std::source_location& Location = std::source_location::current());
-
 wil::unique_socket Connect(
     _In_ const GUID& VmId,
     _In_ unsigned long Port,

--- a/src/windows/common/socket.cpp
+++ b/src/windows/common/socket.cpp
@@ -26,30 +26,32 @@ void wsl::windows::common::socket::SetAcceptContext(_In_ SOCKET AcceptedSocket, 
         std::format("{}", Location).c_str());
 }
 
-bool wsl::windows::common::socket::CancellableAccept(
-    _In_ SOCKET ListenSocket, _In_ SOCKET Socket, _In_ DWORD Timeout, _In_opt_ HANDLE ExitHandle, _In_ const std::source_location& Location)
+std::optional<wil::unique_socket> wsl::windows::common::socket::CancellableAccept(
+    _In_ SOCKET ListenSocket, _In_ DWORD Timeout, _In_opt_ HANDLE ExitHandle, _In_ const std::source_location& Location)
 {
     io::MultiHandleWait io;
 
-    bool accepted = false;
+    std::optional<wil::unique_socket> accepted;
 
-    io.AddHandle(std::make_unique<io::SingleAcceptHandle>(ListenSocket, Socket, [&]() { accepted = true; }), io::MultiHandleWait::CancelOnCompleted);
+    io.AddHandle(
+        std::make_unique<io::AcceptHandle>(
+            ListenSocket, true, [&accepted](wil::unique_socket&& socket) { accepted = std::move(socket); }),
+        io::MultiHandleWait::CancelOnCompleted);
 
     if (ExitHandle != nullptr)
     {
         io.AddHandle(std::make_unique<io::EventHandle>(ExitHandle), io::MultiHandleWait::CancelOnCompleted);
     }
 
-    io.Run(std::chrono::milliseconds(Timeout));
-
-    if (!accepted)
+    std::optional<std::chrono::milliseconds> timeout;
+    if (Timeout != INFINITE)
     {
-        return false; // Accept was cancelled by the exit event.
+        timeout = std::chrono::milliseconds(Timeout);
     }
 
-    SetAcceptContext(Socket, ListenSocket, Location);
+    io.Run(timeout);
 
-    return true;
+    return accepted;
 }
 
 std::pair<DWORD, DWORD> wsl::windows::common::socket::GetResult(

--- a/src/windows/common/socket.cpp
+++ b/src/windows/common/socket.cpp
@@ -49,7 +49,16 @@ std::optional<wil::unique_socket> wsl::windows::common::socket::CancellableAccep
         timeout = std::chrono::milliseconds(Timeout);
     }
 
-    io.Run(timeout);
+    try
+    {
+
+        io.Run(timeout);
+    }
+    catch (...)
+    {
+        auto hr = wil::ResultFromCaughtException();
+        THROW_HR_MSG(hr, "Failed to accept socket. From: %hs", std::format("{}", Location).c_str());
+    }
 
     return accepted;
 }

--- a/src/windows/common/socket.hpp
+++ b/src/windows/common/socket.hpp
@@ -21,9 +21,8 @@ namespace wsl::windows::common::socket {
 // Sets SO_UPDATE_ACCEPT_CONTEXT on a socket accepted via AcceptEx to mark it as connected.
 void SetAcceptContext(_In_ SOCKET AcceptedSocket, _In_ SOCKET ListenSocket, _In_ const std::source_location& Location = std::source_location::current());
 
-bool CancellableAccept(
+std::optional<wil::unique_socket> CancellableAccept(
     _In_ SOCKET ListenSocket,
-    _In_ SOCKET Socket,
     _In_ DWORD Timeout,
     _In_opt_ HANDLE ExitHandle,
     _In_ const std::source_location& Location = std::source_location::current());

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -387,7 +387,7 @@ try
 {
     RETURN_HR_IF_NULL(E_POINTER, Socket);
 
-    auto socket = wsl::windows::common::hvsocket::CancellableAccept(m_listenSocket.get(), m_bootTimeoutMs, m_vmExitEvent.get());
+    auto socket = socket::CancellableAccept(m_listenSocket.get(), m_bootTimeoutMs, m_vmExitEvent.get());
     THROW_HR_IF(E_ABORT, !socket.has_value());
 
     *Socket = reinterpret_cast<HANDLE>(socket->release());

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2636,7 +2636,7 @@ try
                     }
 
                     THROW_HR_IF_MSG(
-                        E_UNEXPECTED, !pendingBytes->empty(), "Received message with additional bytes: %lu", pendingBytes->size());
+                        E_UNEXPECTED, !pendingBytes->empty(), "Received message with additional bytes: %zu", pendingBytes->size());
 
                     try
                     {
@@ -2661,6 +2661,8 @@ std::vector<char> WslCoreVm::ProcessVirtioFsRequest(_In_ gsl::span<gsl::byte> Re
     const auto* header = gslhelpers::try_get_struct<MESSAGE_HEADER>(Request);
     THROW_HR_IF(E_UNEXPECTED, !header);
 
+    WSL_LOG("VirtiofsMessageRequest", TraceLoggingValue(header->PrettyPrint().c_str(), "Content"));
+
     auto buildResponse = [header](const std::wstring& tag, const std::wstring& source, HRESULT result) {
         // Respond to the guest with the tag that should be used to mount the device.
         wsl::shared::MessageWriter<LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE> response(LxInitMessageAddVirtioFsDeviceResponse);
@@ -2671,6 +2673,8 @@ std::vector<char> WslCoreVm::ProcessVirtioFsRequest(_In_ gsl::span<gsl::byte> Re
         // Echo the request's transaction id and mark the message as the first (and only) reply.
         response->Header.TransactionId = header->TransactionId;
         response->Header.TransactionStep = static_cast<unsigned int>(TRANSACTION_STEP::FIRST_REPLY);
+
+        WSL_LOG("VirtiofsMessageResponse", TraceLoggingValue(response->PrettyPrint().c_str(), "Content"));
 
         const auto span = response.Span();
         return std::vector<char>(reinterpret_cast<const char*>(span.data()), reinterpret_cast<const char*>(span.data()) + span.size());

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -856,7 +856,7 @@ WslCoreVm::~WslCoreVm() noexcept
 
 wil::unique_socket WslCoreVm::AcceptConnection(_In_ DWORD ReceiveTimeout, _In_ const std::source_location& Location) const
 {
-    auto socket = hvsocket::CancellableAccept(m_listenSocket.get(), m_vmConfig.KernelBootTimeout, m_terminatingEvent.get(), Location);
+    auto socket = socket::CancellableAccept(m_listenSocket.get(), m_vmConfig.KernelBootTimeout, m_terminatingEvent.get(), Location);
     THROW_HR_IF(E_ABORT, !socket.has_value());
 
     if (ReceiveTimeout != 0)
@@ -1087,7 +1087,7 @@ void WslCoreVm::CollectCrashDumps(wil::unique_socket&& listenSocket) const
     {
         try
         {
-            auto socket = hvsocket::CancellableAccept(listenSocket.get(), INFINITE, m_terminatingEvent.get());
+            auto socket = socket::CancellableAccept(listenSocket.get(), INFINITE, m_terminatingEvent.get());
             if (!socket.has_value())
             {
                 break; // VM is exiting.

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2617,92 +2617,112 @@ try
 {
     wsl::windows::common::wslutil::SetThreadDescription(L"VirtioFs - Worker");
 
-    for (;;)
-    {
-        // Create a worker thread to handle each request.
+    io::MultiHandleWait io;
 
-        auto socket = hvsocket::CancellableAccept(listenSocket.get(), INFINITE, m_terminatingEvent.get());
-        if (!socket.has_value())
-        {
-            break;
-        }
+    io.AddHandle(std::make_unique<io::AcceptHandle>(listenSocket.get(), false, [this, &io](wil::unique_socket&& socket) {
+        auto channel = std::make_shared<wsl::shared::SocketChannel>(std::move(socket), "VirtioFs");
+        auto buffer = std::make_shared<std::vector<gsl::byte>>();
+        auto pendingBytes = std::make_shared<std::vector<gsl::byte>>();
 
-        wsl::shared::SocketChannel channel{std::move(socket.value()), "VirtioFs", {m_terminatingEvent.get()}};
-        std::thread([this, channel = std::move(channel)]() mutable {
-            try
-            {
-                wsl::windows::common::wslutil::SetThreadDescription(L"VirtioFs - Request");
+        io.AddHandle(
+            std::make_unique<io::ReadSocketMessageHandle>(
+                io::HandleWrapper(channel->Socket()),
+                *buffer,
+                *pendingBytes,
+                [this, &io, channel, buffer, pendingBytes](const gsl::span<gsl::byte>& message) {
+                    if (message.empty())
+                    {
+                        return; // Channel closed, exit.
+                    }
 
-                auto transaction = channel.ReceiveTransaction();
-                auto [message, span] = transaction.ReceiveOrClosed<MESSAGE_HEADER>();
-                if (message == nullptr)
-                {
-                    return;
-                }
+                    THROW_HR_IF_MSG(
+                        E_UNEXPECTED, !pendingBytes->empty(), "Received message with additional bytes: %lu", pendingBytes->size());
 
-                auto respondWithTag = [&](const std::wstring& tag, const std::wstring& source, HRESULT result) {
-                    // Respond to the guest with the tag that should be used to mount the device.
+                    try
+                    {
+                        auto response = ProcessVirtioFsRequest(message);
 
-                    wsl::shared::MessageWriter<LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE> response(LxInitMessageAddVirtioFsDeviceResponse);
-                    response->Result = SUCCEEDED(result) ? 0 : EINVAL; // TODO: Improved HRESULT -> errno mapping.
-                    response.WriteString(response->TagOffset, tag);
-                    response.WriteString(response->SourceOffset, source);
+                        // Move the socket out of the channel into the WriteHandle so it is closed once the reply is sent.
+                        io.AddHandle(std::make_unique<io::WriteHandle>(channel->Release(), response), io::MultiHandleWait::IgnoreErrors);
+                    }
+                    CATCH_LOG();
+                }),
+            io::MultiHandleWait::IgnoreErrors);
+    }));
 
-                    transaction.Send<LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE>(response.Span());
-                };
+    io.AddHandle(std::make_unique<io::EventHandle>(m_terminatingEvent.get()), io::MultiHandleWait::CancelOnCompleted);
 
-                if (message->MessageType == LxInitMessageAddVirtioFsDevice)
-                {
-                    std::wstring tag;
-                    std::wstring source;
-                    const auto result = wil::ResultFromException([this, span, &tag, &source]() {
-                        const auto* addShare = gslhelpers::try_get_struct<LX_INIT_ADD_VIRTIOFS_SHARE_MESSAGE>(span);
-                        THROW_HR_IF(E_UNEXPECTED, !addShare);
-
-                        const auto path = wsl::shared::string::FromSpan(span, addShare->PathOffset);
-                        const auto pathWide = wsl::shared::string::MultiByteToWide(path);
-                        const auto options = wsl::shared::string::FromSpan(span, addShare->OptionsOffset);
-                        const auto optionsWide = wsl::shared::string::MultiByteToWide(options);
-
-                        // Acquire the lock and attempt to add the device.
-                        auto guestDeviceLock = m_guestDeviceLock.lock_exclusive();
-                        std::tie(tag, source) = AddVirtioFsShare(addShare->Admin, pathWide.c_str(), optionsWide.c_str());
-                    });
-
-                    respondWithTag(tag, source, result);
-                }
-                else if (message->MessageType == LxInitMessageRemountVirtioFsDevice)
-                {
-                    std::wstring newTag;
-                    std::wstring source;
-                    const auto result = wil::ResultFromException([this, span, &newTag, &source]() {
-                        const auto* remountShare = gslhelpers::try_get_struct<LX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE>(span);
-                        THROW_HR_IF(E_UNEXPECTED, !remountShare);
-
-                        const std::string tag = wsl::shared::string::FromSpan(span, remountShare->TagOffset);
-                        const auto tagWide = wsl::shared::string::MultiByteToWide(tag);
-                        auto guestDeviceLock = m_guestDeviceLock.lock_exclusive();
-                        const auto foundShare = FindVirtioFsShare(tagWide.c_str(), !remountShare->Admin);
-                        THROW_HR_IF_MSG(E_UNEXPECTED, !foundShare.has_value(), "Unknown tag %ls", tagWide.c_str());
-
-                        std::tie(newTag, source) =
-                            AddVirtioFsShare(remountShare->Admin, foundShare->Path.c_str(), foundShare->OptionsString().c_str());
-
-                        WI_ASSERT(source == foundShare->Path);
-                    });
-
-                    respondWithTag(newTag, source, result);
-                }
-                else
-                {
-                    THROW_HR_MSG(E_UNEXPECTED, "Unexpected MessageType %d", message->MessageType);
-                }
-            }
-            CATCH_LOG()
-        }).detach();
-    }
+    io.Run({});
 }
 CATCH_LOG()
+
+std::vector<char> WslCoreVm::ProcessVirtioFsRequest(_In_ gsl::span<gsl::byte> Request)
+{
+    const auto* header = gslhelpers::try_get_struct<MESSAGE_HEADER>(Request);
+    THROW_HR_IF(E_UNEXPECTED, !header);
+
+    auto buildResponse = [header](const std::wstring& tag, const std::wstring& source, HRESULT result) {
+        // Respond to the guest with the tag that should be used to mount the device.
+        wsl::shared::MessageWriter<LX_INIT_ADD_VIRTIOFS_SHARE_RESPONSE_MESSAGE> response(LxInitMessageAddVirtioFsDeviceResponse);
+        response->Result = SUCCEEDED(result) ? 0 : EINVAL; // TODO: Improved HRESULT -> errno mapping.
+        response.WriteString(response->TagOffset, tag);
+        response.WriteString(response->SourceOffset, source);
+
+        // Echo the request's transaction id and mark the message as the first (and only) reply.
+        response->Header.TransactionId = header->TransactionId;
+        response->Header.TransactionStep = static_cast<unsigned int>(TRANSACTION_STEP::FIRST_REPLY);
+
+        const auto span = response.Span();
+        return std::vector<char>(reinterpret_cast<const char*>(span.data()), reinterpret_cast<const char*>(span.data()) + span.size());
+    };
+
+    if (header->MessageType == LxInitMessageAddVirtioFsDevice)
+    {
+        std::wstring tag;
+        std::wstring source;
+        const auto result = wil::ResultFromException([&]() {
+            const auto* addShare = gslhelpers::try_get_struct<LX_INIT_ADD_VIRTIOFS_SHARE_MESSAGE>(Request);
+            THROW_HR_IF(E_UNEXPECTED, !addShare);
+
+            const auto path = wsl::shared::string::FromSpan(Request, addShare->PathOffset);
+            const auto pathWide = wsl::shared::string::MultiByteToWide(path);
+            const auto options = wsl::shared::string::FromSpan(Request, addShare->OptionsOffset);
+            const auto optionsWide = wsl::shared::string::MultiByteToWide(options);
+
+            // Acquire the lock and attempt to add the device.
+            auto guestDeviceLock = m_guestDeviceLock.lock_exclusive();
+            std::tie(tag, source) = AddVirtioFsShare(addShare->Admin, pathWide.c_str(), optionsWide.c_str());
+        });
+
+        return buildResponse(tag, source, result);
+    }
+    else if (header->MessageType == LxInitMessageRemountVirtioFsDevice)
+    {
+        std::wstring newTag;
+        std::wstring source;
+        const auto result = wil::ResultFromException([&]() {
+            const auto* remountShare = gslhelpers::try_get_struct<LX_INIT_REMOUNT_VIRTIOFS_SHARE_MESSAGE>(Request);
+            THROW_HR_IF(E_UNEXPECTED, !remountShare);
+
+            const std::string tag = wsl::shared::string::FromSpan(Request, remountShare->TagOffset);
+            const auto tagWide = wsl::shared::string::MultiByteToWide(tag);
+            auto guestDeviceLock = m_guestDeviceLock.lock_exclusive();
+            const auto foundShare = FindVirtioFsShare(tagWide.c_str(), !remountShare->Admin);
+            THROW_HR_IF_MSG(E_UNEXPECTED, !foundShare.has_value(), "Unknown tag %ls", tagWide.c_str());
+
+            std::tie(newTag, source) =
+                AddVirtioFsShare(remountShare->Admin, foundShare->Path.c_str(), foundShare->OptionsString().c_str());
+
+            WI_ASSERT(source == foundShare->Path);
+        });
+
+        return buildResponse(newTag, source, result);
+    }
+    else
+    {
+        THROW_HR_MSG(E_UNEXPECTED, "Unexpected MessageType %d", header->MessageType);
+    }
+}
 
 std::string WslCoreVm::s_GetMountTargetName(_In_ PCWSTR Disk, _In_opt_ PCWSTR Name, _In_ int PartitionIndex)
 {

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -251,6 +251,8 @@ private:
 
     void VirtioFsWorker(_In_ const wil::unique_socket& socket);
 
+    std::vector<char> ProcessVirtioFsRequest(_In_ gsl::span<gsl::byte> Request);
+
     static std::string s_GetMountTargetName(_In_ PCWSTR Disk, _In_opt_ PCWSTR Name, _In_ int PartitionIndex);
 
     static LX_INIT_DRVFS_MOUNT s_InitializeDrvFs(_Inout_ WslCoreVm* VmContext, _In_ HANDLE UserToken);

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -1259,7 +1259,7 @@ void WSLCVirtualMachine::CollectCrashDumps(wil::unique_socket&& listenSocket)
     {
         try
         {
-            auto socket = hvsocket::CancellableAccept(listenSocket.get(), INFINITE, m_vmTerminatingEvent.get());
+            auto socket = socket::CancellableAccept(listenSocket.get(), INFINITE, m_vmTerminatingEvent.get());
             if (!socket)
             {
                 // VM is exiting.

--- a/src/windows/wslrelay/localhost.cpp
+++ b/src/windows/wslrelay/localhost.cpp
@@ -291,15 +291,11 @@ try
 {
     // Begin accepting connections until the relay is stopped.
 
-    const int AddressFamily = WindowsAddressFamily(Arguments->Family);
-
     for (;;)
     {
-        wil::unique_socket InetSocket(WSASocket(AddressFamily, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED));
-        THROW_LAST_ERROR_IF(!InetSocket);
-
-        if (!wsl::windows::common::socket::CancellableAccept(
-                Arguments->ListenSocket.get(), InetSocket.get(), INFINITE, Arguments->ExitEvent.get()))
+        auto InetSocket = wsl::windows::common::socket::CancellableAccept(
+            Arguments->ListenSocket.get(), INFINITE, Arguments->ExitEvent.get());
+        if (!InetSocket)
         {
             break; // Exit event was signaled, exit.
         }
@@ -308,7 +304,7 @@ try
 
         WSL_LOG("PortRelayUsage", TraceLoggingValue(Arguments->Family, "family"), TraceLoggingValue(Arguments->Port, "port"), TraceLoggingLevel(WINEVENT_LEVEL_INFO));
 
-        auto RelayThread = std::thread([Arguments, InetSocket = std::move(InetSocket)]() {
+        auto RelayThread = std::thread([Arguments, InetSocket = std::move(*InetSocket)]() {
             try
             {
                 wsl::windows::common::wslutil::SetThreadDescription(L"Port relay");

--- a/src/windows/wslrelay/localhost.cpp
+++ b/src/windows/wslrelay/localhost.cpp
@@ -293,8 +293,8 @@ try
 
     for (;;)
     {
-        auto InetSocket = wsl::windows::common::socket::CancellableAccept(
-            Arguments->ListenSocket.get(), INFINITE, Arguments->ExitEvent.get());
+        auto InetSocket =
+            wsl::windows::common::socket::CancellableAccept(Arguments->ListenSocket.get(), INFINITE, Arguments->ExitEvent.get());
         if (!InetSocket)
         {
             break; // Exit event was signaled, exit.

--- a/src/windows/wslrelay/main.cpp
+++ b/src/windows/wslrelay/main.cpp
@@ -123,17 +123,15 @@ try
 
         THROW_LAST_ERROR_IF(listen(listenSocket.get(), 1) == SOCKET_ERROR);
 
-        const wil::unique_socket socket(WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED));
-        THROW_LAST_ERROR_IF(!socket);
-
-        if (!wsl::windows::common::socket::CancellableAccept(listenSocket.get(), socket.get(), INFINITE, exitEvent.get()))
+        auto socket = wsl::windows::common::socket::CancellableAccept(listenSocket.get(), INFINITE, exitEvent.get());
+        if (!socket)
         {
             return 1;
         }
 
         // Begin the relay.
         wsl::windows::common::relay::BidirectionalRelay(
-            reinterpret_cast<HANDLE>(socket.get()), pipe.get(), 0x1000, wsl::windows::common::relay::RelayFlags::LeftIsSocket);
+            reinterpret_cast<HANDLE>(socket->get()), pipe.get(), 0x1000, wsl::windows::common::relay::RelayFlags::LeftIsSocket);
 
         break;
     }

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -409,6 +409,59 @@ public:
         VERIFY_IS_TRUE(out.find(L"test-file.txt") != std::wstring::npos);
     }
 
+    void DrvfsMountManyVirtioFsShares(DrvFsMode Mode)
+    {
+        if (Mode != DrvFsMode::VirtioFs)
+        {
+            LogSkipped("This test is only applicable to VirtioFs");
+            return;
+        }
+
+        WINDOWS_11_TEST_ONLY();
+        SKIP_TEST_ARM64();
+
+        constexpr auto c_iterations = 20;
+        auto testDir = std::filesystem::current_path() / "virtiofs-loop-test";
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LxsstuLaunchWsl(L"umount /tmp/virtiofs-loop-test-*");
+
+            std::error_code ec;
+            std::filesystem::remove_all(testDir, ec);
+        });
+
+        for (int i = 0; i < c_iterations; ++i)
+        {
+            const auto sourceDir = testDir / std::to_string(i);
+            std::filesystem::create_directories(sourceDir);
+
+            const auto expected = std::format("virtiofs share {}", i);
+            {
+                std::ofstream markerFile(std::filesystem::path(sourceDir) / L"marker");
+                markerFile << expected;
+            }
+
+            const auto mountPoint = std::format(L"/tmp/virtiofs-loop-test-{}", i);
+
+            // Mount the share.
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mkdir -p '{}'", mountPoint)), 0);
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mount -t drvfs '{}' '{}'", sourceDir.string(), mountPoint)), 0);
+
+            // Validate that it can be accessed.
+            {
+                auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"cat '{}/marker'", mountPoint));
+                VERIFY_ARE_EQUAL(out, wsl::shared::string::MultiByteToWide(expected));
+            }
+
+            // Validate the mount options.
+            {
+                auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"findmnt -ln '{}'", mountPoint));
+
+                VerifyPatternMatch(wsl::shared::string::WideToMultiByte(out.c_str()), std::format("{} * virtiofs rw,relatime\n", mountPoint));
+            }
+        }
+    }
+
     // DrvFsTests Private Methods
 private:
     static VOID CreateDrvFsTestFiles(bool Metadata)
@@ -1302,6 +1355,11 @@ class WSL1 : public DrvFsTests
         WSL2_TEST_METHOD(DrvFsMountUnicodePath) \
         { \
             DrvFsTests::DrvFsMountUnicodePath(DrvFsMode::##_mode##); \
+        } \
+\
+        WSL2_TEST_METHOD(DrvfsMountManyVirtioFsShares) \
+        { \
+            DrvFsTests::DrvfsMountManyVirtioFsShares(DrvFsMode::##_mode##); \
         } \
     }
 

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -420,7 +420,7 @@ public:
         WINDOWS_11_TEST_ONLY();
         SKIP_TEST_ARM64();
 
-        constexpr auto c_iterations = 20;
+        constexpr auto c_iterations = 15;
         auto testDir = std::filesystem::current_path() / "virtiofs-loop-test";
 
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a potential use-after-free caused by the lack of synchronization with threads that are spawned to handle virtiofs requests from the guest. 

To solve this, this change moves that method to use overlapped IO and handle both the accepts() and the requests with a single thread

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
