### PR TITLE
Fix race condition causing errors in the wslc.exe tests

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -316,17 +316,6 @@ void EnsureContainerDoesNotExist(const std::wstring& containerName)
         return;
     }
 
-    if (it->State == WSLCContainerState::WslcContainerStateRunning)
-    {
-        auto result = RunWslc(std::format(L"container kill {}", containerName));
-        // Tolerate WSLC_E_CONTAINER_NOT_FOUND - container already stopped/removed
-        if (result.ExitCode != 0 &&
-            (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))
-        {
-            result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
-        }
-    }
-
     auto result = RunWslc(std::format(L"container remove --force {}", containerName));
     // Tolerate WSLC_E_CONTAINER_NOT_FOUND - container already removed
     if (result.ExitCode != 0 && (!result.Stderr.has_value() || result.Stderr.value().find(L"WSLC_E_CONTAINER_NOT_FOUND") == std::wstring::npos))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a TOCTOU condition in the wslc tests that can occur if a container is stopping. This change solves the issue by removing the explicit `kill` (which fails if the container is not running), and relying on `rm -f` to stop it instead.

This issue could result in errors like:
```
Summary of Errors Outside of Tests:
    Error: Verify: AreEqual(*expected.Stderr, *Stderr) - Values (, Container '05fb5e1dfef56690520e0e8f931f9990ba7281a4f46c529cb35ac0aefc5e912b' is not running.
Error code: WSLC_E_CONTAINER_NOT_RUNNING
) [File: C:\Users\piboulay\repos\wsl\test\windows\wslc\e2e\WSLCExecutor.cpp, Function: WSLCE2ETests::WSLCExecutionResult::Verify, Line: 89]
    Error: TAEF: Cleanup fixture 'WSLCE2ETests::WSLCE2EContainerLogsTests::ClassCleanup' for the scope 'WSLCE2ETests::WSLCE2EContainerLogsTests' failed.

```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
