### PR TITLE
WSLC SDK install fallback uses repair

### DIFF
--- a/src/windows/WslcSDK/wslcsdk.cpp
+++ b/src/windows/WslcSDK/wslcsdk.cpp
@@ -1731,7 +1731,8 @@ try
             {
                 callback(0);
             }
-            wsl::windows::common::install::UpdatePackage(true, false, false);
+            // Use pre-release builds and repair semantics (required since this function uses the SDK binary version as a filter).
+            wsl::windows::common::install::UpdatePackage(true, true, false);
             if (callback)
             {
                 callback(100);

--- a/src/windows/common/install.cpp
+++ b/src/windows/common/install.cpp
@@ -101,7 +101,7 @@ int UpdatePackageImpl(bool preRelease, bool repair, bool callerOwnsProcess)
     }
 
     const bool msiInstall = wsl::shared::string::EndsWith<wchar_t>(release.name, L".msi");
-    const auto downloadPath = DownloadFile(release.url, release.name);
+    const auto downloadPath = DownloadFile(release.url, release.name, callerOwnsProcess);
     if (msiInstall)
     {
         auto logFile = std::filesystem::temp_directory_path() / L"wsl-install-logs.txt";

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -348,15 +348,23 @@ GUID wsl::windows::common::wslutil::CreateV5Uuid(const GUID& namespaceGuid, cons
     return EndianSwap(newGuid);
 }
 
-std::wstring wsl::windows::common::wslutil::DownloadFile(std::wstring_view Url, std::wstring Filename)
+std::wstring wsl::windows::common::wslutil::DownloadFile(std::wstring_view Url, std::wstring Filename, bool reportProgress)
 {
     wsl::windows::common::ConsoleProgressBar progressBar;
     auto progress = [&](auto current, auto total) {
-        progressBar.Print(current, total);
+        if (reportProgress)
+        {
+            progressBar.Print(current, total);
+        }
         return true;
     };
 
-    auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { progressBar.Clear(); });
+    auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+        if (reportProgress)
+        {
+            progressBar.Clear();
+        }
+    });
 
     return DownloadFileImpl(Url, Filename, progress);
 }

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -209,7 +209,7 @@ std::wstring ConstructPipePath(_In_ std::wstring_view PipeName);
 
 GUID CreateV5Uuid(const GUID& namespaceGuid, const std::span<const std::byte> name);
 
-std::wstring DownloadFile(std::wstring_view Url, std::wstring Filename);
+std::wstring DownloadFile(std::wstring_view Url, std::wstring Filename, bool reportProgress = true);
 
 std::wstring DownloadFileImpl(std::wstring_view Url, std::wstring Filename, const std::function<void(uint64_t, uint64_t)>& Progress);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Use repair semantics in the temporary WSLC SDK install API fallback to GitHub.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Switch to repair semantics for this fallback path to prevent the SDK's version from being used as the current WSL install version:
https://github.com/microsoft/WSL/blob/f0ba469c5ce99424d57c0084e08421c3d4499cb0/src/windows/common/install.cpp#L89

Also passes along the "we don't own the process" flag to `DownloadFile` to prevent progress output.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually confirmed that the latest GH release is installed when no DCAT is available.