### PR TITLE
Rename VirtioProxy networking mode to Consomme

### DIFF
--- a/doc/docs/technical-documentation/localhost.md
+++ b/doc/docs/technical-documentation/localhost.md
@@ -19,7 +19,7 @@ Bound guest ports are tracked and forwarded to the host, optionally via [wslrela
 
 See `src/windows/common/ConsommeNetworking.cpp`.
 
-See `src/linux/localhost.cpp`.
+See `src/linux/init/localhost.cpp`.
 
 [consomme]: https://github.com/microsoft/openvmm/tree/main/vm/devices/net/net_consomme/consomme
 [openvmm]: https://github.com/microsoft/openvmm

--- a/doc/docs/technical-documentation/localhost.md
+++ b/doc/docs/technical-documentation/localhost.md
@@ -11,4 +11,15 @@ When `wsl2.networkingMode` is set to NAT, `localhost` will watch for bound TCP p
 
 In mirrored mode, `localhost` registers a BPF program to intercept calls to `bind()`, and forward the calls to Windows via [wslservice.exe](wslservice.exe.md) so Windows can route the network traffic directly to the WSL2 virtual machine.
 
+## Consomme networking
+
+When `wsl2.networkingMode` is set to `Consomme`, the VM is given a virtio-net adapter whose host side is backed by [Consomme][consomme], the user-mode NAT from the [OpenVMM][openvmm] project. The guest sees a normal network (a DHCP-assigned address, a default gateway, and working DNS), but rather than going through a host NAT or bridge, its raw Ethernet frames are parsed by a user-mode process on the host and translated into ordinary host sockets. Because all traffic flows through standard host sockets, host networking policies (firewall, VPN routing, proxy settings) apply just as they would for any other host application.
+
+Bound guest ports are tracked and forwarded to the host, optionally via [wslrelay.exe](wslrelay.exe.md).
+
+See `src/windows/common/ConsommeNetworking.cpp`.
+
 See `src/linux/localhost.cpp`.
+
+[consomme]: https://github.com/microsoft/openvmm/tree/main/vm/devices/net/net_consomme/consomme
+[openvmm]: https://github.com/microsoft/openvmm

--- a/intune/en-US/WSL.adml
+++ b/intune/en-US/WSL.adml
@@ -48,7 +48,7 @@
         <string id="NetworkingModeNone"><!-- _locComment_text="{Locked}" -->None</string>
         <string id="NetworkingModeNAT"><!-- _locComment_text="{Locked}" -->NAT</string>
         <string id="NetworkingModeMirrored"><!-- _locComment_text="{Locked}" -->Mirrored</string>
-        <string id="NetworkingModeVirtioProxy"><!-- _locComment_text="{Locked}" -->VirtioProxy</string>
+        <string id="NetworkingModeVirtioProxy"><!-- _locComment_text="{Locked}" -->Consomme</string>
 
         <string id="WSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->WSL container</string>
 

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1132,7 +1132,7 @@ Attempting web download...</value>
   </data>
   <data name="MessageConsommeRequiresVirtio" xml:space="preserve">
     <value>Consomme networking is not supported when wsl2.virtio is disabled; falling back to networkingMode {}.</value>
-    <comment>{Locked="wsl2.virtio"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+    <comment>{Locked="wsl2.virtio"}{Locked="Consomme"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageSwiotlbKernelUnsupported" xml:space="preserve">
     <value>The running kernel is missing a patch that significantly improves virtio device performance. Update to a more recent WSL kernel to enable this optimization.</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1130,9 +1130,9 @@ Attempting web download...</value>
   <data name="MessageConfigVirtio9pDisabled" xml:space="preserve">
     <value>wsl2.virtio9p is disabled, falling back to 9p with vsock transport.</value>
   </data>
-  <data name="MessageVirtioProxyRequiresVirtio" xml:space="preserve">
-    <value>VirtioProxy networking is not supported when wsl2.virtio is disabled; falling back to networkingMode {}.</value>
-    <comment>{Locked="wsl2.virtio"}{Locked="VirtioProxy"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  <data name="MessageConsommeRequiresVirtio" xml:space="preserve">
+    <value>Consomme networking is not supported when wsl2.virtio is disabled; falling back to networkingMode {}.</value>
+    <comment>{Locked="wsl2.virtio"}{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageSwiotlbKernelUnsupported" xml:space="preserve">
     <value>The running kernel is missing a patch that significantly improves virtio device performance. Update to a more recent WSL kernel to enable this optimization.</value>

--- a/src/linux/init/localhost.cpp
+++ b/src/linux/init/localhost.cpp
@@ -444,7 +444,7 @@ int RunPortTracker(int Argc, char** Argv)
         return 1;
     }
 
-    if (NetworkingMode < LxMiniInitNetworkingModeNone || NetworkingMode > LxMiniInitNetworkingModeVirtioProxy)
+    if (NetworkingMode < LxMiniInitNetworkingModeNone || NetworkingMode > LxMiniInitNetworkingModeConsomme)
     {
         std::cerr << "Invalid networking mode (" << NetworkingMode << ")\n";
         return 1;

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -1276,7 +1276,7 @@ try
     const auto& response = transaction.Receive<RESULT_MESSAGE<uint8_t>>();
     auto NetworkingMode = static_cast<LX_MINI_INIT_NETWORKING_MODE>(response.Result);
 
-    THROW_ERRNO_IF(EINVAL, NetworkingMode < LxMiniInitNetworkingModeNone || NetworkingMode > LxMiniInitNetworkingModeVirtioProxy);
+    THROW_ERRNO_IF(EINVAL, NetworkingMode < LxMiniInitNetworkingModeNone || NetworkingMode > LxMiniInitNetworkingModeConsomme);
 
     return NetworkingMode;
 }

--- a/src/linux/init/wslinfo.cpp
+++ b/src/linux/init/wslinfo.cpp
@@ -111,8 +111,8 @@ Return Value:
                 std::cout << "mirrored";
                 break;
 
-            case LxMiniInitNetworkingModeVirtioProxy:
-                std::cout << "virtioproxy";
+            case LxMiniInitNetworkingModeConsomme:
+                std::cout << "consomme";
                 break;
 
             default:

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1307,7 +1307,7 @@ typedef enum _LX_MINI_INIT_NETWORKING_MODE
     LxMiniInitNetworkingModeNat = 1,
     LxMiniInitNetworkingModeBridged = 2,
     LxMiniInitNetworkingModeMirrored = 3,
-    LxMiniInitNetworkingModeVirtioProxy = 4
+    LxMiniInitNetworkingModeConsomme = 4
 } LX_MINI_INIT_NETWORKING_MODE,
     *PLX_MINI_INIT_NETWORKING_MODE;
 

--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -435,7 +435,7 @@ try
     runtimeSettings.CpuCount = internalType->cpuCount;
     runtimeSettings.MemoryMb = internalType->memoryMb;
     runtimeSettings.BootTimeoutMs = internalType->timeoutMS;
-    runtimeSettings.NetworkingMode = WSLCNetworkingModeVirtioProxy;
+    runtimeSettings.NetworkingMode = WSLCNetworkingModeConsomme;
     runtimeSettings.FeatureFlags = ConvertFlags(internalType->featureFlags);
     WI_SetFlag(runtimeSettings.FeatureFlags, WslcFeatureFlagsVirtioFs);
     WI_SetFlag(runtimeSettings.FeatureFlags, WslcFeatureFlagsDnsTunneling);

--- a/src/windows/common/CMakeLists.txt
+++ b/src/windows/common/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SOURCES
     VTSupport.cpp
     WindowsUpdateIntegration.cpp
     WSLCContainerLauncher.cpp
-    VirtioNetworking.cpp
+    ConsommeNetworking.cpp
     WSLCProcessLauncher.cpp
     WslClient.cpp
     WslCoreConfig.cpp
@@ -126,7 +126,7 @@ set(HEADERS
     VTSupport.h
     WindowsUpdateIntegration.h
     WSLCContainerLauncher.h
-    VirtioNetworking.h
+    ConsommeNetworking.h
     WSLCProcessLauncher.h
     WslClient.h
     WslCoreConfig.h

--- a/src/windows/common/ConsommeNetworking.cpp
+++ b/src/windows/common/ConsommeNetworking.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 #include "precomp.h"
-#include "VirtioNetworking.h"
+#include "ConsommeNetworking.h"
 #include "GuestDeviceManager.h"
 #include "Stringify.h"
 #include "stringshared.h"
@@ -9,14 +9,14 @@
 using namespace wsl::core::networking;
 using namespace wsl::shared;
 using namespace wsl::windows::common::stringify;
-using wsl::core::VirtioNetworking;
+using wsl::core::ConsommeNetworking;
 
 static constexpr auto c_eth0DeviceName = L"eth0";
 static constexpr auto c_loopbackDeviceName = TEXT(LX_INIT_LOOPBACK_DEVICE_NAME);
 
-VirtioNetworking::VirtioNetworking(
+ConsommeNetworking::ConsommeNetworking(
     GnsChannel&& gnsChannel,
-    VirtioNetworkingFlags flags,
+    ConsommeNetworkingFlags flags,
     LPCWSTR dnsOptions,
     std::shared_ptr<GuestDeviceManager> guestDeviceManager,
     wil::shared_handle userToken,
@@ -30,7 +30,7 @@ VirtioNetworking::VirtioNetworking(
 {
 }
 
-VirtioNetworking::~VirtioNetworking()
+ConsommeNetworking::~ConsommeNetworking()
 {
     // Unregister the network notification callback to prevent it from using the GNS channel.
     m_networkNotifyHandle.reset();
@@ -39,35 +39,35 @@ VirtioNetworking::~VirtioNetworking()
     m_gnsChannel.Stop();
 }
 
-void VirtioNetworking::Initialize()
+void ConsommeNetworking::Initialize()
 {
     // Initialize adapter state.
     RefreshGuestConnection();
 
-    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::LocalhostRelay))
+    if (WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::LocalhostRelay))
     {
         SetupLoopbackDevice();
     }
 
-    THROW_IF_WIN32_ERROR(NotifyNetworkConnectivityHintChange(&VirtioNetworking::OnNetworkConnectivityChange, this, TRUE, &m_networkNotifyHandle));
+    THROW_IF_WIN32_ERROR(NotifyNetworkConnectivityHintChange(&ConsommeNetworking::OnNetworkConnectivityChange, this, TRUE, &m_networkNotifyHandle));
 }
 
-void VirtioNetworking::TraceLoggingRundown() noexcept
+void ConsommeNetworking::TraceLoggingRundown() noexcept
 {
     auto lock = m_lock.lock_exclusive();
 
-    WSL_LOG("VirtioNetworking::TraceLoggingRundown", TRACE_NETWORKSETTINGS_OBJECT(m_networkSettings));
+    WSL_LOG("ConsommeNetworking::TraceLoggingRundown", TRACE_NETWORKSETTINGS_OBJECT(m_networkSettings));
 }
 
-void VirtioNetworking::FillInitialConfiguration(LX_MINI_INIT_NETWORKING_CONFIGURATION& message)
+void ConsommeNetworking::FillInitialConfiguration(LX_MINI_INIT_NETWORKING_CONFIGURATION& message)
 {
-    message.NetworkingMode = LxMiniInitNetworkingModeVirtioProxy;
-    message.DisableIpv6 = WI_IsFlagClear(m_flags, VirtioNetworkingFlags::Ipv6);
+    message.NetworkingMode = LxMiniInitNetworkingModeConsomme;
+    message.DisableIpv6 = WI_IsFlagClear(m_flags, ConsommeNetworkingFlags::Ipv6);
     message.EnableDhcpClient = false;
     message.PortTrackerType = LX_MINI_INIT_PORT_TRACKER_TYPE::LxMiniInitPortTrackerTypeMirrored;
 }
 
-void VirtioNetworking::StartPortTracker(wil::unique_socket&& socket)
+void ConsommeNetworking::StartPortTracker(wil::unique_socket&& socket)
 {
     WI_ASSERT(!m_gnsPortTrackerChannel.has_value());
 
@@ -81,16 +81,16 @@ void VirtioNetworking::StartPortTracker(wil::unique_socket&& socket)
         [](const std::string&, bool) {}); // TODO: reconsider if InterfaceStateCallback is needed.
 }
 
-void NETIOAPI_API_ VirtioNetworking::OnNetworkConnectivityChange(PVOID context, NL_NETWORK_CONNECTIVITY_HINT hint)
+void NETIOAPI_API_ ConsommeNetworking::OnNetworkConnectivityChange(PVOID context, NL_NETWORK_CONNECTIVITY_HINT hint)
 try
 {
-    static_cast<VirtioNetworking*>(context)->RefreshGuestConnection();
+    static_cast<ConsommeNetworking*>(context)->RefreshGuestConnection();
 }
 CATCH_LOG()
 
-uint16_t VirtioNetworking::HandlePortNotification(const SOCKADDR_INET& addr, int protocol, uint16_t guestPort, bool allocate) const
+uint16_t ConsommeNetworking::HandlePortNotification(const SOCKADDR_INET& addr, int protocol, uint16_t guestPort, bool allocate) const
 {
-    if (addr.si_family == AF_INET6 && WI_IsFlagClear(m_flags, VirtioNetworkingFlags::Ipv6))
+    if (addr.si_family == AF_INET6 && WI_IsFlagClear(m_flags, ConsommeNetworkingFlags::Ipv6))
     {
         return 0;
     }
@@ -118,7 +118,7 @@ uint16_t VirtioNetworking::HandlePortNotification(const SOCKADDR_INET& addr, int
         }
     });
 
-    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::LocalhostRelay) && (unspecified || loopback))
+    if (WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::LocalhostRelay) && (unspecified || loopback))
     {
         if (!loopback)
         {
@@ -149,7 +149,7 @@ uint16_t VirtioNetworking::HandlePortNotification(const SOCKADDR_INET& addr, int
     return hostPort;
 }
 
-uint16_t VirtioNetworking::ModifyOpenPorts(
+uint16_t ConsommeNetworking::ModifyOpenPorts(
     _In_ PCWSTR tag, _In_ const SOCKADDR_INET& hostAddress, _In_ uint16_t HostPort, _In_ uint16_t GuestPort, _In_ int protocol, _In_ bool isOpen) const
 {
     THROW_HR_IF_MSG(
@@ -194,7 +194,7 @@ uint16_t VirtioNetworking::ModifyOpenPorts(
     return HostPort;
 }
 
-HRESULT VirtioNetworking::MapPort(_In_ const SOCKADDR_INET& ListenAddress, _In_ USHORT GuestPort, _In_ int Protocol, _Out_ USHORT* AllocatedHostPort) const
+HRESULT ConsommeNetworking::MapPort(_In_ const SOCKADDR_INET& ListenAddress, _In_ USHORT GuestPort, _In_ int Protocol, _Out_ USHORT* AllocatedHostPort) const
 try
 {
     RETURN_HR_IF(E_POINTER, AllocatedHostPort == nullptr);
@@ -208,7 +208,7 @@ try
 }
 CATCH_RETURN()
 
-HRESULT VirtioNetworking::UnmapPort(_In_ const SOCKADDR_INET& ListenAddress, _In_ USHORT GuestPort, _In_ int Protocol) const
+HRESULT ConsommeNetworking::UnmapPort(_In_ const SOCKADDR_INET& ListenAddress, _In_ USHORT GuestPort, _In_ int Protocol) const
 try
 {
     RETURN_HR_IF(E_INVALIDARG, Protocol != IPPROTO_TCP && Protocol != IPPROTO_UDP);
@@ -219,7 +219,7 @@ try
 }
 CATCH_RETURN()
 
-void VirtioNetworking::RefreshGuestConnection()
+void ConsommeNetworking::RefreshGuestConnection()
 {
     // Query current networking information before acquiring the lock.
     auto networkSettings = GetHostEndpointSettings();
@@ -243,20 +243,20 @@ void VirtioNetworking::RefreshGuestConnection()
     appendOption(L"client_ip", networkSettings->PreferredIpAddress.AddressString);
     std::wstring default_route = networkSettings->GetBestGatewayAddressString();
     appendOption(L"gateway_ip", default_route);
-    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6))
+    if (WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::Ipv6))
     {
         appendOption(L"client_ip_ipv6", networkSettings->PreferredIpv6Address.AddressString);
     }
 
     networking::DnsInfo currentDns{};
-    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::DnsTunneling))
+    if (WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::DnsTunneling))
     {
         currentDns = networking::HostDnsInfo::GetDnsTunnelingSettings(default_route);
     }
     else
     {
         wsl::core::networking::DnsSettingsFlags dnsFlags = networking::DnsSettingsFlags::IncludeVpn;
-        WI_SetFlagIf(dnsFlags, networking::DnsSettingsFlags::IncludeIpv6Servers, WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+        WI_SetFlagIf(dnsFlags, networking::DnsSettingsFlags::IncludeIpv6Servers, WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::Ipv6));
         currentDns = networking::HostDnsInfo::GetDnsSettings(dnsFlags);
     }
 
@@ -294,7 +294,7 @@ void VirtioNetworking::RefreshGuestConnection()
     }
 
     UpdateIpv4Address(networkSettings->PreferredIpAddress);
-    if (WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6))
+    if (WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::Ipv6))
     {
         UpdateIpv6Address(networkSettings->PreferredIpv6Address);
     }
@@ -307,9 +307,9 @@ void VirtioNetworking::RefreshGuestConnection()
     m_networkSettings = std::move(networkSettings);
 }
 
-void VirtioNetworking::SetupLoopbackDevice()
+void ConsommeNetworking::SetupLoopbackDevice()
 {
-    const auto* clientIp = WI_IsFlagSet(m_flags, VirtioNetworkingFlags::LoopbackClientIp) ? L"127.0.0.1" : L"169.254.73.250";
+    const auto* clientIp = WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::LoopbackClientIp) ? L"127.0.0.1" : L"169.254.73.250";
     const auto deviceOptions =
         std::format(L"client_ip={};client_mac=00:11:22:33:44:55;gateway_ip=169.254.73.249;netmask=255.255.255.248", clientIp);
 
@@ -344,7 +344,7 @@ void VirtioNetworking::SetupLoopbackDevice()
     m_gnsChannel.SendNetworkDeviceMessage(loopbackType, ToJsonW(createLoopbackDevice).c_str());
 }
 
-void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, hns::ModifyRequestType requestType)
+void ConsommeNetworking::SendDefaultRoute(const std::wstring& gateway, hns::ModifyRequestType requestType)
 {
     if (gateway.empty() || !m_adapterId.has_value())
     {
@@ -363,7 +363,7 @@ void VirtioNetworking::SendDefaultRoute(const std::wstring& gateway, hns::Modify
     m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId.value());
 }
 
-void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway)
+void ConsommeNetworking::UpdateDefaultRoute(const std::wstring& gateway)
 {
     if (gateway == m_trackedDefaultRoute || !m_adapterId.has_value())
     {
@@ -375,7 +375,7 @@ void VirtioNetworking::UpdateDefaultRoute(const std::wstring& gateway)
     SendDefaultRoute(gateway, hns::ModifyRequestType::Add);
 }
 
-void VirtioNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
+void ConsommeNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
 {
     if (dns == m_trackedDnsSettings || !m_adapterId.has_value())
     {
@@ -391,7 +391,7 @@ void VirtioNetworking::UpdateDnsSettings(const networking::DnsInfo& dns)
     m_gnsChannel.SendHnsNotification(ToJsonW(notification).c_str(), m_adapterId.value());
 }
 
-void VirtioNetworking::UpdateIpv4Address(const networking::EndpointIpAddress& ipAddress)
+void ConsommeNetworking::UpdateIpv4Address(const networking::EndpointIpAddress& ipAddress)
 {
     if (ipAddress == m_trackedIpv4Address || ipAddress.AddressString.empty() || !m_adapterId.has_value())
     {
@@ -409,9 +409,9 @@ void VirtioNetworking::UpdateIpv4Address(const networking::EndpointIpAddress& ip
     m_gnsChannel.SendEndpointState(endpointProperties);
 }
 
-void VirtioNetworking::SendIpv6Address(const networking::EndpointIpAddress& ipAddress, hns::ModifyRequestType requestType)
+void ConsommeNetworking::SendIpv6Address(const networking::EndpointIpAddress& ipAddress, hns::ModifyRequestType requestType)
 {
-    WI_ASSERT(WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+    WI_ASSERT(WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::Ipv6));
 
     if (ipAddress.AddressString.empty() || !m_adapterId.has_value())
     {
@@ -429,9 +429,9 @@ void VirtioNetworking::SendIpv6Address(const networking::EndpointIpAddress& ipAd
     m_gnsChannel.SendHnsNotification(ToJsonW(request).c_str(), m_adapterId.value());
 }
 
-void VirtioNetworking::UpdateIpv6Address(const networking::EndpointIpAddress& ipAddress)
+void ConsommeNetworking::UpdateIpv6Address(const networking::EndpointIpAddress& ipAddress)
 {
-    WI_ASSERT(WI_IsFlagSet(m_flags, VirtioNetworkingFlags::Ipv6));
+    WI_ASSERT(WI_IsFlagSet(m_flags, ConsommeNetworkingFlags::Ipv6));
 
     if (ipAddress == m_trackedIpv6Address || !m_adapterId.has_value())
     {
@@ -443,7 +443,7 @@ void VirtioNetworking::UpdateIpv6Address(const networking::EndpointIpAddress& ip
     SendIpv6Address(ipAddress, hns::ModifyRequestType::Add);
 }
 
-void VirtioNetworking::UpdateMtu(std::optional<ULONG> mtu)
+void ConsommeNetworking::UpdateMtu(std::optional<ULONG> mtu)
 {
     if (!mtu || mtu.value() == m_networkMtu || !m_adapterId.has_value())
     {

--- a/src/windows/common/ConsommeNetworking.h
+++ b/src/windows/common/ConsommeNetworking.h
@@ -10,7 +10,7 @@
 
 namespace wsl::core {
 
-enum class VirtioNetworkingFlags
+enum class ConsommeNetworkingFlags
 {
     None = 0x0,
     LocalhostRelay = 0x1,
@@ -18,26 +18,26 @@ enum class VirtioNetworkingFlags
     Ipv6 = 0x4,
     LoopbackClientIp = 0x8,
 };
-DEFINE_ENUM_FLAG_OPERATORS(VirtioNetworkingFlags);
+DEFINE_ENUM_FLAG_OPERATORS(ConsommeNetworkingFlags);
 
-class VirtioNetworking : public INetworkingEngine
+class ConsommeNetworking : public INetworkingEngine
 {
 public:
-    VirtioNetworking(
+    ConsommeNetworking(
         GnsChannel&& gnsChannel,
-        VirtioNetworkingFlags flags,
+        ConsommeNetworkingFlags flags,
         LPCWSTR dnsOptions,
         std::shared_ptr<GuestDeviceManager> guestDeviceManager,
         wil::shared_handle userToken,
         std::wstring swiotlbConfig);
 
-    ~VirtioNetworking();
+    ~ConsommeNetworking();
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.
-    VirtioNetworking(const VirtioNetworking&) = delete;
-    VirtioNetworking(VirtioNetworking&&) = delete;
-    VirtioNetworking& operator=(const VirtioNetworking&) = delete;
-    VirtioNetworking& operator=(VirtioNetworking&&) = delete;
+    ConsommeNetworking(const ConsommeNetworking&) = delete;
+    ConsommeNetworking(ConsommeNetworking&&) = delete;
+    ConsommeNetworking& operator=(const ConsommeNetworking&) = delete;
+    ConsommeNetworking& operator=(ConsommeNetworking&&) = delete;
 
     // INetworkingEngine
     void Initialize() override;
@@ -72,7 +72,7 @@ private:
     GnsChannel m_gnsChannel;
     std::optional<GnsPortTrackerChannel> m_gnsPortTrackerChannel;
     std::shared_ptr<networking::NetworkSettings> m_networkSettings;
-    VirtioNetworkingFlags m_flags = VirtioNetworkingFlags::None;
+    ConsommeNetworkingFlags m_flags = ConsommeNetworkingFlags::None;
     LPCWSTR m_dnsOptions = nullptr;
     std::wstring m_swiotlbOption;
     std::optional<GUID> m_localhostAdapterId;

--- a/src/windows/common/ConsommeNetworking.h
+++ b/src/windows/common/ConsommeNetworking.h
@@ -31,7 +31,7 @@ public:
         wil::shared_handle userToken,
         std::wstring swiotlbConfig);
 
-    ~ConsommeNetworking();
+    ~ConsommeNetworking() override;
 
     // Note: This class cannot be moved because m_networkNotifyHandle captures a 'this' pointer.
     ConsommeNetworking(const ConsommeNetworking&) = delete;

--- a/src/windows/common/WSLCUserSettings.cpp
+++ b/src/windows/common/WSLCUserSettings.cpp
@@ -89,9 +89,9 @@ namespace details {
         {
             return WSLCNetworkingModeNAT;
         }
-        if (value == "virtioproxy")
+        if (value == "consomme")
         {
-            return WSLCNetworkingModeVirtioProxy;
+            return WSLCNetworkingModeConsomme;
         }
 
         return std::nullopt;

--- a/src/windows/common/WSLCUserSettings.h
+++ b/src/windows/common/WSLCUserSettings.h
@@ -92,7 +92,7 @@ namespace details {
     DEFINE_SETTING_MAPPING(SessionCpuCount,          uint32_t,    uint32_t,            0,                             "session.cpuCount")
     DEFINE_SETTING_MAPPING(SessionMemoryMb,          std::string, uint32_t,            0,                             "session.memorySize")
     DEFINE_SETTING_MAPPING(SessionStorageSizeMb,     std::string, uint32_t,            1048576,                       "session.maxStorageSize")
-    DEFINE_SETTING_MAPPING(SessionNetworkingMode,    std::string, WSLCNetworkingMode,  WSLCNetworkingModeVirtioProxy, "session.networkingMode")
+    DEFINE_SETTING_MAPPING(SessionNetworkingMode,    std::string, WSLCNetworkingMode,  WSLCNetworkingModeConsomme,    "session.networkingMode")
     DEFINE_SETTING_MAPPING(SessionHostFileShareMode, std::string, HostFileShareMode,   HostFileShareMode::VirtioFs,   "session.hostFileShareMode")
     DEFINE_SETTING_MAPPING(SessionDnsTunneling,      bool,        bool,                true,                          "session.dnsTunneling")
     DEFINE_SETTING_MAPPING(CredentialStore,          std::string, CredentialStoreType, CredentialStoreType::WinCred,  "credentialStore")

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -361,7 +361,7 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
         case wsl::core::NetworkingMode::None:
         case wsl::core::NetworkingMode::Nat:
         case wsl::core::NetworkingMode::Mirrored:
-        case wsl::core::NetworkingMode::VirtioProxy:
+        case wsl::core::NetworkingMode::Consomme:
             defaultNetworkingMode = static_cast<wsl::core::NetworkingMode>(setting.value());
             break;
 
@@ -442,10 +442,10 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
         VALIDATE_CONFIG_OPTION(!EnableVirtio, EnableVirtioFs, false);
         VALIDATE_CONFIG_OPTION(!EnableVirtio, SwiotlbSizeBytes, 0);
 
-        if (NetworkingMode == NetworkingMode::VirtioProxy)
+        if (NetworkingMode == NetworkingMode::Consomme)
         {
-            NetworkingMode = (defaultNetworkingMode == NetworkingMode::VirtioProxy) ? NetworkingMode::None : NetworkingMode::Nat;
-            EMIT_USER_WARNING(wsl::shared::Localization::MessageVirtioProxyRequiresVirtio(ToString(NetworkingMode)));
+            NetworkingMode = (defaultNetworkingMode == NetworkingMode::Consomme) ? NetworkingMode::None : NetworkingMode::Nat;
+            EMIT_USER_WARNING(wsl::shared::Localization::MessageConsommeRequiresVirtio(ToString(NetworkingMode)));
         }
     }
 
@@ -457,15 +457,15 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
 
     // Compute a default swiotlb config only when a virtio device that requires bounce buffers is present.
     // N.B. Must run after policy overrides so networking/fs modes reflect final values.
-    if (SwiotlbSizeBytes == 0 && (EnableVirtioFs || EnableVirtio9p || (NetworkingMode == NetworkingMode::VirtioProxy)))
+    if (SwiotlbSizeBytes == 0 && (EnableVirtioFs || EnableVirtio9p || (NetworkingMode == NetworkingMode::Consomme)))
     {
         SwiotlbSizeBytes = wsl::windows::common::helpers::ComputeDefaultSwiotlbConfig(MemorySizeBytes);
     }
 
-    if (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::VirtioProxy)
+    if (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::Consomme)
     {
         VALIDATE_CONFIG_OPTION(
-            (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::VirtioProxy),
+            (NetworkingMode != NetworkingMode::Nat && NetworkingMode != NetworkingMode::Mirrored && NetworkingMode != NetworkingMode::Consomme),
             EnableDnsTunneling,
             false);
     }
@@ -483,7 +483,7 @@ void wsl::core::Config::Initialize(_In_opt_ HANDLE UserToken)
     }
 
     // Load NAT configuration from the registry.
-    // N.B. This must be done after all networking mode adjustments (e.g. VirtioProxy -> NAT fallback).
+    // N.B. This must be done after all networking mode adjustments (e.g. Consomme -> NAT fallback).
     if (NetworkingMode == wsl::core::NetworkingMode::Nat)
     {
         try

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -88,7 +88,7 @@ enum NetworkingMode
     Nat = 1,
     Bridged = 2,
     Mirrored = 3,
-    VirtioProxy = 4
+    Consomme = 4
 };
 
 // Ensure the WslCoreConfig versions of the enum match the version that's used in mini init.
@@ -96,7 +96,7 @@ static_assert(static_cast<ULONG>(NetworkingMode::None) == LxMiniInitNetworkingMo
 static_assert(static_cast<ULONG>(NetworkingMode::Nat) == LxMiniInitNetworkingModeNat);
 static_assert(static_cast<ULONG>(NetworkingMode::Bridged) == LxMiniInitNetworkingModeBridged);
 static_assert(static_cast<ULONG>(NetworkingMode::Mirrored) == LxMiniInitNetworkingModeMirrored);
-static_assert(static_cast<ULONG>(NetworkingMode::VirtioProxy) == LxMiniInitNetworkingModeVirtioProxy);
+static_assert(static_cast<ULONG>(NetworkingMode::Consomme) == LxMiniInitNetworkingModeConsomme);
 
 constexpr auto ToString(NetworkingMode config) noexcept
 {
@@ -110,8 +110,8 @@ constexpr auto ToString(NetworkingMode config) noexcept
         return "Bridged";
     case NetworkingMode::Mirrored:
         return "Mirrored";
-    case NetworkingMode::VirtioProxy:
-        return "VirtioProxy";
+    case NetworkingMode::Consomme:
+        return "Consomme";
     default:
         return "Invalid";
     }
@@ -122,7 +122,9 @@ const std::map<std::string, wsl::core::NetworkingMode, shared::string::CaseInsen
     {ToString(NetworkingMode::Nat), NetworkingMode::Nat},
     {ToString(NetworkingMode::Bridged), NetworkingMode::Bridged},
     {ToString(NetworkingMode::Mirrored), NetworkingMode::Mirrored},
-    {ToString(NetworkingMode::VirtioProxy), NetworkingMode::VirtioProxy}};
+    {ToString(NetworkingMode::Consomme), NetworkingMode::Consomme},
+    // Legacy alias: the Consomme networking mode was previously named "VirtioProxy".
+    {"VirtioProxy", NetworkingMode::Consomme}};
 
 enum class FirewallAction
 {

--- a/src/windows/inc/WslCoreConfigInterface.h
+++ b/src/windows/inc/WslCoreConfigInterface.h
@@ -55,7 +55,7 @@ enum NetworkingConfiguration
     Nat = 1,
     Bridged = 2,
     Mirrored = 3,
-    VirtioProxy = 4
+    Consomme = 4
 };
 
 enum MemoryReclaimConfiguration

--- a/src/windows/libwsl/WslCoreConfigInterface.cpp
+++ b/src/windows/libwsl/WslCoreConfigInterface.cpp
@@ -23,7 +23,7 @@ static_assert(NetworkingConfiguration::None == static_cast<int32_t>(wsl::core::N
 static_assert(NetworkingConfiguration::Nat == static_cast<int32_t>(wsl::core::NetworkingMode::Nat));
 static_assert(NetworkingConfiguration::Bridged == static_cast<int32_t>(wsl::core::NetworkingMode::Bridged));
 static_assert(NetworkingConfiguration::Mirrored == static_cast<int32_t>(wsl::core::NetworkingMode::Mirrored));
-static_assert(NetworkingConfiguration::VirtioProxy == static_cast<int32_t>(wsl::core::NetworkingMode::VirtioProxy));
+static_assert(NetworkingConfiguration::Consomme == static_cast<int32_t>(wsl::core::NetworkingMode::Consomme));
 
 static_assert(MemoryReclaimConfiguration::Disabled == static_cast<int32_t>(wsl::core::MemoryReclaimMode::Disabled));
 static_assert(MemoryReclaimConfiguration::Gradual == static_cast<int32_t>(wsl::core::MemoryReclaimMode::Gradual));

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -437,7 +437,7 @@ try
     // The DNS hvsocket is only allocated for NAT mode.
     THROW_HR_IF(E_INVALIDARG, (FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode == WSLCNetworkingModeNAT) != (DnsSocket != nullptr));
 
-    // The check still applies to virtio proxy because the host virtio proxy uses the same Windows DNS APIs.
+    // The check still applies to Consomme because the host Consomme NAT uses the same Windows DNS APIs.
     if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
     {
         const auto result = wsl::core::networking::DnsResolver::LoadDnsResolverMethods();
@@ -714,10 +714,10 @@ try
 
     std::lock_guard lock(m_lock);
 
-    auto* virtioNet = dynamic_cast<wsl::core::ConsommeNetworking*>(m_networkEngine.get());
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), virtioNet == nullptr);
+    auto* consommeNet = dynamic_cast<wsl::core::ConsommeNetworking*>(m_networkEngine.get());
+    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), consommeNet == nullptr);
 
-    return virtioNet->MapPort(CreateListenAddress(ListenAddress, HostPort), GuestPort, Protocol, AllocatedHostPort);
+    return consommeNet->MapPort(CreateListenAddress(ListenAddress, HostPort), GuestPort, Protocol, AllocatedHostPort);
 }
 CATCH_RETURN()
 
@@ -728,10 +728,10 @@ try
 
     std::lock_guard lock(m_lock);
 
-    auto* virtioNet = dynamic_cast<wsl::core::ConsommeNetworking*>(m_networkEngine.get());
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), virtioNet == nullptr);
+    auto* consommeNet = dynamic_cast<wsl::core::ConsommeNetworking*>(m_networkEngine.get());
+    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), consommeNet == nullptr);
 
-    return virtioNet->UnmapPort(CreateListenAddress(ListenAddress, HostPort), GuestPort, Protocol);
+    return consommeNet->UnmapPort(CreateListenAddress(ListenAddress, HostPort), GuestPort, Protocol);
 }
 CATCH_RETURN()
 

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -17,7 +17,7 @@ Abstract:
 #include <string>
 #include <string_view>
 #include "hcs_schema.h"
-#include "VirtioNetworking.h"
+#include "ConsommeNetworking.h"
 #include "NatNetworking.h"
 #include "wslsecurity.h"
 #include "wslutil.h"
@@ -156,10 +156,10 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 #endif
 
     // Compute a swiotlb device-options token sized to fit this VM's RAM, used by the kernel
-    // command line, virtiofs shares, and the VirtioProxy virtio-net adapter.
+    // command line, virtiofs shares, and the Consomme virtio-net adapter.
     // Only needed when a virtio device that requires bounce buffers will be attached.
     ULONG64 swiotlbSizeBytes = 0;
-    if (FeatureEnabled(WslcFeatureFlagsVirtioFs) || m_networkingMode == WSLCNetworkingModeVirtioProxy)
+    if (FeatureEnabled(WslcFeatureFlagsVirtioFs) || m_networkingMode == WSLCNetworkingModeConsomme)
     {
         swiotlbSizeBytes = helpers::ComputeDefaultSwiotlbConfig(static_cast<UINT64>(Settings->MemoryMb) * _1MB);
     }
@@ -309,7 +309,7 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     // Create and start compute system
     m_computeSystem = hcs::CreateComputeSystem(m_vmIdString.c_str(), json.c_str());
 
-    if (FeatureEnabled(WslcFeatureFlagsVirtioFs) || m_networkingMode == WSLCNetworkingModeVirtioProxy)
+    if (FeatureEnabled(WslcFeatureFlagsVirtioFs) || m_networkingMode == WSLCNetworkingModeConsomme)
     {
         m_guestDeviceManager = std::make_shared<::GuestDeviceManager>(m_vmIdString, m_vmId);
     }
@@ -481,20 +481,20 @@ try
             std::move(dnsSocketHandle),
             nullptr);
     }
-    else if (m_networkingMode == WSLCNetworkingModeVirtioProxy)
+    else if (m_networkingMode == WSLCNetworkingModeConsomme)
     {
-        wsl::core::VirtioNetworkingFlags flags = wsl::core::VirtioNetworkingFlags::Ipv6;
+        wsl::core::ConsommeNetworkingFlags flags = wsl::core::ConsommeNetworkingFlags::Ipv6;
         if (FeatureEnabled(WslcFeatureFlagsDnsTunneling))
         {
-            WI_SetFlag(flags, wsl::core::VirtioNetworkingFlags::DnsTunneling);
+            WI_SetFlag(flags, wsl::core::ConsommeNetworkingFlags::DnsTunneling);
         }
 
         if (!FeatureEnabled(WslcFeatureFlagsPortRelayWslRelay))
         {
-            WI_SetFlag(flags, wsl::core::VirtioNetworkingFlags::LocalhostRelay);
+            WI_SetFlag(flags, wsl::core::ConsommeNetworkingFlags::LocalhostRelay);
         }
 
-        m_networkEngine = std::make_unique<wsl::core::VirtioNetworking>(
+        m_networkEngine = std::make_unique<wsl::core::ConsommeNetworking>(
             wsl::core::GnsChannel(std::move(gnsSocketHandle)), flags, nullptr, m_guestDeviceManager, m_userToken, m_swiotlbOption);
     }
     else
@@ -714,7 +714,7 @@ try
 
     std::lock_guard lock(m_lock);
 
-    auto* virtioNet = dynamic_cast<wsl::core::VirtioNetworking*>(m_networkEngine.get());
+    auto* virtioNet = dynamic_cast<wsl::core::ConsommeNetworking*>(m_networkEngine.get());
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), virtioNet == nullptr);
 
     return virtioNet->MapPort(CreateListenAddress(ListenAddress, HostPort), GuestPort, Protocol, AllocatedHostPort);
@@ -728,7 +728,7 @@ try
 
     std::lock_guard lock(m_lock);
 
-    auto* virtioNet = dynamic_cast<wsl::core::VirtioNetworking*>(m_networkEngine.get());
+    auto* virtioNet = dynamic_cast<wsl::core::ConsommeNetworking*>(m_networkEngine.get());
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), virtioNet == nullptr);
 
     return virtioNet->UnmapPort(CreateListenAddress(ListenAddress, HostPort), GuestPort, Protocol);

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -545,7 +545,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     message->MemoryReclaimMode = static_cast<LX_MINI_INIT_MEMORY_RECLAIM_MODE>(m_vmConfig.MemoryReclaim);
     message->EnableDebugShell = m_vmConfig.EnableDebugShell;
     message->EnableSafeMode = m_vmConfig.EnableSafeMode;
-    // Virtio proxy forwards DNS via the host proxy, so the dedicated DNS hvsocket is only used by NAT and Mirrored modes.
+    // Consomme forwards DNS via the host proxy, so the dedicated DNS hvsocket is only used by NAT and Mirrored modes.
     message->EnableDnsTunneling = m_vmConfig.EnableDnsTunneling && m_vmConfig.NetworkingMode != NetworkingMode::Consomme;
     message->DefaultKernel = m_defaultKernel;
     message->KernelModulesDeviceId = m_kernelModulesDeviceId;
@@ -573,7 +573,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
         const auto startTime = std::chrono::steady_clock::now();
 
         // For NAT networking, ensure the network can be created. If creating the network fails, fall back to
-        // virtio proxy networking mode.
+        // Consomme networking mode.
         wsl::windows::common::hcs::unique_hcn_network natNetwork;
         if (m_vmConfig.NetworkingMode == NetworkingMode::Nat)
         {
@@ -610,7 +610,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
                     wsl::core::ConsommeNetworkingFlags::Ipv6 | wsl::core::ConsommeNetworkingFlags::LoopbackClientIp;
                 WI_SetFlagIf(flags, wsl::core::ConsommeNetworkingFlags::LocalhostRelay, m_vmConfig.EnableLocalhostRelay);
                 WI_SetFlagIf(flags, wsl::core::ConsommeNetworkingFlags::DnsTunneling, m_vmConfig.EnableDnsTunneling);
-                // NAT may have fallen back to virtio proxy after the early-config message; drop the unused DNS hvsocket.
+                // NAT may have fallen back to Consomme after the early-config message; drop the unused DNS hvsocket.
                 dnsTunnelingSocket.reset();
 
                 m_networkingEngine = std::make_unique<wsl::core::ConsommeNetworking>(
@@ -2975,7 +2975,7 @@ void WslCoreVm::ValidateNetworkingMode()
         EMIT_USER_WARNING(Localization::MessageLocalhostForwardingNotSupportedMirroredMode());
     }
 
-    // The DnsResolver support check still applies to virtio proxy because the host virtio proxy uses the same Windows DNS APIs.
+    // The DnsResolver support check still applies to Consomme because the host Consomme NAT uses the same Windows DNS APIs.
     if (m_vmConfig.EnableDnsTunneling && !IsDnsTunnelingSupported())
     {
         // Since DNS tunneling is enabled by default, only show the warning if the user explicitly asked for it.

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -23,7 +23,7 @@ Abstract:
 #include "MirroredNetworking.h"
 #include "WslCoreFirewallSupport.h"
 #include "DnsResolver.h"
-#include "VirtioNetworking.h"
+#include "ConsommeNetworking.h"
 
 #include <TraceLoggingProvider.h>
 
@@ -546,7 +546,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     message->EnableDebugShell = m_vmConfig.EnableDebugShell;
     message->EnableSafeMode = m_vmConfig.EnableSafeMode;
     // Virtio proxy forwards DNS via the host proxy, so the dedicated DNS hvsocket is only used by NAT and Mirrored modes.
-    message->EnableDnsTunneling = m_vmConfig.EnableDnsTunneling && m_vmConfig.NetworkingMode != NetworkingMode::VirtioProxy;
+    message->EnableDnsTunneling = m_vmConfig.EnableDnsTunneling && m_vmConfig.NetworkingMode != NetworkingMode::Consomme;
     message->DefaultKernel = m_defaultKernel;
     message->KernelModulesDeviceId = m_kernelModulesDeviceId;
     message.WriteString(message->HostnameOffset, wsl::windows::common::filesystem::GetLinuxHostName());
@@ -584,9 +584,9 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
             if (!natNetwork)
             {
                 EMIT_USER_WARNING(wsl::shared::Localization::MessageNetworkInitializationFailedFallback2(
-                    ToString(m_vmConfig.NetworkingMode), ToString(NetworkingMode::VirtioProxy)));
+                    ToString(m_vmConfig.NetworkingMode), ToString(NetworkingMode::Consomme)));
 
-                m_vmConfig.NetworkingMode = NetworkingMode::VirtioProxy;
+                m_vmConfig.NetworkingMode = NetworkingMode::Consomme;
             }
         }
 
@@ -604,16 +604,16 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
                 m_networkingEngine = std::make_unique<wsl::core::NatNetworking>(
                     m_system.get(), std::move(natNetwork), std::move(gnsChannel), m_vmConfig, std::move(dnsTunnelingSocket));
             }
-            else if (m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy)
+            else if (m_vmConfig.NetworkingMode == NetworkingMode::Consomme)
             {
-                wsl::core::VirtioNetworkingFlags flags =
-                    wsl::core::VirtioNetworkingFlags::Ipv6 | wsl::core::VirtioNetworkingFlags::LoopbackClientIp;
-                WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::LocalhostRelay, m_vmConfig.EnableLocalhostRelay);
-                WI_SetFlagIf(flags, wsl::core::VirtioNetworkingFlags::DnsTunneling, m_vmConfig.EnableDnsTunneling);
+                wsl::core::ConsommeNetworkingFlags flags =
+                    wsl::core::ConsommeNetworkingFlags::Ipv6 | wsl::core::ConsommeNetworkingFlags::LoopbackClientIp;
+                WI_SetFlagIf(flags, wsl::core::ConsommeNetworkingFlags::LocalhostRelay, m_vmConfig.EnableLocalhostRelay);
+                WI_SetFlagIf(flags, wsl::core::ConsommeNetworkingFlags::DnsTunneling, m_vmConfig.EnableDnsTunneling);
                 // NAT may have fallen back to virtio proxy after the early-config message; drop the unused DNS hvsocket.
                 dnsTunnelingSocket.reset();
 
-                m_networkingEngine = std::make_unique<wsl::core::VirtioNetworking>(
+                m_networkingEngine = std::make_unique<wsl::core::ConsommeNetworking>(
                     std::move(gnsChannel), flags, LX_INIT_RESOLVCONF_FULL_HEADER, m_guestDeviceManager, m_userToken, m_swiotlbOption);
             }
             else if (m_vmConfig.NetworkingMode == NetworkingMode::Bridged)
@@ -1978,7 +1978,7 @@ bool WslCoreVm::IsDnsTunnelingSupported() const
 {
     WI_ASSERT(
         m_vmConfig.NetworkingMode == NetworkingMode::Nat || m_vmConfig.NetworkingMode == NetworkingMode::Mirrored ||
-        m_vmConfig.NetworkingMode == NetworkingMode::VirtioProxy);
+        m_vmConfig.NetworkingMode == NetworkingMode::Consomme);
 
     return SUCCEEDED_LOG(wsl::core::networking::DnsResolver::LoadDnsResolverMethods());
 }

--- a/src/windows/service/inc/WSLCShared.idl
+++ b/src/windows/service/inc/WSLCShared.idl
@@ -143,7 +143,7 @@ typedef enum _WSLCNetworkingMode
 {
     WSLCNetworkingModeNone,
     WSLCNetworkingModeNAT,
-    WSLCNetworkingModeVirtioProxy
+    WSLCNetworkingModeConsomme
 } WSLCNetworkingMode;
 
 typedef enum _WSLCFeatureFlags
@@ -154,7 +154,7 @@ typedef enum _WSLCFeatureFlags
     WslcFeatureFlagsGPU = 4,
     WslcFeatureFlagsVirtioFs = 8,
     WslcFeatureFlagsDebug = 16,
-    WslcFeatureFlagsPortRelayWslRelay = 32, // Use the wslrelay-based localhost port relay in VirtioProxy networking mode.
+    WslcFeatureFlagsPortRelayWslRelay = 32, // Use the wslrelay-based localhost port relay in Consomme networking mode.
 } WSLCFeatureFlags;
 
 cpp_quote("#define WSLCFeatureFlagsValid (WslcFeatureFlagsDnsTunneling | WslcFeatureFlagsEarlyBootDmesg | WslcFeatureFlagsGPU | WslcFeatureFlagsVirtioFs | WslcFeatureFlagsDebug | WslcFeatureFlagsPortRelayWslRelay)")

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -367,7 +367,7 @@ void WSLCVirtualMachine::ConfigureNetworking()
     std::vector<WSLCProcessFd> fds;
     fds.emplace_back(WSLCProcessFd{.Fd = -1, .Type = WSLCFdType::WSLCFdTypeDefault});
 
-    // Virtio proxy forwards DNS via the host proxy, so the DNS channel and /gns args are only needed for NAT mode.
+    // Consomme forwards DNS via the host proxy, so the DNS channel and /gns args are only needed for NAT mode.
     const bool enableDnsTunneling = FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode != WSLCNetworkingModeConsomme;
     if (enableDnsTunneling)
     {

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -314,7 +314,7 @@ void WSLCVirtualMachine::Initialize()
     Mount(m_initChannel, modulesDevice.c_str(), "", "ext4", "ro", WSLC_MOUNT::KernelModules);
 
     // Discover the per-VM guest capabilities (currently the hv_pci swiotlb pool) and forward them
-    // to the service so virtio device-options (virtiofs shares, VirtioProxy networking) can include
+    // to the service so virtio device-options (virtiofs shares, Consomme networking) can include
     // the swiotlb token.
     ReadGuestCapabilities();
 
@@ -368,7 +368,7 @@ void WSLCVirtualMachine::ConfigureNetworking()
     fds.emplace_back(WSLCProcessFd{.Fd = -1, .Type = WSLCFdType::WSLCFdTypeDefault});
 
     // Virtio proxy forwards DNS via the host proxy, so the DNS channel and /gns args are only needed for NAT mode.
-    const bool enableDnsTunneling = FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode != WSLCNetworkingModeVirtioProxy;
+    const bool enableDnsTunneling = FeatureEnabled(WslcFeatureFlagsDnsTunneling) && m_networkingMode != WSLCNetworkingModeConsomme;
     if (enableDnsTunneling)
     {
         fds.emplace_back(WSLCProcessFd{.Fd = -1, .Type = WSLCFdType::WSLCFdTypeDefault});
@@ -455,7 +455,7 @@ WSLCNetworkingMode WSLCVirtualMachine::NetworkingMode() const
 bool WSLCVirtualMachine::UseWslRelayPortForwarding() const
 {
     return m_networkingMode == WSLCNetworkingModeNAT ||
-           (m_networkingMode == WSLCNetworkingModeVirtioProxy && FeatureEnabled(WslcFeatureFlagsPortRelayWslRelay));
+           (m_networkingMode == WSLCNetworkingModeConsomme && FeatureEnabled(WslcFeatureFlagsPortRelayWslRelay));
 }
 
 void WSLCVirtualMachine::WatchForExitedProcesses(wsl::shared::SocketChannel& Channel)
@@ -976,7 +976,7 @@ void WSLCVirtualMachine::MapPort(VMPortMapping& Mapping)
 
         MapRelayPort(Mapping.BindAddress.si_family, Mapping.HostPort(), Mapping.VmPort->Port(), false);
     }
-    else if (m_networkingMode == WSLCNetworkingModeVirtioProxy)
+    else if (m_networkingMode == WSLCNetworkingModeConsomme)
     {
         USHORT allocatedHostPort = 0;
         auto result = m_vm->MapVirtioNetPort(
@@ -1023,7 +1023,7 @@ void WSLCVirtualMachine::UnmapPort(VMPortMapping& Mapping)
     {
         MapRelayPort(Mapping.BindAddress.si_family, Mapping.HostPort(), Mapping.VmPort->Port(), true);
     }
-    else if (m_networkingMode == WSLCNetworkingModeVirtioProxy)
+    else if (m_networkingMode == WSLCNetworkingModeConsomme)
     {
         THROW_IF_FAILED(m_vm->UnmapVirtioNetPort(
             Mapping.HostPort(), Mapping.VmPort->Port(), Mapping.Protocol, Mapping.BindingAddressString().c_str()));

--- a/src/windows/wslsettings/LibWsl.cs
+++ b/src/windows/wslsettings/LibWsl.cs
@@ -52,7 +52,7 @@ namespace LibWsl
         Nat = 1,
         Bridged = 2,
         Mirrored = 3,
-        VirtioProxy = 4
+        Consomme = 4
     }
 
     public enum MemoryReclaimMode

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -101,7 +101,7 @@ bool TryLoadWinhttpProxyMethods() noexcept
         } \
     }
 
-#define VIRTIOPROXY_TEST_ONLY() \
+#define CONSOMME_TEST_ONLY() \
     { \
     }
 
@@ -163,7 +163,7 @@ public:
 
 namespace NetworkTests {
 
-class VirtioProxyTests;
+class ConsommeTests;
 
 class NetworkTests
 {
@@ -171,7 +171,7 @@ class NetworkTests
 
     friend class MirroredTests;
     friend class BridgedTests;
-    friend class VirtioProxyTests;
+    friend class ConsommeTests;
 
     struct IpAddress
     {
@@ -1802,7 +1802,7 @@ class NetworkTests
             WINDOWS_11_TEST_ONLY();
             __fallthrough;
         case wsl::core::NetworkingMode::Mirrored:
-        case wsl::core::NetworkingMode::VirtioProxy:
+        case wsl::core::NetworkingMode::Consomme:
             if (!LxsstuVmMode())
             {
                 LogSkipped("This test is only applicable to WSL2");
@@ -4911,9 +4911,9 @@ class BridgedTests
     }
 };
 
-class VirtioProxyTests
+class ConsommeTests
 {
-    WSL_TEST_CLASS(VirtioProxyTests)
+    WSL_TEST_CLASS(ConsommeTests)
 
     std::optional<WslConfigChange> m_config;
 
@@ -4923,7 +4923,7 @@ class VirtioProxyTests
 
         if (LxsstuVmMode())
         {
-            m_config.emplace(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+            m_config.emplace(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
         }
 
         return true;
@@ -4940,9 +4940,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(SmokeTest)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         // Verify that we have a working connection
         NetworkTests::GuestClient(L"tcp-connect:bing.com:80");
@@ -4950,9 +4950,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(InternetConnectivityV4)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         if (!NetworkTests::HostHasInternetConnectivity(AF_INET))
         {
@@ -4965,9 +4965,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(InternetConnectivityV6)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         if (!NetworkTests::HostHasInternetConnectivity(AF_INET6))
         {
@@ -4982,9 +4982,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(Configuration)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         const auto state = NetworkTests::GetInterfaceState(L"eth0");
         VERIFY_IS_FALSE(state.V4Addresses.empty());
@@ -5007,9 +5007,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(ValidateMacAddress)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         // eth0 should have wsldevicehost's default client MAC. Update if that default changes.
         VERIFY_ARE_EQUAL(GetMacAddress(L"eth0"), std::wstring(L"00:00:00:00:01:00"));
@@ -5017,9 +5017,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(GuestPortIsReleased)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         // Make sure the VM doesn't time out
         WslKeepAlive keepAlive;
@@ -5045,9 +5045,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(LoopbackGuestToHost)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         // Verify guest can connect to host on loopback (TCP only, UDP not supported)
         NetworkTests::VerifyLoopbackGuestToHost(L"127.0.0.1", IPPROTO_TCP);
@@ -5059,9 +5059,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(UdpBindDoesNotPreventTcpBind)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         auto tcpPort = NetworkTests::BindGuestPort(L"TCP4-LISTEN:1234", true);
         auto udpPort = NetworkTests::BindGuestPort(L"UDP4-LISTEN:1234", true);
@@ -5069,9 +5069,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(HostUdpBindDoesNotPreventGuestTcpBind)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         auto udpPort = NetworkTests::BindHostPort(2345, SOCK_DGRAM, IPPROTO_UDP, true);
         auto tcpPort = NetworkTests::BindGuestPort(L"TCP4-LISTEN:2345", true);
@@ -5079,36 +5079,36 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(PortZeroBindIsTracked)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         NetworkTests::VerifyPortZeroBindIsTracked();
     }
 
     WSL2_TEST_METHOD(PortZeroRebindSucceeds)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         NetworkTests::VerifyPortZeroRebindSucceeds();
     }
 
     WSL2_TEST_METHOD(HttpProxySimple)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
         WINHTTP_PROXY_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .autoProxy = true}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .autoProxy = true}));
         NetworkTests::VerifyHttpProxySimple();
     }
 
     WSL2_TEST_METHOD(ConfigurationV6)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         if (!NetworkTests::HostHasInternetConnectivity(AF_INET6))
         {
@@ -5181,10 +5181,10 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(GuestPortIsReleasedV6)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
         WINDOWS_11_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         // Make sure the VM doesn't time out
         WslKeepAlive keepAlive;
@@ -5210,9 +5210,9 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(ConfigurationV6DnsServers)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         if (!NetworkTests::HostHasInternetConnectivity(AF_INET6))
         {
@@ -5235,62 +5235,62 @@ class VirtioProxyTests
 
     WSL2_TEST_METHOD(DnsResolutionBasic)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = false}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .dnsTunneling = false}));
         NetworkTests::VerifyDnsResolutionBasic();
     }
 
     WSL2_TEST_METHOD(DnsResolutionDig)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = false}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .dnsTunneling = false}));
         NetworkTests::VerifyDnsResolutionDig();
     }
 
     WSL2_TEST_METHOD(DnsResolutionRecordTypes)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = false}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .dnsTunneling = false}));
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
 
     WSL2_TEST_METHOD(DnsResolutionBasicDnsTunneling)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
         DNS_TUNNELING_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .dnsTunneling = true}));
         NetworkTests::VerifyDnsResolutionBasic();
     }
 
     WSL2_TEST_METHOD(DnsResolutionDigDnsTunneling)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
         DNS_TUNNELING_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .dnsTunneling = true}));
         NetworkTests::VerifyDnsResolutionDig();
     }
 
     WSL2_TEST_METHOD(DnsResolutionRecordTypesDnsTunneling)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
         DNS_TUNNELING_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .dnsTunneling = true}));
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
 
     // Verifies that virtio proxy + dnsTunneling points resolv.conf at the gateway, not the hvsocket listener IP.
     WSL2_TEST_METHOD(DnsTunnelingResolvConfUsesGateway)
     {
-        VIRTIOPROXY_TEST_ONLY();
+        CONSOMME_TEST_ONLY();
         DNS_TUNNELING_TEST_ONLY();
 
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy, .dnsTunneling = true}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme, .dnsTunneling = true}));
 
         const auto state = NetworkTests::GetInterfaceState(L"eth0");
         VERIFY_IS_TRUE(state.Gateway.has_value());

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -5284,7 +5284,7 @@ class ConsommeTests
         NetworkTests::VerifyDnsResolutionRecordTypes();
     }
 
-    // Verifies that virtio proxy + dnsTunneling points resolv.conf at the gateway, not the hvsocket listener IP.
+    // Verifies that Consomme + dnsTunneling points resolv.conf at the gateway, not the hvsocket listener IP.
     WSL2_TEST_METHOD(DnsTunnelingResolvConfUsesGateway)
     {
         CONSOMME_TEST_ONLY();

--- a/test/windows/PluginTests.cpp
+++ b/test/windows/PluginTests.cpp
@@ -684,7 +684,7 @@ class PluginTests
         ConfigurePlugin(PluginTestType::WslcImagePull);
 
         {
-            auto session = CreateWslcSession(L"plugin-wslc-pull-test", WSLCNetworkingModeVirtioProxy);
+            auto session = CreateWslcSession(L"plugin-wslc-pull-test", WSLCNetworkingModeConsomme);
 
             // Load the registry and debian images.
             LoadTestImage(*session, "debian:latest");

--- a/test/windows/PolicyTests.cpp
+++ b/test/windows/PolicyTests.cpp
@@ -261,7 +261,7 @@ class PolicyTest
 
     WSL2_TEST_METHOD(CustomNetworkingMode)
     {
-        WslConfigChange config(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+        WslConfigChange config(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         {
             auto revert = SetPolicy(c_allowCustomNetworkingModeUserSetting, 1);
@@ -284,8 +284,8 @@ class PolicyTest
             ValidateWarnings(L"");
 
             // Validate that no warnings are shown if the default networking mode is set to the same value as .wslconfig.
-            auto revertDefault = SetPolicy(c_defaultNetworkingMode, static_cast<DWORD>(wsl::core::NetworkingMode::VirtioProxy));
-            config.Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::VirtioProxy}));
+            auto revertDefault = SetPolicy(c_defaultNetworkingMode, static_cast<DWORD>(wsl::core::NetworkingMode::Consomme));
+            config.Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
             ValidateWarnings(L"");
         }
     }
@@ -414,10 +414,10 @@ class PolicyTest
         }
 
         {
-            auto revert = SetPolicy(c_defaultNetworkingMode, static_cast<DWORD>(wsl::core::NetworkingMode::VirtioProxy));
+            auto revert = SetPolicy(c_defaultNetworkingMode, static_cast<DWORD>(wsl::core::NetworkingMode::Consomme));
             WslShutdown();
 
-            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"wslinfo --networking-mode | grep -iF 'virtioproxy'"), 0u);
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"wslinfo --networking-mode | grep -iF 'consomme'"), 0u);
         }
     }
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2147,7 +2147,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         validateWarnings(L"NoEqual", std::format(L"wsl: Expected '=' in {}:21\r\n", wslConfigPath));
         validateWarnings(
             L"networkingMode=InvalidMode",
-            std::format(L"wsl: Invalid value 'InvalidMode' for config key 'wsl2.networkingMode' in {}:2 (Valid values: Bridged, Mirrored, Nat, None, VirtioProxy)\r\n", wslConfigPath),
+            std::format(L"wsl: Invalid value 'InvalidMode' for config key 'wsl2.networkingMode' in {}:2 (Valid values: Bridged, Consomme, Mirrored, Nat, None, VirtioProxy)\r\n", wslConfigPath),
             L"[wsl2]\n");
         validateWarnings(
             L"networkingMode=a\\m", std::format(L"wsl: Invalid escaped character: 'm' in {}:2\r\n", wslConfigPath), L"[wsl2]\n");
@@ -2166,7 +2166,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         validateWarnings(L"debugConsole=", std::format(L"wsl: Invalid boolean value '' for key 'wsl2.debugConsole' in {}:21\r\n", wslConfigPath));
         validateWarnings(
             L"networkingMode=",
-            std::format(L"wsl: Invalid value '' for config key 'wsl2.networkingMode' in {}:21 (Valid values: Bridged, Mirrored, Nat, None, VirtioProxy)\r\n", wslConfigPath));
+            std::format(L"wsl: Invalid value '' for config key 'wsl2.networkingMode' in {}:21 (Valid values: Bridged, Consomme, Mirrored, Nat, None, VirtioProxy)\r\n", wslConfigPath));
 
         validateWarnings(
             L"ipv6=true\nipv6=false",
@@ -3563,7 +3563,7 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
                 {NetworkingConfiguration::Nat, NetworkingConfiguration::Nat},
                 {NetworkingConfiguration::Bridged, NetworkingConfiguration::Bridged},
                 {NetworkingConfiguration::Mirrored, NetworkingConfiguration::Mirrored},
-                {NetworkingConfiguration::VirtioProxy, NetworkingConfiguration::VirtioProxy},
+                {NetworkingConfiguration::Consomme, NetworkingConfiguration::Consomme},
             };
 
             // tuple: WslConfigSetting, expectedValue, actualValue

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3171,7 +3171,7 @@ class WSLCTests
 
             if (mode == WSLCNetworkingModeConsomme)
             {
-                // Virtio proxy points resolv.conf at the eth0 gateway.
+                // Consomme points resolv.conf at the eth0 gateway.
                 ExpectCommandResult(
                     session.get(),
                     {"/bin/sh",

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -54,7 +54,7 @@ class WSLCTests
 
         // The WSLC SDK tests use this same storage to reduce pull overhead.
         m_storagePath = std::filesystem::current_path() / "test-storage";
-        m_defaultSessionSettings = GetDefaultSessionSettings(c_testSessionName, true, WSLCNetworkingModeVirtioProxy);
+        m_defaultSessionSettings = GetDefaultSessionSettings(c_testSessionName, true, WSLCNetworkingModeConsomme);
         m_defaultSession = CreateSession(m_defaultSessionSettings);
 
         wil::unique_cotaskmem_array_ptr<WSLCImageInformation> images;
@@ -782,7 +782,7 @@ class WSLCTests
         // Validate that PullImage() fails appropriately when the session runs out of space.
         {
             auto settings = GetDefaultSessionSettings(L"wslc-pull-image-out-of-space", false);
-            settings.NetworkingMode = WSLCNetworkingModeVirtioProxy;
+            settings.NetworkingMode = WSLCNetworkingModeConsomme;
             settings.MemoryMb = 1024;
             auto session = CreateSession(settings);
 
@@ -3169,7 +3169,7 @@ class WSLCTests
         {
             auto result = ExpectCommandResult(session.get(), {"/bin/grep", "-iF", "nameserver ", "/etc/resolv.conf"}, 0);
 
-            if (mode == WSLCNetworkingModeVirtioProxy)
+            if (mode == WSLCNetworkingModeConsomme)
             {
                 // Virtio proxy points resolv.conf at the eth0 gateway.
                 ExpectCommandResult(
@@ -3205,15 +3205,15 @@ class WSLCTests
         ValidateNetworking(WSLCNetworkingModeNAT, true);
     }
 
-    TEST_METHOD(VirtioProxyNetworking)
+    TEST_METHOD(ConsommeNetworking)
     {
-        ValidateNetworking(WSLCNetworkingModeVirtioProxy);
+        ValidateNetworking(WSLCNetworkingModeConsomme);
     }
 
-    TEST_METHOD(VirtioProxyNetworkingWithDnsTunneling)
+    TEST_METHOD(ConsommeNetworkingWithDnsTunneling)
     {
         WINDOWS_11_TEST_ONLY();
-        ValidateNetworking(WSLCNetworkingModeVirtioProxy, true);
+        ValidateNetworking(WSLCNetworkingModeConsomme, true);
     }
 
     // DNS test helpers
@@ -3399,9 +3399,9 @@ class WSLCTests
         ValidatePortMapping(WSLCNetworkingModeNAT);
     }
 
-    TEST_METHOD(PortMappingVirtioProxy)
+    TEST_METHOD(PortMappingConsomme)
     {
-        ValidatePortMapping(WSLCNetworkingModeVirtioProxy);
+        ValidatePortMapping(WSLCNetworkingModeConsomme);
     }
 
     WSLC_TEST_METHOD(StuckVmTermination)
@@ -7962,17 +7962,17 @@ class WSLCTests
         RunPortMappingsTest(*session, "host", false);
     }
 
-    WSLC_TEST_METHOD(PortMappingsVirtioProxy)
+    WSLC_TEST_METHOD(PortMappingsConsomme)
     {
-        auto [restore, session] = SetupPortMappingsTest(WSLCNetworkingModeVirtioProxy);
+        auto [restore, session] = SetupPortMappingsTest(WSLCNetworkingModeConsomme);
 
         RunPortMappingsTest(*session, "bridge", true);
         RunPortMappingsTest(*session, "host", true);
     }
 
-    WSLC_TEST_METHOD(PortMappingsVirtioProxyWslRelay)
+    WSLC_TEST_METHOD(PortMappingsConsommeWslRelay)
     {
-        auto [restore, session] = SetupPortMappingsTest(WSLCNetworkingModeVirtioProxy, WslcFeatureFlagsPortRelayWslRelay);
+        auto [restore, session] = SetupPortMappingsTest(WSLCNetworkingModeConsomme, WslcFeatureFlagsPortRelayWslRelay);
 
         RunPortMappingsTest(*session, "bridge", false);
         RunPortMappingsTest(*session, "host", false);
@@ -7980,7 +7980,7 @@ class WSLCTests
 
     WSLC_TEST_METHOD(PortMappingsAdvanced)
     {
-        auto [restore, session] = SetupPortMappingsTest(WSLCNetworkingModeVirtioProxy);
+        auto [restore, session] = SetupPortMappingsTest(WSLCNetworkingModeConsomme);
 
         // Helper to resolve the first non-loopback IPv4 address on an active host adapter.
         auto getHostAdapterIpv4 = []() -> std::optional<std::string> {
@@ -11137,7 +11137,7 @@ class WSLCTests
 
         // Phase 1: Create a session and inject a container with a corrupt WSLC metadata label via docker CLI.
         {
-            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeVirtioProxy);
+            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeConsomme);
             settings.StoragePath = storagePath.c_str();
             auto session = CreateSession(settings);
 
@@ -11160,7 +11160,7 @@ class WSLCTests
             // Phase 2: Create a new session pointing to the same storage with a warning callback.
             auto warningCallback = Microsoft::WRL::Make<CapturingWarningCallback>();
 
-            auto settings2 = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeVirtioProxy);
+            auto settings2 = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeConsomme);
             settings2.StoragePath = storagePath.c_str();
 
             const auto sessionManager2 = OpenSessionManager();
@@ -11195,7 +11195,7 @@ class WSLCTests
 
         // Phase 1: Create a session with a VHD volume, then get the VHD path.
         {
-            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeVirtioProxy);
+            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeConsomme);
             settings.StoragePath = storagePath.c_str();
             auto session = CreateSession(settings);
 
@@ -11228,7 +11228,7 @@ class WSLCTests
         {
             auto warningCallback = Microsoft::WRL::Make<CapturingWarningCallback>();
 
-            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeVirtioProxy);
+            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeConsomme);
             settings.StoragePath = storagePath.c_str();
 
             const auto sessionManager = OpenSessionManager();
@@ -11266,7 +11266,7 @@ class WSLCTests
         // This bypasses our CreateVolume validation, leaving a volume that WSLCGuestVolumeImpl::Open will reject when the next
         // session recovers it.
         {
-            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeVirtioProxy);
+            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeConsomme);
             settings.StoragePath = storagePath.c_str();
             auto session = CreateSession(settings);
 
@@ -11293,7 +11293,7 @@ class WSLCTests
         {
             auto warningCallback = Microsoft::WRL::Make<CapturingWarningCallback>();
 
-            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeVirtioProxy);
+            auto settings = GetDefaultSessionSettings(c_sessionName, false, WSLCNetworkingModeConsomme);
             settings.StoragePath = storagePath.c_str();
 
             const auto sessionManager = OpenSessionManager();

--- a/test/windows/wslc/WSLCCLISettingsUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLISettingsUnitTests.cpp
@@ -305,7 +305,7 @@ class WSLCCLISettingsUnitTests
         VERIFY_ARE_EQUAL(0u, s.Get<Setting::SessionCpuCount>());
         VERIFY_ARE_EQUAL(0u, s.Get<Setting::SessionMemoryMb>());
         VERIFY_ARE_EQUAL(1048576u, s.Get<Setting::SessionStorageSizeMb>());
-        VERIFY_ARE_EQUAL(static_cast<int>(WSLCNetworkingModeVirtioProxy), static_cast<int>(s.Get<Setting::SessionNetworkingMode>()));
+        VERIFY_ARE_EQUAL(static_cast<int>(WSLCNetworkingModeConsomme), static_cast<int>(s.Get<Setting::SessionNetworkingMode>()));
         VERIFY_ARE_EQUAL(static_cast<int>(HostFileShareMode::VirtioFs), static_cast<int>(s.Get<Setting::SessionHostFileShareMode>()));
         VERIFY_IS_TRUE(s.Get<Setting::SessionDnsTunneling>());
         VERIFY_ARE_EQUAL(static_cast<int>(PortRelayType::VirtioNet), static_cast<int>(s.Get<Setting::SessionPortRelay>()));
@@ -372,7 +372,7 @@ class WSLCCLISettingsUnitTests
         VERIFY_ARE_EQUAL(
             Loc::WSLCUserSettings_Warning_InvalidValue(L"credentialStore", s.SettingsFilePath().wstring(), 3), s.GetWarnings()[1].Message);
         // Values still fall back to built-in defaults.
-        VERIFY_ARE_EQUAL(static_cast<int>(WSLCNetworkingModeVirtioProxy), static_cast<int>(s.Get<Setting::SessionNetworkingMode>()));
+        VERIFY_ARE_EQUAL(static_cast<int>(WSLCNetworkingModeConsomme), static_cast<int>(s.Get<Setting::SessionNetworkingMode>()));
         VERIFY_ARE_EQUAL(static_cast<int>(CredentialStoreType::WinCred), static_cast<int>(s.Get<Setting::CredentialStore>()));
     }
 


### PR DESCRIPTION
Renames the `VirtioProxy` networking mode to `Consomme` (after [OpenVMM's consomme](https://github.com/microsoft/openvmm/tree/main/vm/devices/net/net_consomme/consomme) user-mode NAT), including the `VirtioNetworking` engine class/files. The `.wslconfig` `networkingMode` parser still accepts the legacy `virtioproxy` string as an alias.