### PR TITLE
Reject invalid network driver options in wslc network create

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2326,6 +2326,14 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>Unsupported network driver: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcInvalidNetworkDriverOption" xml:space="preserve">
+    <value>Unsupported network driver option: '{}'</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslcGatewayRequiresSubnet" xml:space="preserve">
+    <value>Network driver option 'Gateway' requires 'Subnet' to also be specified.</value>
+    <comment>{Locked="Gateway"}{Locked="Subnet"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name = "MessageWslcNetworkInUse" xml:space = "preserve" >
     <value>Network '{}' has active endpoints.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2377,16 +2377,13 @@ try
     static constexpr std::array<std::string_view, 3> c_supportedDriverOpts{"Internal", "Subnet", "Gateway"};
     for (const auto& [key, _] : driverOpts)
     {
-        const bool supported = std::any_of(c_supportedDriverOpts.begin(), c_supportedDriverOpts.end(), [&](std::string_view opt) {
-            return key == opt;
-        });
+        const bool supported = std::any_of(
+            c_supportedDriverOpts.begin(), c_supportedDriverOpts.end(), [&](std::string_view opt) { return key == opt; });
         THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcInvalidNetworkDriverOption(key), !supported);
     }
 
     THROW_HR_WITH_USER_ERROR_IF(
-        E_INVALIDARG,
-        Localization::MessageWslcGatewayRequiresSubnet(),
-        driverOpts.contains("Gateway") && !driverOpts.contains("Subnet"));
+        E_INVALIDARG, Localization::MessageWslcGatewayRequiresSubnet(), driverOpts.contains("Gateway") && !driverOpts.contains("Subnet"));
 
     auto lock = m_lock.lock_shared();
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2375,6 +2375,20 @@ try
     auto driverOpts = wslutil::ParseKeyValuePairs(Options->DriverOpts, Options->DriverOptsCount);
     auto labels = wslutil::ParseKeyValuePairs(Options->Labels, Options->LabelsCount, WSLCNetworkManagedLabel);
 
+    static constexpr std::array<std::string_view, 3> c_supportedDriverOpts{"Internal", "Subnet", "Gateway"};
+    for (const auto& [key, _] : driverOpts)
+    {
+        const bool supported = std::any_of(c_supportedDriverOpts.begin(), c_supportedDriverOpts.end(), [&](std::string_view opt) {
+            return key == opt;
+        });
+        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcInvalidNetworkDriverOption(key), !supported);
+    }
+
+    THROW_HR_WITH_USER_ERROR_IF(
+        E_INVALIDARG,
+        Localization::MessageWslcGatewayRequiresSubnet(),
+        driverOpts.contains("Gateway") && !driverOpts.contains("Subnet"));
+
     auto lock = m_lock.lock_shared();
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient);
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_virtualMachine);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5078,18 +5078,49 @@ class WSLCTests
         VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
     }
 
-    WSLC_TEST_METHOD(NetworkCreateInvalidDriverTest)
+    WSLC_TEST_METHOD(NetworkCreateInvalidDriverAndOptionTest)
     {
         WSLCNetworkOptions options{};
-        options.Name = "bad-driver-net";
+        options.Name = "bad-network-create-input";
+        options.Driver = "bridge";
         options.DriverOpts = nullptr;
         options.DriverOptsCount = 0;
 
-        for (const char* driver : {"overlay", "Bridge", ""})
-        {
-            options.Driver = driver;
+        auto verifyInvalid = [&](PCWSTR expectedMessage) {
             VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateNetwork(&options, nullptr));
-            ValidateCOMErrorMessageContains(L"Unsupported network driver:");
+            ValidateCOMErrorMessageContains(expectedMessage);
+        };
+
+        // Invalid drivers (unknown, wrong case, empty)
+        {
+            options.DriverOpts = nullptr;
+            options.DriverOptsCount = 0;
+            for (const char* driver : {"overlay", "Bridge", ""})
+            {
+                options.Driver = driver;
+                verifyInvalid(L"Unsupported network driver:");
+            }
+        }
+
+        // Invalid driver options (wrong case and unknown keys)
+        {
+            options.Driver = "bridge";
+            for (const char* key : {"internal", "subnet", "gateway", "foo"})
+            {
+                WSLCDriverOption opt{key, "true"};
+                options.DriverOpts = &opt;
+                options.DriverOptsCount = 1;
+                verifyInvalid(wsl::shared::string::MultiByteToWide(key).c_str());
+            }
+        }
+
+        // Gateway specified without Subnet
+        {
+            options.Driver = "bridge";
+            WSLCDriverOption opt{"Gateway", "172.44.0.1"};
+            options.DriverOpts = &opt;
+            options.DriverOptsCount = 1;
+            verifyInvalid(L"requires 'Subnet'");
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When creating a network with  wslc network create --opt internal=true , lowercase option keys were silently ignored, causing the network to fall back to auto-allocated settings. This PR adds strict validation that rejects unknown or incorrectly-cased driver option keys with a clear error message.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #62736708
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
wslc network create accepts --opt key-value pairs for Internal, Subnet, and Gateway. These keys were matched case-sensitively via driverOpts.find("Internal") etc., but there was no validation rejecting unknown keys. This meant:

--opt internal=true (lowercase) was silently ignored → Internal defaulted to false
--opt subnet=172.44.0.0/16 (lowercase) was silently ignored → subnet auto-allocated
--opt foo=bar (typo/unknown) was silently ignored
--opt Gateway=172.44.0.1 without Subnet was silently dropped (Gateway is only read inside the Subnet block)

Fix:
WSLCSession.cpp - After parsing driver options, validate every key is one of {"Internal", "Subnet", "Gateway"}. Also reject Gateway without Subnet. Both throw E_INVALIDARG with localized error messages.
Resources.resw - Added MessageWslcInvalidNetworkDriverOption and MessageWslcGatewayRequiresSubnet localization entries.
WSLCTests.cpp - Combined NetworkCreateInvalidDriverTest and the new driver-option validation into NetworkCreateInvalidDriverAndOptionTest with a shared verifyInvalid lambda covering three scenarios: invalid drivers, invalid driver options, and Gateway-without-Subnet.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
