### PR TITLE
Fix relay bug causing image import to fail without a proper error

### DIFF
--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -340,7 +340,7 @@ void HandleMessageImpl(
             }
             else if (UtilWriteBuffer(socket.get(), relayBuffer.data(), bytesRead) < 0)
             {
-                if (errno == ECONNRESET)
+                if (errno == ECONNRESET || errno == EPIPE)
                 {
                     // The other side of the socket has been closed. This isn't necessarily an error, so stop relaying this direction.
                     pollDescriptors[1].fd = -1;

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -340,6 +340,13 @@ void HandleMessageImpl(
             }
             else if (UtilWriteBuffer(socket.get(), relayBuffer.data(), bytesRead) < 0)
             {
+                if (errno == ECONNRESET)
+                {
+                    // The other side of the socket has been closed. This isn't necessarily an error, so stop relaying this direction.
+                    pollDescriptors[1].fd = -1;
+                    continue;
+                }
+
                 LOG_ERROR("write failed {}", errno);
                 break;
             }

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1327,6 +1327,30 @@ class WSLCTests
             ValidateCOMErrorMessage(L"archive/tar: invalid tar header");
         }
 
+        // Validate that a large (300MB) invalid tar fails with proper error message and code.
+        {
+            auto largeFile =
+                wil::create_new_file(L"largefile", GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ, nullptr, FILE_FLAG_DELETE_ON_CLOSE);
+
+            // Create an invalid header (docker ignores the entire file if it's header is only null bytes).
+            DWORD bytesWritten{};
+            THROW_IF_WIN32_BOOL_FALSE(WriteFile(largeFile.get(), "foo", 3, &bytesWritten, nullptr));
+            THROW_LAST_ERROR_IF(SetFilePointer(largeFile.get(), 300 * _1MB, nullptr, FILE_BEGIN) == INVALID_SET_FILE_POINTER);
+
+            THROW_IF_WIN32_BOOL_FALSE(SetEndOfFile(largeFile.get()));
+            THROW_LAST_ERROR_IF(SetFilePointer(largeFile.get(), 0, nullptr, FILE_BEGIN) == INVALID_SET_FILE_POINTER);
+
+            VERIFY_IS_TRUE(GetFileSizeEx(largeFile.get(), &fileSize));
+            VERIFY_ARE_EQUAL(fileSize.QuadPart, 300 * _1MB);
+
+            VERIFY_ARE_EQUAL(
+                m_defaultSession->ImportImage(
+                    ToCOMInputHandle(largeFile.get()), "invalid-large-image:test", nullptr, fileSize.QuadPart, nullptr, &imageId),
+                E_FAIL);
+
+            ValidateCOMErrorMessage(L"archive/tar: invalid tar header");
+        }
+
         // Validate that ImportImage fails when the input pipe is closed during reading.
         {
             wil::unique_handle pipeRead;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1332,10 +1332,10 @@ class WSLCTests
             auto largeFile =
                 wil::create_new_file(L"largefile", GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ, nullptr, FILE_FLAG_DELETE_ON_CLOSE);
 
-            // Create an invalid header (docker ignores the entire file if it's header is only null bytes).
+            // Create an invalid header (docker ignores the entire file if its header is only null bytes).
             DWORD bytesWritten{};
             THROW_IF_WIN32_BOOL_FALSE(WriteFile(largeFile.get(), "foo", 3, &bytesWritten, nullptr));
-            THROW_LAST_ERROR_IF(SetFilePointer(largeFile.get(), 300 * _1MB, nullptr, FILE_BEGIN) == INVALID_SET_FILE_POINTER);
+            THROW_LAST_ERROR_IF(SetFilePointer(largeFile.get(), static_cast<LONG>(300 * _1MB), nullptr, FILE_BEGIN) == INVALID_SET_FILE_POINTER);
 
             THROW_IF_WIN32_BOOL_FALSE(SetEndOfFile(largeFile.get()));
             THROW_LAST_ERROR_IF(SetFilePointer(largeFile.get(), 0, nullptr, FILE_BEGIN) == INVALID_SET_FILE_POINTER);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a relay bug where the relay exits as soon as docker close the read side of its socket, which causes the service not to see the HTTP request response and fail with a generic `E_UNEXPECTED` instead of the proper error. 

Validated that the test reproduces the issue without the fix

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
