### PR TITLE
 Update Microsoft.WSLg to 1.0.79

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -24,7 +24,7 @@
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
-  <package id="Microsoft.WSLg" version="1.0.79-Beta2" />
+  <package id="Microsoft.WSLg" version="1.0.79" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="vswhere" version="3.1.7" />
   <package id="WinUIEx" version="2.9.0" />

--- a/packages.config
+++ b/packages.config
@@ -24,7 +24,7 @@
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
-  <package id="Microsoft.WSLg" version="1.0.78" />
+  <package id="Microsoft.WSLg" version="1.0.79-Beta2" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />
   <package id="vswhere" version="3.1.7" />
   <package id="WinUIEx" version="2.9.0" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Update Microsoft.WSLg from 1.0.78 → 1.0.79 in packages.config.
This is the first WSLg release that includes the Mesa NOTICE entry, which is required for OSS compliance in the WSL MSI. After this bump lands and the notice pipeline re-runs, the auto-generated NOTICE will  finally include Mesa.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
1.0.79 is the first WSLg release that ships the Mesa NOTICE entry, which is required for the OSS NOTICE.txt we install via the MSI (#40893). Without this update, the auto-generated NOTICE updates (e.g.  #40898) cannot include Mesa.
Note: the package is available on the shine-oss WslDependencies feed this repo restores from.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
 - cmake . restored Microsoft.WSLg.1.0.79 from the shine-oss WslDependencies feed cleanly
 - Full build (cmake --build . -- -m) completed with no errors
 - Deployed via tools\deploy\deploy-to-host.ps1
 - wsl --version reports WSLg version: 1.0.79
 - Firefox (firefox-esr) launches and renders correctly on the Windows desktop
<img width="556" height="224" alt="image" src="https://github.com/user-attachments/assets/ef05e3e8-af94-407d-a678-b031daece4f5" />


 