### PR TITLE
Pass the mounting user's token on VHD restore (2.7 backport)

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -3206,10 +3206,20 @@ try
 
     // Attach the disk to the VM, reusing the same LUN if possible.
     //
-    // N.B. The user token is not provided because the key that holds the disk
-    // state can only be written by elevated users.
+    // N.B. The disk-mount state is stored under the user's SID in a volatile (per-boot)
+    // registry key, so the disk being restored here was mounted earlier in this same boot
+    // by this same user. For a VHD we therefore pass the user token so the access grant and
+    // the path resolution run under the mounting user's identity: a privileged operation can
+    // only ever touch a file that user can already reach, which closes the restore-time
+    // junction/symlink swap (TOCTOU) without re-resolving the path as SYSTEM.
+    //
+    // A pass-through (raw block device) attach is elevation-gated and the reconnecting user
+    // may no longer be elevated, so it is restored as SYSTEM (no token). Block-device paths
+    // (\\.\PhysicalDriveN) have no reparse-point surface, so there is no swap to defend
+    // against.
     auto lun = std::stoul(LunStr);
-    m_utilityVm->AttachDisk(path.c_str(), diskType, lun, true, nullptr);
+    const HANDLE userToken = (diskType == WslCoreVm::DiskType::VHD) ? m_userToken.get() : nullptr;
+    m_utilityVm->AttachDisk(path.c_str(), diskType, lun, true, userToken);
 
     // Restore each mount point.
     for (const auto& e : wsl::windows::common::registry::EnumKeys(Key, KEY_READ))

--- a/test/windows/MountTests.cpp
+++ b/test/windows/MountTests.cpp
@@ -460,6 +460,65 @@ class MountTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + absolutePath.wstring()), (DWORD)0);
     }
 
+    // A VHD whose path is a symbolic link is a legitimate, supported scenario: the link is
+    // followed and the real VHD is attached. Access is granted while impersonating the user,
+    // so the user can only ever attach a file they can already reach; there is no need to
+    // reject reparse points in the path.
+    WSL2_TEST_METHOD(MountVhdThroughSymlinkSucceeds)
+    {
+        SKIP_UNSUPPORTED_ARM64_MOUNT_TEST();
+
+        const auto symlink = std::filesystem::absolute(L"TestVhdSymlink.vhd");
+        DeleteFileW(symlink.c_str());
+
+        const auto absoluteTarget = std::filesystem::absolute(TEST_MOUNT_VHD);
+
+        // Create a file symbolic link pointing at the real VHD.
+        VERIFY_IS_TRUE(CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE));
+
+        auto cleanup = wil::scope_exit([&]() { DeleteFileW(symlink.c_str()); });
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--mount " + symlink.wstring() + L" --vhd --bare"), (DWORD)0);
+
+        const auto disk = GetBlockDeviceInWsl();
+        VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + symlink.wstring()), (DWORD)0);
+    }
+
+    // A symlinked VHD must still be restored after the VM is torn down on idle. Restore runs
+    // under the mounting user's identity (the disk-mount state is stored per-SID for the
+    // current boot), so the same access check applies and the symlinked VHD re-attaches.
+    WSL2_TEST_METHOD(MountVhdThroughSymlinkSurvivesVmTimeout)
+    {
+        SKIP_UNSUPPORTED_ARM64_MOUNT_TEST();
+
+        const auto symlink = std::filesystem::absolute(L"TestVhdSymlinkRestore.vhd");
+        DeleteFileW(symlink.c_str());
+
+        const auto absoluteTarget = std::filesystem::absolute(TEST_MOUNT_VHD);
+
+        VERIFY_IS_TRUE(CreateSymbolicLinkW(symlink.c_str(), absoluteTarget.c_str(), SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE));
+
+        auto cleanup = wil::scope_exit([&]() { DeleteFileW(symlink.c_str()); });
+
+        WslKeepAlive keepAlive;
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--mount " + symlink.wstring() + L" --vhd --bare"), (DWORD)0);
+
+        auto disk = GetBlockDeviceInWsl();
+        VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
+
+        WaitForVmTimeout(keepAlive);
+
+        // Recreating the VM restores the persisted disk mount; the symlinked VHD must re-attach. The
+        // block device name is not guaranteed to be stable across the VM teardown, so re-query it.
+        disk = GetBlockDeviceInWsl();
+        VERIFY_IS_TRUE(IsBlockDevicePresent(disk));
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--unmount " + symlink.wstring()), (DWORD)0);
+    }
+
     // Attach a disk, but don't mount it
     WSL2_TEST_METHOD(TestBareMount)
     {


### PR DESCRIPTION
Backport of #40782 to `release/2.7`.

## Summary

On VHD disk restore (`_LoadDiskMount`, when the utility VM is recreated), the persisted VHD was re-attached as SYSTEM with no user token, re-resolving a user-controllable path. This passes the mounting user's token for VHD restore so the access grant and path resolution run under the user's identity, matching the live `wsl --mount --vhd` behavior. Pass-through (raw block device) restore stays SYSTEM (elevation-gated, no reparse surface).

Clean cherry-pick of f0f4b10 with no conflicts; `WslCoreVm::AttachDisk` already takes the user-token parameter on this branch.
