### PR TITLE
Fix wslc network create default driver handling when --driver is not specified

### DIFF
--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -709,7 +709,7 @@ typedef struct _WSLCVolumeInformation
 typedef struct _WSLCNetworkOptions
 {
     LPCSTR Name;
-    LPCSTR Driver;
+    [unique] LPCSTR Driver;
     [unique, size_is(DriverOptsCount)] const WSLCDriverOption* DriverOpts;
     ULONG DriverOptsCount;
     [unique, size_is(LabelsCount)] const WSLCLabel* Labels;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2333,7 +2333,7 @@ try
     RETURN_HR_IF_NULL(E_POINTER, Options->Name);
 
     std::string name = Options->Name;
-    std::string driver = (Options->Driver != nullptr && Options->Driver[0] != '\0') ? Options->Driver : WSLCBridgeNetworkDriver;
+    std::string driver = (Options->Driver != nullptr) ? Options->Driver : WSLCBridgeNetworkDriver;
 
     ValidateName(name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
 

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2331,10 +2331,9 @@ try
 
     RETURN_HR_IF_NULL(E_POINTER, Options);
     RETURN_HR_IF_NULL(E_POINTER, Options->Name);
-    RETURN_HR_IF_NULL(E_POINTER, Options->Driver);
 
     std::string name = Options->Name;
-    std::string driver = Options->Driver;
+    std::string driver = (Options->Driver != nullptr && Options->Driver[0] != '\0') ? Options->Driver : WSLCBridgeNetworkDriver;
 
     ValidateName(name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5084,7 +5084,7 @@ class WSLCTests
         options.DriverOpts = nullptr;
         options.DriverOptsCount = 0;
 
-        for (const char* driver : {"overlay", "Bridge"})
+        for (const char* driver : {"overlay", "Bridge", ""})
         {
             options.Driver = driver;
             VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateNetwork(&options, nullptr));
@@ -5096,26 +5096,23 @@ class WSLCTests
     {
         const std::string networkName = "default-driver-net";
 
-        for (const char* driver : {static_cast<const char*>(nullptr), ""})
-        {
-            LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
 
-            WSLCNetworkOptions options{};
-            options.Name = networkName.c_str();
-            options.Driver = driver;
-            options.DriverOpts = nullptr;
-            options.DriverOptsCount = 0;
+        WSLCNetworkOptions options{};
+        options.Name = networkName.c_str();
+        options.Driver = nullptr;
+        options.DriverOpts = nullptr;
+        options.DriverOptsCount = 0;
 
-            auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
 
-            VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options, nullptr));
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options, nullptr));
 
-            wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-            VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(networks.addressof(), networks.size_address<ULONG>()));
-            VERIFY_ARE_EQUAL(1u, networks.size());
-            VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
-            VERIFY_ARE_EQUAL(std::string("bridge"), std::string(networks[0].Driver));
-        }
+        wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
+        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(networks.addressof(), networks.size_address<ULONG>()));
+        VERIFY_ARE_EQUAL(1u, networks.size());
+        VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
+        VERIFY_ARE_EQUAL(std::string("bridge"), std::string(networks[0].Driver));
     }
 
     WSLC_TEST_METHOD(NetworkCreateReservedNameTest)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5084,11 +5084,37 @@ class WSLCTests
         options.DriverOpts = nullptr;
         options.DriverOptsCount = 0;
 
-        for (const char* driver : {"overlay", "Bridge", ""})
+        for (const char* driver : {"overlay", "Bridge"})
         {
             options.Driver = driver;
             VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateNetwork(&options, nullptr));
             ValidateCOMErrorMessageContains(L"Unsupported network driver:");
+        }
+    }
+
+    WSLC_TEST_METHOD(NetworkCreateDefaultDriverTest)
+    {
+        const std::string networkName = "default-driver-net";
+
+        for (const char* driver : {static_cast<const char*>(nullptr), ""})
+        {
+            LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+            WSLCNetworkOptions options{};
+            options.Name = networkName.c_str();
+            options.Driver = driver;
+            options.DriverOpts = nullptr;
+            options.DriverOptsCount = 0;
+
+            auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+            VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options, nullptr));
+
+            wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
+            VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(networks.addressof(), networks.size_address<ULONG>()));
+            VERIFY_ARE_EQUAL(1u, networks.size());
+            VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
+            VERIFY_ARE_EQUAL(std::string("bridge"), std::string(networks[0].Driver));
         }
     }
 

--- a/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
@@ -49,9 +49,6 @@ class WSLCE2ENetworkCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Network_Create_DefaultDriver_Success)
     {
-        // TODO: http://task.ms/62564313
-        SKIP_TEST_UNSTABLE();
-
         auto result = RunWslc(std::format(L"network create {}", TestNetworkName));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         VERIFY_ARE_EQUAL(TestNetworkName, result.GetStdoutOneLine());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
his PR fixes wslc network create <name> failing with Invalid pointer (0x80004003) when --driver is not provided.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
What changed:
- Made WSLCNetworkOptions.Driver nullable in IDL ([unique] LPCSTR Driver).
- Updated WSLCSession::CreateNetwork to default to "bridge" when driver is null or empty.
- Updated tests:
  - NetworkCreateInvalidDriverTest no longer treats empty driver as invalid.
  - Added NetworkCreateDefaultDriverTest for null/empty driver default behavior.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
