### PR TITLE
wslc: Grant VM access to a caller-supplied root VHD override as the user

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -259,7 +259,7 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
     // Setup boot VHDs
     hcs::Scsi scsiController{};
-    auto attachScsiDisk = [&](PCWSTR path) {
+    auto attachScsiDisk = [&](PCWSTR path, bool grantUserAccess) {
         const ULONG lun = AllocateLun();
         hcs::Attachment disk{};
         disk.Type = hcs::AttachmentType::VirtualDisk;
@@ -269,12 +269,21 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
         disk.AlwaysAllowSparseFiles = true;
         disk.SupportEncryptedFiles = true;
         scsiController.Attachments[std::to_string(lun)] = std::move(disk);
+
         DiskInfo diskInfo{path};
+
+        if (grantUserAccess)
+        {
+            auto runAsUser = wil::impersonate_token(m_userToken.get());
+            hcs::GrantVmAccess(m_vmIdString.c_str(), path);
+            diskInfo.AccessGranted = true;
+        }
+
         m_attachedDisks.emplace(lun, std::move(diskInfo));
     };
 
-    attachScsiDisk(rootVhdPath.c_str());
-    attachScsiDisk(kernelModulesPath.c_str());
+    attachScsiDisk(rootVhdPath.c_str(), Settings->RootVhdOverride != nullptr);
+    attachScsiDisk(kernelModulesPath.c_str(), false);
 
     vmSettings.Devices.Scsi["0"] = std::move(scsiController);
 


### PR DESCRIPTION
## Summary

The WSLC boot path attached the root VHD to the VM without granting VM access. For a caller-supplied `RootVhdOverride`, that meant the VM worker process opened the file with no check that the user actually has access to it.

This grants VM access while impersonating the user (mirroring the WSL2 boot path in `WslCoreVm::GenerateConfigJson`). The grant requires the user to have access to the target, so an override can only ever point at a VHD the user can already reach. The grant is tracked via `DiskInfo::AccessGranted` and revoked on teardown.

The install-dir default root/modules VHDs are already reachable by the VM worker process and are left unchanged.
