### PR TITLE
Fix input validation gaps in driver arguments and network aliases

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3111,9 +3111,6 @@ On first run, creates the file with all settings commented out at their defaults
     <value>Invalid {} value: driver name cannot be empty or whitespace</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
-  <data name="WSLCCLI_DriverOptionKeyEmptyError" xml:space="preserve">
-    <value>Driver option key cannot be empty</value>
-  </data>
   <data name="WSLCCLI_OptionsArgDescription" xml:space="preserve">
     <value>Set driver specific options</value>
   </data>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3107,6 +3107,13 @@ On first run, creates the file with all settings commented out at their defaults
     <value>Specify volume driver name, e.g. 'guest' or 'vhd' (default: guest)</value>
     <comment>{Locked="guest"}{Locked="vhd"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="WSLCCLI_DriverEmptyError" xml:space="preserve">
+    <value>Invalid {} value: driver name cannot be empty or whitespace</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_DriverOptionKeyEmptyError" xml:space="preserve">
+    <value>Driver option key cannot be empty</value>
+  </data>
   <data name="WSLCCLI_OptionsArgDescription" xml:space="preserve">
     <value>Set driver specific options</value>
   </data>

--- a/src/windows/wslc/arguments/ArgumentValidation.cpp
+++ b/src/windows/wslc/arguments/ArgumentValidation.cpp
@@ -424,20 +424,13 @@ std::pair<std::string, std::string> ParseLabel(const std::wstring& value)
 
 std::pair<std::string, std::string> ParseDriverOption(const std::wstring& value)
 {
-    std::pair<std::string, std::string> result{};
     auto pos = value.find('=');
     if (pos == std::wstring::npos)
     {
-        result.first = WideToMultiByte(value);
-    }
-    else
-    {
-        result.first = WideToMultiByte(value.substr(0, pos));
-        result.second = WideToMultiByte(value.substr(pos + 1));
+        return {WideToMultiByte(value), std::string{}};
     }
 
-    THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::WSLCCLI_DriverOptionKeyEmptyError(), result.first.empty());
-    return result;
+    return {WideToMultiByte(value.substr(0, pos)), WideToMultiByte(value.substr(pos + 1))};
 }
 
 } // namespace wsl::windows::wslc::validation

--- a/src/windows/wslc/arguments/ArgumentValidation.cpp
+++ b/src/windows/wslc/arguments/ArgumentValidation.cpp
@@ -106,6 +106,17 @@ void Argument::Validate(const ArgMap& execArgs) const
         break;
     }
 
+    case ArgType::Driver:
+    {
+        const auto& value = execArgs.Get<ArgType::Driver>();
+        if (value.empty() ||
+            std::all_of(value.begin(), value.end(), [](wchar_t c) { return std::iswspace(static_cast<wint_t>(c)); }))
+        {
+            throw ArgumentException(Localization::WSLCCLI_DriverEmptyError(m_name));
+        }
+        break;
+    }
+
     case ArgType::Network:
     {
         for (const auto& value : execArgs.GetAll<ArgType::Network>())
@@ -413,13 +424,20 @@ std::pair<std::string, std::string> ParseLabel(const std::wstring& value)
 
 std::pair<std::string, std::string> ParseDriverOption(const std::wstring& value)
 {
+    std::pair<std::string, std::string> result{};
     auto pos = value.find('=');
     if (pos == std::wstring::npos)
     {
-        return {WideToMultiByte(value), std::string{}};
+        result.first = WideToMultiByte(value);
+    }
+    else
+    {
+        result.first = WideToMultiByte(value.substr(0, pos));
+        result.second = WideToMultiByte(value.substr(pos + 1));
     }
 
-    return {WideToMultiByte(value.substr(0, pos)), WideToMultiByte(value.substr(pos + 1))};
+    THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::WSLCCLI_DriverOptionKeyEmptyError(), result.first.empty());
+    return result;
 }
 
 } // namespace wsl::windows::wslc::validation

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -72,7 +72,7 @@ static wsl::windows::common::RunningWSLCContainer CreateInternal(
         THROW_HR_WITH_USER_ERROR_IF(
             E_INVALIDARG,
             Localization::MessageWslcAliasRequiresUserDefinedNetwork(),
-            primary == "bridge" || primary == "host" || primary == "none" || primary.starts_with("container:"));
+            primary.empty() || primary == "bridge" || primary == "host" || primary == "none" || primary.starts_with("container:"));
 
         for (const auto& alias : options.NetworkAliases)
         {

--- a/test/windows/wslc/WSLCCLIOptionsParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOptionsParserUnitTests.cpp
@@ -30,6 +30,8 @@ class WSLCCLIOptionsParserUnitTests
             {L"SizeBytes=3145728", "SizeBytes", "3145728"},
             {L"ReadOnly", "ReadOnly", ""},
             {L"key=", "key", ""},
+            {L"=value", "", "value"},
+            {L"", "", ""},
             {L"key=a=b=c", "key", "a=b=c"},
         };
 
@@ -38,32 +40,6 @@ class WSLCCLIOptionsParserUnitTests
             auto result = validation::ParseDriverOption(input);
             VERIFY_ARE_EQUAL(expectedKey, result.first);
             VERIFY_ARE_EQUAL(expectedValue, result.second);
-        }
-    }
-
-    TEST_METHOD(WSLCCLIOptionsParser_InvalidOptions)
-    {
-        std::vector<std::wstring> invalidOptions = {
-            L"",
-            L"=",
-            L"=value",
-        };
-
-        for (const auto& input : invalidOptions)
-        {
-            try
-            {
-                (void)validation::ParseDriverOption(input);
-                VERIFY_FAIL(L"Expected exception");
-            }
-            catch (const wil::ResultException& ex)
-            {
-                VERIFY_ARE_EQUAL(E_INVALIDARG, ex.GetErrorCode());
-
-                const auto raw = ex.GetFailureInfo().pszMessage;
-                std::wstring message = raw ? raw : L"";
-                VERIFY_ARE_EQUAL(L"Driver option key cannot be empty", message);
-            }
         }
     }
 };

--- a/test/windows/wslc/WSLCCLIOptionsParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOptionsParserUnitTests.cpp
@@ -30,8 +30,6 @@ class WSLCCLIOptionsParserUnitTests
             {L"SizeBytes=3145728", "SizeBytes", "3145728"},
             {L"ReadOnly", "ReadOnly", ""},
             {L"key=", "key", ""},
-            {L"=value", "", "value"},
-            {L"", "", ""},
             {L"key=a=b=c", "key", "a=b=c"},
         };
 
@@ -40,6 +38,32 @@ class WSLCCLIOptionsParserUnitTests
             auto result = validation::ParseDriverOption(input);
             VERIFY_ARE_EQUAL(expectedKey, result.first);
             VERIFY_ARE_EQUAL(expectedValue, result.second);
+        }
+    }
+
+    TEST_METHOD(WSLCCLIOptionsParser_InvalidOptions)
+    {
+        std::vector<std::wstring> invalidOptions = {
+            L"",
+            L"=",
+            L"=value",
+        };
+
+        for (const auto& input : invalidOptions)
+        {
+            try
+            {
+                (void)validation::ParseDriverOption(input);
+                VERIFY_FAIL(L"Expected exception");
+            }
+            catch (const wil::ResultException& ex)
+            {
+                VERIFY_ARE_EQUAL(E_INVALIDARG, ex.GetErrorCode());
+
+                const auto raw = ex.GetFailureInfo().pszMessage;
+                std::wstring message = raw ? raw : L"";
+                VERIFY_ARE_EQUAL(L"Driver option key cannot be empty", message);
+            }
         }
     }
 };


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1. --driver "" or --driver "   " was silently accepted by the CLI parser, passing an empty/whitespace driver name to the service layer. Added ArgType::Driver validation to reject these inputs, consistent with the existing ArgType::Network and ArgType::WorkDir checks.

2. The network-alias  in ContainerService::CreateInternal did not check for primary.empty(), allowing an empty-string network name (from a direct SDK/COM caller) to bypass the user-defined network requirement.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [X] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
ArgumentValidation.cpp : Added ArgType::Driver case to Argument::Validate() matching the ArgType::WorkDir pattern. Rewrote ParseDriverOption to match `ParseLabel`'s structure and empty-key rejection.

ContainerService.cpp : Added primary.empty() to the alias guard condition. Defense-in-depth: the CLI already rejects empty --network values, but SDK/COM callers bypass CLI validation.

Resources.resw : One new localization strings: WSLCCLI_DriverEmptyError (with {FixedPlaceholder} for the arg name) 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
