### PR TITLE
Fix wslc image inspect missing RootFS, ExposedPorts, Volumes, and StopSignal

### DIFF
--- a/src/shared/inc/JsonUtils.h
+++ b/src/shared/inc/JsonUtils.h
@@ -34,6 +34,19 @@ namespace wsl::shared {
 
 constexpr int c_jsonPrettyPrintIndent = 2;
 
+struct EmptyObject
+{
+};
+
+inline void to_json(nlohmann::json& j, const EmptyObject&)
+{
+    j = nlohmann::json::object();
+}
+
+inline void from_json(const nlohmann::json&, EmptyObject&)
+{
+}
+
 template <typename T>
 std::string ToJson(const T& Value, int indent = -1)
 {

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -20,6 +20,8 @@ Abstract:
 
 namespace wsl::windows::common::docker_schema {
 
+using wsl::shared::EmptyObject;
+
 struct CreatedContainer
 {
     std::string Id;
@@ -169,23 +171,6 @@ struct ContainerNetworkRequest
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(ContainerNetworkRequest, Container);
 };
-
-struct EmptyObject
-{
-};
-
-inline void to_json(nlohmann::json& j, const EmptyObject& memory)
-{
-    UNREFERENCED_PARAMETER(memory);
-    j = nlohmann::json::object();
-}
-
-inline void from_json(const nlohmann::json& j, EmptyObject& obj)
-{
-    // EmptyObject has no fields, so nothing to deserialize
-    UNREFERENCED_PARAMETER(j);
-    UNREFERENCED_PARAMETER(obj);
-}
 
 struct Mount
 {

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -18,6 +18,22 @@ Abstract:
 
 namespace wsl::windows::common::wslc_schema {
 
+struct EmptyObject
+{
+};
+
+inline void to_json(nlohmann::json& j, const EmptyObject& obj)
+{
+    UNREFERENCED_PARAMETER(obj);
+    j = nlohmann::json::object();
+}
+
+inline void from_json(const nlohmann::json& j, EmptyObject& obj)
+{
+    UNREFERENCED_PARAMETER(j);
+    UNREFERENCED_PARAMETER(obj);
+}
+
 struct InspectPortBinding
 {
     // WSLC always binds to localhost. Included for Docker API compatibility.
@@ -119,11 +135,23 @@ struct ImageConfig
     std::optional<std::vector<std::string>> Cmd;
     std::optional<std::vector<std::string>> Entrypoint;
     std::optional<std::vector<std::string>> Env;
+    std::optional<std::map<std::string, EmptyObject>> ExposedPorts;
     std::optional<std::map<std::string, std::string>> Labels;
+    std::string StopSignal;
     std::string User;
+    std::optional<std::map<std::string, EmptyObject>> Volumes;
     std::string WorkingDir;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ImageConfig, Cmd, Entrypoint, Env, Labels, User, WorkingDir);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(
+        ImageConfig, Cmd, Entrypoint, Env, ExposedPorts, Labels, StopSignal, User, Volumes, WorkingDir);
+};
+
+struct ImageRootFS
+{
+    std::string Type;
+    std::optional<std::vector<std::string>> Layers;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ImageRootFS, Type, Layers);
 };
 
 struct InspectImage
@@ -140,9 +168,10 @@ struct InspectImage
     int64_t Size{};
     std::optional<std::map<std::string, std::string>> Metadata;
     std::optional<ImageConfig> Config;
+    std::optional<ImageRootFS> RootFS;
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(
-        InspectImage, Id, RepoTags, RepoDigests, Parent, Comment, Created, Author, Architecture, Os, Size, Metadata, Config);
+        InspectImage, Id, RepoTags, RepoDigests, Parent, Comment, Created, Author, Architecture, Os, Size, Metadata, Config, RootFS);
 };
 
 struct InspectVolume

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -18,21 +18,7 @@ Abstract:
 
 namespace wsl::windows::common::wslc_schema {
 
-struct EmptyObject
-{
-};
-
-inline void to_json(nlohmann::json& j, const EmptyObject& obj)
-{
-    UNREFERENCED_PARAMETER(obj);
-    j = nlohmann::json::object();
-}
-
-inline void from_json(const nlohmann::json& j, EmptyObject& obj)
-{
-    UNREFERENCED_PARAMETER(j);
-    UNREFERENCED_PARAMETER(obj);
-}
+using wsl::shared::EmptyObject;
 
 struct InspectPortBinding
 {

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -142,8 +142,7 @@ struct ImageConfig
     std::optional<std::map<std::string, EmptyObject>> Volumes;
     std::string WorkingDir;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(
-        ImageConfig, Cmd, Entrypoint, Env, ExposedPorts, Labels, StopSignal, User, Volumes, WorkingDir);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ImageConfig, Cmd, Entrypoint, Env, ExposedPorts, Labels, StopSignal, User, Volumes, WorkingDir);
 };
 
 struct ImageRootFS

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -124,10 +124,40 @@ wslc_schema::InspectImage ConvertInspectImage(const docker_schema::InspectImage&
         wslcConfig.Entrypoint = dockerConfig.Entrypoint;
         wslcConfig.Env = dockerConfig.Env;
         wslcConfig.Labels = dockerConfig.Labels;
+        wslcConfig.StopSignal = dockerConfig.StopSignal;
         wslcConfig.User = dockerConfig.User;
         wslcConfig.WorkingDir = dockerConfig.WorkingDir;
 
+        if (dockerConfig.ExposedPorts.has_value())
+        {
+            std::map<std::string, wslc_schema::EmptyObject> ports;
+            for (const auto& [port, _] : dockerConfig.ExposedPorts.value())
+            {
+                ports.emplace(port, wslc_schema::EmptyObject{});
+            }
+            wslcConfig.ExposedPorts = std::move(ports);
+        }
+
+        if (dockerConfig.Volumes.has_value())
+        {
+            std::map<std::string, wslc_schema::EmptyObject> volumes;
+            for (const auto& [path, _] : dockerConfig.Volumes.value())
+            {
+                volumes.emplace(path, wslc_schema::EmptyObject{});
+            }
+            wslcConfig.Volumes = std::move(volumes);
+        }
+
         wslcInspect.Config = wslcConfig;
+    }
+
+    if (dockerInspect.RootFS.has_value())
+    {
+        const auto& dockerRootFS = dockerInspect.RootFS.value();
+        wslc_schema::ImageRootFS wslcRootFS{};
+        wslcRootFS.Type = dockerRootFS.Type;
+        wslcRootFS.Layers = dockerRootFS.Layers;
+        wslcInspect.RootFS = std::move(wslcRootFS);
     }
 
     return wslcInspect;

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -553,6 +553,14 @@ void WriteTestFile(const std::filesystem::path& filePath, const std::vector<std:
     VERIFY_IS_TRUE(file.good());
 }
 
+void WriteTestFileContent(const std::filesystem::path& filePath, const std::string& content)
+{
+    std::ofstream file(filePath, std::ios::out | std::ios::trunc | std::ios::binary);
+    THROW_HR_IF_MSG(E_FAIL, !file.is_open(), "Failed to open %ls for writing", filePath.c_str());
+    file << content;
+    THROW_HR_IF_MSG(E_FAIL, !file.good(), "Failed to write to %ls", filePath.c_str());
+}
+
 std::wstring GetPythonHttpServerScript(uint16_t port)
 {
     return std::format(L"python3 -m http.server {}", port);

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -128,6 +128,24 @@ void EnsureVolumeDoesNotExist(const std::wstring& volumeName);
 void EnsureNetworkDoesNotExist(const std::wstring& networkName);
 
 void WriteTestFile(const std::filesystem::path& filePath, const std::vector<std::string>& envVariableLines);
+void WriteTestFileContent(const std::filesystem::path& filePath, const std::string& content);
+
+// Sets up a clean test directory and returns a scope_exit to remove it.
+inline auto SetupTestDirectory(const std::filesystem::path& directory)
+{
+    std::error_code ec;
+    std::filesystem::remove_all(directory, ec);
+    THROW_HR_IF_MSG(E_FAIL, ec.value() != 0 && std::filesystem::exists(directory), "%hs", ec.message().c_str());
+
+    std::filesystem::create_directories(directory, ec);
+    THROW_HR_IF_MSG(E_FAIL, ec.value() != 0 || !std::filesystem::exists(directory), "%hs", ec.message().c_str());
+
+    return wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [directory]() {
+        std::error_code removeError;
+        std::filesystem::remove_all(directory, removeError);
+    });
+}
+
 std::wstring GetPythonHttpServerScript(uint16_t port);
 
 // Default timeout of 0 will execute once.

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -15,7 +15,6 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
-#include <fstream>
 
 namespace WSLCE2ETests {
 
@@ -60,7 +59,7 @@ class WSLCE2EImageBuildTests
         THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
 
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFile(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"wslc-e2e-build-ok\"]\n");
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"wslc-e2e-build-ok\"]\n");
 
         auto buildResult = RunWslc(
             std::format(L"build \"{}\" -f \"{}\" -t {}", contextDir.wstring(), dockerfilePath.wstring(), BuiltImage.NameAndTag()));
@@ -84,10 +83,10 @@ class WSLCE2EImageBuildTests
 
         // Create a simple file in the context directory
         auto filePath = contextDir / L"hello.txt";
-        WriteTestFile(filePath, "hello from wslc build\n");
+        WriteTestFileContent(filePath, "hello from wslc build\n");
 
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFile(
+        WriteTestFileContent(
             dockerfilePath,
             "FROM debian:latest\n"
             "ARG TEST_LABEL=default_value\n"
@@ -134,7 +133,7 @@ class WSLCE2EImageBuildTests
         THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
 
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFile(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"pull-ok\"]\n");
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"pull-ok\"]\n");
 
         // Build with --pull --verbose. When --pull causes docker to resolve the base image
         // from the registry, the FROM step includes a @sha256: digest (e.g.
@@ -158,7 +157,7 @@ class WSLCE2EImageBuildTests
         THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
 
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFile(
+        WriteTestFileContent(
             dockerfilePath,
             "FROM debian:latest AS build-stage\n"
             "RUN echo build > /stage.txt\n"
@@ -198,8 +197,8 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-both-files";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        WriteTestFile(testRoot / L"Dockerfile", "FROM debian:latest\n");
-        WriteTestFile(testRoot / L"Containerfile", "FROM debian:latest\n");
+        WriteTestFileContent(testRoot / L"Dockerfile", "FROM debian:latest\n");
+        WriteTestFileContent(testRoot / L"Containerfile", "FROM debian:latest\n");
 
         auto buildResult = RunWslc(std::format(L"build \"{}\"", testRoot.wstring()));
         buildResult.Verify(
@@ -226,7 +225,7 @@ class WSLCE2EImageBuildTests
         auto cleanup = SetupTestDirectory(testRoot);
 
         auto containerfilePath = testRoot / L"Containerfile";
-        WriteTestFile(containerfilePath, "FROM debian:latest\n");
+        WriteTestFileContent(containerfilePath, "FROM debian:latest\n");
 
         // Deny read access so wslc cannot open the file.
         SetPathAccess(containerfilePath, GENERIC_READ, DENY_ACCESS);
@@ -254,7 +253,7 @@ class WSLCE2EImageBuildTests
         // `RUN date +%N` produces a different output each invocation, so without caching the
         // resulting layer (and therefore the image id) changes every build.
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFile(
+        WriteTestFileContent(
             dockerfilePath,
             "FROM debian:latest\n"
             "RUN date +%N > /timestamp.txt\n");
@@ -296,7 +295,7 @@ private:
         auto testRoot = std::filesystem::current_path() / image.Name;
         auto cleanup = SetupTestDirectory(testRoot);
 
-        WriteTestFile(testRoot / fileName, "FROM debian:latest\nCMD [\"echo\", \"build-ok\"]\n");
+        WriteTestFileContent(testRoot / fileName, "FROM debian:latest\nCMD [\"echo\", \"build-ok\"]\n");
 
         auto buildResult = RunWslc(std::format(L"build \"{}\" -t {}", testRoot.wstring(), image.NameAndTag()));
         buildResult.Verify({.Stderr = L"", .ExitCode = 0});
@@ -317,30 +316,6 @@ private:
         EnsureImageIsDeleted(BuiltImageDockerfile);
         EnsureImageIsDeleted(BuiltImageContainerfile);
         EnsureImageIsDeleted(BuiltImageNoCache);
-    }
-
-    static auto SetupTestDirectory(const std::filesystem::path& testRoot)
-    {
-        std::error_code ec;
-        std::filesystem::remove_all(testRoot, ec);
-        THROW_HR_IF_MSG(E_FAIL, ec.value() != 0 && std::filesystem::exists(testRoot), "%hs", ec.message().c_str());
-
-        std::filesystem::create_directories(testRoot, ec);
-        THROW_HR_IF_MSG(E_FAIL, ec.value() != 0 || !std::filesystem::exists(testRoot), "%hs", ec.message().c_str());
-
-        return wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [testRoot]() {
-            std::error_code removeError;
-            std::filesystem::remove_all(testRoot, removeError);
-        });
-    }
-
-    static void WriteTestFile(const std::filesystem::path& path, const std::string& content)
-    {
-        std::ofstream file(path);
-        THROW_HR_IF(E_FAIL, !file.is_open());
-        file << content;
-        THROW_HR_IF(E_FAIL, !file.good());
-        file.close();
     }
 };
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EImageInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageInspectTests.cpp
@@ -32,6 +32,7 @@ class WSLCE2EImageInspectTests
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
+        EnsureImageIsDeleted(BuiltExposeImage);
         EnsureImageIsDeleted(DebianImage);
         return true;
     }
@@ -64,12 +65,67 @@ class WSLCE2EImageInspectTests
         VERIFY_IS_TRUE(inspectData[0].RepoTags.has_value());
         VERIFY_ARE_EQUAL(1u, inspectData[0].RepoTags.value().size());
         VERIFY_ARE_EQUAL(DebianImage.NameAndTag(), wsl::shared::string::MultiByteToWide(inspectData[0].RepoTags.value()[0]));
+
+        // Verify RootFS is populated.
+        VERIFY_IS_TRUE(inspectData[0].RootFS.has_value());
+        VERIFY_ARE_EQUAL(std::string{"layers"}, inspectData[0].RootFS.value().Type);
+        VERIFY_IS_TRUE(inspectData[0].RootFS.value().Layers.has_value());
+        VERIFY_IS_GREATER_THAN(inspectData[0].RootFS.value().Layers.value().size(), 0u);
+
+        // Debian has no ExposedPorts or Volumes.
+        VERIFY_IS_TRUE(inspectData[0].Config.has_value());
+        VERIFY_IS_FALSE(inspectData[0].Config.value().ExposedPorts.has_value());
+        VERIFY_IS_FALSE(inspectData[0].Config.value().Volumes.has_value());
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Inspect_ConfigExtras_Success)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-inspect-config-extras";
+        auto cleanupDir = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(
+            dockerfilePath,
+            std::format(
+                "FROM {}\n"
+                "EXPOSE 8080/tcp\n"
+                "EXPOSE 9090/udp\n"
+                "VOLUME /data\n"
+                "VOLUME /var/log/app\n"
+                "STOPSIGNAL SIGTERM\n",
+                wsl::shared::string::WideToMultiByte(DebianImage.NameAndTag())));
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {}", contextDir.wstring(), dockerfilePath.wstring(), BuiltExposeImage.NameAndTag()));
+        buildResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto inspectData = InspectImage(BuiltExposeImage.NameAndTag());
+        VERIFY_IS_TRUE(inspectData.Config.has_value());
+        const auto& config = inspectData.Config.value();
+
+        VERIFY_IS_TRUE(config.ExposedPorts.has_value());
+        const auto& ports = config.ExposedPorts.value();
+        VERIFY_IS_TRUE(ports.contains("8080/tcp"));
+        VERIFY_IS_TRUE(ports.contains("9090/udp"));
+
+        VERIFY_IS_TRUE(config.Volumes.has_value());
+        const auto& volumes = config.Volumes.value();
+        VERIFY_IS_TRUE(volumes.contains("/data"));
+        VERIFY_IS_TRUE(volumes.contains("/var/log/app"));
+
+        VERIFY_ARE_EQUAL(std::string{"SIGTERM"}, config.StopSignal);
     }
 
 private:
     const std::wstring WslcContainerName = L"wslc-test-container";
     const TestImage& DebianImage = DebianTestImage();
     const TestImage& InvalidImage = InvalidTestImage();
+    const TestImage BuiltExposeImage{L"wslc-e2e-inspect-config-extras", L"latest", L""};
 
     std::wstring GetHelpMessage() const
     {


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
wslc image inspect was missing several fields compared to docker image inspect: RootFS.Layers, Config.ExposedPorts, Config.Volumes, and Config.StopSignal. The Docker API response already contained them, but wslc_schema::InspectImage and ImageConfig didn't declare these fields, so ConvertInspectImage silently dropped them during the docker→wslc conversion.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #62098442
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Schema changes (wslc_schema.h):

- Added EmptyObject helper struct 

- Added ExposedPorts, StopSignal, Volumes to ImageConfig

- Added ImageRootFS struct with Type and Layers

- Added RootFS field to InspectImage

- Converter changes (WSLCSession.cpp): ConvertInspectImage now maps ExposedPorts, Volumes (with has_value() guard to preserve nullopt-vs-populated semantics), StopSignal, and RootFS from the Docker response.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
