### PR TITLE
Update Microsoft.WSL.DeviceHost to 1.2.39-0

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.36-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.39-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.2-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />


### PR DESCRIPTION
Updates the Microsoft.WSL.DeviceHost package from 1.2.36-0 to 1.2.39-0.

The major change in this version is https://github.com/microsoft/openvmm/pull/3780