### PR TITLE
[CLI] Init support for network prune command

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3069,6 +3069,16 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_NetworkListQuietArgDesc" xml:space="preserve">
     <value>Outputs the network names only</value>
   </data>
+  <data name="WSLCCLI_NetworkPruneDesc" xml:space="preserve">
+    <value>Remove all unused networks.</value>
+  </data>
+  <data name="WSLCCLI_NetworkPruneLongDesc" xml:space="preserve">
+    <value>Removes all unused networks. A network is considered unused when it is not referenced by any container.</value>
+  </data>
+  <data name="WSLCCLI_NetworkPruneDeleted" xml:space="preserve">
+    <value>Deleted: {}</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="WSLCCLI_VolumeCommandDesc" xml:space="preserve">
     <value>Manage volumes.</value>
   </data>

--- a/src/windows/wslc/commands/NetworkCommand.cpp
+++ b/src/windows/wslc/commands/NetworkCommand.cpp
@@ -26,6 +26,7 @@ std::vector<std::unique_ptr<Command>> NetworkCommand::GetCommands() const
     commands.push_back(std::make_unique<NetworkRemoveCommand>(FullName()));
     commands.push_back(std::make_unique<NetworkInspectCommand>(FullName()));
     commands.push_back(std::make_unique<NetworkListCommand>(FullName()));
+    commands.push_back(std::make_unique<NetworkPruneCommand>(FullName()));
     return commands;
 }
 

--- a/src/windows/wslc/commands/NetworkCommand.h
+++ b/src/windows/wslc/commands/NetworkCommand.h
@@ -92,4 +92,19 @@ protected:
     void ValidateArgumentsInternal(const ArgMap& execArgs) const override;
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
+
+// Prune Command
+struct NetworkPruneCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"prune";
+    NetworkPruneCommand(const std::wstring& parent) : Command(CommandName, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/NetworkPruneCommand.cpp
+++ b/src/windows/wslc/commands/NetworkPruneCommand.cpp
@@ -1,0 +1,51 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    NetworkPruneCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+
+#include "NetworkCommand.h"
+#include "CLIExecutionContext.h"
+#include "SessionTasks.h"
+#include "NetworkTasks.h"
+#include "Task.h"
+
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
+
+namespace wsl::windows::wslc {
+// Network Prune Command
+std::vector<Argument> NetworkPruneCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::Filter, false, NO_LIMIT),
+        Argument::Create(ArgType::Session),
+    };
+}
+
+std::wstring NetworkPruneCommand::ShortDescription() const
+{
+    return Localization::WSLCCLI_NetworkPruneDesc();
+}
+
+std::wstring NetworkPruneCommand::LongDescription() const
+{
+    return Localization::WSLCCLI_NetworkPruneLongDesc();
+}
+
+void NetworkPruneCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    context              //
+        << CreateSession //
+        << PruneNetworks;
+}
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/services/NetworkModel.h
+++ b/src/windows/wslc/services/NetworkModel.h
@@ -27,4 +27,9 @@ struct CreateNetworkOptions
     std::vector<std::pair<std::string, std::string>> Labels{};
 };
 
+struct PruneNetworksResult
+{
+    std::vector<std::string> PrunedNetworks;
+};
+
 } // namespace wsl::windows::wslc::models

--- a/src/windows/wslc/services/NetworkService.cpp
+++ b/src/windows/wslc/services/NetworkService.cpp
@@ -93,10 +93,7 @@ models::PruneNetworksResult NetworkService::Prune(models::Session& session, cons
 
     wil::unique_cotaskmem_array_ptr<WSLCNetworkName> networks;
     THROW_IF_FAILED(session.Get()->PruneNetworks(
-        filterEntries.empty() ? nullptr : filterEntries.data(),
-        static_cast<ULONG>(filterEntries.size()),
-        &networks,
-        networks.size_address<ULONG>()));
+        filterEntries.empty() ? nullptr : filterEntries.data(), static_cast<ULONG>(filterEntries.size()), &networks, networks.size_address<ULONG>()));
 
     models::PruneNetworksResult result;
     result.PrunedNetworks.reserve(networks.size());

--- a/src/windows/wslc/services/NetworkService.cpp
+++ b/src/windows/wslc/services/NetworkService.cpp
@@ -81,4 +81,30 @@ wsl::windows::common::wslc_schema::Network NetworkService::Inspect(models::Sessi
     THROW_IF_FAILED(session.Get()->InspectNetwork(name.c_str(), &output));
     return FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
 }
+
+models::PruneNetworksResult NetworkService::Prune(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
+{
+    std::vector<WSLCFilter> filterEntries;
+    filterEntries.reserve(filters.size());
+    for (const auto& [key, value] : filters)
+    {
+        filterEntries.push_back({.Key = key.c_str(), .Value = value.c_str()});
+    }
+
+    wil::unique_cotaskmem_array_ptr<WSLCNetworkName> networks;
+    THROW_IF_FAILED(session.Get()->PruneNetworks(
+        filterEntries.empty() ? nullptr : filterEntries.data(),
+        static_cast<ULONG>(filterEntries.size()),
+        &networks,
+        networks.size_address<ULONG>()));
+
+    models::PruneNetworksResult result;
+    result.PrunedNetworks.reserve(networks.size());
+    for (auto ptr = networks.get(), end = networks.get() + networks.size(); ptr != end; ++ptr)
+    {
+        result.PrunedNetworks.emplace_back(*ptr);
+    }
+
+    return result;
+}
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/services/NetworkService.h
+++ b/src/windows/wslc/services/NetworkService.h
@@ -24,5 +24,6 @@ struct NetworkService
     static void Delete(models::Session& session, const std::string& name);
     static std::vector<WSLCNetworkInformation> List(models::Session& session);
     static wsl::windows::common::wslc_schema::Network Inspect(models::Session& session, const std::string& name);
+    static models::PruneNetworksResult Prune(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
 };
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -191,4 +191,23 @@ void ListNetworks(CLIExecutionContext& context)
         THROW_HR(E_UNEXPECTED);
     }
 }
+
+void PruneNetworks(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Session));
+    auto& session = context.Data.Get<Data::Session>();
+
+    std::vector<std::pair<std::string, std::string>> filters;
+    for (const auto& value : context.Args.GetAll<ArgType::Filter>())
+    {
+        filters.push_back(validation::ParseFilter(value));
+    }
+
+    auto result = NetworkService::Prune(session, filters);
+
+    for (const auto& networkName : result.PrunedNetworks)
+    {
+        PrintMessage(Localization::WSLCCLI_NetworkPruneDeleted(MultiByteToWide(networkName)));
+    }
+}
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslc/tasks/NetworkTasks.h
+++ b/src/windows/wslc/tasks/NetworkTasks.h
@@ -21,4 +21,5 @@ void DeleteNetworks(wsl::windows::wslc::execution::CLIExecutionContext& context)
 void GetNetworks(wsl::windows::wslc::execution::CLIExecutionContext& context);
 void InspectNetworks(wsl::windows::wslc::execution::CLIExecutionContext& context);
 void ListNetworks(wsl::windows::wslc::execution::CLIExecutionContext& context);
+void PruneNetworks(wsl::windows::wslc::execution::CLIExecutionContext& context);
 } // namespace wsl::windows::wslc::task

--- a/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
@@ -148,8 +148,7 @@ class WSLCE2ENetworkPruneTests
 
     WSLC_TEST_METHOD(WSLCE2E_Network_Prune_LabelFilter_MatchingValueIsDeleted)
     {
-        RunWslc(std::format(L"network create --driver bridge --label wslc.test.prune=keep {}", TestNetworkName))
-            .Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"network create --driver bridge --label wslc.test.prune=keep {}", TestNetworkName)).Verify({.Stderr = L"", .ExitCode = 0});
         RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName2)).Verify({.Stderr = L"", .ExitCode = 0});
         VerifyNetworkIsListed(TestNetworkName);
         VerifyNetworkIsListed(TestNetworkName2);
@@ -173,8 +172,7 @@ class WSLCE2ENetworkPruneTests
 
     WSLC_TEST_METHOD(WSLCE2E_Network_Prune_NegatedLabelFilter_PreservesLabeledNetwork)
     {
-        RunWslc(std::format(L"network create --driver bridge --label wslc.test.keep=yes {}", TestNetworkName))
-            .Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"network create --driver bridge --label wslc.test.keep=yes {}", TestNetworkName)).Verify({.Stderr = L"", .ExitCode = 0});
         RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName2)).Verify({.Stderr = L"", .ExitCode = 0});
         VerifyNetworkIsListed(TestNetworkName);
         VerifyNetworkIsListed(TestNetworkName2);

--- a/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
@@ -55,8 +55,8 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_FALSE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
-        VERIFY_IS_FALSE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)));
+        VERIFY_IS_FALSE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
+        VERIFY_IS_FALSE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Network_Prune_RemovesUnusedNetwork)
@@ -69,7 +69,9 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+        auto output = result.GetStdoutLines();
+        VERIFY_ARE_EQUAL(1u, output.size());
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, output[0].find(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
 
         VerifyNetworkIsNotListed(TestNetworkName);
     }
@@ -89,8 +91,8 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)));
 
         VerifyNetworkIsNotListed(TestNetworkName);
         VerifyNetworkIsNotListed(TestNetworkName2);
@@ -115,7 +117,7 @@ class WSLCE2ENetworkPruneTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         VERIFY_IS_FALSE(
-            result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)),
+            result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)),
             L"Network in use by a running container must not be pruned");
 
         VerifyNetworkIsListed(TestNetworkName);
@@ -132,7 +134,7 @@ class WSLCE2ENetworkPruneTests
         const auto filteredPrune = RunWslc(L"network prune --filter label=wslc.test.never=present");
         filteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
         VERIFY_IS_FALSE(
-            filteredPrune.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)),
+            filteredPrune.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)),
             L"Filtered prune should not have deleted the non-matching network");
         VerifyNetworkIsListed(TestNetworkName);
 
@@ -140,7 +142,7 @@ class WSLCE2ENetworkPruneTests
         // was the reason it survived.
         const auto unfilteredPrune = RunWslc(L"network prune");
         unfilteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
-        VERIFY_IS_TRUE(unfilteredPrune.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+        VERIFY_IS_TRUE(unfilteredPrune.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
         VerifyNetworkIsNotListed(TestNetworkName);
     }
 
@@ -160,9 +162,9 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune --filter label=wslc.test.prune=keep");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
         VERIFY_IS_FALSE(
-            result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)),
+            result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)),
             L"Network without the matching label must not be deleted");
 
         VerifyNetworkIsNotListed(TestNetworkName);
@@ -185,9 +187,9 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune --filter label!=wslc.test.keep");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)));
         VERIFY_IS_FALSE(
-            result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)),
+            result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)),
             L"Labeled network must be preserved when prune negates that label");
 
         VerifyNetworkIsListed(TestNetworkName);

--- a/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
@@ -1,0 +1,253 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WSLCE2ENetworkPruneTests.cpp
+
+Abstract:
+
+    This file contains end-to-end tests for the WSLC network prune command.
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCExecutor.h"
+#include "WSLCE2EHelpers.h"
+
+namespace WSLCE2ETests {
+using namespace wsl::shared;
+
+class WSLCE2ENetworkPruneTests
+{
+    WSLC_TEST_CLASS(WSLCE2ENetworkPruneTests)
+
+    TEST_CLASS_SETUP(ClassSetup)
+    {
+        EnsureImageIsLoaded(DebianImage);
+        CleanUpAllTestState();
+        return true;
+    }
+
+    TEST_METHOD_SETUP(MethodSetup)
+    {
+        CleanUpAllTestState();
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(ClassCleanup)
+    {
+        CleanUpAllTestState();
+        EnsureImageIsDeleted(DebianImage);
+        return true;
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_HelpCommand)
+    {
+        const auto result = RunWslc(L"network prune --help");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_NoNetworks)
+    {
+        // Prune when no unused networks exist should succeed without reporting any of our test networks.
+        const auto result = RunWslc(L"network prune");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_FALSE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+        VERIFY_IS_FALSE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_RemovesUnusedNetwork)
+    {
+        RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName)).Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsListed(TestNetworkName);
+
+        auto cleanup = wil::scope_exit([&]() { EnsureNetworkDoesNotExist(TestNetworkName); });
+
+        const auto result = RunWslc(L"network prune");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+
+        VerifyNetworkIsNotListed(TestNetworkName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_RemovesMultipleNetworks)
+    {
+        RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName)).Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName2)).Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsListed(TestNetworkName);
+        VerifyNetworkIsListed(TestNetworkName2);
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureNetworkDoesNotExist(TestNetworkName);
+            EnsureNetworkDoesNotExist(TestNetworkName2);
+        });
+
+        const auto result = RunWslc(L"network prune");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)));
+
+        VerifyNetworkIsNotListed(TestNetworkName);
+        VerifyNetworkIsNotListed(TestNetworkName2);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_InUseNetwork_Preserved)
+    {
+        RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName)).Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsListed(TestNetworkName);
+
+        // Start a container attached to the network so it is considered in use.
+        RunWslc(std::format(
+                    L"container run -d --name {} --network {} {} sleep infinity", WslcContainerName, TestNetworkName, DebianImage.NameAndTag()))
+            .Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureContainerDoesNotExist(WslcContainerName);
+            EnsureNetworkDoesNotExist(TestNetworkName);
+        });
+
+        const auto result = RunWslc(L"network prune");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_FALSE(
+            result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)),
+            L"Network in use by a running container must not be pruned");
+
+        VerifyNetworkIsListed(TestNetworkName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_LabelFilter_PreservesNonMatchingNetwork)
+    {
+        RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName)).Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsListed(TestNetworkName);
+
+        auto cleanup = wil::scope_exit([&]() { EnsureNetworkDoesNotExist(TestNetworkName); });
+
+        // A label filter that does not match the network should preserve it.
+        const auto filteredPrune = RunWslc(L"network prune --filter label=wslc.test.never=present");
+        filteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_FALSE(
+            filteredPrune.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)),
+            L"Filtered prune should not have deleted the non-matching network");
+        VerifyNetworkIsListed(TestNetworkName);
+
+        // A subsequent unfiltered prune should still remove it, proving the filter
+        // was the reason it survived.
+        const auto unfilteredPrune = RunWslc(L"network prune");
+        unfilteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(unfilteredPrune.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+        VerifyNetworkIsNotListed(TestNetworkName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_LabelFilter_MatchingValueIsDeleted)
+    {
+        RunWslc(std::format(L"network create --driver bridge --label wslc.test.prune=keep {}", TestNetworkName))
+            .Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName2)).Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsListed(TestNetworkName);
+        VerifyNetworkIsListed(TestNetworkName2);
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureNetworkDoesNotExist(TestNetworkName);
+            EnsureNetworkDoesNotExist(TestNetworkName2);
+        });
+
+        const auto result = RunWslc(L"network prune --filter label=wslc.test.prune=keep");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)));
+        VERIFY_IS_FALSE(
+            result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)),
+            L"Network without the matching label must not be deleted");
+
+        VerifyNetworkIsNotListed(TestNetworkName);
+        VerifyNetworkIsListed(TestNetworkName2);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_NegatedLabelFilter_PreservesLabeledNetwork)
+    {
+        RunWslc(std::format(L"network create --driver bridge --label wslc.test.keep=yes {}", TestNetworkName))
+            .Verify({.Stderr = L"", .ExitCode = 0});
+        RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName2)).Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsListed(TestNetworkName);
+        VerifyNetworkIsListed(TestNetworkName2);
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureNetworkDoesNotExist(TestNetworkName);
+            EnsureNetworkDoesNotExist(TestNetworkName2);
+        });
+
+        const auto result = RunWslc(L"network prune --filter label!=wslc.test.keep");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName2)));
+        VERIFY_IS_FALSE(
+            result.StdoutContainsLine(std::format(L"Deleted: {}", TestNetworkName)),
+            L"Labeled network must be preserved when prune negates that label");
+
+        VerifyNetworkIsListed(TestNetworkName);
+        VerifyNetworkIsNotListed(TestNetworkName2);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_Filter_MalformedValue)
+    {
+        const auto result = RunWslc(L"network prune --filter label");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = Localization::WSLCCLI_InvalidFilterError(L"label") + L"\r\n", .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Prune_Filter_InvalidKey)
+    {
+        const auto result = RunWslc(L"network prune --filter color=red");
+        result.Verify({.Stdout = L"", .Stderr = L"invalid filter 'color'\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
+    }
+
+private:
+    const TestImage& DebianImage = DebianTestImage();
+    const std::wstring TestNetworkName = L"wslc-e2e-network-prune";
+    const std::wstring TestNetworkName2 = L"wslc-e2e-network-prune-2";
+    const std::wstring WslcContainerName = L"wslc-network-prune-test-container";
+
+    void CleanUpAllTestState()
+    {
+        EnsureContainerDoesNotExist(WslcContainerName);
+        EnsureNetworkDoesNotExist(TestNetworkName);
+        EnsureNetworkDoesNotExist(TestNetworkName2);
+    }
+
+    std::wstring GetHelpMessage() const
+    {
+        std::wstringstream output;
+        output << GetWslcHeader()  //
+               << GetDescription() //
+               << GetUsage()       //
+               << GetAvailableOptions();
+        return output.str();
+    }
+
+    std::wstring GetDescription() const
+    {
+        return Localization::WSLCCLI_NetworkPruneLongDesc() + L"\r\n\r\n";
+    }
+
+    std::wstring GetUsage() const
+    {
+        return L"Usage: wslc network prune [<options>]\r\n\r\n";
+    }
+
+    std::wstring GetAvailableOptions() const
+    {
+        std::wstringstream options;
+        options << L"The following options are available:\r\n"
+                << L"  -f,--filter  " << Localization::WSLCCLI_FilterArgDescription() << L"\r\n"
+                << L"  --session    " << Localization::WSLCCLI_SessionIdArgDescription() << L"\r\n"
+                << L"  -?,--help    " << Localization::WSLCCLI_HelpArgDescription() << L"\r\n"
+                << L"\r\n";
+        return options.str();
+    }
+};
+} // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2ENetworkTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkTests.cpp
@@ -71,6 +71,7 @@ private:
             {L"remove", Localization::WSLCCLI_NetworkRemoveDesc()},
             {L"inspect", Localization::WSLCCLI_NetworkInspectDesc()},
             {L"list", Localization::WSLCCLI_NetworkListDesc()},
+            {L"prune", Localization::WSLCCLI_NetworkPruneDesc()},
         };
 
         size_t maxLen = 0;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds CLI wiring for network prune, mirroring volume prune.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
