### PR TITLE
Install NOTICE.txt to the install directory via MSI

### DIFF
--- a/.pipelines/wsl-build-notice.yml
+++ b/.pipelines/wsl-build-notice.yml
@@ -16,11 +16,38 @@ steps:
 - task: ComponentGovernanceComponentDetection@0
   displayName: Component Detection
 
+# Append the WSLg NuGet's NOTICE: it covers Linux OSS shipped as binaries, which
+# Component Governance doesn't detect.
+- task: NuGetToolInstaller@1
+  displayName: Install NuGet
+
+- task: NuGetCommand@2
+  displayName: Restore packages (for the WSLg NOTICE)
+  inputs:
+    command: restore
+    restoreSolution: packages.config
+    feedsToUse: config
+    nugetConfigPath: NuGet.Config
+    restoreDirectory: $(Build.SourcesDirectory)/packages
+
+- powershell: |
+    $version = ([xml](Get-Content packages.config)).packages.package |
+        Where-Object { $_.id -eq 'Microsoft.WSLg' } |
+        Select-Object -ExpandProperty version
+    $notice = "$(Build.SourcesDirectory)/packages/Microsoft.WSLg.$version/NOTICE.txt"
+    if (-not (Test-Path $notice)) {
+        Write-Error "WSLg NOTICE not found at $notice"
+        exit 1
+    }
+    Write-Host "##vso[task.setvariable variable=WslgNoticePath]$notice"
+  displayName: Resolve WSLg NOTICE path
+
 - task: notice@0
   displayName: Generate NOTICE file
   inputs:
     outputfile: $(System.DefaultWorkingDirectory)/NOTICE.txt
     outputformat: text
+    additionaldata: $(WslgNoticePath)
 
 - task: PipAuthenticate@1
   inputs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,6 @@ find_nuget_package(Microsoft.WSL.LinuxSdk LINUXSDK /)
 find_nuget_package(Microsoft.WSL.TestDistro TEST_DISTRO /)
 find_nuget_package(Microsoft.WSL.TestData WSL_TEST_DATA /)
 find_nuget_package(Microsoft.WSLg WSLG /)
-set(WSLG_NOTICE_PATH "${WSLG_SOURCE_DIR}/NOTICE.txt")
 find_nuget_package(vswhere VSWHERE /tools)
 find_nuget_package(Wix WIX /tools/net6.0/any)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,9 @@ find_nuget_package(Microsoft.WSL.LinuxSdk LINUXSDK /)
 find_nuget_package(Microsoft.WSL.TestDistro TEST_DISTRO /)
 find_nuget_package(Microsoft.WSL.TestData WSL_TEST_DATA /)
 find_nuget_package(Microsoft.WSLg WSLG /build/native/bin)
+# NOTICE.txt is published at the root of the Microsoft.WSLg NuGet (not under build/native/bin),
+# so compute its path explicitly rather than walking up from WSLG_SOURCE_DIR.
+set(WSLG_NOTICE_PATH "${CMAKE_BINARY_DIR}/packages/Microsoft.WSLg.${WSLG_VERSION}/NOTICE.txt")
 find_nuget_package(vswhere VSWHERE /tools)
 find_nuget_package(Wix WIX /tools/net6.0/any)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,9 @@ find_nuget_package(Microsoft.WSL.TestDistro TEST_DISTRO /)
 find_nuget_package(Microsoft.WSL.TestData WSL_TEST_DATA /)
 find_nuget_package(Microsoft.WSLg WSLG /build/native/bin)
 # NOTICE.txt is published at the root of the Microsoft.WSLg NuGet (not under build/native/bin),
-# so compute its path explicitly rather than walking up from WSLG_SOURCE_DIR.
-set(WSLG_NOTICE_PATH "${CMAKE_BINARY_DIR}/packages/Microsoft.WSLg.${WSLG_VERSION}/NOTICE.txt")
+# so resolve the package root via find_nuget_package rather than re-deriving the restore layout.
+find_nuget_package(Microsoft.WSLg WSLG_ROOT /)
+set(WSLG_NOTICE_PATH "${WSLG_ROOT_SOURCE_DIR}/NOTICE.txt")
 find_nuget_package(vswhere VSWHERE /tools)
 find_nuget_package(Wix WIX /tools/net6.0/any)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,11 +132,8 @@ find_nuget_package(Microsoft.WSL.bsdtar BSDTARD /build/native/bin)
 find_nuget_package(Microsoft.WSL.LinuxSdk LINUXSDK /)
 find_nuget_package(Microsoft.WSL.TestDistro TEST_DISTRO /)
 find_nuget_package(Microsoft.WSL.TestData WSL_TEST_DATA /)
-find_nuget_package(Microsoft.WSLg WSLG /build/native/bin)
-# NOTICE.txt is published at the root of the Microsoft.WSLg NuGet (not under build/native/bin),
-# so resolve the package root via find_nuget_package rather than re-deriving the restore layout.
-find_nuget_package(Microsoft.WSLg WSLG_ROOT /)
-set(WSLG_NOTICE_PATH "${WSLG_ROOT_SOURCE_DIR}/NOTICE.txt")
+find_nuget_package(Microsoft.WSLg WSLG /)
+set(WSLG_NOTICE_PATH "${WSLG_SOURCE_DIR}/NOTICE.txt")
 find_nuget_package(vswhere VSWHERE /tools)
 find_nuget_package(Wix WIX /tools/net6.0/any)
 
@@ -239,8 +236,8 @@ set(PACKAGE_CERTIFICATE ${GENERATED_DIR}/dev-cert.pfx)
 # and the pipeline's symbol publishing step find them. Without the PDBs here,
 # Watson can't resolve function names in their crash frames.
 string(REPLACE ".dll" ".pdb" WSLG_TS_PLUGIN_PDB ${WSLG_TS_PLUGIN_DLL})
-file(CREATE_LINK ${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_DLL} ${BIN}/${WSLG_TS_PLUGIN_DLL})
-file(CREATE_LINK ${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_PDB} ${BIN}/${WSLG_TS_PLUGIN_PDB})
+file(CREATE_LINK ${WSLG_SOURCE_DIR}/build/native/bin/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_DLL} ${BIN}/${WSLG_TS_PLUGIN_DLL})
+file(CREATE_LINK ${WSLG_SOURCE_DIR}/build/native/bin/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_PDB} ${BIN}/${WSLG_TS_PLUGIN_PDB})
 file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.dll ${BIN}/wsldeps.dll)
 file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.pdb ${BIN}/wsldeps.pdb)
 # wsldevicehost.dll is packaged directly from its NuGet package, so only its PDB

--- a/msipackage/CMakeLists.txt
+++ b/msipackage/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_command(
     COMMAND ${WIX_SOURCE_DIR}/wix.exe build ${PACKAGE_WIX} -o ${OUTPUT_PACKAGE} -arch ${TARGET_PLATFORM} -dcl ${COMPRESSION} -cc ${CAB_CACHE} -pdbtype none
     COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/msipackage"
     VERBATIM
-    DEPENDS ${PACKAGE_WIX} ${BINARIES_DEPENDENCIES} # Make sure the package is rebuilt if any of the binaries or resources change
+    DEPENDS ${PACKAGE_WIX} ${BINARIES_DEPENDENCIES} ${WSLG_NOTICE_PATH} # Make sure the package is rebuilt if any of the binaries or resources change
 )
 
 add_custom_target(msipackage DEPENDS ${OUTPUT_PACKAGE})

--- a/msipackage/CMakeLists.txt
+++ b/msipackage/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_command(
     COMMAND ${WIX_SOURCE_DIR}/wix.exe build ${PACKAGE_WIX} -o ${OUTPUT_PACKAGE} -arch ${TARGET_PLATFORM} -dcl ${COMPRESSION} -cc ${CAB_CACHE} -pdbtype none
     COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/CmakeFiles/msipackage"
     VERBATIM
-    DEPENDS ${PACKAGE_WIX} ${BINARIES_DEPENDENCIES} ${WSLG_NOTICE_PATH} # Make sure the package is rebuilt if any of the binaries or resources change
+    DEPENDS ${PACKAGE_WIX} ${BINARIES_DEPENDENCIES} ${CMAKE_SOURCE_DIR}/NOTICE.txt # Make sure the package is rebuilt if any of the binaries or resources change
 )
 
 add_custom_target(msipackage DEPENDS ${OUTPUT_PACKAGE})

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -34,6 +34,11 @@
                 <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${PACKAGE_INPUT_DIR}/wslserviceproxystub.dll" />
                 <File Id="wsldeps.dll" Name="wsldeps.dll" Source="${PACKAGE_INPUT_DIR}/wsldeps.dll" />
 
+                <!-- Third-party OSS attributions. NOTICE.txt lives at the root of the Microsoft.WSLg NuGet, while
+                     WSLG_SOURCE_DIR points at <package>/build/native/bin, hence the relative path up to the package root.
+                     Staged to the install directory so the notice is discoverable per OSS attribution requirements. -->
+                <File Id="NOTICE.txt" Name="NOTICE.txt" Source="${WSLG_SOURCE_DIR}/../../../NOTICE.txt" />
+
                 <?if "${WSL_BUILD_WSL_SETTINGS}" = "true" ?>
                     <File Id="libwsl.dll" Name="libwsl.dll" Source="${PACKAGE_INPUT_DIR}/libwsl.dll" />
                 <?endif?>

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -34,10 +34,10 @@
                 <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${PACKAGE_INPUT_DIR}/wslserviceproxystub.dll" />
                 <File Id="wsldeps.dll" Name="wsldeps.dll" Source="${PACKAGE_INPUT_DIR}/wsldeps.dll" />
 
-                <!-- Third-party OSS attributions. NOTICE.txt lives at the root of the Microsoft.WSLg NuGet, while
-                     WSLG_SOURCE_DIR points at <package>/build/native/bin, hence the relative path up to the package root.
-                     Staged to the install directory so the notice is discoverable per OSS attribution requirements. -->
-                <File Id="NOTICE.txt" Name="NOTICE.txt" Source="${WSLG_SOURCE_DIR}/../../../NOTICE.txt" />
+                <!-- Third-party OSS attributions from the Microsoft.WSLg NuGet, staged to the install
+                     directory so the notice is discoverable per OSS attribution requirements.
+                     WSLG_NOTICE_PATH is computed in the root CMakeLists.txt. -->
+                <File Id="NOTICE.txt" Name="NOTICE.txt" Source="${WSLG_NOTICE_PATH}" />
 
                 <?if "${WSL_BUILD_WSL_SETTINGS}" = "true" ?>
                     <File Id="libwsl.dll" Name="libwsl.dll" Source="${PACKAGE_INPUT_DIR}/libwsl.dll" />

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -34,9 +34,6 @@
                 <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${PACKAGE_INPUT_DIR}/wslserviceproxystub.dll" />
                 <File Id="wsldeps.dll" Name="wsldeps.dll" Source="${PACKAGE_INPUT_DIR}/wsldeps.dll" />
 
-                <!-- Third-party OSS attributions from the Microsoft.WSLg NuGet, staged to the install
-                     directory so the notice is discoverable per OSS attribution requirements.
-                     WSLG_NOTICE_PATH is computed in the root CMakeLists.txt. -->
                 <File Id="NOTICE.txt" Name="NOTICE.txt" Source="${WSLG_NOTICE_PATH}" />
 
                 <?if "${WSL_BUILD_WSL_SETTINGS}" = "true" ?>
@@ -44,7 +41,7 @@
                 <?endif?>
 
                 <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
-                <File Id="system.vhd" Source="${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd"/>
+                <File Id="system.vhd" Source="${WSLG_SOURCE_DIR}/build/native/bin/${TARGET_PLATFORM}/system.vhd"/>
                 <?endif?>
 
                 <!-- Add INSTALLDIR to system PATH to make wslc.exe and other CLI tools accessible. -->
@@ -444,8 +441,8 @@
             <Component Id="wslg" Guid="F0C8D6BA-1502-41E7-BF72-D93DFA134731" UninstallWhenSuperseded="yes" DisableRegistryReflection="yes" Bitness="always64">
                 <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
                     <File Id="msrdc.exe" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/msrdc.exe" />
-                    <File Id="wslg.rdp" Source="${WSLG_SOURCE_DIR}/wslg.rdp" />
-                    <File Id="wslg_desktop.rdp" Source="${WSLG_SOURCE_DIR}/wslg_desktop.rdp" />
+                    <File Id="wslg.rdp" Source="${WSLG_SOURCE_DIR}/build/native/bin/wslg.rdp" />
+                    <File Id="wslg_desktop.rdp" Source="${WSLG_SOURCE_DIR}/build/native/bin/wslg_desktop.rdp" />
                     <File Id="rdclientax.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdclientax.dll" />
                     <File Id="rdpnanoTransport.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdpnanoTransport.dll" />
                     <File Id="RdpWinStlHelper.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/RdpWinStlHelper.dll" />

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -34,7 +34,7 @@
                 <File Id="wslserviceproxystub.dll" Name="wslserviceproxystub.dll" Source="${PACKAGE_INPUT_DIR}/wslserviceproxystub.dll" />
                 <File Id="wsldeps.dll" Name="wsldeps.dll" Source="${PACKAGE_INPUT_DIR}/wsldeps.dll" />
 
-                <File Id="NOTICE.txt" Name="NOTICE.txt" Source="${WSLG_NOTICE_PATH}" />
+                <File Id="NOTICE.txt" Name="NOTICE.txt" Source="${CMAKE_SOURCE_DIR}/NOTICE.txt" />
 
                 <?if "${WSL_BUILD_WSL_SETTINGS}" = "true" ?>
                     <File Id="libwsl.dll" Name="libwsl.dll" Source="${PACKAGE_INPUT_DIR}/libwsl.dll" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Ensures a complete third-party OSS NOTICE.txt  is installed into the WSL install directory via the MSI. Two gaps are closed: (1) the MSI never shipped any NOTICE, so it wasn't present on the user's machine  after install; and (2) the repo-root NOTICE only covered the Windows components- the Linux OSS bundled through the  Microsoft.WSLg  NuGet (FreeRDP, PulseAudio, Weston, Wayland/Xwayland, Mesa, etc.) was never  reflected anywhere on-machine, because Component Governance doesn't detect components that ship as binaries rather than declared dependencies.directory.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Detailed Description of the Pull Request / Additional comments

 The WSL repo-root  NOTICE.txt  is generated by  .pipelines/wsl-build-notice.yml  (Component Governance + the  notice@0  task) and committed back to the repo. The Linux-side OSS shipped via the  Microsoft.WSLg   NuGet has its own  NOTICE.txt  at the package root, but CG never folded it into WSL's NOTICE, and the MSI never installed any NOTICE at all.

 This PR addresses both:
 1. Make the repo-root NOTICE comprehensive ( .pipelines/wsl-build-notice.yml )
 • Restore packages so WSLg's  NOTICE.txt  is on disk.
 • Resolve the WSLg version from  packages.config  (no hardcoding) and locate its  NOTICE.txt .
 • Append it to the generated NOTICE via the  notice@0  task's  additionaldata  input, so the regenerated repo-root NOTICE covers both the Windows and the WSLg Linux components.

 2. Install the NOTICE on-machine ( msipackage/ )
 •  package.wix.in  adds a  NOTICE.txt   <File>  under the main  wsl  component, sourced from the repo-root  NOTICE.txt  ( ${CMAKE_SOURCE_DIR}/NOTICE.txt ).
 •  CMakeLists.txt  lists the root NOTICE in the MSI's  DEPENDS  so the package rebuilds when it changes.

 Notes:
 • The MSI ships the repo-root NOTICE (now comprehensive), not WSLg's NOTICE directly - so there's a single source of truth.
 • The  <File>  entry is placed unconditionally (outside the dev-binary / settings build guards) so the notice always ships.
 • The merge materializes after the notice pipeline next runs on master (it auto-opens a follow-up PR with the regenerated NOTICE).
 • Delivery is independent of which  Microsoft.WSLg  version is pinned in  packages.config ; once the NuGet is bumped to the version containing the Mesa attribution, the pipeline picks it up automatically with no further WiX change.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
