### PR TITLE
fix(wslc): early boot dmesg collection on arm64

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -165,7 +165,7 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
         if constexpr (!wsl::shared::Arm64)
         {
             kernelCmdLine += L" earlycon=uart8250,io,0x3f8,115200";
-        }   
+        }
         else
         {
             kernelCmdLine += L" earlycon=pl011,0xeffec000,115200";

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -162,7 +162,15 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
     if (FeatureEnabled(WslcFeatureFlagsEarlyBootDmesg))
     {
-        kernelCmdLine += L" earlycon=uart8250,io,0x3f8,115200";
+        if constexpr (!wsl::shared::Arm64)
+        {
+            kernelCmdLine += L" earlycon=uart8250,io,0x3f8,115200";
+        }   
+        else
+        {
+            kernelCmdLine += L" earlycon=pl011,0xeffec000,115200";
+        }
+
         vmSettings.Devices.ComPorts["0"] = hcs::ComPort{m_dmesgCollector->EarlyConsoleName()};
     }
 


### PR DESCRIPTION
The wrong kernel command line arguments are passed when the `EarlyBootDmesg` feature is enabled in WSLC. This causes a hang on VM boot. 