### PR TITLE
Display output for teardown commands

### DIFF
--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -360,6 +360,7 @@ void RemoveContainers(CLIExecutionContext& context)
     for (const auto& id : containerIds)
     {
         ContainerService::Delete(session, WideToMultiByte(id), force);
+        PrintMessage(id);
     }
 }
 
@@ -750,6 +751,7 @@ void StopContainers(CLIExecutionContext& context)
     for (const auto& id : containersToStop)
     {
         ContainerService::Stop(context.Data.Get<Data::Session>(), WideToMultiByte(id), options);
+        PrintMessage(id);
     }
 }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -75,7 +75,7 @@ class WSLCE2EContainerRemoveTests
 
         // Delete the container
         result = RunWslc(std::format(L"container remove {}", WslcContainerName));
-        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n", WslcContainerName), .Stderr = L"", .ExitCode = 0});
 
         // Verify the container is no longer listed
         VerifyContainerIsNotListed(WslcContainerName);
@@ -93,7 +93,7 @@ class WSLCE2EContainerRemoveTests
         VerifyContainerIsListed(containerId, L"created");
 
         result = RunWslc(std::format(L"container remove {}", containerId));
-        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n", containerId), .Stderr = L"", .ExitCode = 0});
 
         VerifyContainerIsNotListed(containerId);
         VerifyContainerIsNotListed(WslcContainerName);
@@ -123,7 +123,7 @@ class WSLCE2EContainerRemoveTests
 
         // Removing with force should succeed
         result = RunWslc(std::format(L"container remove --force {}", containerId));
-        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n", containerId), .Stderr = L"", .ExitCode = 0});
 
         VerifyContainerIsNotListed(containerId);
         VerifyContainerIsNotListed(WslcContainerName);
@@ -148,7 +148,7 @@ class WSLCE2EContainerRemoveTests
         VerifyContainerIsListed(containerId2, L"created");
 
         result = RunWslc(std::format(L"container remove {} {}", containerId1, containerId2));
-        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n{}\r\n", containerId1, containerId2), .Stderr = L"", .ExitCode = 0});
 
         VerifyContainerIsNotListed(containerId1);
         VerifyContainerIsNotListed(containerId2);

--- a/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
@@ -79,7 +79,7 @@ class WSLCE2EContainerStopTests
 
         // Stop the container
         result = RunWslc(std::format(L"container stop {} -t 0", containerId));
-        result.Verify({.Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n", containerId), .Stderr = L"", .ExitCode = 0});
 
         // Verify the container is no longer running
         VerifyContainerIsListed(containerId, L"exited");
@@ -98,7 +98,7 @@ class WSLCE2EContainerStopTests
 
         // Stop by container name
         result = RunWslc(std::format(L"container stop {} -t 0", WslcContainerName));
-        result.Verify({.Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n", WslcContainerName), .Stderr = L"", .ExitCode = 0});
 
         // Verify container is no longer running
         VerifyContainerIsListed(containerId, L"exited");
@@ -153,7 +153,7 @@ class WSLCE2EContainerStopTests
 
         // Stop only the first container
         result = RunWslc(std::format(L"container stop {} -t 0", firstContainerId));
-        result.Verify({.Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n", firstContainerId), .Stderr = L"", .ExitCode = 0});
 
         // Verify first exited, second still running
         VerifyContainerIsListed(firstContainerId, L"exited");
@@ -173,7 +173,7 @@ class WSLCE2EContainerStopTests
 
         // Stop the container using signal name
         result = RunWslc(std::format(L"container stop {} -s SIGKILL -t 0", containerId));
-        result.Verify({.Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = std::format(L"{}\r\n", containerId), .Stderr = L"", .ExitCode = 0});
 
         // Verify the container is no longer running
         VerifyContainerIsListed(containerId, L"exited");

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -351,7 +351,7 @@ void EnsureImageContainersAreDeleted(const TestImage& image)
         if (container.Image.find(nameAndTag) != std::string::npos)
         {
             auto result = RunWslc(std::format(L"container remove --force {}", container.Id));
-            result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+            result.Verify({.Stdout = std::format(L"{}\r\n", container.Id), .Stderr = L"", .ExitCode = 0});
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- https://task.ms/62483515

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
