### PR TITLE
Fix race condition when starting a local registry

### DIFF
--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -19,6 +19,7 @@ Abstract:
 #include "WSLCContainerLauncher.h"
 #include "WSLCProcessLauncher.h"
 #include "wslc_schema.h"
+#include "wslc/e2e/WSLCE2EHelpers.h"
 #include <optional>
 
 extern std::wstring g_testDataPath;
@@ -2225,30 +2226,9 @@ class WslcSdkTests
     std::pair<wsl::windows::common::RunningWSLCContainer, std::string> StartLocalRegistry(
         const std::string& username = {}, const std::string& password = {}, uint16_t port = 5000)
     {
-        VERIFY_IS_TRUE(HasImage("wslc-registry:latest"));
-
-        std::vector<std::string> env = {std::format("REGISTRY_HTTP_ADDR=0.0.0.0:{}", port)};
-        if (!username.empty())
-        {
-            env.push_back(std::format("USERNAME={}", username));
-            env.push_back(std::format("PASSWORD={}", password));
-        }
-
-        wsl::windows::common::WSLCContainerLauncher launcher("wslc-registry:latest", {}, {}, env);
-        launcher.SetEntrypoint({"/entrypoint.sh"});
-        launcher.AddPort(port, port, AF_INET);
-
-        // Get the IWSLCSession COM object from the SDK session handle.
+        // Get the IWSLCSession COM object from the SDK session handle and delegate to the shared helper.
         auto& session = *reinterpret_cast<WslcSessionImpl*>(m_defaultSession)->session;
-        auto container = launcher.Launch(session, WSLCContainerStartFlagsNone);
-
-        auto registryAddress = std::format("127.0.0.1:{}", port);
-
-        // Wait for the registry to be ready by probing from the host.
-        auto hostUrl = std::format(L"http://{}", registryAddress);
-        ExpectHttpResponse(hostUrl.c_str(), 200, true);
-
-        return {std::move(container), registryAddress};
+        return WSLCE2ETests::StartLocalRegistry(session, username, password, port);
     }
 
     // Tags and pushes an image to a local registry via the SDK APIs.

--- a/test/windows/WslcSdkWinRTTests.cpp
+++ b/test/windows/WslcSdkWinRTTests.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include "WslcsdkPrivate.h"
 #include "WSLCContainerLauncher.h"
 #include "wslutil.h"
+#include "wslc/e2e/WSLCE2EHelpers.h"
 
 #include "winrt/Session.h"
 #include "winrt/Helpers.h"
@@ -171,30 +172,9 @@ class WslcSdkWinRtTests
     std::pair<wsl::windows::common::RunningWSLCContainer, std::string> StartLocalRegistry(
         const std::string& username = {}, const std::string& password = {}, uint16_t port = 5000)
     {
-        VERIFY_IS_TRUE(HasImage(L"wslc-registry:latest"));
-
-        std::vector<std::string> env = {std::format("REGISTRY_HTTP_ADDR=0.0.0.0:{}", port)};
-        if (!username.empty())
-        {
-            env.push_back(std::format("USERNAME={}", username));
-            env.push_back(std::format("PASSWORD={}", password));
-        }
-
-        wsl::windows::common::WSLCContainerLauncher launcher("wslc-registry:latest", {}, {}, env);
-        launcher.SetEntrypoint({"/entrypoint.sh"});
-        launcher.AddPort(port, port, AF_INET);
-
-        // Get the IWSLCSession COM object from the SDK session handle.
+        // Get the IWSLCSession COM object from the SDK session handle and delegate to the shared helper.
         auto& comSession = *reinterpret_cast<WslcSessionImpl*>(WSLCSDK::implementation::GetHandle(m_defaultSession))->session;
-        auto container = launcher.Launch(comSession, WSLCContainerStartFlagsNone);
-
-        auto registryAddress = std::format("127.0.0.1:{}", port);
-
-        // Wait for the registry to be ready by probing from the host.
-        auto hostUrl = std::format(L"http://{}", registryAddress);
-        ExpectHttpResponse(hostUrl.c_str(), 200, true);
-
-        return {std::move(container), registryAddress};
+        return WSLCE2ETests::StartLocalRegistry(comSession, username, password, port);
     }
 
     // Tags and pushes an image to a local registry via the SDK APIs.

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -519,7 +519,11 @@ std::pair<RunningWSLCContainer, std::string> StartLocalRegistry(IWSLCSession& se
     launcher.SetEntrypoint({"/entrypoint.sh"});
     launcher.AddPort(port, port, AF_INET);
 
-    auto container = launcher.Launch(session, WSLCContainerStartFlagsNone);
+    auto container = launcher.Launch(session);
+
+    // Wait for the registry to bind the port before continuing.
+    auto initProcess = container.GetInitProcess();
+    WaitForOutput(initProcess.GetStdHandle(2), std::format("listening on [::]:{}", port));
 
     auto address = std::format("127.0.0.1:{}", port);
     auto url = std::format(L"http://{}/v2/", wsl::shared::string::MultiByteToWide(address));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a timing issue by actually waiting for the newly created local registry to have the port bound before returning so the caller can immediately call into the registry

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
