### PR TITLE
Add --force option to wslc volume rm and network rm commands

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2844,6 +2844,9 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_NetworkArgDescription" xml:space="preserve">
     <value>Connect a container to a network</value>
   </data>
+  <data name="WSLCCLI_NetworkForceArgDescription" xml:space="preserve">
+    <value>Do not error if the network does not exist</value>
+  </data>
   <data name="WSLCCLI_NetworkEmptyError" xml:space="preserve">
     <value>Invalid {} value: network name cannot be empty or whitespace</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
@@ -2937,6 +2940,9 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_VolumeArgDescription" xml:space="preserve">
     <value>Bind mount a volume to the container</value>
+  </data>
+  <data name="WSLCCLI_VolumeForceArgDescription" xml:space="preserve">
+    <value>Do not error if the volume does not exist</value>
   </data>
   <data name="WSLCCLI_WorkingDirArgDescription" xml:space="preserve">
     <value>Working directory inside the container</value>

--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -77,6 +77,7 @@ _(Memory,         "memory",              L"m",              Kind::Value,       L
 _(Name,           "name",                NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NameArgDescription()) \
 _(Network,        "network",             NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NetworkArgDescription()) \
 _(NetworkAlias,   "network-alias",       NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NetworkAliasArgDescription()) \
+_(NetworkForce,   "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_NetworkForceArgDescription()) \
 _(NetworkName,    "network-name",        NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_NetworkNameArgDescription()) \
 /*_(NoDNS,          "no-dns",              NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NoDNSArgDescription())*/ \
 _(NoCache,        "no-cache",            NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NoCacheArgDescription()) \
@@ -118,6 +119,7 @@ _(Verbose,        "verbose",             NO_ALIAS,          Kind::Flag,        L
 _(Version,        "version",             L"v",              Kind::Flag,        Localization::WSLCCLI_VersionArgDescription()) \
 /*_(Virtual,        "virtualization",      NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_VirtualArgDescription())*/ \
 _(Volume,         "volume",              L"v",              Kind::Value,       Localization::WSLCCLI_VolumeArgDescription()) \
+_(VolumeForce,    "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_VolumeForceArgDescription()) \
 _(VolumeName,     "volume-name",         NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_VolumeNameArgDescription()) \
 _(WorkDir,        "workdir",             L"w",              Kind::Value,       Localization::WSLCCLI_WorkingDirArgDescription()) \
 // clang-format on

--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -77,7 +77,6 @@ _(Memory,         "memory",              L"m",              Kind::Value,       L
 _(Name,           "name",                NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NameArgDescription()) \
 _(Network,        "network",             NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NetworkArgDescription()) \
 _(NetworkAlias,   "network-alias",       NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NetworkAliasArgDescription()) \
-_(NetworkForce,   "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_NetworkForceArgDescription()) \
 _(NetworkName,    "network-name",        NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_NetworkNameArgDescription()) \
 /*_(NoDNS,          "no-dns",              NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NoDNSArgDescription())*/ \
 _(NoCache,        "no-cache",            NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NoCacheArgDescription()) \
@@ -119,7 +118,6 @@ _(Verbose,        "verbose",             NO_ALIAS,          Kind::Flag,        L
 _(Version,        "version",             L"v",              Kind::Flag,        Localization::WSLCCLI_VersionArgDescription()) \
 /*_(Virtual,        "virtualization",      NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_VirtualArgDescription())*/ \
 _(Volume,         "volume",              L"v",              Kind::Value,       Localization::WSLCCLI_VolumeArgDescription()) \
-_(VolumeForce,    "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_VolumeForceArgDescription()) \
 _(VolumeName,     "volume-name",         NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_VolumeNameArgDescription()) \
 _(WorkDir,        "workdir",             L"w",              Kind::Value,       Localization::WSLCCLI_WorkingDirArgDescription()) \
 // clang-format on

--- a/src/windows/wslc/commands/NetworkRemoveCommand.cpp
+++ b/src/windows/wslc/commands/NetworkRemoveCommand.cpp
@@ -27,6 +27,7 @@ namespace wsl::windows::wslc {
 std::vector<Argument> NetworkRemoveCommand::GetArguments() const
 {
     return {
+        Argument::Create(ArgType::NetworkForce),
         Argument::Create(ArgType::NetworkName, true, NO_LIMIT),
     };
 }

--- a/src/windows/wslc/commands/NetworkRemoveCommand.cpp
+++ b/src/windows/wslc/commands/NetworkRemoveCommand.cpp
@@ -27,8 +27,8 @@ namespace wsl::windows::wslc {
 std::vector<Argument> NetworkRemoveCommand::GetArguments() const
 {
     return {
-        Argument::Create(ArgType::NetworkForce),
         Argument::Create(ArgType::NetworkName, true, NO_LIMIT),
+        Argument::Create(ArgType::Force, std::nullopt, std::nullopt, Localization::WSLCCLI_NetworkForceArgDescription()),
     };
 }
 

--- a/src/windows/wslc/commands/VolumeRemoveCommand.cpp
+++ b/src/windows/wslc/commands/VolumeRemoveCommand.cpp
@@ -27,6 +27,7 @@ namespace wsl::windows::wslc {
 std::vector<Argument> VolumeRemoveCommand::GetArguments() const
 {
     return {
+        Argument::Create(ArgType::VolumeForce),
         Argument::Create(ArgType::VolumeName, true, NO_LIMIT),
     };
 }

--- a/src/windows/wslc/commands/VolumeRemoveCommand.cpp
+++ b/src/windows/wslc/commands/VolumeRemoveCommand.cpp
@@ -27,8 +27,8 @@ namespace wsl::windows::wslc {
 std::vector<Argument> VolumeRemoveCommand::GetArguments() const
 {
     return {
-        Argument::Create(ArgType::VolumeForce),
         Argument::Create(ArgType::VolumeName, true, NO_LIMIT),
+        Argument::Create(ArgType::Force, std::nullopt, std::nullopt, Localization::WSLCCLI_VolumeForceArgDescription()),
     };
 }
 

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -49,7 +49,7 @@ static bool TryInspectNetwork(Session& session, const std::string& networkName, 
     }
 }
 
-static bool TryDeleteNetwork(Session& session, const std::string& networkName)
+static bool TryDeleteNetwork(Session& session, const std::string& networkName, bool force)
 {
     try
     {
@@ -60,7 +60,11 @@ static bool TryDeleteNetwork(Session& session, const std::string& networkName)
     {
         if (ex.GetErrorCode() == WSLC_E_NETWORK_NOT_FOUND)
         {
-            PrintMessage(Localization::MessageWslcNetworkNotFound(networkName.c_str()), stderr);
+            if (!force)
+            {
+                PrintMessage(Localization::MessageWslcNetworkNotFound(networkName.c_str()), stderr);
+            }
+
             return false;
         }
 
@@ -100,13 +104,14 @@ void DeleteNetworks(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Session));
     auto& session = context.Data.Get<Data::Session>();
     auto networkNames = context.Args.GetAll<ArgType::NetworkName>();
+    const bool force = context.Args.Contains(ArgType::NetworkForce);
     for (const auto& name : networkNames)
     {
-        if (TryDeleteNetwork(session, WideToMultiByte(name)))
+        if (TryDeleteNetwork(session, WideToMultiByte(name), force))
         {
             PrintMessage(name);
         }
-        else
+        else if (!force)
         {
             context.ExitCode = 1;
         }

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -104,7 +104,7 @@ void DeleteNetworks(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Session));
     auto& session = context.Data.Get<Data::Session>();
     auto networkNames = context.Args.GetAll<ArgType::NetworkName>();
-    const bool force = context.Args.Contains(ArgType::NetworkForce);
+    const bool force = context.Args.Contains(ArgType::Force);
     for (const auto& name : networkNames)
     {
         if (TryDeleteNetwork(session, WideToMultiByte(name), force))

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -108,7 +108,7 @@ void DeleteVolumes(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Session));
     auto& session = context.Data.Get<Data::Session>();
     auto volumeNames = context.Args.GetAll<ArgType::VolumeName>();
-    const bool force = context.Args.Contains(ArgType::VolumeForce);
+    const bool force = context.Args.Contains(ArgType::Force);
     for (const auto& name : volumeNames)
     {
         if (TryDeleteVolume(session, WideToMultiByte(name), force))

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -49,7 +49,7 @@ static bool TryInspectVolume(Session& session, const std::string& volumeName, st
     }
 }
 
-static bool TryDeleteVolume(Session& session, const std::string& volumeName)
+static bool TryDeleteVolume(Session& session, const std::string& volumeName, bool force)
 {
     try
     {
@@ -60,7 +60,11 @@ static bool TryDeleteVolume(Session& session, const std::string& volumeName)
     {
         if (ex.GetErrorCode() == WSLC_E_VOLUME_NOT_FOUND)
         {
-            PrintMessage(Localization::MessageWslcVolumeNotFound(volumeName.c_str()), stderr);
+            if (!force)
+            {
+                PrintMessage(Localization::MessageWslcVolumeNotFound(volumeName.c_str()), stderr);
+            }
+
             return false;
         }
 
@@ -104,13 +108,14 @@ void DeleteVolumes(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Session));
     auto& session = context.Data.Get<Data::Session>();
     auto volumeNames = context.Args.GetAll<ArgType::VolumeName>();
+    const bool force = context.Args.Contains(ArgType::VolumeForce);
     for (const auto& name : volumeNames)
     {
-        if (TryDeleteVolume(session, WideToMultiByte(name)))
+        if (TryDeleteVolume(session, WideToMultiByte(name), force))
         {
             PrintMessage(name);
         }
-        else
+        else if (!force)
         {
             context.ExitCode = 1;
         }

--- a/test/windows/wslc/e2e/WSLCE2ENetworkRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkRemoveTests.cpp
@@ -172,9 +172,9 @@ private:
     std::wstring GetAvailableOptions() const
     {
         std::wstringstream options;
-        options << L"The following options are available:\r\n"                          //
+        options << L"The following options are available:\r\n"                         //
                 << L"  -f,--force      Do not error if the network does not exist\r\n" //
-                << L"  -?,--help       Shows help about the selected command\r\n"       //
+                << L"  -?,--help       Shows help about the selected command\r\n"      //
                 << L"\r\n";
         return options.str();
     }

--- a/test/windows/wslc/e2e/WSLCE2ENetworkRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkRemoveTests.cpp
@@ -99,6 +99,36 @@ class WSLCE2ENetworkRemoveTests
         VerifyNetworkIsNotListed(TestNetworkName);
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Network_Remove_Force_NotFound)
+    {
+        auto result = RunWslc(std::format(L"network remove --force {}", TestNetworkName));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Remove_Force_Valid)
+    {
+        auto result = RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VerifyNetworkIsListed(TestNetworkName);
+
+        result = RunWslc(std::format(L"network remove --force {}", TestNetworkName));
+        result.Verify({.Stdout = std::format(L"{}\r\n", TestNetworkName), .Stderr = L"", .ExitCode = 0});
+
+        VerifyNetworkIsNotListed(TestNetworkName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Remove_Force_MixedFoundNotFound)
+    {
+        auto result = RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsListed(TestNetworkName);
+
+        result = RunWslc(std::format(L"network remove --force {} {}", TestNetworkName, TestNetworkName2));
+        result.Verify({.Stdout = std::format(L"{}\r\n", TestNetworkName), .Stderr = L"", .ExitCode = 0});
+        VerifyNetworkIsNotListed(TestNetworkName);
+    }
+
 private:
     const std::wstring TestNetworkName = L"wslc-e2e-network-remove";
     const std::wstring TestNetworkName2 = L"wslc-e2e-network-remove-2";
@@ -142,8 +172,9 @@ private:
     std::wstring GetAvailableOptions() const
     {
         std::wstringstream options;
-        options << L"The following options are available:\r\n"                    //
-                << L"  -?,--help       Shows help about the selected command\r\n" //
+        options << L"The following options are available:\r\n"                          //
+                << L"  -f,--force      Do not error if the network does not exist\r\n" //
+                << L"  -?,--help       Shows help about the selected command\r\n"       //
                 << L"\r\n";
         return options.str();
     }

--- a/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
@@ -206,9 +206,9 @@ private:
     std::wstring GetAvailableOptions() const
     {
         std::wstringstream options;
-        options << L"The following options are available:\r\n"                   //
+        options << L"The following options are available:\r\n"                       //
                 << L"  -f,--force     Do not error if the volume does not exist\r\n" //
-                << L"  -?,--help      Shows help about the selected command\r\n" //
+                << L"  -?,--help      Shows help about the selected command\r\n"     //
                 << L"\r\n";
         return options.str();
     }

--- a/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
@@ -131,6 +131,36 @@ class WSLCE2EVolumeRemoveTests
         VerifyVolumeIsListed(TestVolumeName);
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Remove_Force_NotFound)
+    {
+        auto result = RunWslc(std::format(L"volume remove --force {}", TestVolumeName));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Remove_Force_Valid)
+    {
+        auto result = RunWslc(std::format(L"volume create {}", TestVolumeName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        VerifyVolumeIsListed(TestVolumeName);
+
+        result = RunWslc(std::format(L"volume remove --force {}", TestVolumeName));
+        result.Verify({.Stdout = std::format(L"{}\r\n", TestVolumeName), .Stderr = L"", .ExitCode = 0});
+
+        VerifyVolumeIsNotListed(TestVolumeName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Remove_Force_MixedFoundNotFound)
+    {
+        auto result = RunWslc(std::format(L"volume create {}", TestVolumeName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyVolumeIsListed(TestVolumeName);
+
+        result = RunWslc(std::format(L"volume remove --force {} {}", TestVolumeName, TestVolumeName2));
+        result.Verify({.Stdout = std::format(L"{}\r\n", TestVolumeName), .Stderr = L"", .ExitCode = 0});
+        VerifyVolumeIsNotListed(TestVolumeName);
+    }
+
 private:
     const std::wstring WslcContainerName = L"wslc-test-container";
     const TestImage& DebianImage = DebianTestImage();
@@ -177,6 +207,7 @@ private:
     {
         std::wstringstream options;
         options << L"The following options are available:\r\n"                   //
+                << L"  -f,--force     Do not error if the volume does not exist\r\n" //
                 << L"  -?,--help      Shows help about the selected command\r\n" //
                 << L"\r\n";
         return options.str();

--- a/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
@@ -161,6 +161,31 @@ class WSLCE2EVolumeRemoveTests
         VerifyVolumeIsNotListed(TestVolumeName);
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Remove_Force_VolumeInUse_Fail)
+    {
+        auto result = RunWslc(std::format(L"volume create {}", TestVolumeName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyVolumeIsListed(TestVolumeName);
+
+        // Create a container that uses the volume to ensure it's in use
+        result = RunWslc(std::format(
+            L"container run -d --name {} -v {}:/data {} sh -c \"echo -n 'WSLC Volume In Use Test' > /data/test.txt && sleep "
+            L"infinity\"",
+            WslcContainerName,
+            TestVolumeName,
+            DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        // --force does not bypass in-use checks, volume should still fail to be removed
+        result = RunWslc(std::format(L"volume remove --force {}", TestVolumeName));
+        result.Verify(
+            {.Stdout = L"",
+             .Stderr = std::format(L"Volume '{}' is in use.\r\nError code: ERROR_SHARING_VIOLATION\r\n", TestVolumeName),
+             .ExitCode = 1});
+
+        VerifyVolumeIsListed(TestVolumeName);
+    }
+
 private:
     const std::wstring WslcContainerName = L"wslc-test-container";
     const TestImage& DebianImage = DebianTestImage();


### PR DESCRIPTION
## Summary

Add `--force` / `-f` flag to `wslc volume rm` and `wslc network rm` commands.

## What `--force` does

When `--force` is specified:

- **Not-found errors are silently suppressed.** Removing a volume or network that does not exist exits with code 0 and produces no stderr output, instead of printing an error and exiting with code 1.
- **Existing volumes/networks are removed normally.** If the resource exists, it is deleted and its name is printed to stdout, same as without `--force`.
- **In-use safety checks are not bypassed.** Attempting to remove a volume that is mounted by a running container still fails with `ERROR_SHARING_VIOLATION`, even with `--force`.

## How this tracks Docker behavior

This matches the semantics of `docker volume rm --force` and `docker network rm --force`, which suppress not-found errors so that `rm --force` is idempotent (safe to call in scripts and cleanup paths without checking existence first). Docker's `--force` on volume/network rm does **not** bypass in-use checks either — that is specific to `docker container rm --force`.

## Third-party storage plugins

In Docker, `--force` additionally allows untracking a volume when a third-party storage plugin is unreachable (the volume metadata is removed even if the plugin cannot clean up the underlying storage). WSLC does not support third-party storage plugins — volumes are either guest volumes (backed by the in-VM Docker local driver) or VHD volumes (backed by a host `.vhdx` file). Since there is no external plugin failure path, `--force` does not need to handle that scenario.

## Changes

- **ArgumentDefinitions.h**: New `VolumeForce` and `NetworkForce` arg types
- **VolumeRemoveCommand.cpp / NetworkRemoveCommand.cpp**: Register `--force` argument
- **VolumeTasks.cpp / NetworkTasks.cpp**: Read force flag; suppress not-found errors and exit code when set
- **Resources.resw**: Localization strings for the new argument descriptions
- **E2E tests**: Force + not-found, force + valid removal, force + mixed found/not-found scenarios; updated help message expectations