### PR TITLE
Improve registry enumeration performance

### DIFF
--- a/src/windows/common/registry.cpp
+++ b/src/windows/common/registry.cpp
@@ -321,7 +321,13 @@ wil::unique_hkey wsl::windows::common::registry::OpenOrCreateLxssDiskMountsKey(_
     return CreateKey(HKEY_LOCAL_MACHINE, path.c_str(), KEY_ALL_ACCESS, nullptr, REG_OPTION_VOLATILE);
 }
 
-void wsl::windows::common::registry::QueryInfo(_In_ HKEY Key, _In_opt_ DWORD* MaxSubKeySize, _In_opt_ DWORD* MaxValueNameSize, _In_opt_ DWORD* MaxValueDataSize, _In_opt_ DWORD* SubKeyCount, _In_opt_ DWORD* ValueCount)
+void wsl::windows::common::registry::QueryInfo(
+    _In_ HKEY Key,
+    _In_opt_ DWORD* MaxSubKeySize,
+    _In_opt_ DWORD* MaxValueNameSize,
+    _In_opt_ DWORD* MaxValueDataSize,
+    _Out_opt_ DWORD* SubKeyCount,
+    _Out_opt_ DWORD* ValueCount)
 {
     const auto error = (RegQueryInfoKeyW(
         Key, nullptr, nullptr, nullptr, SubKeyCount, MaxSubKeySize, nullptr, ValueCount, MaxValueNameSize, MaxValueDataSize, nullptr, nullptr));

--- a/src/windows/common/registry.cpp
+++ b/src/windows/common/registry.cpp
@@ -76,12 +76,14 @@ void ReportErrorIfFailed(_In_ LSTATUS Error, _In_ HKEY Key, _In_opt_ LPCWSTR Sub
     auto path = GetKeyPath(Key);
     if (Subkey != nullptr)
     {
-        path += L"\\" + std::wstring(Subkey);
+        path += L'\\';
+        path += Subkey;
     }
 
     if (Value != nullptr)
     {
-        path += L"\\" + std::wstring(Value);
+        path += L'\\';
+        path += Value;
     }
 
     if (wsl::windows::common::ExecutionContext::ShouldCollectErrorMessage())
@@ -174,6 +176,9 @@ std::vector<std::pair<GUID, std::wstring>> wsl::windows::common::registry::EnumG
     // Iterate through the provided keys and return a list of all sub-keys that are GUIDs.
     WCHAR buffer[39];
     std::vector<std::pair<GUID, std::wstring>> subKeys;
+    DWORD subKeyCount = 0;
+    QueryInfo(Key, nullptr, nullptr, nullptr, &subKeyCount);
+    subKeys.reserve(subKeyCount);
     DWORD index = 0;
     for (;;)
     {
@@ -198,7 +203,7 @@ std::vector<std::pair<GUID, std::wstring>> wsl::windows::common::registry::EnumG
             continue;
         }
 
-        subKeys.emplace_back(std::make_pair(guid.value(), std::wstring(buffer)));
+        subKeys.emplace_back(guid.value(), std::wstring(buffer));
     }
 
     return subKeys;
@@ -208,7 +213,9 @@ std::vector<std::pair<std::wstring, DWORD>> wsl::windows::common::registry::Enum
 {
     std::vector<std::pair<std::wstring, DWORD>> values;
     DWORD maxValueNameSize = 0;
-    QueryInfo(Key, nullptr, &maxValueNameSize);
+    DWORD valueCount = 0;
+    QueryInfo(Key, nullptr, &maxValueNameSize, nullptr, nullptr, &valueCount);
+    values.reserve(valueCount);
 
     for (DWORD Index = 0;; Index++)
     {
@@ -314,10 +321,10 @@ wil::unique_hkey wsl::windows::common::registry::OpenOrCreateLxssDiskMountsKey(_
     return CreateKey(HKEY_LOCAL_MACHINE, path.c_str(), KEY_ALL_ACCESS, nullptr, REG_OPTION_VOLATILE);
 }
 
-void wsl::windows::common::registry::QueryInfo(_In_ HKEY Key, _In_opt_ DWORD* MaxSubKeySize, _In_opt_ DWORD* MaxValueNameSize, _In_opt_ DWORD* MaxValueDataSize)
+void wsl::windows::common::registry::QueryInfo(_In_ HKEY Key, _In_opt_ DWORD* MaxSubKeySize, _In_opt_ DWORD* MaxValueNameSize, _In_opt_ DWORD* MaxValueDataSize, _In_opt_ DWORD* SubKeyCount, _In_opt_ DWORD* ValueCount)
 {
     const auto error = (RegQueryInfoKeyW(
-        Key, nullptr, nullptr, nullptr, nullptr, MaxSubKeySize, nullptr, nullptr, MaxValueNameSize, MaxValueDataSize, nullptr, nullptr));
+        Key, nullptr, nullptr, nullptr, SubKeyCount, MaxSubKeySize, nullptr, ValueCount, MaxValueNameSize, MaxValueDataSize, nullptr, nullptr));
 
     ReportErrorIfFailed(error, Key, nullptr, nullptr);
 }

--- a/src/windows/common/registry.hpp
+++ b/src/windows/common/registry.hpp
@@ -58,8 +58,8 @@ void QueryInfo(
     _In_opt_ DWORD* MaxSubKeySize = nullptr,
     _In_opt_ DWORD* MaxValueNameSize = nullptr,
     _In_opt_ DWORD* MaxValueDataSize = nullptr,
-    _In_opt_ DWORD* SubKeyCount = nullptr,
-    _In_opt_ DWORD* ValueCount = nullptr);
+    _Out_opt_ DWORD* SubKeyCount = nullptr,
+    _Out_opt_ DWORD* ValueCount = nullptr);
 
 DWORD
 ReadDword(_In_ HKEY Key, _In_opt_ LPCWSTR KeyName, _In_opt_ LPCWSTR ValueName, _In_ DWORD DefaultValue);

--- a/src/windows/common/registry.hpp
+++ b/src/windows/common/registry.hpp
@@ -53,7 +53,13 @@ wil::unique_hkey OpenLxssUserKey();
 
 wil::unique_hkey OpenOrCreateLxssDiskMountsKey(_In_ PSID UserSid);
 
-void QueryInfo(_In_ HKEY Key, _In_opt_ DWORD* MaxSubKeySize = nullptr, _In_opt_ DWORD* MaxValueNameSize = nullptr, _In_opt_ DWORD* MaxValueDataSize = nullptr);
+void QueryInfo(
+    _In_ HKEY Key,
+    _In_opt_ DWORD* MaxSubKeySize = nullptr,
+    _In_opt_ DWORD* MaxValueNameSize = nullptr,
+    _In_opt_ DWORD* MaxValueDataSize = nullptr,
+    _In_opt_ DWORD* SubKeyCount = nullptr,
+    _In_opt_ DWORD* ValueCount = nullptr);
 
 DWORD
 ReadDword(_In_ HKEY Key, _In_opt_ LPCWSTR KeyName, _In_opt_ LPCWSTR ValueName, _In_ DWORD DefaultValue);


### PR DESCRIPTION
Registry enumeration functions (`EnumGuidKeys`, `EnumValues`) are on the critical path for distro listing (`wsl -l`), plugin loading, and user session initialization, yet they were growing their result vectors without pre-allocating capacity. This PR eliminates that overhead with a small, backward-compatible extension to `QueryInfo`.

## Approach

`RegQueryInfoKeyW` already returns subkey and value counts -- `QueryInfo` just wasn't exposing them. By adding two optional out-parameters (`SubKeyCount`, `ValueCount`) with `nullptr` defaults, existing callers are unaffected while enumeration functions can now `reserve()` upfront.

With that in place, the PR makes four targeted fixes:

- **`EnumGuidKeys`**: queries subkey count and calls `reserve()` before the enumeration loop; also replaces `emplace_back(std::make_pair(...))` with direct `emplace_back(...)` to avoid a redundant temporary pair.
- **`EnumValues`**: queries value count and calls `reserve()` before the enumeration loop.
- **`ReportErrorIfFailed`**: replaces `L"\\" + std::wstring(Subkey)` concatenation (which heap-allocates a throwaway `wstring`) with two direct `+=` appends (`L'\\'` then the raw `LPCWSTR`).

## Impact

For a system with N installed distros, `EnumGuidKeys` previously performed O(log N) reallocations; now it performs zero. The same applies to `EnumValues` during plugin registry scanning. The string-concat fix in `ReportErrorIfFailed` removes two unnecessary heap allocations per error path invocation.