### PR TITLE
Use a local registry in the WSLCE2E_Container_Create_InvalidImage test case

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -95,7 +95,7 @@ class WSLCE2EContainerCreateTests
 
         std::wstringstream expectedError;
         expectedError << L"Image '" << reference << L"' not found, pulling\r\n"
-                      << L"manifest for " << reference << L" not found: manifest unknown: manifest tagged by \"latest\" is not found\r\n"
+                      << L"manifest for " << reference << L" not found: manifest unknown: manifest unknown\r\n"
                       << L"Error code: WSLC_E_IMAGE_NOT_FOUND\r\n";
         result.Verify({.Stderr = expectedError.str(), .ExitCode = 1});
     }
@@ -120,12 +120,8 @@ class WSLCE2EContainerCreateTests
         VERIFY_IS_TRUE(DeleteFileW(cidFilePath.c_str()));
         auto deleteCidFile = wil::scope_exit([&]() { VERIFY_IS_TRUE(DeleteFileW(cidFilePath.c_str())); });
 
-        auto result = RunWslc(
-            std::format(
-                L"container create --cidfile \"{}\" --name {} {}",
-                EscapePath(cidFilePath.wstring()),
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --cidfile \"{}\" --name {} {}", EscapePath(cidFilePath.wstring()), WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto containerId = result.GetStdoutOneLine();
@@ -138,12 +134,8 @@ class WSLCE2EContainerCreateTests
         const auto cidFilePath = wsl::windows::common::filesystem::GetTempFilename();
         auto deleteCidFile = wil::scope_exit([&]() { VERIFY_IS_TRUE(DeleteFileW(cidFilePath.c_str())); });
 
-        auto result = RunWslc(
-            std::format(
-                L"container create --cidfile \"{}\" --name {} {}",
-                EscapePath(cidFilePath.wstring()),
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --cidfile \"{}\" --name {} {}", EscapePath(cidFilePath.wstring()), WslcContainerName, DebianImage.NameAndTag()));
         result.Verify(
             {.Stderr = std::format(L"CID file '{}' already exists\r\nError code: ERROR_FILE_EXISTS\r\n", EscapePath(cidFilePath.wstring())),
              .ExitCode = 1});
@@ -178,13 +170,12 @@ class WSLCE2EContainerCreateTests
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
 
-        auto result = RunWslc(
-            std::format(
-                L"container run --name {} --volume \"{}:/data:ro\" {} cat /data/{}",
-                WslcContainerName,
-                hostDirectory.wstring(),
-                AlpineImage.NameAndTag(),
-                fileName));
+        auto result = RunWslc(std::format(
+            L"container run --name {} --volume \"{}:/data:ro\" {} cat /data/{}",
+            WslcContainerName,
+            hostDirectory.wstring(),
+            AlpineImage.NameAndTag(),
+            fileName));
         result.Verify({.Stdout = L"WSLC Volume Test", .Stderr = L"", .ExitCode = 0});
     }
 
@@ -192,13 +183,12 @@ class WSLCE2EContainerCreateTests
     {
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
-        auto result = RunWslc(
-            std::format(
-                L"container run --name {} --volume \"{}:/data\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
-                WslcContainerName,
-                hostDirectory.wstring(),
-                AlpineImage.NameAndTag(),
-                fileName));
+        auto result = RunWslc(std::format(
+            L"container run --name {} --volume \"{}:/data\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
+            WslcContainerName,
+            hostDirectory.wstring(),
+            AlpineImage.NameAndTag(),
+            fileName));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Read all file content
@@ -210,13 +200,12 @@ class WSLCE2EContainerCreateTests
     {
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
-        auto result = RunWslc(
-            std::format(
-                L"container run --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
-                WslcContainerName,
-                hostDirectory.wstring(),
-                AlpineImage.NameAndTag(),
-                fileName));
+        auto result = RunWslc(std::format(
+            L"container run --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
+            WslcContainerName,
+            hostDirectory.wstring(),
+            AlpineImage.NameAndTag(),
+            fileName));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Read all file content
@@ -230,13 +219,12 @@ class WSLCE2EContainerCreateTests
     {
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
-        auto result = RunWslc(
-            std::format(
-                L"container run --name {} --volume \"{}:/data:ro\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
-                WslcContainerName,
-                hostDirectory.wstring(),
-                AlpineImage.NameAndTag(),
-                fileName));
+        auto result = RunWslc(std::format(
+            L"container run --name {} --volume \"{}:/data:ro\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
+            WslcContainerName,
+            hostDirectory.wstring(),
+            AlpineImage.NameAndTag(),
+            fileName));
         auto errorMessage = std::format(L"sh: can't create /data/{}: Read-only file system\n", fileName);
         result.Verify({.Stdout = L"", .Stderr = errorMessage, .ExitCode = 1});
     }
@@ -248,17 +236,16 @@ class WSLCE2EContainerCreateTests
         auto fileName1 = VolumeTestFile1.filename().wstring();
         auto hostDirectory2 = VolumeTestFile2.parent_path();
         auto fileName2 = VolumeTestFile2.filename().wstring();
-        auto result = RunWslc(
-            std::format(
-                L"container run --name {} --volume \"{}:/data1:rw\" --volume \"{}:/data2:rw\" {} sh -c \"echo -n 'Test1' > "
-                L"/data1/{} && "
-                L"echo -n 'Test2' > /data2/{}\"",
-                WslcContainerName,
-                hostDirectory1.wstring(),
-                hostDirectory2.wstring(),
-                AlpineImage.NameAndTag(),
-                fileName1,
-                fileName2));
+        auto result = RunWslc(std::format(
+            L"container run --name {} --volume \"{}:/data1:rw\" --volume \"{}:/data2:rw\" {} sh -c \"echo -n 'Test1' > "
+            L"/data1/{} && "
+            L"echo -n 'Test2' > /data2/{}\"",
+            WslcContainerName,
+            hostDirectory1.wstring(),
+            hostDirectory2.wstring(),
+            AlpineImage.NameAndTag(),
+            fileName1,
+            fileName2));
 
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
@@ -298,24 +285,22 @@ class WSLCE2EContainerCreateTests
             VERIFY_IS_TRUE(out.good(), L"Failed to write to test file (host -> container test)");
         }
 
-        auto result = RunWslc(
-            std::format(
-                L"container run --rm --name {} --volume \"{}:/data:ro\" {} cat /data/reltest.txt",
-                WslcContainerName,
-                relativeDir,
-                AlpineImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container run --rm --name {} --volume \"{}:/data:ro\" {} cat /data/reltest.txt",
+            WslcContainerName,
+            relativeDir,
+            AlpineImage.NameAndTag()));
         result.Verify({.Stdout = L"WSLC Relative Path Test", .Stderr = L"", .ExitCode = 0});
 
         EnsureContainerDoesNotExist(WslcContainerName);
 
         // Write a file from the container and verify the host can read it back via the relative path mount.
-        result = RunWslc(
-            std::format(
-                L"container run --rm --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Relative Path Write Test' > "
-                L"/data/reltest.txt\"",
-                WslcContainerName,
-                relativeDir,
-                AlpineImage.NameAndTag()));
+        result = RunWslc(std::format(
+            L"container run --rm --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Relative Path Write Test' > "
+            L"/data/reltest.txt\"",
+            WslcContainerName,
+            relativeDir,
+            AlpineImage.NameAndTag()));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         std::ifstream in(testFile);
@@ -383,26 +368,22 @@ class WSLCE2EContainerCreateTests
         }
 
         {
-            auto result = RunWslc(
-                std::format(
-                    L"container run --name {} --volume C:\\hostPath:/containerPath:invalid_mode {}",
-                    WslcContainerName,
-                    AlpineImage.NameAndTag()));
+            auto result = RunWslc(std::format(
+                L"container run --name {} --volume C:\\hostPath:/containerPath:invalid_mode {}", WslcContainerName, AlpineImage.NameAndTag()));
             result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:invalid_mode'. Container path must be an absolute path (starting with '/'). Expected format: <host path | named volume>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
         {
-            auto result = RunWslc(
-                std::format(
-                    L"container run --name {} --volume C:\\hostPath:/containerPath:ro:extra {}", WslcContainerName, AlpineImage.NameAndTag()));
+            auto result = RunWslc(std::format(
+                L"container run --name {} --volume C:\\hostPath:/containerPath:ro:extra {}", WslcContainerName, AlpineImage.NameAndTag()));
             result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:ro:extra'. Container path must be an absolute path (starting with '/'). Expected format: <host path | named volume>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
         {
-            auto result = RunWslc(
-                std::format(L"container run --name {} --volume C:\\hostPath:/containerPath: {}", WslcContainerName, AlpineImage.NameAndTag()));
+            auto result = RunWslc(std::format(
+                L"container run --name {} --volume C:\\hostPath:/containerPath: {}", WslcContainerName, AlpineImage.NameAndTag()));
             result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:'. Container path cannot be empty. Expected format: <host path | named volume>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
@@ -488,8 +469,8 @@ class WSLCE2EContainerCreateTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         const auto& prompt = ">";
-        auto result = RunWslc(
-            std::format(L"container create -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto containerId = result.GetStdoutOneLine();
 
@@ -549,8 +530,8 @@ class WSLCE2EContainerCreateTests
 
         constexpr auto ExpectedExitCode = 37;
 
-        auto result = RunWslc(
-            std::format(L"container create --name {} {} sh -c \"echo lifecycle works; exit {}\"", WslcContainerName, AlpineImage.NameAndTag(), ExpectedExitCode));
+        auto result = RunWslc(std::format(
+            L"container create --name {} {} sh -c \"echo lifecycle works; exit {}\"", WslcContainerName, AlpineImage.NameAndTag(), ExpectedExitCode));
 
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
@@ -570,9 +551,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_UserOption_NameGroupRoot)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} -u root:root {} sh -c \"id -un; id -u; id -g\"", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} -u root:root {} sh -c \"id -un; id -u; id -g\"", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -592,12 +572,11 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --tmpfs /wslc-tmpfs {} sh -c \"echo -n 'tmpfs_test' > /wslc-tmpfs/data && cat "
-                L"/wslc-tmpfs/data\"",
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --tmpfs /wslc-tmpfs {} sh -c \"echo -n 'tmpfs_test' > /wslc-tmpfs/data && cat "
+            L"/wslc-tmpfs/data\"",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -606,13 +585,12 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs_With_Options)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --tmpfs /wslc-tmpfs:size=64k {} sh -c \"mount | grep -q ' on /wslc-tmpfs type tmpfs "
-                L"' "
-                L"&& echo mounted\"",
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --tmpfs /wslc-tmpfs:size=64k {} sh -c \"mount | grep -q ' on /wslc-tmpfs type tmpfs "
+            L"' "
+            L"&& echo mounted\"",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -621,13 +599,12 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs_Multiple_With_Options)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --tmpfs /wslc-tmpfs1:size=64k --tmpfs /wslc-tmpfs2:size=128k {} sh -c \"mount | "
-                L"grep -q "
-                L"' on /wslc-tmpfs1 type tmpfs ' && mount | grep -q ' on /wslc-tmpfs2 type tmpfs ' && echo mounted\"",
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --tmpfs /wslc-tmpfs1:size=64k --tmpfs /wslc-tmpfs2:size=128k {} sh -c \"mount | "
+            L"grep -q "
+            L"' on /wslc-tmpfs1 type tmpfs ' && mount | grep -q ' on /wslc-tmpfs2 type tmpfs ' && echo mounted\"",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -671,8 +648,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Hostname)
     {
-        auto result = RunWslc(
-            std::format(L"container create --name {} --hostname my-test-host {} hostname", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --hostname my-test-host {} hostname", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -681,8 +658,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Domainname)
     {
-        auto result = RunWslc(
-            std::format(L"container create --name {} --domainname my-test-domain {} dnsdomainname", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --domainname my-test-domain {} dnsdomainname", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -691,9 +668,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_DNS)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --dns 1.1.1.1 --dns 8.8.8.8 {} cat /etc/resolv.conf", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --dns 1.1.1.1 --dns 8.8.8.8 {} cat /etc/resolv.conf", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -704,11 +680,10 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_DNSSearch)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --dns-search example.com --dns-search test.local {} cat /etc/resolv.conf",
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --dns-search example.com --dns-search test.local {} cat /etc/resolv.conf",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -718,11 +693,10 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_DNSOption)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --dns-option ndots:5 --dns-option timeout:3 {} cat /etc/resolv.conf",
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --dns-option ndots:5 --dns-option timeout:3 {} cat /etc/resolv.conf",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -733,12 +707,11 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_StopSignal)
     {
         constexpr int ExpectedExitCode = 42;
-        auto result = RunWslc(
-            std::format(
-                LR"(container create --stop-signal SIGUSR1 --name {} {} bash -c "trap 'exit {}' SIGUSR1; while true; do sleep 1; done")",
-                WslcContainerName,
-                DebianImage.NameAndTag(),
-                ExpectedExitCode));
+        auto result = RunWslc(std::format(
+            LR"(container create --stop-signal SIGUSR1 --name {} {} bash -c "trap 'exit {}' SIGUSR1; while true; do sleep 1; done")",
+            WslcContainerName,
+            DebianImage.NameAndTag(),
+            ExpectedExitCode));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         const auto containerId = result.GetStdoutOneLine();
         VerifyContainerIsListed(containerId, L"created");
@@ -826,8 +799,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Network_HostMode_WithMultipleNetworks_Rejected)
     {
-        auto result = RunWslc(
-            std::format(L"container create --name {} --network bridge --network host {} true", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --network bridge --network host {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"host mode networking is not supported\r\n", .ExitCode = 1});
         VerifyContainerIsNotListed(WslcContainerName);
     }
@@ -838,8 +811,8 @@ class WSLCE2EContainerCreateTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
 
-        result = RunWslc(
-            std::format(L"container create --name {} --network {} {} true", WslcContainerName, TestNetworkName, DebianImage.NameAndTag()));
+        result = RunWslc(std::format(
+            L"container create --name {} --network {} {} true", WslcContainerName, TestNetworkName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto inspect = InspectContainer(WslcContainerName);
@@ -867,12 +840,8 @@ class WSLCE2EContainerCreateTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
 
-        result = RunWslc(
-            std::format(
-                L"container create --name {} --network {} --network-alias db {} true",
-                WslcContainerName,
-                TestNetworkName,
-                DebianImage.NameAndTag()));
+        result = RunWslc(std::format(
+            L"container create --name {} --network {} --network-alias db {} true", WslcContainerName, TestNetworkName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto inspect = InspectContainer(WslcContainerName);
@@ -895,8 +864,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_NetworkAlias_NoneMode_Rejected)
     {
-        auto result = RunWslc(
-            std::format(L"container create --network none --network-alias db --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --network none --network-alias db --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify(
             {.Stderr =
                  L"Network aliases require a user-defined network. Use --network to specify one.\r\nError code: E_INVALIDARG\r\n",
@@ -906,11 +875,10 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_NetworkAlias_MultipleNetworks_Rejected)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --network bridge --network bridge --network-alias db --name {} {} true",
-                WslcContainerName,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --network bridge --network bridge --network-alias db --name {} {} true",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"Network aliases cannot be specified when multiple networks are requested. Use a single --network argument.\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
         VerifyContainerIsNotListed(WslcContainerName);
     }
@@ -960,9 +928,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Ulimit)
     {
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --ulimit nofile=1024:2048 --ulimit nproc=512 {} true", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --ulimit nofile=1024:2048 --ulimit nproc=512 {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto inspect = InspectContainer(WslcContainerName);
@@ -1006,12 +973,8 @@ class WSLCE2EContainerCreateTests
         WriteTestFile(
             EnvTestFile1, {"WSLC_TEST_CREATE_ENV_FILE_A=create-env-file-a", "WSLC_TEST_CREATE_ENV_FILE_B=create-env-file-b"});
 
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --env-file {} {} env",
-                WslcContainerName,
-                EscapePath(EnvTestFile1.wstring()),
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --env-file {} {} env", WslcContainerName, EscapePath(EnvTestFile1.wstring()), DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -1023,8 +986,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_EnvFile_MissingFile)
     {
-        auto result = RunWslc(
-            std::format(L"container create --name {} --env-file ENV_FILE_NOT_FOUND {} env", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --env-file ENV_FILE_NOT_FOUND {} env", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify(
             {.Stderr = L"Environment file 'ENV_FILE_NOT_FOUND' cannot be opened for reading\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
         EnsureContainerDoesNotExist(WslcContainerName);
@@ -1034,12 +997,8 @@ class WSLCE2EContainerCreateTests
     {
         WriteTestFile(EnvTestFile1, {"WSLC_TEST_ENV_VALID=ok", "BAD KEY=value"});
 
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} --env-file {} {} env",
-                WslcContainerName,
-                EscapePath(EnvTestFile1.wstring()),
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} --env-file {} {} env", WslcContainerName, EscapePath(EnvTestFile1.wstring()), DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"Environment variable key 'BAD KEY' cannot contain whitespace\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
         EnsureContainerDoesNotExist(WslcContainerName);
     }
@@ -1047,13 +1006,8 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Publish_TCP)
     {
         // Port bindings only show up in inspect after start, so create then start before inspecting.
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} -p {}:{} {} sleep 5",
-                WslcContainerName,
-                HostTestPort1,
-                ContainerTestPort,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} -p {}:{} {} sleep 5", WslcContainerName, HostTestPort1, ContainerTestPort, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start {}", WslcContainerName));
@@ -1073,15 +1027,14 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Publish_MultipleMappings)
     {
         // Map two host ports to the same container port.
-        auto result = RunWslc(
-            std::format(
-                L"container create --name {} -p {}:{} -p {}:{} {} sleep 5",
-                WslcContainerName,
-                HostTestPort1,
-                ContainerTestPort,
-                HostTestPort2,
-                ContainerTestPort,
-                DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} -p {}:{} -p {}:{} {} sleep 5",
+            WslcContainerName,
+            HostTestPort1,
+            ContainerTestPort,
+            HostTestPort2,
+            ContainerTestPort,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start {}", WslcContainerName));
@@ -1116,8 +1069,8 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Publish_Ephemeral)
     {
         // -p <containerPort> (no host port) means the host picks a random port.
-        auto result = RunWslc(
-            std::format(L"container create --name {} -p {} {} sleep 5", WslcContainerName, ContainerTestPort, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --name {} -p {} {} sleep 5", WslcContainerName, ContainerTestPort, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start {}", WslcContainerName));

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -86,11 +86,16 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_InvalidImage)
     {
-        auto result = RunWslc(L"container create --name " + WslcContainerName + L" " + InvalidImage.NameAndTag());
+        auto session = OpenDefaultElevatedSession();
+
+        auto [registryContainer, registryAddress] = StartLocalRegistry(*session, "", "", 5000);
+        auto reference = std::format(L"{}/invalid-image:latest", registryAddress);
+
+        auto result = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, reference));
+
         std::wstringstream expectedError;
-        expectedError << L"Image '" << InvalidImage.NameAndTag() << L"' not found, pulling\r\n"
-                      << L"manifest for " << InvalidImage.NameAndTag()
-                      << L" not found: manifest unknown: manifest tagged by \"latest\" is not found\r\n"
+        expectedError << L"Image '" << reference << L"' not found, pulling\r\n"
+                      << L"manifest for " << reference << L" not found: manifest unknown: manifest tagged by \"latest\" is not found\r\n"
                       << L"Error code: WSLC_E_IMAGE_NOT_FOUND\r\n";
         result.Verify({.Stderr = expectedError.str(), .ExitCode = 1});
     }
@@ -115,8 +120,12 @@ class WSLCE2EContainerCreateTests
         VERIFY_IS_TRUE(DeleteFileW(cidFilePath.c_str()));
         auto deleteCidFile = wil::scope_exit([&]() { VERIFY_IS_TRUE(DeleteFileW(cidFilePath.c_str())); });
 
-        auto result = RunWslc(std::format(
-            L"container create --cidfile \"{}\" --name {} {}", EscapePath(cidFilePath.wstring()), WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --cidfile \"{}\" --name {} {}",
+                EscapePath(cidFilePath.wstring()),
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto containerId = result.GetStdoutOneLine();
@@ -129,8 +138,12 @@ class WSLCE2EContainerCreateTests
         const auto cidFilePath = wsl::windows::common::filesystem::GetTempFilename();
         auto deleteCidFile = wil::scope_exit([&]() { VERIFY_IS_TRUE(DeleteFileW(cidFilePath.c_str())); });
 
-        auto result = RunWslc(std::format(
-            L"container create --cidfile \"{}\" --name {} {}", EscapePath(cidFilePath.wstring()), WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --cidfile \"{}\" --name {} {}",
+                EscapePath(cidFilePath.wstring()),
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify(
             {.Stderr = std::format(L"CID file '{}' already exists\r\nError code: ERROR_FILE_EXISTS\r\n", EscapePath(cidFilePath.wstring())),
              .ExitCode = 1});
@@ -165,12 +178,13 @@ class WSLCE2EContainerCreateTests
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
 
-        auto result = RunWslc(std::format(
-            L"container run --name {} --volume \"{}:/data:ro\" {} cat /data/{}",
-            WslcContainerName,
-            hostDirectory.wstring(),
-            AlpineImage.NameAndTag(),
-            fileName));
+        auto result = RunWslc(
+            std::format(
+                L"container run --name {} --volume \"{}:/data:ro\" {} cat /data/{}",
+                WslcContainerName,
+                hostDirectory.wstring(),
+                AlpineImage.NameAndTag(),
+                fileName));
         result.Verify({.Stdout = L"WSLC Volume Test", .Stderr = L"", .ExitCode = 0});
     }
 
@@ -178,12 +192,13 @@ class WSLCE2EContainerCreateTests
     {
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
-        auto result = RunWslc(std::format(
-            L"container run --name {} --volume \"{}:/data\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
-            WslcContainerName,
-            hostDirectory.wstring(),
-            AlpineImage.NameAndTag(),
-            fileName));
+        auto result = RunWslc(
+            std::format(
+                L"container run --name {} --volume \"{}:/data\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
+                WslcContainerName,
+                hostDirectory.wstring(),
+                AlpineImage.NameAndTag(),
+                fileName));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Read all file content
@@ -195,12 +210,13 @@ class WSLCE2EContainerCreateTests
     {
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
-        auto result = RunWslc(std::format(
-            L"container run --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
-            WslcContainerName,
-            hostDirectory.wstring(),
-            AlpineImage.NameAndTag(),
-            fileName));
+        auto result = RunWslc(
+            std::format(
+                L"container run --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
+                WslcContainerName,
+                hostDirectory.wstring(),
+                AlpineImage.NameAndTag(),
+                fileName));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Read all file content
@@ -214,12 +230,13 @@ class WSLCE2EContainerCreateTests
     {
         auto hostDirectory = VolumeTestFile1.parent_path();
         auto fileName = VolumeTestFile1.filename().wstring();
-        auto result = RunWslc(std::format(
-            L"container run --name {} --volume \"{}:/data:ro\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
-            WslcContainerName,
-            hostDirectory.wstring(),
-            AlpineImage.NameAndTag(),
-            fileName));
+        auto result = RunWslc(
+            std::format(
+                L"container run --name {} --volume \"{}:/data:ro\" {} sh -c \"echo -n 'WSLC Volume Test' > /data/{}\"",
+                WslcContainerName,
+                hostDirectory.wstring(),
+                AlpineImage.NameAndTag(),
+                fileName));
         auto errorMessage = std::format(L"sh: can't create /data/{}: Read-only file system\n", fileName);
         result.Verify({.Stdout = L"", .Stderr = errorMessage, .ExitCode = 1});
     }
@@ -231,16 +248,17 @@ class WSLCE2EContainerCreateTests
         auto fileName1 = VolumeTestFile1.filename().wstring();
         auto hostDirectory2 = VolumeTestFile2.parent_path();
         auto fileName2 = VolumeTestFile2.filename().wstring();
-        auto result = RunWslc(std::format(
-            L"container run --name {} --volume \"{}:/data1:rw\" --volume \"{}:/data2:rw\" {} sh -c \"echo -n 'Test1' > "
-            L"/data1/{} && "
-            L"echo -n 'Test2' > /data2/{}\"",
-            WslcContainerName,
-            hostDirectory1.wstring(),
-            hostDirectory2.wstring(),
-            AlpineImage.NameAndTag(),
-            fileName1,
-            fileName2));
+        auto result = RunWslc(
+            std::format(
+                L"container run --name {} --volume \"{}:/data1:rw\" --volume \"{}:/data2:rw\" {} sh -c \"echo -n 'Test1' > "
+                L"/data1/{} && "
+                L"echo -n 'Test2' > /data2/{}\"",
+                WslcContainerName,
+                hostDirectory1.wstring(),
+                hostDirectory2.wstring(),
+                AlpineImage.NameAndTag(),
+                fileName1,
+                fileName2));
 
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
@@ -280,22 +298,24 @@ class WSLCE2EContainerCreateTests
             VERIFY_IS_TRUE(out.good(), L"Failed to write to test file (host -> container test)");
         }
 
-        auto result = RunWslc(std::format(
-            L"container run --rm --name {} --volume \"{}:/data:ro\" {} cat /data/reltest.txt",
-            WslcContainerName,
-            relativeDir,
-            AlpineImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container run --rm --name {} --volume \"{}:/data:ro\" {} cat /data/reltest.txt",
+                WslcContainerName,
+                relativeDir,
+                AlpineImage.NameAndTag()));
         result.Verify({.Stdout = L"WSLC Relative Path Test", .Stderr = L"", .ExitCode = 0});
 
         EnsureContainerDoesNotExist(WslcContainerName);
 
         // Write a file from the container and verify the host can read it back via the relative path mount.
-        result = RunWslc(std::format(
-            L"container run --rm --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Relative Path Write Test' > "
-            L"/data/reltest.txt\"",
-            WslcContainerName,
-            relativeDir,
-            AlpineImage.NameAndTag()));
+        result = RunWslc(
+            std::format(
+                L"container run --rm --name {} --volume \"{}:/data:rw\" {} sh -c \"echo -n 'WSLC Relative Path Write Test' > "
+                L"/data/reltest.txt\"",
+                WslcContainerName,
+                relativeDir,
+                AlpineImage.NameAndTag()));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         std::ifstream in(testFile);
@@ -363,22 +383,26 @@ class WSLCE2EContainerCreateTests
         }
 
         {
-            auto result = RunWslc(std::format(
-                L"container run --name {} --volume C:\\hostPath:/containerPath:invalid_mode {}", WslcContainerName, AlpineImage.NameAndTag()));
+            auto result = RunWslc(
+                std::format(
+                    L"container run --name {} --volume C:\\hostPath:/containerPath:invalid_mode {}",
+                    WslcContainerName,
+                    AlpineImage.NameAndTag()));
             result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:invalid_mode'. Container path must be an absolute path (starting with '/'). Expected format: <host path | named volume>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
         {
-            auto result = RunWslc(std::format(
-                L"container run --name {} --volume C:\\hostPath:/containerPath:ro:extra {}", WslcContainerName, AlpineImage.NameAndTag()));
+            auto result = RunWslc(
+                std::format(
+                    L"container run --name {} --volume C:\\hostPath:/containerPath:ro:extra {}", WslcContainerName, AlpineImage.NameAndTag()));
             result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:ro:extra'. Container path must be an absolute path (starting with '/'). Expected format: <host path | named volume>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
 
         {
-            auto result = RunWslc(std::format(
-                L"container run --name {} --volume C:\\hostPath:/containerPath: {}", WslcContainerName, AlpineImage.NameAndTag()));
+            auto result = RunWslc(
+                std::format(L"container run --name {} --volume C:\\hostPath:/containerPath: {}", WslcContainerName, AlpineImage.NameAndTag()));
             result.Verify({.Stderr = L"Invalid volume specifications: 'C:\\hostPath:/containerPath:'. Container path cannot be empty. Expected format: <host path | named volume>:<container path>[:mode]\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
             EnsureContainerDoesNotExist(WslcContainerName);
         }
@@ -464,8 +488,8 @@ class WSLCE2EContainerCreateTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         const auto& prompt = ">";
-        auto result = RunWslc(std::format(
-            L"container create -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto containerId = result.GetStdoutOneLine();
 
@@ -525,8 +549,8 @@ class WSLCE2EContainerCreateTests
 
         constexpr auto ExpectedExitCode = 37;
 
-        auto result = RunWslc(std::format(
-            L"container create --name {} {} sh -c \"echo lifecycle works; exit {}\"", WslcContainerName, AlpineImage.NameAndTag(), ExpectedExitCode));
+        auto result = RunWslc(
+            std::format(L"container create --name {} {} sh -c \"echo lifecycle works; exit {}\"", WslcContainerName, AlpineImage.NameAndTag(), ExpectedExitCode));
 
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
@@ -546,8 +570,9 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_UserOption_NameGroupRoot)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} -u root:root {} sh -c \"id -un; id -u; id -g\"", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} -u root:root {} sh -c \"id -un; id -u; id -g\"", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -567,11 +592,12 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --tmpfs /wslc-tmpfs {} sh -c \"echo -n 'tmpfs_test' > /wslc-tmpfs/data && cat "
-            L"/wslc-tmpfs/data\"",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --tmpfs /wslc-tmpfs {} sh -c \"echo -n 'tmpfs_test' > /wslc-tmpfs/data && cat "
+                L"/wslc-tmpfs/data\"",
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -580,11 +606,13 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs_With_Options)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --tmpfs /wslc-tmpfs:size=64k {} sh -c \"mount | grep -q ' on /wslc-tmpfs type tmpfs ' "
-            L"&& echo mounted\"",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --tmpfs /wslc-tmpfs:size=64k {} sh -c \"mount | grep -q ' on /wslc-tmpfs type tmpfs "
+                L"' "
+                L"&& echo mounted\"",
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -593,11 +621,13 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs_Multiple_With_Options)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --tmpfs /wslc-tmpfs1:size=64k --tmpfs /wslc-tmpfs2:size=128k {} sh -c \"mount | grep -q "
-            L"' on /wslc-tmpfs1 type tmpfs ' && mount | grep -q ' on /wslc-tmpfs2 type tmpfs ' && echo mounted\"",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --tmpfs /wslc-tmpfs1:size=64k --tmpfs /wslc-tmpfs2:size=128k {} sh -c \"mount | "
+                L"grep -q "
+                L"' on /wslc-tmpfs1 type tmpfs ' && mount | grep -q ' on /wslc-tmpfs2 type tmpfs ' && echo mounted\"",
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -641,8 +671,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Hostname)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --hostname my-test-host {} hostname", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} --hostname my-test-host {} hostname", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -651,8 +681,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Domainname)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --domainname my-test-domain {} dnsdomainname", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} --domainname my-test-domain {} dnsdomainname", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -661,8 +691,9 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_DNS)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --dns 1.1.1.1 --dns 8.8.8.8 {} cat /etc/resolv.conf", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --dns 1.1.1.1 --dns 8.8.8.8 {} cat /etc/resolv.conf", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -673,10 +704,11 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_DNSSearch)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --dns-search example.com --dns-search test.local {} cat /etc/resolv.conf",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --dns-search example.com --dns-search test.local {} cat /etc/resolv.conf",
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -686,10 +718,11 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_DNSOption)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --dns-option ndots:5 --dns-option timeout:3 {} cat /etc/resolv.conf",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --dns-option ndots:5 --dns-option timeout:3 {} cat /etc/resolv.conf",
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -700,11 +733,12 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_StopSignal)
     {
         constexpr int ExpectedExitCode = 42;
-        auto result = RunWslc(std::format(
-            LR"(container create --stop-signal SIGUSR1 --name {} {} bash -c "trap 'exit {}' SIGUSR1; while true; do sleep 1; done")",
-            WslcContainerName,
-            DebianImage.NameAndTag(),
-            ExpectedExitCode));
+        auto result = RunWslc(
+            std::format(
+                LR"(container create --stop-signal SIGUSR1 --name {} {} bash -c "trap 'exit {}' SIGUSR1; while true; do sleep 1; done")",
+                WslcContainerName,
+                DebianImage.NameAndTag(),
+                ExpectedExitCode));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         const auto containerId = result.GetStdoutOneLine();
         VerifyContainerIsListed(containerId, L"created");
@@ -792,8 +826,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Network_HostMode_WithMultipleNetworks_Rejected)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --network bridge --network host {} true", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} --network bridge --network host {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"host mode networking is not supported\r\n", .ExitCode = 1});
         VerifyContainerIsNotListed(WslcContainerName);
     }
@@ -804,8 +838,8 @@ class WSLCE2EContainerCreateTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
 
-        result = RunWslc(std::format(
-            L"container create --name {} --network {} {} true", WslcContainerName, TestNetworkName, DebianImage.NameAndTag()));
+        result = RunWslc(
+            std::format(L"container create --name {} --network {} {} true", WslcContainerName, TestNetworkName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto inspect = InspectContainer(WslcContainerName);
@@ -833,8 +867,12 @@ class WSLCE2EContainerCreateTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
 
-        result = RunWslc(std::format(
-            L"container create --name {} --network {} --network-alias db {} true", WslcContainerName, TestNetworkName, DebianImage.NameAndTag()));
+        result = RunWslc(
+            std::format(
+                L"container create --name {} --network {} --network-alias db {} true",
+                WslcContainerName,
+                TestNetworkName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto inspect = InspectContainer(WslcContainerName);
@@ -857,8 +895,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_NetworkAlias_NoneMode_Rejected)
     {
-        auto result = RunWslc(std::format(
-            L"container create --network none --network-alias db --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --network none --network-alias db --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify(
             {.Stderr =
                  L"Network aliases require a user-defined network. Use --network to specify one.\r\nError code: E_INVALIDARG\r\n",
@@ -868,10 +906,11 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_NetworkAlias_MultipleNetworks_Rejected)
     {
-        auto result = RunWslc(std::format(
-            L"container create --network bridge --network bridge --network-alias db --name {} {} true",
-            WslcContainerName,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --network bridge --network bridge --network-alias db --name {} {} true",
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"Network aliases cannot be specified when multiple networks are requested. Use a single --network argument.\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
         VerifyContainerIsNotListed(WslcContainerName);
     }
@@ -921,8 +960,9 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Ulimit)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --ulimit nofile=1024:2048 --ulimit nproc=512 {} true", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --ulimit nofile=1024:2048 --ulimit nproc=512 {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         const auto inspect = InspectContainer(WslcContainerName);
@@ -966,8 +1006,12 @@ class WSLCE2EContainerCreateTests
         WriteTestFile(
             EnvTestFile1, {"WSLC_TEST_CREATE_ENV_FILE_A=create-env-file-a", "WSLC_TEST_CREATE_ENV_FILE_B=create-env-file-b"});
 
-        auto result = RunWslc(std::format(
-            L"container create --name {} --env-file {} {} env", WslcContainerName, EscapePath(EnvTestFile1.wstring()), DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --env-file {} {} env",
+                WslcContainerName,
+                EscapePath(EnvTestFile1.wstring()),
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
@@ -979,8 +1023,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_EnvFile_MissingFile)
     {
-        auto result = RunWslc(std::format(
-            L"container create --name {} --env-file ENV_FILE_NOT_FOUND {} env", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} --env-file ENV_FILE_NOT_FOUND {} env", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify(
             {.Stderr = L"Environment file 'ENV_FILE_NOT_FOUND' cannot be opened for reading\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
         EnsureContainerDoesNotExist(WslcContainerName);
@@ -990,8 +1034,12 @@ class WSLCE2EContainerCreateTests
     {
         WriteTestFile(EnvTestFile1, {"WSLC_TEST_ENV_VALID=ok", "BAD KEY=value"});
 
-        auto result = RunWslc(std::format(
-            L"container create --name {} --env-file {} {} env", WslcContainerName, EscapePath(EnvTestFile1.wstring()), DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} --env-file {} {} env",
+                WslcContainerName,
+                EscapePath(EnvTestFile1.wstring()),
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"Environment variable key 'BAD KEY' cannot contain whitespace\r\nError code: E_INVALIDARG\r\n", .ExitCode = 1});
         EnsureContainerDoesNotExist(WslcContainerName);
     }
@@ -999,8 +1047,13 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Publish_TCP)
     {
         // Port bindings only show up in inspect after start, so create then start before inspecting.
-        auto result = RunWslc(std::format(
-            L"container create --name {} -p {}:{} {} sleep 5", WslcContainerName, HostTestPort1, ContainerTestPort, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} -p {}:{} {} sleep 5",
+                WslcContainerName,
+                HostTestPort1,
+                ContainerTestPort,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start {}", WslcContainerName));
@@ -1020,14 +1073,15 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Publish_MultipleMappings)
     {
         // Map two host ports to the same container port.
-        auto result = RunWslc(std::format(
-            L"container create --name {} -p {}:{} -p {}:{} {} sleep 5",
-            WslcContainerName,
-            HostTestPort1,
-            ContainerTestPort,
-            HostTestPort2,
-            ContainerTestPort,
-            DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create --name {} -p {}:{} -p {}:{} {} sleep 5",
+                WslcContainerName,
+                HostTestPort1,
+                ContainerTestPort,
+                HostTestPort2,
+                ContainerTestPort,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start {}", WslcContainerName));
@@ -1062,8 +1116,8 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Publish_Ephemeral)
     {
         // -p <containerPort> (no host port) means the host picks a random port.
-        auto result = RunWslc(std::format(
-            L"container create --name {} -p {} {} sleep 5", WslcContainerName, ContainerTestPort, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} -p {} {} sleep 5", WslcContainerName, ContainerTestPort, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start {}", WslcContainerName));

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -586,8 +586,7 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs_With_Options)
     {
         auto result = RunWslc(std::format(
-            L"container create --name {} --tmpfs /wslc-tmpfs:size=64k {} sh -c \"mount | grep -q ' on /wslc-tmpfs type tmpfs "
-            L"' "
+            L"container create --name {} --tmpfs /wslc-tmpfs:size=64k {} sh -c \"mount | grep -q ' on /wslc-tmpfs type tmpfs ' "
             L"&& echo mounted\"",
             WslcContainerName,
             DebianImage.NameAndTag()));
@@ -600,8 +599,7 @@ class WSLCE2EContainerCreateTests
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Tmpfs_Multiple_With_Options)
     {
         auto result = RunWslc(std::format(
-            L"container create --name {} --tmpfs /wslc-tmpfs1:size=64k --tmpfs /wslc-tmpfs2:size=128k {} sh -c \"mount | "
-            L"grep -q "
+            L"container create --name {} --tmpfs /wslc-tmpfs1:size=64k --tmpfs /wslc-tmpfs2:size=128k {} sh -c \"mount | grep -q "
             L"' on /wslc-tmpfs1 type tmpfs ' && mount | grep -q ' on /wslc-tmpfs2 type tmpfs ' && echo mounted\"",
             WslcContainerName,
             DebianImage.NameAndTag()));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change fixes a flaky test (WSLCE2E_Container_Create_InvalidImage), which actually calls to the registry and therefore fails once we hit the API limit. 

This change solves the issue by using a local registry

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
