### PR TITLE
Add hybrid CRT link for Windows binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,15 @@ if (${TARGET_PLATFORM} STREQUAL "x64")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /CETCOMPAT")
 endif()
 
+# Hybrid CRT: static-link the C++ runtime and STL (/MT|/MTd from CMAKE_MSVC_RUNTIME_LIBRARY),
+# but dynamic-link the Universal CRT (ucrt.dll) which is an OS component on Windows 10+.
+# This eliminates the VCRUNTIME/MSVCP redistributable dependency while avoiding the size
+# cost of statically linking the UCRT. See https://aka.ms/hybridcrt for details.
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE    "${CMAKE_EXE_LINKER_FLAGS_RELEASE}    /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
+set(CMAKE_SHARED_LINKER_FLAGS_DEBUG   "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}   /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG      "${CMAKE_EXE_LINKER_FLAGS_DEBUG}      /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
+
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)
 set(COMMON_LINK_LIBRARIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,10 +332,12 @@ endif()
 # but dynamic-link the Universal CRT (ucrt.dll) which is an OS component on Windows 10+.
 # This eliminates the VCRUNTIME/MSVCP redistributable dependency while avoiding the size
 # cost of statically linking the UCRT. See https://aka.ms/hybridcrt for details.
-set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
-set(CMAKE_EXE_LINKER_FLAGS_RELEASE    "${CMAKE_EXE_LINKER_FLAGS_RELEASE}    /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
-set(CMAKE_SHARED_LINKER_FLAGS_DEBUG   "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}   /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
-set(CMAKE_EXE_LINKER_FLAGS_DEBUG      "${CMAKE_EXE_LINKER_FLAGS_DEBUG}      /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
+foreach(config RELEASE RELWITHDEBINFO MINSIZEREL)
+    set(CMAKE_SHARED_LINKER_FLAGS_${config} "${CMAKE_SHARED_LINKER_FLAGS_${config}} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
+    set(CMAKE_EXE_LINKER_FLAGS_${config}    "${CMAKE_EXE_LINKER_FLAGS_${config}}    /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
+endforeach()
+set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG    "${CMAKE_EXE_LINKER_FLAGS_DEBUG}    /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
 
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,10 +334,8 @@ endif()
 # cost of statically linking the UCRT. See https://aka.ms/hybridcrt for details.
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE    "${CMAKE_EXE_LINKER_FLAGS_RELEASE}    /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
-set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG   "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}   /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG      "${CMAKE_EXE_LINKER_FLAGS_DEBUG}      /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
-set(CMAKE_STATIC_LINKER_FLAGS_DEBUG   "${CMAKE_STATIC_LINKER_FLAGS_DEBUG}   /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
 
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,12 +332,12 @@ endif()
 # but dynamic-link the Universal CRT (ucrt.dll) which is an OS component on Windows 10+.
 # This eliminates the VCRUNTIME/MSVCP redistributable dependency while avoiding the size
 # cost of statically linking the UCRT. See https://aka.ms/hybridcrt for details.
-foreach(config RELEASE RELWITHDEBINFO MINSIZEREL)
-    set(CMAKE_SHARED_LINKER_FLAGS_${config} "${CMAKE_SHARED_LINKER_FLAGS_${config}} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
-    set(CMAKE_EXE_LINKER_FLAGS_${config}    "${CMAKE_EXE_LINKER_FLAGS_${config}}    /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
-endforeach()
-set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
-set(CMAKE_EXE_LINKER_FLAGS_DEBUG    "${CMAKE_EXE_LINKER_FLAGS_DEBUG}    /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE    "${CMAKE_EXE_LINKER_FLAGS_RELEASE}    /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
+set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /defaultlib:ucrt.lib")
+set(CMAKE_SHARED_LINKER_FLAGS_DEBUG   "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}   /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG      "${CMAKE_EXE_LINKER_FLAGS_DEBUG}      /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
+set(CMAKE_STATIC_LINKER_FLAGS_DEBUG   "${CMAKE_STATIC_LINKER_FLAGS_DEBUG}   /NODEFAULTLIB:libucrtd.lib /defaultlib:ucrtd.lib")
 
 # Common link libraries
 link_directories(${WSLDEPS_SOURCE_DIR}/lib/)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Configures hybrid static linkage for Windows binaries in the build.  See https://aka.ms/hybridcrt for details on this model.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The Windows binaries are all already statically linking the runtime.  Switching to the hybrid model will cut non-trivial size from every binary, without adding any new dependency requirements.

I also understand if we want to wait on taking this until after a significant release so it may have more time to stabilize.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built debug locally, ran an arbitrary test.