### PR TITLE
Fix use-after-free in WSLCContainerImpl exec-process teardown

### DIFF
--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -2090,7 +2090,6 @@ void WSLCContainerImpl::UnmapPorts()
 __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::ReleaseProcesses()
 {
     // Snapshot under the lock, then notify outside it, pinning each control via lock() first
-    // (avoids the use after free, and avoids calling back under m_processesLock).
     decltype(m_processes) processes;
     {
         std::lock_guard processesLock{m_processesLock};

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -588,7 +588,10 @@ WSLCContainerImpl::~WSLCContainerImpl()
 
     for (auto& process : processes)
     {
-        process->OnContainerReleased();
+        if (auto control = process.lock())
+        {
+            control->OnContainerReleased();
+        }
     }
 
     m_containerEvents.Reset();
@@ -601,16 +604,6 @@ WSLCContainerImpl::~WSLCContainerImpl()
         auto lock = m_lock.lock_exclusive();
         wrapper = ReleaseResources();
     }
-}
-
-void WSLCContainerImpl::OnProcessReleased(DockerExecProcessControl* process) noexcept
-{
-    std::lock_guard processesLock{m_processesLock};
-
-    auto remove = std::ranges::remove_if(m_processes, [process](const auto* e) { return e == process; });
-    WI_ASSERT(remove.size() == 1);
-
-    m_processes.erase(remove.begin(), remove.end());
 }
 
 void WSLCContainerImpl::SetExitCode(int ExitCode) noexcept
@@ -1225,13 +1218,15 @@ void WSLCContainerImpl::Exec(const WSLCProcessOptions* Options, const WSLCProces
             io = CreateRelayedProcessIO(std::move(stream), Options->Flags);
         }
 
-        auto control = std::make_unique<DockerExecProcessControl>(*this, result.Id, m_dockerClient, m_eventTracker);
+        auto control = std::make_shared<DockerExecProcessControl>(*this, result.Id, m_dockerClient, m_eventTracker);
 
         {
             std::lock_guard processesLock{m_processesLock};
 
-            // Store a non owning reference to the process.
-            m_processes.push_back(control.get());
+            // Drop entries for execs that have since been released, then store a non-owning weak
+            // reference. The owning shared_ptr is moved into the COM WSLCProcess returned below.
+            std::erase_if(m_processes, [](const auto& weak) { return weak.expired(); });
+            m_processes.push_back(control);
         }
 
         // Poll for the exec'd process to either be running, or failed.
@@ -2094,16 +2089,23 @@ void WSLCContainerImpl::UnmapPorts()
 
 __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::ReleaseProcesses()
 {
-    std::lock_guard processesLock{m_processesLock};
+    // Snapshot under the lock, then notify outside it, pinning each control via lock() first
+    // (avoids the use after free, and avoids calling back under m_processesLock).
+    decltype(m_processes) processes;
+    {
+        std::lock_guard processesLock{m_processesLock};
+        processes = std::exchange(m_processes, {});
+    }
 
     // Notify all processes that the container has exited.
     // The exec callback isn't always sent to execed processes, so do this to avoid 'stuck' processes.
-    for (auto& process : m_processes)
+    for (auto& process : processes)
     {
-        process->OnContainerReleased();
+        if (auto control = process.lock())
+        {
+            control->OnContainerReleased();
+        }
     }
-
-    m_processes.clear();
 }
 
 __requires_exclusive_lock_held(m_lock) void WSLCContainerImpl::ReleaseRuntimeResources()

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -119,8 +119,6 @@ public:
 
     __requires_lock_held(m_lock) void Transition(WSLCContainerState State, std::optional<std::uint64_t> stateChangedAt = std::nullopt) noexcept;
 
-    void OnProcessReleased(DockerExecProcessControl* process) noexcept;
-
     const std::string& ID() const noexcept;
 
     // Returns the container flags used to decide whether to
@@ -186,7 +184,7 @@ private:
     WSLCProcessFlags m_initProcessFlags{};
     WSLCContainerFlags m_containerFlags{};
     mutable std::mutex m_processesLock;
-    __guarded_by(m_processesLock) std::vector<DockerExecProcessControl*> m_processes;
+    __guarded_by(m_processesLock) std::vector<std::weak_ptr<DockerExecProcessControl>> m_processes;
     __guarded_by(m_processesLock) Microsoft::WRL::ComPtr<IWSLCProcess> m_initProcess;
     __guarded_by(m_processesLock) DockerContainerProcessControl* m_initProcessControl = nullptr;
 

--- a/src/windows/wslcsession/WSLCProcessControl.cpp
+++ b/src/windows/wslcsession/WSLCProcessControl.cpp
@@ -116,11 +116,6 @@ DockerExecProcessControl::DockerExecProcessControl(
 {
 }
 
-DockerExecProcessControl::~DockerExecProcessControl()
-{
-    // The container holds only a weak reference to this control.
-}
-
 int DockerExecProcessControl::GetPid() const
 {
     std::lock_guard lock{m_lock};

--- a/src/windows/wslcsession/WSLCProcessControl.cpp
+++ b/src/windows/wslcsession/WSLCProcessControl.cpp
@@ -118,11 +118,7 @@ DockerExecProcessControl::DockerExecProcessControl(
 
 DockerExecProcessControl::~DockerExecProcessControl()
 {
-    std::lock_guard lock{m_lock};
-    if (m_container != nullptr)
-    {
-        m_container->OnProcessReleased(this);
-    }
+    // The container holds only a weak reference to this control.
 }
 
 int DockerExecProcessControl::GetPid() const

--- a/src/windows/wslcsession/WSLCProcessControl.h
+++ b/src/windows/wslcsession/WSLCProcessControl.h
@@ -63,7 +63,6 @@ class DockerExecProcessControl : public WSLCProcessControl
 {
 public:
     DockerExecProcessControl(WSLCContainerImpl& Container, const std::string& Id, DockerHTTPClient& DockerClient, DockerEventTracker& EventTracker);
-    ~DockerExecProcessControl();
     void Signal(int Signal) override;
     void ResizeTty(ULONG Rows, ULONG Columns) override;
     int GetPid() const override;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Change m_processes to use weak pointers instead of raw pointers. Use lock() to pin on use.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Existing tests