### PR TITLE
Don't hard-fail the distro validation script when a download fails

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -520,7 +520,11 @@ def read_url(url: dict, elf_magic):
                         tar_format = MAGIC.from_buffer(e)
 
                 file.seek(0, 0)
-                read_tar(url, file, elf_magic)
+
+                try:
+                    read_tar(url, file, elf_magic)
+                except Exception as e:
+                    error(url, f"Failed to read tar from URL: {url}: {type(e).__name__}")
 
 
      expected_sha = url['Sha256']() if 'Sha256' in url else None

--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -524,7 +524,7 @@ def read_url(url: dict, elf_magic):
                 try:
                     read_tar(url, file, elf_magic)
                 except Exception as e:
-                    error(url, f"Failed to read tar from URL: {url}: {type(e).__name__}")
+                    error(url, f"Failed to read tar from URL: {address}: {e}")
 
 
      expected_sha = url['Sha256']() if 'Sha256' in url else None


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the distro validation script not to fail immediately if a download fails. This makes it easier to identify when multiple distros fail to download

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
