### PR TITLE
Update MSRDC to 1.2.7214 to fix CVE-2026-32157

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
   <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.8" />
   <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.8" />
-  <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6676" />
+  <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.7214" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.CsWinRT" version="2.2.0" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.251108.1" targetFramework="native" />


### PR DESCRIPTION
## Summary

Bumps Microsoft.RemoteDesktop.Client.MSRDC.SessionHost from **1.2.6676** to **1.2.7214** in packages.config.

This addresses **CVE-2026-32157** (a use-after-free RCE in the Remote Desktop client), which was first fixed upstream in MSRDC **1.2.7099**. Pinning to **1.2.7214** (latest GA, June 10 2026) also picks up several additional CVE fixes shipped after 7099: CVE-2026-45639, -42908, -42909, -42913, -42992, -44799, -44801, -42985, -47289.

The matching Microsoft.RemoteDesktop.Client.MSRDC.SessionHost 1.2.7214 package has been mirrored to the `WslDependencies` feed so the build can restore it. Package layout is unchanged (`build/native/bin/{x64,x86,arm64}/msrdc.exe` plus `rdclientax.dll`, `rdpnanoTransport.dll`, `RdpWinStlHelper.dll` and MUIs), so this is a drop-in version bump. `MSRDC_VERSION` (used in `wsl --version`) is derived automatically from `packages.config`.

Fixes #40868