### PR TITLE
Scope ABI-stability guidance to SDK-facing WSLCCompat.idl

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,7 +140,7 @@ When modifying service interfaces (`src/windows/service/inc/`):
 - String params: `[in, unique] LPCWSTR` with `[string]` for marshaled strings
 - Handle params: `[in, system_handle(sh_file)] HANDLE`
 - User-facing errors: pass `[in, out] LXSS_ERROR_INFO* Error`
-- **ABI stability applies only to SDK-facing and public surfaces.** `WSLCCompat.idl` (the WSLC SDK-facing layer) and the public plugin API (`WslPluginApi.h`) must stay backward compatible: do not add, remove, or reorder methods on their existing interfaces, and do not change struct layouts. Introduce a new versioned interface with a new IID instead. Every other in-box interface (`IWSLCSession` in `wslc.idl`, the interfaces in `wslservice.idl`, etc.) is rebuilt and shipped in lockstep with its only clients, so appending new methods to those is fine.
+- **ABI stability applies only to SDK-facing and public surfaces.** `WSLCCompat.idl` (the WSLC SDK-facing layer) and the public plugin API (`WslPluginApi.h`) must stay backward compatible: do not add, remove, or reorder methods on their existing interfaces, and do not change struct layouts. Introduce a new versioned interface with a new IID instead. Every other interface (`IWSLCSession` in `wslc.idl`, the interfaces in `wslservice.idl`, etc.) is internal and non-stable: rebuilt and shipped in lockstep with its only clients, so appending new methods to those is fine.
 - Custom error codes: `WSL_E_xxx` via `MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, WSL_E_BASE + N)`
 
 ### Config File (.wslconfig) Conventions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,7 +140,7 @@ When modifying service interfaces (`src/windows/service/inc/`):
 - String params: `[in, unique] LPCWSTR` with `[string]` for marshaled strings
 - Handle params: `[in, system_handle(sh_file)] HANDLE`
 - User-facing errors: pass `[in, out] LXSS_ERROR_INFO* Error`
-- **ABI stability applies only to SDK-facing and public surfaces.** `WSLCCompat.idl` (the WSLC SDK-facing layer) and the public plugin API (`WslPluginApi.h`) must stay backward compatible: do not add or reorder methods on their existing interfaces, and do not change struct layouts. Introduce a new versioned interface with a new IID instead. Every other in-box interface (`IWSLCSession` in `wslc.idl`, the interfaces in `wslservice.idl`, etc.) is rebuilt and shipped in lockstep with its only clients, so appending new methods to those is fine.
+- **ABI stability applies only to SDK-facing and public surfaces.** `WSLCCompat.idl` (the WSLC SDK-facing layer) and the public plugin API (`WslPluginApi.h`) must stay backward compatible: do not add, remove, or reorder methods on their existing interfaces, and do not change struct layouts. Introduce a new versioned interface with a new IID instead. Every other in-box interface (`IWSLCSession` in `wslc.idl`, the interfaces in `wslservice.idl`, etc.) is rebuilt and shipped in lockstep with its only clients, so appending new methods to those is fine.
 - Custom error codes: `WSL_E_xxx` via `MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, WSL_E_BASE + N)`
 
 ### Config File (.wslconfig) Conventions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,7 +140,7 @@ When modifying service interfaces (`src/windows/service/inc/`):
 - String params: `[in, unique] LPCWSTR` with `[string]` for marshaled strings
 - Handle params: `[in, system_handle(sh_file)] HANDLE`
 - User-facing errors: pass `[in, out] LXSS_ERROR_INFO* Error`
-- **Adding methods to an existing interface is an ABI break** — create a new versioned interface with a new IID
+- **ABI stability applies only to SDK-facing and public surfaces.** `WSLCCompat.idl` (the WSLC SDK-facing layer) and the public plugin API (`WslPluginApi.h`) must stay backward compatible: do not add or reorder methods on their existing interfaces, and do not change struct layouts. Introduce a new versioned interface with a new IID instead. Every other in-box interface (`IWSLCSession` in `wslc.idl`, the interfaces in `wslservice.idl`, etc.) is rebuilt and shipped in lockstep with its only clients, so appending new methods to those is fine.
 - Custom error codes: `WSL_E_xxx` via `MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, WSL_E_BASE + N)`
 
 ### Config File (.wslconfig) Conventions

--- a/.github/copilot/review.md
+++ b/.github/copilot/review.md
@@ -4,7 +4,7 @@ When reviewing code, enforce the conventions in `.github/copilot-instructions.md
 
 ### ABI Safety (Critical)
 Only the SDK-facing and public surfaces require a backward-compatible ABI. Every other COM interface (`wslc.idl`, `wslservice.idl`, etc.) is in-box and shipped in lockstep with its only clients, with the proxy/stub regenerated each build, so methods may be appended to those freely. Do **not** flag in-box interfaces.
-- **Flag** ABI-breaking changes (new or reordered methods, changed struct layouts) only in the stable surfaces: `WSLCCompat.idl` (the WSLC SDK-facing layer, which must stay backward compatible) and the public plugin API (`WSLPluginHooksV1` / `WSLPluginAPIV1` structs in `WslPluginApi.h`).
+- **Flag** ABI-breaking changes (new, removed, or reordered methods, changed struct layouts) only in the stable surfaces: `WSLCCompat.idl` (the WSLC SDK-facing layer, which must stay backward compatible) and the public plugin API (`WSLPluginHooksV1` / `WSLPluginAPIV1` structs in `WslPluginApi.h`).
 - **Do not flag** new methods appended to in-box interfaces such as `IWSLCSession` in `wslc.idl`, or interfaces in `wslservice.idl`.
 
 ### Resource Safety

--- a/.github/copilot/review.md
+++ b/.github/copilot/review.md
@@ -3,9 +3,9 @@
 When reviewing code, enforce the conventions in `.github/copilot-instructions.md`. Focus especially on these high-risk areas:
 
 ### ABI Safety (Critical)
-- **Flag** new methods added to existing COM interfaces without a new versioned interface/IID
-- **Flag** changed struct layouts in IDL files
-- **Flag** changes to `WSLPluginHooksV1` or `WSLPluginAPIV1` structs (public API)
+Only the SDK-facing and public surfaces require a backward-compatible ABI. Every other COM interface (`wslc.idl`, `wslservice.idl`, etc.) is in-box and shipped in lockstep with its only clients, with the proxy/stub regenerated each build, so methods may be appended to those freely. Do **not** flag in-box interfaces.
+- **Flag** ABI-breaking changes (new or reordered methods, changed struct layouts) only in the stable surfaces: `WSLCCompat.idl` (the WSLC SDK-facing layer, which must stay backward compatible) and the public plugin API (`WSLPluginHooksV1` / `WSLPluginAPIV1` structs in `WslPluginApi.h`).
+- **Do not flag** new methods appended to in-box interfaces such as `IWSLCSession` in `wslc.idl`, or interfaces in `wslservice.idl`.
 
 ### Resource Safety
 - **Flag** raw `CloseHandle()`, `delete`, `free()`, or manual resource cleanup — require WIL smart pointers

--- a/.github/copilot/review.md
+++ b/.github/copilot/review.md
@@ -3,9 +3,9 @@
 When reviewing code, enforce the conventions in `.github/copilot-instructions.md`. Focus especially on these high-risk areas:
 
 ### ABI Safety (Critical)
-Only the SDK-facing and public surfaces require a backward-compatible ABI. Every other COM interface (`wslc.idl`, `wslservice.idl`, etc.) is in-box and shipped in lockstep with its only clients, with the proxy/stub regenerated each build, so methods may be appended to those freely. Do **not** flag in-box interfaces.
+Only the SDK-facing and public surfaces require a backward-compatible ABI. Every other COM interface (`wslc.idl`, `wslservice.idl`, etc.) is internal and non-stable: shipped in lockstep with its only clients, with the proxy/stub regenerated each build, so methods may be appended to those freely. Do **not** flag internal, non-stable interfaces.
 - **Flag** ABI-breaking changes (new, removed, or reordered methods, changed struct layouts) only in the stable surfaces: `WSLCCompat.idl` (the WSLC SDK-facing layer, which must stay backward compatible) and the public plugin API (`WSLPluginHooksV1` / `WSLPluginAPIV1` structs in `WslPluginApi.h`).
-- **Do not flag** new methods appended to in-box interfaces such as `IWSLCSession` in `wslc.idl`, or interfaces in `wslservice.idl`.
+- **Do not flag** new methods appended to internal, non-stable interfaces such as `IWSLCSession` in `wslc.idl`, or interfaces in `wslservice.idl`.
 
 ### Resource Safety
 - **Flag** raw `CloseHandle()`, `delete`, `free()`, or manual resource cleanup — require WIL smart pointers

--- a/src/windows/service/inc/wslservice.idl
+++ b/src/windows/service/inc/wslservice.idl
@@ -10,6 +10,8 @@ Abstract:
 
     This file contains the COM object definitions used to talk with the WSL
     service "WslService"
+    // N.B. These interfaces are internal and non-stable. ABI breaking changes in this
+    // file are OK, since the client and service always ship together in the same package.
 
 --*/
 


### PR DESCRIPTION
Only `WSLCCompat.idl` (the WSLC SDK-facing layer) and the public plugin API (`WslPluginApi.h`) require a backward-compatible ABI. Other interfaces (`IWSLCSession` in `wslc.idl`, `wslservice.idl`, etc.) are **internal and non-stable**: they ship in lockstep with their only clients and regenerate proxy/stubs each build, so appending methods is fine. This stops the review bot from incorrectly flagging method additions to those interfaces. Also adds a matching non-stable note to `wslservice.idl` (`wslc.idl` already had one).