### PR TITLE
Authorize host-bound interop messages by peer credentials

### DIFF
--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -339,7 +339,8 @@ void ConfigHandleInteropMessage(
     bool Elevated,
     gsl::span<gsl::byte> Message,
     const MESSAGE_HEADER* Header,
-    const wsl::linux::WslDistributionConfig& Config)
+    const wsl::linux::WslDistributionConfig& Config,
+    uid_t PeerUid)
 
 /*++
 
@@ -361,6 +362,12 @@ Arguments:
 
     Header- Supplies the message Header.
 
+    Config - Supplies the distribution configuration.
+
+    PeerUid - Supplies the user ID of the connecting peer, as reported by
+        SO_PEERCRED, or (uid_t)-1 if the peer could not be identified. Used to
+        authorize privileged message types.
+
 Return Value:
 
     None.
@@ -372,6 +379,19 @@ try
     switch (Header->MessageType)
     {
     case LxInitMessageCreateProcessUtilityVm:
+
+        //
+        // This message is relayed to wslservice on the host, which creates a
+        // process in the Windows session owner's token. Only root inside the
+        // distribution may drive it from init's interop socket.
+        //
+
+        if (PeerUid != 0)
+        {
+            LOG_ERROR("LxInitMessageCreateProcessUtilityVm denied: peer uid {}", PeerUid);
+            break;
+        }
+
         if (InteropChannel.Socket() > 0)
         {
             InteropChannel.SendMessage<LX_INIT_CREATE_NT_PROCESS_UTILITY_VM>(Message);
@@ -974,6 +994,8 @@ try
                     continue;
                 }
 
+                const uid_t PeerUid = UtilGetPeerUid(ClientChannel.Socket());
+
                 auto transaction = ClientChannel.ReceiveTransaction();
                 auto [Message, Span] = transaction.ReceiveOrClosed<MESSAGE_HEADER>();
                 if (Message == nullptr)
@@ -981,7 +1003,7 @@ try
                     continue;
                 }
 
-                ConfigHandleInteropMessage(transaction, InteropChannel, Elevated, Span, Message, Config);
+                ConfigHandleInteropMessage(transaction, InteropChannel, Elevated, Span, Message, Config, PeerUid);
             }
         });
 

--- a/src/linux/init/config.h
+++ b/src/linux/init/config.h
@@ -405,7 +405,8 @@ void ConfigHandleInteropMessage(
     bool Elevated,
     gsl::span<gsl::byte> Message,
     const MESSAGE_HEADER* Header,
-    const wsl::linux::WslDistributionConfig& Config);
+    const wsl::linux::WslDistributionConfig& Config,
+    uid_t PeerUid);
 
 void ConfigInitializeCgroups(wsl::linux::WslDistributionConfig& Config);
 

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -1966,6 +1966,8 @@ Return Value:
                 continue;
             }
 
+            const uid_t PeerUid = UtilGetPeerUid(channel.Socket());
+
             auto transaction = channel.ReceiveTransaction();
             auto [Header, Span] = transaction.ReceiveOrClosed<MESSAGE_HEADER>();
             if (Header != nullptr)
@@ -1973,7 +1975,7 @@ Return Value:
                 try
                 {
                     ConfigHandleInteropMessage(
-                        transaction, ControlChannel, WI_IsFlagSet(CreateProcess.Common.Flags, LxInitCreateProcessFlagsElevated), Span, Header, Config);
+                        transaction, ControlChannel, WI_IsFlagSet(CreateProcess.Common.Flags, LxInitCreateProcessFlagsElevated), Span, Header, Config, PeerUid);
                 }
                 CATCH_LOG();
             }

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include <sys/utsname.h>
 #include <sys/types.h>
 #include <sys/sysinfo.h>
+#include <sys/socket.h>
 #include <grp.h>
 #include <unistd.h>
 #include <sys/prctl.h>
@@ -438,6 +439,39 @@ Return Value:
 
 {
     Path.resize(UtilCanonicalisePathSeparator(Path.data(), Separator));
+}
+
+uid_t UtilGetPeerUid(int Socket)
+
+/*++
+
+Routine Description:
+
+    This routine queries the credentials of the peer connected to a Unix
+    domain socket so that privileged interop messages can be authorized
+    against the caller's user ID.
+
+Arguments:
+
+    Socket - Supplies the accepted socket file descriptor.
+
+Return Value:
+
+    The peer's user ID, or (uid_t)-1 on failure. Callers must fail closed
+    when the peer cannot be identified.
+
+--*/
+
+{
+    struct ucred Credentials{};
+    socklen_t Length = sizeof(Credentials);
+    if (getsockopt(Socket, SOL_SOCKET, SO_PEERCRED, &Credentials, &Length) < 0)
+    {
+        LOG_ERROR("getsockopt(SO_PEERCRED) failed {}", errno);
+        return static_cast<uid_t>(-1);
+    }
+
+    return Credentials.uid;
 }
 
 wil::unique_fd UtilConnectToInteropServer(std::optional<pid_t> Pid)

--- a/src/linux/init/util.h
+++ b/src/linux/init/util.h
@@ -128,6 +128,8 @@ void UtilCanonicalisePathSeparator(std::string& Path, char Separator);
 
 wil::unique_fd UtilConnectToInteropServer(std::optional<pid_t> Pid = {});
 
+uid_t UtilGetPeerUid(int Socket);
+
 wil::unique_fd UtilConnectUnix(const char* Path);
 
 wil::unique_fd UtilConnectVsock(


### PR DESCRIPTION
Gates the host-bound interop message on the connecting peer's credentials. init's interop Unix socket is world-connectable by design, but the dispatcher never checked who connected.

The `CreateProcessUtilityVm` message is relayed to the host service, which creates a process in the Windows session owner's token, so any uid in the distro could drive a host-side process creation through it.

Capture the peer uid via `SO_PEERCRED` at accept time (fail closed) and require the peer to be root before forwarding `CreateProcessUtilityVm`. Other interop messages are unchanged.