### PR TITLE
Fix IPv6 guest port reservation leak in VirtioProxy networking

### DIFF
--- a/src/windows/common/VirtioNetworking.cpp
+++ b/src/windows/common/VirtioNetworking.cpp
@@ -156,15 +156,8 @@ int VirtioNetworking::ModifyOpenPorts(_In_ PCWSTR tag, _In_ const SOCKADDR_INET&
             portString += L";udp";
         }
 
-        if (!isOpen)
-        {
-            portString += L";allocate=false";
-        }
-        else
-        {
-            const auto addrStr = wsl::windows::common::string::SockAddrInetToWstring(addr);
-            portString += std::format(L";listen_addr={}", addrStr);
-        }
+        const auto addrStr = wsl::windows::common::string::SockAddrInetToWstring(addr);
+        portString += std::format(L";listen_addr={};allocate={}", addrStr, isOpen ? L"true" : L"false");
 
         LOG_IF_FAILED(server->AddShare(portString.c_str(), nullptr, 0));
     }


### PR DESCRIPTION
## Summary

Fixes an IPv6 guest port reservation leak in VirtioProxy networking. `VirtioProxyTests::GuestPortIsReleasedV6` fails because a host-side port reservation for an IPv6 guest listener is never released after the guest closes the port.

## Root cause

`VirtioNetworking::ModifyOpenPorts` only sent the `listen_addr` (and therefore the address family) to the device host when **opening** a port, not when **closing** it.

The consomme port-forward table in the device host is keyed by `(address family, port)`. To unbind the correct listener the device host must know the family. With no address supplied on close, the device host defaulted the family to IPv4, so IPv6 ports were never unbound and their host-side reservations leaked until the process exited.

IPv4 release worked only by accident: IPv4 is the default family, so an IPv4 close happened to match.

This was exposed by the consomme change that made the port-forward table family-specific (previously it was keyed by port alone, so the missing family on close did not matter).

## Fix

Always include `listen_addr` in the port string passed to the device host, on both open and close, so the address family is available when unbinding.

Since the address is now always present, the open/close branch collapses: `allocate` is sent explicitly (`true` on open, `false` on close) instead of relying on the device host default of `true` when the token is absent. The device host already parses `allocate=true`, so behavior is unchanged.

## Testing

- `VirtioProxyTests::GuestPortIsReleasedV6` now passes.
- `VirtioProxyTests::GuestPortIsReleased` (IPv4) and `NetworkTests::HostToGuestLoopback` (all configs) still pass.
- clang-format clean.

> [!NOTE]
> This is one of two fixes for VirtioProxy networking regressions. The companion fix for the IPv4 host-to-guest loopback handshake lives in openvmm/consomme (microsoft/openvmm#3742) and ships via a DeviceHost package bump.