### PR TITLE
Add test to repeatedly use session storage

### DIFF
--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2765,6 +2765,11 @@ class WslcSdkTests
         // without errors.
         std::filesystem::path sessionStorage = m_storagePath / "wslc-resource-reuse-storage";
 
+        auto cleanupStorage = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            std::error_code ec;
+            std::filesystem::remove_all(sessionStorage, ec);
+        });
+
         WslcSessionSettings sessionSettings;
         VERIFY_SUCCEEDED(WslcInitSessionSettings(L"wslc-resource-reuse", sessionStorage.c_str(), &sessionSettings));
         VERIFY_SUCCEEDED(WslcSetSessionSettingsCpuCount(&sessionSettings, 2));
@@ -2799,7 +2804,7 @@ class WslcSdkTests
             // resources are freed so that the next iteration can reopen the same storage without error.
             VERIFY_SUCCEEDED(WslcTerminateSession(session.get()));
             VERIFY_SUCCEEDED(WslcReleaseSession(session.get()));
-            session.release(); // ownership transferred to the explicit calls above
+            session.release(); // explicit calls above
         }
     }
 

--- a/test/windows/WslcSdkTests.cpp
+++ b/test/windows/WslcSdkTests.cpp
@@ -2756,6 +2756,53 @@ class WslcSdkTests
         }
     }
 
+    WSLC_TEST_METHOD(ResourceReuseAfterCleanup)
+    {
+        // Each iteration exercises the complete lifecycle: create session → load image → run container
+        // → terminate session → release session. Running 10 times on the same storage path verifies
+        // that all resources (VHD locks, image store, container overlays, process handles, VM) are
+        // fully freed by the time WslcReleaseSession returns, so the next iteration can reuse them
+        // without errors.
+        std::filesystem::path sessionStorage = m_storagePath / "wslc-resource-reuse-storage";
+
+        WslcSessionSettings sessionSettings;
+        VERIFY_SUCCEEDED(WslcInitSessionSettings(L"wslc-resource-reuse", sessionStorage.c_str(), &sessionSettings));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsCpuCount(&sessionSettings, 2));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsMemory(&sessionSettings, 1024));
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsTimeout(&sessionSettings, 30 * 1000));
+
+        WslcVhdRequirements vhdReqs{};
+        vhdReqs.sizeBytes = 2048ull * 1024 * 1024; // 2 GB
+        vhdReqs.type = WSLC_VHD_TYPE_DYNAMIC;
+        VERIFY_SUCCEEDED(WslcSetSessionSettingsVhd(&sessionSettings, &vhdReqs));
+
+        constexpr auto c_imageName = "hello-world:latest";
+        constexpr int c_iterationCount = 10;
+
+        for (int i = 0; i < c_iterationCount; ++i)
+        {
+            LogInfo("ResourceReuseAfterCleanup: iteration %d / %d", i + 1, c_iterationCount);
+
+            // Create the session, reusing the same storage path every iteration.
+            UniqueSession session;
+            VERIFY_SUCCEEDED(WslcCreateSession(&sessionSettings, &session, nullptr));
+            VERIFY_IS_NOT_NULL(session.get());
+
+            // Load the test image into the session.
+            VERIFY_SUCCEEDED(WslcLoadSessionImageFromFile(session.get(), GetTestImagePath(c_imageName).c_str(), nullptr, nullptr));
+
+            // Run a container using the image's default entrypoint and capture its output.
+            auto output = RunContainerAndCapture(session.get(), c_imageName, {});
+            VERIFY_IS_TRUE(output.stdoutOutput.find("Hello from Docker!") != std::string::npos);
+
+            // Terminate the session, then release it. WslcReleaseSession must return only after all
+            // resources are freed so that the next iteration can reopen the same storage without error.
+            VERIFY_SUCCEEDED(WslcTerminateSession(session.get()));
+            VERIFY_SUCCEEDED(WslcReleaseSession(session.get()));
+            session.release(); // ownership transferred to the explicit calls above
+        }
+    }
+
     WSLC_TEST_METHOD(StopContainerTimeout)
     {
         WslcProcessSettings procSettings;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a test that repeatedly creates a session using the same storage.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This test is intended to detect any lingering resources being held by a session after the SDK terminate/release calls.  If the session cannot be started immediately afterward, something is being held open longer than it should or not properly synchronized against during the terminate and release of the session handle.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
The new test.