### PR TITLE
Revert WSLG_SOURCE_DIR remap to fix UserConfig.cmake.sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ find_nuget_package(Microsoft.WSL.bsdtar BSDTARD /build/native/bin)
 find_nuget_package(Microsoft.WSL.LinuxSdk LINUXSDK /)
 find_nuget_package(Microsoft.WSL.TestDistro TEST_DISTRO /)
 find_nuget_package(Microsoft.WSL.TestData WSL_TEST_DATA /)
-find_nuget_package(Microsoft.WSLg WSLG /)
+find_nuget_package(Microsoft.WSLg WSLG /build/native/bin)
 find_nuget_package(vswhere VSWHERE /tools)
 find_nuget_package(Wix WIX /tools/net6.0/any)
 
@@ -235,8 +235,8 @@ set(PACKAGE_CERTIFICATE ${GENERATED_DIR}/dev-cert.pfx)
 # and the pipeline's symbol publishing step find them. Without the PDBs here,
 # Watson can't resolve function names in their crash frames.
 string(REPLACE ".dll" ".pdb" WSLG_TS_PLUGIN_PDB ${WSLG_TS_PLUGIN_DLL})
-file(CREATE_LINK ${WSLG_SOURCE_DIR}/build/native/bin/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_DLL} ${BIN}/${WSLG_TS_PLUGIN_DLL})
-file(CREATE_LINK ${WSLG_SOURCE_DIR}/build/native/bin/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_PDB} ${BIN}/${WSLG_TS_PLUGIN_PDB})
+file(CREATE_LINK ${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_DLL} ${BIN}/${WSLG_TS_PLUGIN_DLL})
+file(CREATE_LINK ${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/${WSLG_TS_PLUGIN_PDB} ${BIN}/${WSLG_TS_PLUGIN_PDB})
 file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.dll ${BIN}/wsldeps.dll)
 file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.pdb ${BIN}/wsldeps.pdb)
 # wsldevicehost.dll is packaged directly from its NuGet package, so only its PDB

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -41,7 +41,7 @@
                 <?endif?>
 
                 <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
-                <File Id="system.vhd" Source="${WSLG_SOURCE_DIR}/build/native/bin/${TARGET_PLATFORM}/system.vhd"/>
+                <File Id="system.vhd" Source="${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd"/>
                 <?endif?>
 
                 <!-- Add INSTALLDIR to system PATH to make wslc.exe and other CLI tools accessible. -->
@@ -441,8 +441,8 @@
             <Component Id="wslg" Guid="F0C8D6BA-1502-41E7-BF72-D93DFA134731" UninstallWhenSuperseded="yes" DisableRegistryReflection="yes" Bitness="always64">
                 <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
                     <File Id="msrdc.exe" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/msrdc.exe" />
-                    <File Id="wslg.rdp" Source="${WSLG_SOURCE_DIR}/build/native/bin/wslg.rdp" />
-                    <File Id="wslg_desktop.rdp" Source="${WSLG_SOURCE_DIR}/build/native/bin/wslg_desktop.rdp" />
+                    <File Id="wslg.rdp" Source="${WSLG_SOURCE_DIR}/wslg.rdp" />
+                    <File Id="wslg_desktop.rdp" Source="${WSLG_SOURCE_DIR}/wslg_desktop.rdp" />
                     <File Id="rdclientax.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdclientax.dll" />
                     <File Id="rdpnanoTransport.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/rdpnanoTransport.dll" />
                     <File Id="RdpWinStlHelper.dll" Source="${MSRDC_SOURCE_DIR}/${TARGET_PLATFORM}/RdpWinStlHelper.dll" />

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -41,7 +41,7 @@
                 <?endif?>
 
                 <?if "${WSL_DEV_BINARY_PATH}" = "" ?>
-                <File Id="system.vhd" Source="${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd"/>
+                    <File Id="system.vhd" Source="${WSLG_SOURCE_DIR}/${TARGET_PLATFORM}/system.vhd" />
                 <?endif?>
 
                 <!-- Add INSTALLDIR to system PATH to make wslc.exe and other CLI tools accessible. -->


### PR DESCRIPTION
PR #40893 remapped WSLG_SOURCE_DIR from the package's build/native/bin directory to the package root, then re-added /build/native/bin/ at every existing call site. The remap was needed for an earlier design where the MSI was going to install WSLg's NOTICE.txt directly from the package root, but we pivoted to having the notice pipeline merge WSLg's NOTICE into the repo's root NOTICE.txt. In the final design nothing needs WSLG_SOURCE_DIR pointed at the package root.

The remap also broke UserConfig.cmake.sample, which expected WSLG_SOURCE_DIR to point at build/native/bin (it references `//system.vhd` and
`/wslg.rdp`).

Revert to the previous convention so UserConfig.cmake.sample works and the awkward /build/native/bin/ concatenations are no longer needed.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
