### PR TITLE
Add GetDisplayName to IWSLCSession

### DIFF
--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -564,6 +564,7 @@ typedef struct _WSLCSessionInitSettings
 interface IWSLCSession : IUnknown
 {
     HRESULT GetId([out] ULONG* Id);
+    HRESULT GetDisplayName([out] LPWSTR* DisplayName);
     HRESULT GetState([out] WSLCSessionState* State);
 
     // Returns a one-off event that is signaled when the session terminates, whether due to an

--- a/src/windows/wslc/services/SessionModel.h
+++ b/src/windows/wslc/services/SessionModel.h
@@ -31,19 +31,8 @@ struct Session
         return m_session.get();
     }
 
-    const std::optional<std::wstring>& DisplayName() const noexcept
-    {
-        return m_displayName;
-    }
-
-    void SetDisplayName(std::wstring name)
-    {
-        m_displayName = std::move(name);
-    }
-
 private:
     wil::com_ptr<IWSLCSession> m_session;
-    std::optional<std::wstring> m_displayName;
 };
 
 } // namespace wsl::windows::wslc::models

--- a/src/windows/wslc/services/SessionService.cpp
+++ b/src/windows/wslc/services/SessionService.cpp
@@ -38,12 +38,7 @@ Session SessionService::OpenSessionByName(const wil::com_ptr<IWSLCSessionManager
     THROW_IF_FAILED(manager->OpenSessionByName(displayName, &session));
 
     wsl::windows::common::security::ConfigureForCOMImpersonation(session.get());
-    Session result(std::move(session));
-    if (displayName)
-    {
-        result.SetDisplayName(displayName);
-    }
-    return result;
+    return Session(std::move(session));
 }
 
 Session SessionService::OpenSession(const std::wstring& sessionName)
@@ -189,10 +184,12 @@ int SessionService::TerminateSession(const Session& session)
     if (FAILED(hr))
     {
         auto errorString = wsl::windows::common::wslutil::ErrorCodeToString(hr);
-        if (session.DisplayName().has_value())
+
+        wil::unique_cotaskmem_string displayName;
+        if (SUCCEEDED(session.Get()->GetDisplayName(&displayName)) && displayName)
         {
             wslutil::PrintMessage(
-                Localization::MessageErrorCode(Localization::MessageWslcTerminateSessionFailed(session.DisplayName().value()), errorString), stderr);
+                Localization::MessageErrorCode(Localization::MessageWslcTerminateSessionFailed(displayName.get()), errorString), stderr);
         }
         else
         {

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -531,6 +531,17 @@ HRESULT WSLCSession::GetId(ULONG* Id)
     return S_OK;
 }
 
+HRESULT WSLCSession::GetDisplayName(_Out_ LPWSTR* DisplayName)
+try
+{
+    RETURN_HR_IF_NULL(E_POINTER, DisplayName);
+    *DisplayName = nullptr;
+
+    *DisplayName = wil::make_unique_string<wil::unique_cotaskmem_string>(m_displayName.c_str()).release();
+    return S_OK;
+}
+CATCH_RETURN();
+
 void WSLCSession::OnDockerdExited()
 {
     if (!m_sessionTerminatingEvent.is_signaled())

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -98,6 +98,7 @@ public:
         _In_opt_ IWarningCallback* WarningCallback) override;
 
     IFACEMETHOD(GetId)(_Out_ ULONG* Id) override;
+    IFACEMETHOD(GetDisplayName)(_Out_ LPWSTR* DisplayName) override;
     IFACEMETHOD(GetState)(_Out_ WSLCSessionState* State) override;
     IFACEMETHOD(GetTerminationEvent)(_Out_ HANDLE* Event) override;
     IFACEMETHOD(GetTerminationReason)(_Out_ WSLCVirtualMachineTerminationReason* Reason, _Out_ LPWSTR* Details) override;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -409,6 +409,14 @@ class WSLCTests
         VERIFY_ARE_EQUAL(hr, WSLC_E_SESSION_NOT_FOUND);
     }
 
+    WSLC_TEST_METHOD(GetDisplayNameReturnsSessionName)
+    {
+        wil::unique_cotaskmem_string displayName;
+        VERIFY_SUCCEEDED(m_defaultSession->GetDisplayName(&displayName));
+        VERIFY_IS_NOT_NULL(displayName.get());
+        VERIFY_ARE_EQUAL(std::wstring(displayName.get()), c_testSessionName);
+    }
+
     WSLC_TEST_METHOD(CreateSessionValidation)
     {
         auto sessionManager = OpenSessionManager();
@@ -484,6 +492,7 @@ class WSLCTests
 
         // The session object must reject NULL output pointers.
         VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(RPC_X_NULL_REF_POINTER), m_defaultSession->GetId(nullptr));
+        VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(RPC_X_NULL_REF_POINTER), m_defaultSession->GetDisplayName(nullptr));
         VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(RPC_X_NULL_REF_POINTER), m_defaultSession->GetState(nullptr));
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The session's DisplayName was already stored internally (m_displayName in WSLCSession) and populated during Initialize, but was never exposed through the COM interface. Callers had to track the name separately in a client-side model, duplicating state and creating potential inconsistency for something that was already known and defined.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

 - Added GetDisplayName to IWSLCSession (IDL, implementation, header) — returns the session's display name as a CoTaskMem-allocated string, positioned after GetId as a basic session property
 - Removed client-side DisplayName tracking from SessionModel (m_displayName, SetDisplayName(), DisplayName()) — callers now query the session object directly
 - Updated TerminateSession to call GetDisplayName on the COM object instead of reading from the removed model property
 - Added tests — positive test verifying the default session returns the expected name, plus null-pointer rejection test

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* New test builds and passes.