### PR TITLE
Fix stuck systemctl poweroff could block terminate

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2753,21 +2753,14 @@ try
     {
         THROW_LAST_ERROR_IF(UtilSetSignalHandlers(g_SavedSignalActions, false) < 0);
 
+        //
+        // systemctl poweroff is normally async but can block in rare cases.
+        // Run it in a thread so a stuck invocation can't prevent the fallback timeout below.
+        //
         try
         {
             std::thread([]() {
-                //
-                // systemctl poweroff is async after the operation is successfully enqueued.
-                // However, in some rare cases, systemctl poweroff can block.
-                // Run it in a separate thread to avoid blocking the timeout.
-                //
-                int rc = UtilExecCommandLine("systemctl poweroff", nullptr);
-                if (rc < 0)
-                {
-                    LOG_ERROR("systemctl poweroff failed {}, calling reboot(RB_POWER_OFF)", rc);
-                    reboot(RB_POWER_OFF);
-                    FATAL_ERROR("reboot(RB_POWER_OFF) failed {}", errno);
-                }
+                UtilExecCommandLine("systemctl poweroff", nullptr);
             }).detach();
         }
         CATCH_LOG();

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2753,11 +2753,26 @@ try
     {
         THROW_LAST_ERROR_IF(UtilSetSignalHandlers(g_SavedSignalActions, false) < 0);
 
-        if (UtilExecCommandLine("systemctl poweroff", nullptr) == 0)
+        try
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(Config.BootInitTimeout));
-            LOG_ERROR("systemctl poweroff did not terminate the instance in {} ms, calling reboot(RB_POWER_OFF)", Config.BootInitTimeout);
+            std::thread([]() {
+                //
+                // systemctl poweroff is async after the operation is successfully enqueued.
+                // However, in some rare cases, systemctl poweroff can block.
+                // Run it in a separate thread to avoid blocking the timeout.
+                //
+                if (UtilExecCommandLine("systemctl poweroff", nullptr) < 0)
+                {
+                    LOG_ERROR("systemctl poweroff failed {}, calling reboot(RB_POWER_OFF)", errno);
+                    reboot(RB_POWER_OFF);
+                    FATAL_ERROR("reboot(RB_POWER_OFF) failed {}", errno);
+                }
+            }).detach();
         }
+        CATCH_LOG();
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(Config.BootInitTimeout));
+        LOG_ERROR("systemctl poweroff did not terminate the instance in {} ms, calling reboot(RB_POWER_OFF)", Config.BootInitTimeout);
     }
 
     reboot(RB_POWER_OFF);

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2757,11 +2757,7 @@ try
         // systemctl poweroff is normally async but can block in rare cases.
         // Run it in a thread so a stuck invocation can't prevent the fallback timeout below.
         //
-        try
-        {
-            std::thread([]() { UtilExecCommandLine("systemctl poweroff", nullptr); }).detach();
-        }
-        CATCH_LOG();
+        std::thread([]() { UtilExecCommandLine("systemctl poweroff", nullptr); }).detach();
 
         std::this_thread::sleep_for(std::chrono::milliseconds(Config.BootInitTimeout));
         LOG_ERROR("systemctl poweroff did not terminate the instance in {} ms, calling reboot(RB_POWER_OFF)", Config.BootInitTimeout);

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2759,9 +2759,7 @@ try
         //
         try
         {
-            std::thread([]() {
-                UtilExecCommandLine("systemctl poweroff", nullptr);
-            }).detach();
+            std::thread([]() { UtilExecCommandLine("systemctl poweroff", nullptr); }).detach();
         }
         CATCH_LOG();
 

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2761,9 +2761,10 @@ try
                 // However, in some rare cases, systemctl poweroff can block.
                 // Run it in a separate thread to avoid blocking the timeout.
                 //
-                if (UtilExecCommandLine("systemctl poweroff", nullptr) < 0)
+                int rc = UtilExecCommandLine("systemctl poweroff", nullptr);
+                if (rc < 0)
                 {
-                    LOG_ERROR("systemctl poweroff failed {}, calling reboot(RB_POWER_OFF)", errno);
+                    LOG_ERROR("systemctl poweroff failed {}, calling reboot(RB_POWER_OFF)", rc);
                     reboot(RB_POWER_OFF);
                     FATAL_ERROR("reboot(RB_POWER_OFF) failed {}", errno);
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The `systemctl poweroff` call is async after the operation is enqueued per https://man7.org/linux/man-pages/man1/systemctl.1.html. However, in some rare cases it could block. And that will block the `wsl --terminate` call. For example: https://github.com/microsoft/WSL/pull/40433#issuecomment-4745744177
This PR moves the calling logic to a separate thread, so the fallback timeout is always started in the systemd path.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

No new tests are added as the original failure could not be easily reproduced.