### PR TITLE
CLI: Address review feedback for environment options

### DIFF
--- a/src/windows/wslc/core/EnvironmentOptions.cpp
+++ b/src/windows/wslc/core/EnvironmentOptions.cpp
@@ -29,7 +29,7 @@ namespace {
 
 } // namespace
 
-void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs)
+void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs) noexcept
 try
 {
     for (const auto& arg : definedArgs)

--- a/src/windows/wslc/core/EnvironmentOptions.cpp
+++ b/src/windows/wslc/core/EnvironmentOptions.cpp
@@ -14,25 +14,22 @@ namespace wsl::windows::wslc {
 namespace {
 
     // nullopt iff the variable is not defined; engaged (possibly empty) otherwise.
-    std::optional<std::wstring> ReadEnv(const wchar_t* name) noexcept
-    try
+    std::optional<std::wstring> ReadEnv(const wchar_t* name)
     {
         std::wstring value;
         const HRESULT hr = wil::GetEnvironmentVariableW(name, value);
-        if (FAILED(hr))
+        if (hr == HRESULT_FROM_WIN32(ERROR_ENVVAR_NOT_FOUND))
         {
             return std::nullopt;
         }
+
+        THROW_IF_FAILED(hr);
         return value;
-    }
-    catch (...)
-    {
-        return std::nullopt;
     }
 
 } // namespace
 
-void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs) noexcept
+void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs)
 try
 {
     for (const auto& arg : definedArgs)
@@ -69,11 +66,6 @@ try
         }
     }
 }
-catch (...)
-{
-    // Must not throw: runs before NO_COLOR is applied, so a throw could
-    // surface as colored error output from the parser's error path.
-    LOG_CAUGHT_EXCEPTION();
-}
+CATCH_LOG()
 
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/core/EnvironmentOptions.h
+++ b/src/windows/wslc/core/EnvironmentOptions.h
@@ -35,6 +35,6 @@ constexpr EnvBinding c_envBindings[] = {
 
 // Populates target for any ArgType in definedArgs not already set.
 // Never throws on user input or environment state.
-void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs) noexcept;
+void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs);
 
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/core/EnvironmentOptions.h
+++ b/src/windows/wslc/core/EnvironmentOptions.h
@@ -35,6 +35,6 @@ constexpr EnvBinding c_envBindings[] = {
 
 // Populates target for any ArgType in definedArgs not already set.
 // Never throws on user input or environment state.
-void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs);
+void ApplyEnvironmentOptions(argument::ArgMap& target, const std::vector<Argument>& definedArgs) noexcept;
 
 } // namespace wsl::windows::wslc

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2520,10 +2520,12 @@ void Trim(std::wstring& string)
 static std::optional<std::wstring> CaptureEnvValue(const std::wstring& Name)
 {
     std::wstring value;
-    if (FAILED(wil::GetEnvironmentVariableW(Name.c_str(), value)))
+    HRESULT hr = wil::GetEnvironmentVariableW(Name.c_str(), value);
+    if (hr == HRESULT_FROM_WIN32(ERROR_ENVVAR_NOT_FOUND))
     {
         return std::nullopt;
     }
+    THROW_IF_FAILED(hr);
     return value;
 }
 

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2517,12 +2517,38 @@ void Trim(std::wstring& string)
     std::erase_if(string, [](auto c) { return !isalnum(c); });
 }
 
-ScopedEnvVariable::ScopedEnvVariable(const std::wstring& Name, const std::wstring& Value) : m_name(Name)
+static std::optional<std::wstring> CaptureEnvValue(const std::wstring& Name)
+{
+    std::wstring value;
+    if (FAILED(wil::GetEnvironmentVariableW(Name.c_str(), value)))
+    {
+        return std::nullopt;
+    }
+    return value;
+}
+
+ScopedEnvVariable::ScopedEnvVariable(const std::wstring& Name) : m_name(Name), m_originalValue(CaptureEnvValue(Name))
+{
+    VERIFY_IS_TRUE(SetEnvironmentVariable(Name.c_str(), nullptr));
+}
+
+ScopedEnvVariable::ScopedEnvVariable(const std::wstring& Name, const std::wstring& Value) :
+    m_name(Name), m_originalValue(CaptureEnvValue(Name))
 {
     VERIFY_IS_TRUE(SetEnvironmentVariable(Name.c_str(), Value.c_str()));
 }
 
 ScopedEnvVariable::~ScopedEnvVariable()
+{
+    VERIFY_IS_TRUE(SetEnvironmentVariable(m_name.c_str(), m_originalValue.has_value() ? m_originalValue->c_str() : nullptr));
+}
+
+void ScopedEnvVariable::Set(const std::wstring& Value)
+{
+    VERIFY_IS_TRUE(SetEnvironmentVariable(m_name.c_str(), Value.c_str()));
+}
+
+void ScopedEnvVariable::Clear()
 {
     VERIFY_IS_TRUE(SetEnvironmentVariable(m_name.c_str(), nullptr));
 }

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2531,28 +2531,28 @@ static std::optional<std::wstring> CaptureEnvValue(const std::wstring& Name)
 
 ScopedEnvVariable::ScopedEnvVariable(const std::wstring& Name) : m_name(Name), m_originalValue(CaptureEnvValue(Name))
 {
-    VERIFY_IS_TRUE(SetEnvironmentVariable(Name.c_str(), nullptr));
+    VERIFY_IS_TRUE(SetEnvironmentVariableW(Name.c_str(), nullptr));
 }
 
 ScopedEnvVariable::ScopedEnvVariable(const std::wstring& Name, const std::wstring& Value) :
     m_name(Name), m_originalValue(CaptureEnvValue(Name))
 {
-    VERIFY_IS_TRUE(SetEnvironmentVariable(Name.c_str(), Value.c_str()));
+    VERIFY_IS_TRUE(SetEnvironmentVariableW(Name.c_str(), Value.c_str()));
 }
 
 ScopedEnvVariable::~ScopedEnvVariable()
 {
-    VERIFY_IS_TRUE(SetEnvironmentVariable(m_name.c_str(), m_originalValue.has_value() ? m_originalValue->c_str() : nullptr));
+    VERIFY_IS_TRUE(SetEnvironmentVariableW(m_name.c_str(), m_originalValue.has_value() ? m_originalValue->c_str() : nullptr));
 }
 
 void ScopedEnvVariable::Set(const std::wstring& Value)
 {
-    VERIFY_IS_TRUE(SetEnvironmentVariable(m_name.c_str(), Value.c_str()));
+    VERIFY_IS_TRUE(SetEnvironmentVariableW(m_name.c_str(), Value.c_str()));
 }
 
 void ScopedEnvVariable::Clear()
 {
-    VERIFY_IS_TRUE(SetEnvironmentVariable(m_name.c_str(), nullptr));
+    VERIFY_IS_TRUE(SetEnvironmentVariableW(m_name.c_str(), nullptr));
 }
 
 UniqueWebServer::UniqueWebServer(LPCWSTR Endpoint, LPCWSTR Content)

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -330,16 +330,29 @@ private:
 class ScopedEnvVariable
 {
 public:
+    // Captures any existing value and clears the variable.
+    explicit ScopedEnvVariable(const std::wstring& Name);
+
+    // Captures any existing value and sets the variable to Value.
     ScopedEnvVariable(const std::wstring& Name, const std::wstring& Value);
+
+    // Restores the original value.
     ~ScopedEnvVariable();
 
-    ScopedEnvVariable(const WslConfigChange&) = delete;
-    ScopedEnvVariable(WslConfigChange&&) = delete;
+    ScopedEnvVariable(const ScopedEnvVariable&) = delete;
+    ScopedEnvVariable(ScopedEnvVariable&&) = delete;
     const ScopedEnvVariable& operator=(ScopedEnvVariable&&) = delete;
-    const ScopedEnvVariable& operator=(ScopedEnvVariable&) = delete;
+    const ScopedEnvVariable& operator=(const ScopedEnvVariable&) = delete;
+
+    // Sets the variable to a new value.
+    void Set(const std::wstring& Value);
+
+    // Clears (unsets) the variable.
+    void Clear();
 
 private:
     std::wstring m_name;
+    std::optional<std::wstring> m_originalValue;
 };
 
 class UniqueWebServer

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -339,10 +339,8 @@ public:
     // Restores the original value.
     ~ScopedEnvVariable();
 
-    ScopedEnvVariable(const ScopedEnvVariable&) = delete;
-    ScopedEnvVariable(ScopedEnvVariable&&) = delete;
-    const ScopedEnvVariable& operator=(ScopedEnvVariable&&) = delete;
-    const ScopedEnvVariable& operator=(const ScopedEnvVariable&) = delete;
+    NON_COPYABLE(ScopedEnvVariable);
+    NON_MOVABLE(ScopedEnvVariable);
 
     // Sets the variable to a new value.
     void Set(const std::wstring& Value);

--- a/test/windows/wslc/WSLCCLIEnvironmentOptionsUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIEnvironmentOptionsUnitTests.cpp
@@ -34,25 +34,24 @@ class WSLCCLIEnvironmentOptionsUnitTests
 {
     WSLC_TEST_CLASS(WSLCCLIEnvironmentOptionsUnitTests)
 
-    // Tests touch process-wide env state. Capture pre-existing values in setup
-    // and restore them in cleanup so the suite is hermetic and doesn't clobber
-    // values the test host (or CI) may have set.
+    // Tests touch process-wide env state. ScopedEnvVariable captures any
+    // pre-existing value in setup, clears it, and restores it in cleanup so
+    // the suite is hermetic.
     TEST_METHOD_SETUP(TestMethodSetup)
     {
-        m_savedNoColor = CaptureEnv(L"NO_COLOR");
-        VERIFY_IS_TRUE(SetEnvironmentVariableW(L"NO_COLOR", nullptr));
+        m_noColor = std::make_unique<ScopedEnvVariable>(L"NO_COLOR");
         return true;
     }
 
     TEST_METHOD_CLEANUP(TestMethodCleanup)
     {
-        RestoreEnv(L"NO_COLOR", m_savedNoColor);
+        m_noColor.reset();
         return true;
     }
 
     TEST_METHOD(ApplyEnvironmentOptions_NoColorEmptyValue_SetsFlag)
     {
-        VERIFY_IS_TRUE(SetEnvironmentVariableW(L"NO_COLOR", L""));
+        m_noColor->Set(L"");
 
         ArgMap target;
         ApplyEnvironmentOptions(target, NoColorDefs());
@@ -66,7 +65,7 @@ class WSLCCLIEnvironmentOptionsUnitTests
     {
         for (const auto* value : {L"0", L"false", L"FALSE", L"no", L"off"})
         {
-            VERIFY_IS_TRUE(SetEnvironmentVariableW(L"NO_COLOR", value));
+            m_noColor->Set(value);
 
             ArgMap target;
             ApplyEnvironmentOptions(target, NoColorDefs());
@@ -75,13 +74,13 @@ class WSLCCLIEnvironmentOptionsUnitTests
             VERIFY_IS_TRUE(target.Contains(ArgType::NoColor));
             VERIFY_IS_TRUE(target.Get<ArgType::NoColor>());
 
-            VERIFY_IS_TRUE(SetEnvironmentVariableW(L"NO_COLOR", nullptr));
+            m_noColor->Clear();
         }
     }
 
     TEST_METHOD(ApplyEnvironmentOptions_NoColorArbitraryValue_SetsFlag)
     {
-        VERIFY_IS_TRUE(SetEnvironmentVariableW(L"NO_COLOR", L"1"));
+        m_noColor->Set(L"1");
 
         ArgMap target;
         ApplyEnvironmentOptions(target, NoColorDefs());
@@ -101,7 +100,7 @@ class WSLCCLIEnvironmentOptionsUnitTests
     // Env-derived defaults are lowest precedence and must not overwrite.
     TEST_METHOD(ApplyEnvironmentOptions_TargetAlreadyContainsArg_LeavesItUntouched)
     {
-        VERIFY_IS_TRUE(SetEnvironmentVariableW(L"NO_COLOR", L""));
+        m_noColor->Set(L"");
 
         ArgMap target;
         target.Add<ArgType::NoColor>(false);
@@ -118,7 +117,7 @@ class WSLCCLIEnvironmentOptionsUnitTests
     // cause NO_COLOR to leak into target.
     TEST_METHOD(ApplyEnvironmentOptions_UndeclaredArg_IsIgnored)
     {
-        VERIFY_IS_TRUE(SetEnvironmentVariableW(L"NO_COLOR", L""));
+        m_noColor->Set(L"");
 
         std::vector<Argument> defs;
         defs.push_back(Argument::Create(ArgType::Verbose));
@@ -130,30 +129,13 @@ class WSLCCLIEnvironmentOptionsUnitTests
     }
 
 private:
-    std::optional<std::wstring> m_savedNoColor;
+    std::unique_ptr<ScopedEnvVariable> m_noColor;
 
     static std::vector<Argument> NoColorDefs()
     {
         std::vector<Argument> defs;
         defs.push_back(Argument::Create(ArgType::NoColor));
         return defs;
-    }
-
-    // Snapshot a process env var. nullopt means the variable was not defined;
-    // an empty string means it was defined as "".
-    static std::optional<std::wstring> CaptureEnv(const wchar_t* name)
-    {
-        std::wstring value;
-        if (FAILED(wil::GetEnvironmentVariableW(name, value)))
-        {
-            return std::nullopt;
-        }
-        return value;
-    }
-
-    static void RestoreEnv(const wchar_t* name, const std::optional<std::wstring>& saved)
-    {
-        VERIFY_IS_TRUE(SetEnvironmentVariableW(name, saved.has_value() ? saved->c_str() : nullptr));
     }
 };
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Follow-up from #40789 review feedback:

 - EnvironmentOptions.cpp: Removed catch-all from ReadEnv — now returns nullopt only for ERROR_ENVVAR_NOT_FOUND and throws on unexpected HRESULTs. Added CATCH_LOG() in ApplyEnvironmentOptions so unexpected errors are logged, not hidden.
 - ScopedEnvVariable: Enhanced to save/restore original value, added Set()/Clear() methods, fixed copy-paste bug in deleted-function declarations.
 - WSLCCLIEnvironmentOptionsUnitTests: Replaced manual CaptureEnv/RestoreEnv helpers with ScopedEnvVariable.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
