### PR TITLE
fix socket channel set exit events

### DIFF
--- a/src/shared/inc/SocketChannel.h
+++ b/src/shared/inc/SocketChannel.h
@@ -133,9 +133,8 @@ public:
 
     std::vector<HANDLE> SetExitEvents(std::vector<HANDLE>&& exitEvents)
     {
-        std::vector<HANDLE> oldEvents;
-        std::swap(oldEvents, m_exitEvents);
-        return oldEvents;
+        std::swap(exitEvents, m_exitEvents);
+        return std::move(exitEvents);
     }
 
     const std::vector<HANDLE>& GetExitEvents() const

--- a/src/shared/inc/SocketChannel.h
+++ b/src/shared/inc/SocketChannel.h
@@ -133,8 +133,9 @@ public:
 
     std::vector<HANDLE> SetExitEvents(std::vector<HANDLE>&& exitEvents)
     {
-        std::swap(exitEvents, m_exitEvents);
-        return std::move(exitEvents);
+        auto oldExitEvents = std::move(m_exitEvents);
+        m_exitEvents = std::move(exitEvents);
+        return oldExitEvents;
     }
 
     const std::vector<HANDLE>& GetExitEvents() const


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Set the exit events as specified instead of ignoring them.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
