### PR TITLE
CLI: Add container export command

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2391,6 +2391,9 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   <data name="MessageWslcSaveInProgress" xml:space="preserve">
     <value>Save in progress.</value>
   </data>
+  <data name="MessageWslcExportInProgress" xml:space="preserve">
+    <value>Export in progress.</value>
+  </data>
   <data name="WSLCCLI_RootCommandDesc" xml:space="preserve">
     <value>WSLC is the Windows Subsystem for Linux Container CLI tool.</value>
     <comment>{Locked="WSLC"}Product names should not be translated</comment>
@@ -2423,6 +2426,16 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   </data>
   <data name="WSLCCLI_ContainerExecLongDesc" xml:space="preserve">
     <value>Executes a command in a running container.</value>
+  </data>
+  <data name="WSLCCLI_ContainerExportDesc" xml:space="preserve">
+    <value>Export a container's filesystem as a tar archive.</value>
+  </data>
+  <data name="WSLCCLI_ContainerExportLongDesc" xml:space="preserve">
+    <value>Exports a container's filesystem as a tar archive.</value>
+  </data>
+  <data name="WSLCCLI_ContainerExportOutputArgDescription" xml:space="preserve">
+    <value>Write to a file, instead of STDOUT</value>
+    <comment>{Locked="STDOUT"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_ContainerInspectDesc" xml:space="preserve">
     <value>Inspect a container.</value>
@@ -3133,6 +3146,9 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_ImageSaveStdoutIsTerminalError" xml:space="preserve">
     <value>Cannot write image to terminal. Use the -o flag or redirect stdout.</value>
+  </data>
+  <data name="WSLCCLI_ContainerExportStdoutIsTerminalError" xml:space="preserve">
+    <value>Cannot export container to terminal. Use the -o flag or redirect stdout.</value>
   </data>
   <data name="WSLCCLI_VolumeFormatUsage" xml:space="preserve">
     <value>Expected format: &lt;host path | named volume&gt;:&lt;container path&gt;[:mode]</value>

--- a/src/windows/wslc/commands/ContainerCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCommand.cpp
@@ -25,6 +25,7 @@ std::vector<std::unique_ptr<Command>> ContainerCommand::GetCommands() const
     commands.push_back(std::make_unique<ContainerAttachCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerCreateCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerExecCommand>(FullName()));
+    commands.push_back(std::make_unique<ContainerExportCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerInspectCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerKillCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerLogsCommand>(FullName()));

--- a/src/windows/wslc/commands/ContainerCommand.h
+++ b/src/windows/wslc/commands/ContainerCommand.h
@@ -77,6 +77,21 @@ protected:
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
 
+// Export Command
+struct ContainerExportCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"export";
+    ContainerExportCommand(const std::wstring& parent) : Command(CommandName, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
+
 // Inspect Command
 struct ContainerInspectCommand final : public Command
 {

--- a/src/windows/wslc/commands/ContainerExportCommand.cpp
+++ b/src/windows/wslc/commands/ContainerExportCommand.cpp
@@ -1,0 +1,52 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ContainerExportCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+
+#include "ContainerCommand.h"
+#include "CLIExecutionContext.h"
+#include "ContainerTasks.h"
+#include "SessionTasks.h"
+#include "Task.h"
+
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
+
+namespace wsl::windows::wslc {
+// Container Export Command
+std::vector<Argument> ContainerExportCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::ContainerId, true),
+        Argument::Create(ArgType::Output, std::nullopt, std::nullopt, Localization::WSLCCLI_ContainerExportOutputArgDescription()),
+        Argument::Create(ArgType::Session),
+    };
+}
+
+std::wstring ContainerExportCommand::ShortDescription() const
+{
+    return Localization::WSLCCLI_ContainerExportDesc();
+}
+
+std::wstring ContainerExportCommand::LongDescription() const
+{
+    return Localization::WSLCCLI_ContainerExportLongDesc();
+}
+
+void ContainerExportCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    context              //
+        << CreateSession //
+        << ExportContainer;
+}
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/RootCommand.cpp
+++ b/src/windows/wslc/commands/RootCommand.cpp
@@ -42,6 +42,7 @@ std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
     commands.push_back(std::make_unique<ImageBuildCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerCreateCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerExecCommand>(FullName()));
+    commands.push_back(std::make_unique<ContainerExportCommand>(FullName()));
     commands.push_back(std::make_unique<ImageListCommand>(FullName(), true));
     commands.push_back(std::make_unique<ImageImportCommand>(FullName()));
     commands.push_back(std::make_unique<InspectCommand>(FullName()));

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -19,6 +19,7 @@ Abstract:
 #include "ImageProgressCallback.h"
 #include "WarningCallback.h"
 #include <wslutil.h>
+#include <HandleConsoleProgressBar.h>
 #include <WSLCProcessLauncher.h>
 #include <ConsoleState.h>
 #include <CommandLine.h>
@@ -580,6 +581,26 @@ InspectContainer ContainerService::Inspect(Session& session, const std::string& 
     wil::unique_cotaskmem_ansistring output;
     THROW_IF_FAILED(container->Inspect(&output));
     return wsl::shared::FromJson<InspectContainer>(output.get());
+}
+
+void ContainerService::Export(Session& session, const std::string& id, const std::wstring& outputPath)
+{
+    wil::unique_hfile outputFile{
+        CreateFileW(outputPath.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr)};
+    THROW_LAST_ERROR_IF(!outputFile);
+
+    Export(session, id, outputFile.get());
+}
+
+void ContainerService::Export(Session& session, const std::string& id, HANDLE outputHandle)
+{
+    wil::com_ptr<IWSLCContainer> container;
+    THROW_IF_FAILED(session.Get()->OpenContainer(id.c_str(), &container));
+
+    wsl::windows::common::HandleConsoleProgressBar progressBar(
+        outputHandle, Localization::MessageWslcExportInProgress(), wsl::windows::common::HandleConsoleProgressBar::Format::FileSize);
+
+    THROW_IF_FAILED(container->Export(ToCOMInputHandle(outputHandle)));
 }
 
 void ContainerService::Logs(Session& session, const std::string& id, bool follow, bool timestamps, ULONGLONG since, ULONGLONG until, ULONGLONG tail)

--- a/src/windows/wslc/services/ContainerService.h
+++ b/src/windows/wslc/services/ContainerService.h
@@ -34,6 +34,8 @@ struct ContainerService
         models::Session& session, bool all = false, int limit = -1, const std::vector<std::pair<std::string, std::string>>& filters = {});
 
     static int Exec(models::Session& session, const std::string& id, models::ContainerOptions options);
+    static void Export(models::Session& session, const std::string& id, const std::wstring& outputPath);
+    static void Export(models::Session& session, const std::string& id, HANDLE outputHandle);
     static wsl::windows::common::wslc_schema::InspectContainer Inspect(models::Session& session, const std::string& id);
     static void Logs(models::Session& session, const std::string& id, bool follow, bool timestamps, ULONGLONG since, ULONGLONG until, ULONGLONG tail = 0);
     static wsl::windows::common::docker_schema::ContainerStats Stats(models::Session& session, const std::string& id);

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -252,6 +252,30 @@ void KillContainers(CLIExecutionContext& context)
     }
 }
 
+void ExportContainer(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Session));
+    WI_ASSERT(context.Args.Contains(ArgType::ContainerId));
+    auto& session = context.Data.Get<Data::Session>();
+    auto containerId = WideToMultiByte(context.Args.Get<ArgType::ContainerId>());
+
+    if (context.Args.Contains(ArgType::Output))
+    {
+        auto& output = context.Args.Get<ArgType::Output>();
+        ContainerService::Export(session, containerId, output);
+    }
+    else
+    {
+        auto stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (wsl::windows::common::wslutil::IsConsoleHandle(stdoutHandle))
+        {
+            THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::WSLCCLI_ContainerExportStdoutIsTerminalError());
+        }
+
+        ContainerService::Export(session, containerId, stdoutHandle);
+    }
+}
+
 void ListContainers(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Data.Contains(Data::Containers));

--- a/src/windows/wslc/tasks/ContainerTasks.h
+++ b/src/windows/wslc/tasks/ContainerTasks.h
@@ -32,6 +32,7 @@ private:
 
 void CreateContainer(CLIExecutionContext& context);
 void ExecContainer(CLIExecutionContext& context);
+void ExportContainer(CLIExecutionContext& context);
 void GetContainers(CLIExecutionContext& context);
 void InspectContainers(CLIExecutionContext& context);
 void KillContainers(CLIExecutionContext& context);

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -156,6 +156,13 @@ COMMAND_LINE_TEST_CASE(L"container stats cont1", L"stats", true)
 COMMAND_LINE_TEST_CASE(L"container stats cont1 cont2", L"stats", true)
 COMMAND_LINE_TEST_CASE(L"container stats --no-trunc cont1", L"stats", true)
 COMMAND_LINE_TEST_CASE(L"container stats --all", L"stats", true)
+// Export command tests
+COMMAND_LINE_TEST_CASE(L"export cont1", L"export", true)
+COMMAND_LINE_TEST_CASE(L"container export cont1", L"export", true)
+COMMAND_LINE_TEST_CASE(L"container export --output foo cont1", L"export", true)
+COMMAND_LINE_TEST_CASE(L"container export -o foo cont1", L"export", true)
+COMMAND_LINE_TEST_CASE(L"container export cont1 --output foo", L"export", true)
+COMMAND_LINE_TEST_CASE(L"container export cont1 -o foo", L"export", true)
 
 // Logs command
 COMMAND_LINE_TEST_CASE(L"logs cont1", L"logs", true)

--- a/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
@@ -97,19 +97,6 @@ class WSLCE2EContainerExportTests
         VERIFY_ARE_NOT_EQUAL(0u, std::filesystem::file_size(ExportPath));
     }
 
-    WSLC_TEST_METHOD(WSLCE2E_Container_Export_ToTerminal_Fail)
-    {
-        // TODO: Re-enable once the test is stable in console-less pipeline environments.
-        // Opening CONOUT$ may fail when the process has no console attached.
-        SKIP_TEST_UNSTABLE();
-
-        const auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
-        createResult.Verify({.Stderr = L"", .ExitCode = 0});
-
-        const auto result = RunWslcAndRedirectToFile(std::format(L"container export {}", WslcContainerName));
-        result.Verify({.Stderr = L"Cannot export container to terminal. Use the -o flag or redirect stdout.\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
-    }
-
     WSLC_TEST_METHOD(WSLCE2E_Container_Export_RootAlias)
     {
         // `wslc export` should behave identically to `wslc container export`.

--- a/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
@@ -97,19 +97,6 @@ class WSLCE2EContainerExportTests
         VERIFY_ARE_NOT_EQUAL(0u, std::filesystem::file_size(ExportPath));
     }
 
-    WSLC_TEST_METHOD(WSLCE2E_Container_Export_RootAlias)
-    {
-        // `wslc export` should behave identically to `wslc container export`.
-        const auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
-        createResult.Verify({.Stderr = L"", .ExitCode = 0});
-
-        const auto result = RunWslc(std::format(L"export --output \"{}\" {}", ExportPath.wstring(), WslcContainerName));
-        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
-
-        VERIFY_IS_TRUE(std::filesystem::exists(ExportPath));
-        VERIFY_ARE_NOT_EQUAL(0u, std::filesystem::file_size(ExportPath));
-    }
-
 private:
     const std::wstring WslcContainerName = L"wslc-test-container-export";
     const std::wstring InvalidContainerName = L"wslc-nonexistent-container-for-export";

--- a/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
@@ -1,0 +1,174 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WSLCE2EContainerExportTests.cpp
+
+Abstract:
+
+    This file contains end-to-end tests for WSLC container export.
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCExecutor.h"
+#include "WSLCE2EHelpers.h"
+
+namespace WSLCE2ETests {
+using namespace wsl::shared;
+
+class WSLCE2EContainerExportTests
+{
+    WSLC_TEST_CLASS(WSLCE2EContainerExportTests)
+
+    TEST_CLASS_SETUP(ClassSetup)
+    {
+        EnsureImageIsLoaded(DebianImage);
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(ClassCleanup)
+    {
+        EnsureContainerDoesNotExist(WslcContainerName);
+        EnsureImageIsDeleted(DebianImage);
+        return true;
+    }
+
+    TEST_METHOD_SETUP(MethodSetup)
+    {
+        EnsureContainerDoesNotExist(WslcContainerName);
+        ExportPath = wsl::windows::common::filesystem::GetTempFilename();
+        DeleteFileW(ExportPath.c_str());
+        return true;
+    }
+
+    TEST_METHOD_CLEANUP(MethodCleanup)
+    {
+        EnsureContainerDoesNotExist(WslcContainerName);
+        DeleteFileW(ExportPath.c_str());
+        return true;
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Export_HelpCommand)
+    {
+        auto result = RunWslc(L"container export --help");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Export_MissingContainerId)
+    {
+        const auto result = RunWslc(std::format(L"container export --output \"{}\"", ExportPath.wstring()));
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = L"Required argument not provided: 'container-id'\r\n", .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Export_ContainerNotFound)
+    {
+        const auto result = RunWslc(std::format(L"container export --output \"{}\" {}", ExportPath.wstring(), InvalidContainerName));
+        VERIFY_IS_TRUE(result.ExitCode.has_value());
+        VERIFY_ARE_EQUAL(1u, result.ExitCode.value());
+        VERIFY_IS_TRUE(result.Stderr.has_value());
+        VERIFY_ARE_NOT_EQUAL(0u, result.Stderr.value().size());
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Export_ToFile_Success)
+    {
+        // Create a stopped container so it has a filesystem to export.
+        const auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+        createResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto result = RunWslc(std::format(L"container export --output \"{}\" {}", ExportPath.wstring(), WslcContainerName));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_TRUE(std::filesystem::exists(ExportPath));
+        VERIFY_ARE_NOT_EQUAL(0u, std::filesystem::file_size(ExportPath));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Export_ToStdout_Success)
+    {
+        const auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+        createResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto result = RunWslcAndRedirectToFile(std::format(L"container export {}", WslcContainerName), ExportPath);
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_TRUE(std::filesystem::exists(ExportPath));
+        VERIFY_ARE_NOT_EQUAL(0u, std::filesystem::file_size(ExportPath));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Export_ToTerminal_Fail)
+    {
+        // TODO: Re-enable once the test is stable in console-less pipeline environments.
+        // Opening CONOUT$ may fail when the process has no console attached.
+        SKIP_TEST_UNSTABLE();
+
+        const auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+        createResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto result = RunWslcAndRedirectToFile(std::format(L"container export {}", WslcContainerName));
+        result.Verify({.Stderr = L"Cannot export container to terminal. Use the -o flag or redirect stdout.\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Export_RootAlias)
+    {
+        // `wslc export` should behave identically to `wslc container export`.
+        const auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+        createResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto result = RunWslc(std::format(L"export --output \"{}\" {}", ExportPath.wstring(), WslcContainerName));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_TRUE(std::filesystem::exists(ExportPath));
+        VERIFY_ARE_NOT_EQUAL(0u, std::filesystem::file_size(ExportPath));
+    }
+
+private:
+    const std::wstring WslcContainerName = L"wslc-test-container-export";
+    const std::wstring InvalidContainerName = L"wslc-nonexistent-container-for-export";
+    const TestImage& DebianImage = DebianTestImage();
+
+    std::filesystem::path ExportPath{};
+
+    std::wstring GetHelpMessage() const
+    {
+        std::wstringstream output;
+        output << GetWslcHeader()        //
+               << GetDescription()       //
+               << GetUsage()             //
+               << GetAvailableCommands() //
+               << GetAvailableOptions();
+        return output.str();
+    }
+
+    std::wstring GetDescription() const
+    {
+        return Localization::WSLCCLI_ContainerExportLongDesc() + L"\r\n\r\n";
+    }
+
+    std::wstring GetUsage() const
+    {
+        return L"Usage: wslc container export [<options>] <container-id>\r\n\r\n";
+    }
+
+    std::wstring GetAvailableCommands() const
+    {
+        std::wstringstream commands;
+        commands << L"The following arguments are available:\r\n" //
+                 << L"  container-id    Container ID\r\n"         //
+                 << L"\r\n";
+        return commands.str();
+    }
+
+    std::wstring GetAvailableOptions() const
+    {
+        std::wstringstream options;
+        options << L"The following options are available:\r\n"                    //
+                << L"  -o,--output     Write to a file, instead of STDOUT\r\n"    //
+                << L"  --session       Specify the session to use\r\n"            //
+                << L"  -?,--help       Shows help about the selected command\r\n" //
+                << L"\r\n";
+        return options.str();
+    }
+};
+} // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
@@ -72,6 +72,7 @@ private:
             {L"attach", Localization::WSLCCLI_ContainerAttachDesc()},
             {L"create", Localization::WSLCCLI_ContainerCreateDesc()},
             {L"exec", Localization::WSLCCLI_ContainerExecDesc()},
+            {L"export", Localization::WSLCCLI_ContainerExportDesc()},
             {L"inspect", Localization::WSLCCLI_ContainerInspectDesc()},
             {L"kill", Localization::WSLCCLI_ContainerKillDesc()},
             {L"logs", Localization::WSLCCLI_ContainerLogsDesc()},

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -553,6 +553,7 @@ private:
             {L"build", Localization::WSLCCLI_ImageBuildDesc()},
             {L"create", Localization::WSLCCLI_ContainerCreateDesc()},
             {L"exec", Localization::WSLCCLI_ContainerExecDesc()},
+            {L"export", Localization::WSLCCLI_ContainerExportDesc()},
             {L"images", Localization::WSLCCLI_ImageListDesc()},
             {L"import", Localization::WSLCCLI_ImageImportDesc()},
             {L"inspect", Localization::WSLCCLI_InspectDesc()},


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds a new wslc container export command (with root alias wslc export) that exports a container's filesystem as a tar archive, mirroring docker container export.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- New ContainerExportCommand + ExportContainer task + ContainerService::Export(path) / Export(HANDLE) overloads, modeled on image save
- Wraps the IWSLCContainer::Export(TarHandle) COM call in HandleConsoleProgressBar (Format::FileSize) for stderr progress, matching image save
- Adds E2E tests and command line tests for the new command.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Unit tests and E2E tests for Container Export pass.