### PR TITLE
fix: use lowercased key when validating windowsterminal.profileTemplate

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -452,7 +452,7 @@ def read_tar(node, file, elf_magic: str):
             else:
                 warning(node, 'No shortcut.icon provided')
 
-            if terminal_profile := config.get('windowsterminal.profileTemplate', None):
+            if terminal_profile := config.get('windowsterminal.profiletemplate', None):
                 validate_mode(terminal_profile, [oct(0o660), oct(0o640)], 0, 0, 1024 * 1024)
 
                 if not terminal_profile.startswith(USR_LIB_WSL):


### PR DESCRIPTION
## Problem

`read_config_keys` lowercases option names when building its key dict:

```python
keys[f'{section}.{key.lower()}'] = config[section][key]   # line 198
```

So a `[windowsterminal]` section with `profileTemplate = ...` is stored under `windowsterminal.profiletemplate`. But the validation block looks it up with the camelCase key:

```python
if terminal_profile := config.get('windowsterminal.profileTemplate', None):   # line 455
    validate_mode(terminal_profile, [oct(0o660), oct(0o640)], 0, 0, 1024 * 1024)
    if not terminal_profile.startswith(USR_LIB_WSL):
        warning(...)
```

`dict.get` is case-sensitive, so this always returns `None` and the block never runs — the terminal profile template file's mode/size/location checks are silently skipped for every distribution validated. The valid-keys list (line 433) and every other `config.get(...)` in this function already use the lowercase form (`oobe.command`, `shortcut.icon`, `windowsterminal.profiletemplate`, …); line 455 was the lone outlier.

## Reproduction

Using the real `read_config_keys` on the canonical config (`[windowsterminal]` / `profileTemplate = /usr/lib/wsl/terminal.json`, as written in the repo's own tests):

```
stored keys: ['windowsterminal.profiletemplate']
get('windowsterminal.profileTemplate') -> None   # block SKIPPED (bug)
get('windowsterminal.profiletemplate') -> '/usr/lib/wsl/terminal.json'   # block RUNS (fixed)
```

## Fix

Look up the lowercase key at line 455 so the validation block executes. One-character change; behavior of all other keys is unchanged.