### PR TITLE
fix: replace bare except with except Exception in Python scripts

### DIFF
--- a/distributions/validate-modern.py
+++ b/distributions/validate-modern.py
@@ -161,7 +161,7 @@ def main(manifest: str, tar: str, compare_with_branch: str, repo_path: str, arm6
 
             sys.exit(1 if errors else 0)
 
-    except:
+    except Exception:
         if debug:
             import traceback
             traceback.print_exc()

--- a/tools/devops/create-change.py
+++ b/tools/devops/create-change.py
@@ -50,7 +50,7 @@ def main(repo_path: str, token: str, committer: str, message: str, branch: str, 
 
         print(f'Created pull request: {response.json()["html_url"]}')
 
-    except:
+    except Exception:
         if debug:
             import pdb
             import traceback


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in two Python scripts to comply with PEP 8 (E722).

## Changes

**`distributions/validate-modern.py`** (line 164):
```diff
-    except:
+    except Exception:
         if debug:
             import traceback
```

**`tools/devops/create-change.py`** (line 53):
```diff
-    except:
+    except Exception:
         if debug:
             import pdb
```

## Rationale

Both locations are debug/pdb handlers that re-raise the exception. Using `except Exception:` is sufficient for pdb post-mortem and avoids accidentally catching `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which should propagate normally.
