### PR TITLE
Change crash dump PIDs to 32-bit

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -410,7 +410,7 @@ try
     message.WriteString(Argv[2]);
     message->Timestamp = std::strtoull(Argv[1], nullptr, 10);
     message->Signal = std::strtoul(Argv[4], nullptr, 10);
-    message->Pid = std::strtoull(Argv[3], nullptr, 10);
+    message->Pid = std::strtoul(Argv[3], nullptr, 10);
 
     auto result = channel.Transaction<LX_PROCESS_CRASH>(message.Span()).Result;
     if (result != 0)

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -649,7 +649,7 @@ typedef struct _LX_PROCESS_CRASH
     MESSAGE_HEADER Header;
     std::uint64_t Timestamp;
     std::uint32_t Signal;
-    std::uint64_t Pid;
+    std::uint32_t Pid;
 
     char Buffer[];
 

--- a/src/windows/WslcSDK/CrashDumpCallback.cpp
+++ b/src/windows/WslcSDK/CrashDumpCallback.cpp
@@ -20,7 +20,7 @@ CrashDumpCallback::CrashDumpCallback(WslcSessionCrashDumpCallback callback, PVOI
 }
 
 HRESULT STDMETHODCALLTYPE CrashDumpCallback::OnCrashDump(
-    _In_ LPCWSTR DumpPath, _In_opt_ LPCSTR ProcessName, _In_ ULONGLONG Pid, _In_ ULONG Signal, _In_ ULONGLONG Timestamp)
+    _In_ LPCWSTR DumpPath, _In_opt_ LPCSTR ProcessName, _In_ ULONG Pid, _In_ ULONG Signal, _In_ ULONGLONG Timestamp)
 try
 {
     if (m_callback)

--- a/src/windows/WslcSDK/CrashDumpCallback.cpp
+++ b/src/windows/WslcSDK/CrashDumpCallback.cpp
@@ -19,8 +19,7 @@ CrashDumpCallback::CrashDumpCallback(WslcSessionCrashDumpCallback callback, PVOI
 {
 }
 
-HRESULT STDMETHODCALLTYPE CrashDumpCallback::OnCrashDump(
-    _In_ LPCWSTR DumpPath, _In_opt_ LPCSTR ProcessName, _In_ ULONG Pid, _In_ ULONG Signal, _In_ ULONGLONG Timestamp)
+HRESULT STDMETHODCALLTYPE CrashDumpCallback::OnCrashDump(_In_ LPCWSTR DumpPath, _In_opt_ LPCSTR ProcessName, _In_ ULONG Pid, _In_ ULONG Signal, _In_ ULONGLONG Timestamp)
 try
 {
     if (m_callback)

--- a/src/windows/WslcSDK/CrashDumpCallback.h
+++ b/src/windows/WslcSDK/CrashDumpCallback.h
@@ -23,7 +23,7 @@ struct CrashDumpCallback : public winrt::implements<CrashDumpCallback, IWSLCComp
     CrashDumpCallback(WslcSessionCrashDumpCallback callback, PVOID context);
 
     // IWSLCCompatCrashDumpCallback
-    HRESULT STDMETHODCALLTYPE OnCrashDump(_In_ LPCWSTR DumpPath, _In_opt_ LPCSTR ProcessName, _In_ ULONGLONG Pid, _In_ ULONG Signal, _In_ ULONGLONG Timestamp) override;
+    HRESULT STDMETHODCALLTYPE OnCrashDump(_In_ LPCWSTR DumpPath, _In_opt_ LPCSTR ProcessName, _In_ ULONG Pid, _In_ ULONG Signal, _In_ ULONGLONG Timestamp) override;
 
 private:
     WslcSessionCrashDumpCallback m_callback = nullptr;

--- a/src/windows/WslcSDK/wslcsdk.h
+++ b/src/windows/WslcSDK/wslcsdk.h
@@ -128,7 +128,7 @@ typedef struct WslcSessionCrashDumpInfo
 {
     _Field_z_ PCWSTR dumpPath;
     _Field_z_ PCSTR processName;
-    uint64_t pid;
+    uint32_t pid;
     uint32_t signal;
     uint64_t timestamp;
 } WslcSessionCrashDumpInfo;

--- a/src/windows/common/APICompat.cpp
+++ b/src/windows/common/APICompat.cpp
@@ -40,7 +40,7 @@ namespace {
         {
         }
 
-        IFACEMETHOD(OnCrashDump)(LPCWSTR DumpPath, LPCSTR ProcessName, ULONGLONG Pid, ULONG Signal, ULONGLONG Timestamp) override
+        IFACEMETHOD(OnCrashDump)(LPCWSTR DumpPath, LPCSTR ProcessName, ULONG Pid, ULONG Signal, ULONGLONG Timestamp) override
         {
             return m_inner->OnCrashDump(DumpPath, ProcessName, Pid, Signal, Timestamp);
         }

--- a/src/windows/service/inc/WSLCCompat.idl
+++ b/src/windows/service/inc/WSLCCompat.idl
@@ -47,7 +47,7 @@ interface IWSLCCompatCrashDumpCallback : IUnknown
     HRESULT OnCrashDump(
         [in, string] LPCWSTR DumpPath,
         [in, unique, string] LPCSTR ProcessName,
-        [in] ULONGLONG Pid,
+        [in] ULONG Pid,
         [in] ULONG Signal,
         [in] ULONGLONG Timestamp);
 };

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -61,7 +61,7 @@ interface ICrashDumpCallback : IUnknown
     HRESULT OnCrashDump(
         [in, string] LPCWSTR DumpPath,
         [in, unique, string] LPCSTR ProcessName,
-        [in] ULONGLONG Pid,
+        [in] ULONG Pid,
         [in] ULONG Signal,
         [in] ULONGLONG Timestamp);
 };

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2860,7 +2860,7 @@ void WSLCSession::RemoveCrashDumpCallback(CrashDumpCallbackList::iterator It) no
     m_crashDumpCallbacks.erase(It);
 }
 
-void WSLCSession::OnCrashDumpWritten(const std::wstring& DumpPath, const std::string& ProcessName, ULONGLONG Pid, ULONG Signal, ULONGLONG Timestamp)
+void WSLCSession::OnCrashDumpWritten(const std::wstring& DumpPath, const std::string& ProcessName, ULONG Pid, ULONG Signal, ULONGLONG Timestamp)
 try
 {
     // Snapshot the callback list under the lock so that cross-process callback invocations don't

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -268,7 +268,7 @@ private:
     std::string InspectImageLockHeld(const std::string& Id);
     void OnContainerDeleted(const WSLCContainerImpl* Container);
 
-    void OnCrashDumpWritten(const std::wstring& DumpPath, const std::string& ProcessName, ULONGLONG Pid, ULONG Signal, ULONGLONG Timestamp);
+    void OnCrashDumpWritten(const std::wstring& DumpPath, const std::string& ProcessName, ULONG Pid, ULONG Signal, ULONGLONG Timestamp);
 
     _Requires_shared_lock_held_(m_lock)
     void OnImageCreated(const std::string& ImageNameOrId) noexcept;

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -125,7 +125,7 @@ public:
     // ICrashDumpCallback::OnCrashDump. The VM owns producing crash events; the session owns
     // fanning them out to any registered COM callbacks.
     using TOnCrashDump =
-        std::function<void(const std::wstring& DumpPath, const std::string& ProcessName, ULONGLONG Pid, ULONG Signal, ULONGLONG Timestamp)>;
+        std::function<void(const std::wstring& DumpPath, const std::string& ProcessName, ULONG Pid, ULONG Signal, ULONGLONG Timestamp)>;
 
     WSLCVirtualMachine(_In_ IWSLCVirtualMachine* Vm, _In_ const WSLCSessionInitSettings* Settings, _In_ HANDLE SessionTerminatingEvent, _In_ TOnCrashDump&& OnCrashDump);
     ~WSLCVirtualMachine();

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2905,7 +2905,7 @@ class WSLCTests
         {
             std::wstring DumpPath;
             std::string ProcessName;
-            ULONGLONG Pid;
+            ULONG Pid;
             ULONG Signal;
             ULONGLONG Timestamp;
         };
@@ -2919,7 +2919,7 @@ class WSLCTests
             {
             }
 
-            HRESULT OnCrashDump(LPCWSTR DumpPath, LPCSTR ProcessName, ULONGLONG Pid, ULONG Signal, ULONGLONG Timestamp) override
+            HRESULT OnCrashDump(LPCWSTR DumpPath, LPCSTR ProcessName, ULONG Pid, ULONG Signal, ULONGLONG Timestamp) override
             {
                 m_promise.set_value(Invocation{
                     DumpPath ? std::wstring{DumpPath} : std::wstring{}, ProcessName ? std::string{ProcessName} : std::string{}, Pid, Signal, Timestamp});
@@ -2957,7 +2957,7 @@ class WSLCTests
         VERIFY_IS_FALSE(invocation.DumpPath.empty());
         VERIFY_IS_TRUE(invocation.ProcessName.find("sh") != std::string::npos);
         VERIFY_ARE_EQUAL(invocation.Signal, static_cast<ULONG>(WSLCSignalSIGSEGV));
-        VERIFY_IS_GREATER_THAN(invocation.Pid, 0ull);
+        VERIFY_IS_GREATER_THAN(invocation.Pid, 0u);
         VERIFY_IS_GREATER_THAN(invocation.Timestamp, 0ull);
 
         // The dump file should be readable and non-empty.

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -323,7 +323,7 @@ class WslcSdkTests
         {
             std::wstring DumpPath;
             std::string ProcessName;
-            uint64_t Pid;
+            uint32_t Pid;
             uint32_t Signal;
             uint64_t Timestamp;
         };
@@ -372,7 +372,7 @@ class WslcSdkTests
         VERIFY_IS_GREATER_THAN(std::filesystem::file_size(invocation.DumpPath), 0ull);
         VERIFY_IS_TRUE(invocation.ProcessName.find("sh") != std::string::npos);
         VERIFY_ARE_EQUAL(invocation.Signal, static_cast<uint32_t>(WSLCSignalSIGSEGV));
-        VERIFY_IS_GREATER_THAN(invocation.Pid, 0ull);
+        VERIFY_IS_GREATER_THAN(invocation.Pid, 0u);
         VERIFY_IS_GREATER_THAN(invocation.Timestamp, 0ull);
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Moves to 32-bit value for crash dump PIDs from WSLC.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
For consistency with the Process object (and current limits), use 32-bit value for crash dump PIDs.  This changes the value throughout the stack.  It is intertwined with #40840, and depending on which is merged first, the other will need to be updated to change the SDK to use 32-bit values as well.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built and ran existing `CrashDumpCallback` tests.