### PR TITLE
Use strict detection of http line ending for docker response

### DIFF
--- a/src/windows/common/HttpHeaderEndDetector.h
+++ b/src/windows/common/HttpHeaderEndDetector.h
@@ -1,0 +1,66 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    HttpHeaderEndDetector.h
+
+Abstract:
+
+    This file contains a small state machine that detects the end-of-header
+    marker ("\r\n\r\n") in an HTTP message, one byte at a time.
+
+--*/
+
+#pragma once
+
+namespace wsl::windows::common {
+
+// Detects the end-of-header marker ("\r\n\r\n") in an HTTP message
+class HttpHeaderEndDetector
+{
+public:
+    // Returns true once the full "\r\n\r\n" terminator has been consumed.
+    bool Consume(char Byte) noexcept
+    {
+        switch (m_state)
+        {
+        case State::Start:
+            m_state = (Byte == '\r') ? State::Cr : State::Start;
+            break;
+        case State::Cr:
+            m_state = (Byte == '\n') ? State::CrLf : ((Byte == '\r') ? State::Cr : State::Start);
+            break;
+        case State::CrLf:
+            m_state = (Byte == '\r') ? State::CrLfCr : State::Start;
+            break;
+        case State::CrLfCr:
+            m_state = (Byte == '\n') ? State::Done : ((Byte == '\r') ? State::Cr : State::Start);
+            break;
+        case State::Done:
+            break;
+        }
+
+        return m_state == State::Done;
+    }
+
+    bool IsDone() const noexcept
+    {
+        return m_state == State::Done;
+    }
+
+private:
+    enum class State
+    {
+        Start,
+        Cr,
+        CrLf,
+        CrLfCr,
+        Done
+    };
+
+    State m_state = State::Start;
+};
+
+} // namespace wsl::windows::common

--- a/src/windows/common/HttpHeaderEndDetector.h
+++ b/src/windows/common/HttpHeaderEndDetector.h
@@ -1,19 +1,10 @@
-/*++
-
-Copyright (c) Microsoft. All rights reserved.
-
-Module Name:
-
-    HttpHeaderEndDetector.h
-
-Abstract:
-
-    This file contains a small state machine that detects the end-of-header
-    marker ("\r\n\r\n") in an HTTP message, one byte at a time.
-
---*/
+// Copyright (C) Microsoft Corporation. All rights reserved.
 
 #pragma once
+
+#include <algorithm>
+#include <deque>
+#include <string_view>
 
 namespace wsl::windows::common {
 
@@ -22,45 +13,32 @@ class HttpHeaderEndDetector
 {
 public:
     // Returns true once the full "\r\n\r\n" terminator has been consumed.
-    bool Consume(char byte) noexcept
+    bool Consume(char byte)
     {
-        switch (m_state)
+        if (m_done)
         {
-        case State::Start:
-            m_state = (byte == '\r') ? State::Cr : State::Start;
-            break;
-        case State::Cr:
-            m_state = (byte == '\n') ? State::CrLf : ((byte == '\r') ? State::Cr : State::Start);
-            break;
-        case State::CrLf:
-            m_state = (byte == '\r') ? State::CrLfCr : State::Start;
-            break;
-        case State::CrLfCr:
-            m_state = (byte == '\n') ? State::Done : ((byte == '\r') ? State::Cr : State::Start);
-            break;
-        case State::Done:
-            break;
+            return true;
         }
 
-        return m_state == State::Done;
+        m_last4Bytes.push_back(byte);
+        if (m_last4Bytes.size() > 4)
+        {
+            m_last4Bytes.pop_front();
+        }
+
+        static constexpr std::string_view c_terminator = "\r\n\r\n";
+        m_done = std::ranges::equal(m_last4Bytes, c_terminator);
+        return m_done;
     }
 
     bool IsDone() const noexcept
     {
-        return m_state == State::Done;
+        return m_done;
     }
 
 private:
-    enum class State
-    {
-        Start,
-        Cr,
-        CrLf,
-        CrLfCr,
-        Done
-    };
-
-    State m_state = State::Start;
+    std::deque<char> m_last4Bytes;
+    bool m_done = false;
 };
 
 } // namespace wsl::windows::common

--- a/src/windows/common/HttpHeaderEndDetector.h
+++ b/src/windows/common/HttpHeaderEndDetector.h
@@ -22,21 +22,21 @@ class HttpHeaderEndDetector
 {
 public:
     // Returns true once the full "\r\n\r\n" terminator has been consumed.
-    bool Consume(char Byte) noexcept
+    bool Consume(char byte) noexcept
     {
         switch (m_state)
         {
         case State::Start:
-            m_state = (Byte == '\r') ? State::Cr : State::Start;
+            m_state = (byte == '\r') ? State::Cr : State::Start;
             break;
         case State::Cr:
-            m_state = (Byte == '\n') ? State::CrLf : ((Byte == '\r') ? State::Cr : State::Start);
+            m_state = (byte == '\n') ? State::CrLf : ((byte == '\r') ? State::Cr : State::Start);
             break;
         case State::CrLf:
-            m_state = (Byte == '\r') ? State::CrLfCr : State::Start;
+            m_state = (byte == '\r') ? State::CrLfCr : State::Start;
             break;
         case State::CrLfCr:
-            m_state = (Byte == '\n') ? State::Done : ((Byte == '\r') ? State::Cr : State::Start);
+            m_state = (byte == '\n') ? State::Done : ((byte == '\r') ? State::Cr : State::Start);
             break;
         case State::Done:
             break;

--- a/src/windows/wslcsession/DockerHTTPClient.cpp
+++ b/src/windows/wslcsession/DockerHTTPClient.cpp
@@ -661,17 +661,15 @@ void DockerHTTPClient::DockerHttpResponseHandle::OnRead(const gsl::span<char>& C
     }
     else
     {
-        // Otherwise keep parsing the HTTP response header.
+        // Otherwise keep parsing the HTTP response header. Scan for the end-of-header marker
+        // ("\r\n\r\n"); HeaderEnd carries state across reads in case it straddles a boundary.
         size_t i{};
-        for (i = 0; i < Content.size() && LineFeeds < 2; i++)
+        for (i = 0; i < Content.size(); i++)
         {
-            if (Content[i] == '\n')
+            if (HeaderEnd.Consume(Content[i]))
             {
-                LineFeeds++;
-            }
-            else if (Content[i] != '\r')
-            {
-                LineFeeds = 0;
+                i++; // Include the terminating byte in the header.
+                break;
             }
         }
 
@@ -805,7 +803,7 @@ std::pair<DockerHTTPClient::HTTPResponse, wil::unique_socket> DockerHTTPClient::
     parser.eager(false);
     parser.skip(false);
 
-    size_t lineFeeds = 0;
+    HttpHeaderEndDetector headerEnd;
     // Consume the socket until the header end is reached
     while (!parser.is_header_done())
     {
@@ -820,17 +818,17 @@ std::pair<DockerHTTPClient::HTTPResponse, wil::unique_socket> DockerHTTPClient::
 
         THROW_HR_IF(E_ABORT, bytesRead == 0);
 
-        // Scan only the newly peeked bytes [Offset, Offset + bytesRead)
+        // Scan only the newly peeked bytes [Offset, Offset + bytesRead) for the end-of-header
+        // marker. headerEnd carries state across iterations in case it straddles a read boundary.
+        bool headerComplete = false;
         size_t i = 0;
-        for (i = Offset; i < bytesRead + Offset && lineFeeds < 2; i++)
+        for (i = Offset; i < bytesRead + Offset; i++)
         {
-            if (buffer[i] == '\n')
+            if (headerEnd.Consume(buffer[i]))
             {
-                lineFeeds++;
-            }
-            else if (buffer[i] != '\r')
-            {
-                lineFeeds = 0;
+                i++; // Include the terminating byte in the header.
+                headerComplete = true;
+                break;
             }
         }
 
@@ -847,7 +845,7 @@ std::pair<DockerHTTPClient::HTTPResponse, wil::unique_socket> DockerHTTPClient::
         Offset += bytesRead;
         buffer.resize(Offset);
 
-        if (lineFeeds == 2) // Header is complete, feed it to the parser.
+        if (headerComplete) // Header is complete, feed it to the parser.
         {
 
 #ifdef WSLC_HTTP_DEBUG

--- a/src/windows/wslcsession/DockerHTTPClient.cpp
+++ b/src/windows/wslcsession/DockerHTTPClient.cpp
@@ -661,16 +661,11 @@ void DockerHTTPClient::DockerHttpResponseHandle::OnRead(const gsl::span<char>& C
     }
     else
     {
-        // Otherwise keep parsing the HTTP response header. Scan for the end-of-header marker
-        // ("\r\n\r\n"); HeaderEnd carries state across reads in case it straddles a boundary.
+        // Otherwise keep parsing the HTTP response header.
         size_t i{};
-        for (i = 0; i < Content.size(); i++)
+        for (i = 0; i < Content.size() && !HeaderEnd.IsDone(); i++)
         {
-            if (HeaderEnd.Consume(Content[i]))
-            {
-                i++; // Include the terminating byte in the header.
-                break;
-            }
+            HeaderEnd.Consume(Content[i]);
         }
 
         // Feed the parser up to the end of the header.
@@ -818,18 +813,11 @@ std::pair<DockerHTTPClient::HTTPResponse, wil::unique_socket> DockerHTTPClient::
 
         THROW_HR_IF(E_ABORT, bytesRead == 0);
 
-        // Scan only the newly peeked bytes [Offset, Offset + bytesRead) for the end-of-header
-        // marker. headerEnd carries state across iterations in case it straddles a read boundary.
-        bool headerComplete = false;
+        // Scan only the newly peeked bytes [Offset, Offset + bytesRead)
         size_t i = 0;
-        for (i = Offset; i < bytesRead + Offset; i++)
+        for (i = Offset; i < bytesRead + Offset && !headerEnd.IsDone(); i++)
         {
-            if (headerEnd.Consume(buffer[i]))
-            {
-                i++; // Include the terminating byte in the header.
-                headerComplete = true;
-                break;
-            }
+            headerEnd.Consume(buffer[i]);
         }
 
         WI_ASSERT(i >= Offset);
@@ -845,7 +833,7 @@ std::pair<DockerHTTPClient::HTTPResponse, wil::unique_socket> DockerHTTPClient::
         Offset += bytesRead;
         buffer.resize(Offset);
 
-        if (headerComplete) // Header is complete, feed it to the parser.
+        if (headerEnd.IsDone()) // Header is complete, feed it to the parser.
         {
 
 #ifdef WSLC_HTTP_DEBUG

--- a/src/windows/wslcsession/DockerHTTPClient.h
+++ b/src/windows/wslcsession/DockerHTTPClient.h
@@ -40,6 +40,55 @@ Abstract:
 
 namespace wsl::windows::service::wslc {
 
+// Detects the end-of-header marker ("\r\n\r\n") in an HTTP message. State is maintained
+// across successive reads so a terminator split between two reads is handled correctly.
+// N.B. Detection is strict: a bare-LF separator ("\n\n") is not treated as a terminator.
+class HttpHeaderEndDetector
+{
+public:
+    // Advances the state machine over a single byte. Returns true once the full "\r\n\r\n"
+    // terminator has been consumed.
+    bool Consume(char Byte) noexcept
+    {
+        switch (m_state)
+        {
+        case State::Start:
+            m_state = (Byte == '\r') ? State::Cr : State::Start;
+            break;
+        case State::Cr:
+            m_state = (Byte == '\n') ? State::CrLf : ((Byte == '\r') ? State::Cr : State::Start);
+            break;
+        case State::CrLf:
+            m_state = (Byte == '\r') ? State::CrLfCr : State::Start;
+            break;
+        case State::CrLfCr:
+            m_state = (Byte == '\n') ? State::Done : ((Byte == '\r') ? State::Cr : State::Start);
+            break;
+        case State::Done:
+            break;
+        }
+
+        return m_state == State::Done;
+    }
+
+    bool IsDone() const noexcept
+    {
+        return m_state == State::Done;
+    }
+
+private:
+    enum class State
+    {
+        Start,
+        Cr,
+        CrLf,
+        CrLfCr,
+        Done
+    };
+
+    State m_state = State::Start;
+};
+
 class DockerHTTPException : public std::runtime_error
 {
 public:
@@ -199,7 +248,7 @@ public:
         std::function<void(const gsl::span<char>&)> OnResponse;
         std::function<void()> OnCompleted;
         boost::beast::http::response_parser<boost::beast::http::buffer_body> Parser;
-        size_t LineFeeds = 0;
+        HttpHeaderEndDetector HeaderEnd;
         std::optional<size_t> RemainingContentLength;
         std::optional<common::io::HTTPChunkBasedReadHandle> ResponseParser;
     };

--- a/src/windows/wslcsession/DockerHTTPClient.h
+++ b/src/windows/wslcsession/DockerHTTPClient.h
@@ -40,14 +40,11 @@ Abstract:
 
 namespace wsl::windows::service::wslc {
 
-// Detects the end-of-header marker ("\r\n\r\n") in an HTTP message. State is maintained
-// across successive reads so a terminator split between two reads is handled correctly.
-// N.B. Detection is strict: a bare-LF separator ("\n\n") is not treated as a terminator.
+// Detects the end-of-header marker ("\r\n\r\n") in an HTTP message
 class HttpHeaderEndDetector
 {
 public:
-    // Advances the state machine over a single byte. Returns true once the full "\r\n\r\n"
-    // terminator has been consumed.
+    // Returns true once the full "\r\n\r\n" terminator has been consumed.
     bool Consume(char Byte) noexcept
     {
         switch (m_state)

--- a/src/windows/wslcsession/DockerHTTPClient.h
+++ b/src/windows/wslcsession/DockerHTTPClient.h
@@ -20,6 +20,7 @@ Abstract:
 #include <boost/beast/http.hpp>
 #include "relay.hpp"
 #include "docker_schema.h"
+#include "HttpHeaderEndDetector.h"
 
 #define THROW_DOCKER_USER_ERROR_MSG(_Ex, _Msg, ...) \
     if ((_Ex).HasErrorMessage()) \
@@ -39,52 +40,6 @@ Abstract:
     }
 
 namespace wsl::windows::service::wslc {
-
-// Detects the end-of-header marker ("\r\n\r\n") in an HTTP message
-class HttpHeaderEndDetector
-{
-public:
-    // Returns true once the full "\r\n\r\n" terminator has been consumed.
-    bool Consume(char Byte) noexcept
-    {
-        switch (m_state)
-        {
-        case State::Start:
-            m_state = (Byte == '\r') ? State::Cr : State::Start;
-            break;
-        case State::Cr:
-            m_state = (Byte == '\n') ? State::CrLf : ((Byte == '\r') ? State::Cr : State::Start);
-            break;
-        case State::CrLf:
-            m_state = (Byte == '\r') ? State::CrLfCr : State::Start;
-            break;
-        case State::CrLfCr:
-            m_state = (Byte == '\n') ? State::Done : ((Byte == '\r') ? State::Cr : State::Start);
-            break;
-        case State::Done:
-            break;
-        }
-
-        return m_state == State::Done;
-    }
-
-    bool IsDone() const noexcept
-    {
-        return m_state == State::Done;
-    }
-
-private:
-    enum class State
-    {
-        Start,
-        Cr,
-        CrLf,
-        CrLfCr,
-        Done
-    };
-
-    State m_state = State::Start;
-};
 
 class DockerHTTPException : public std::runtime_error
 {
@@ -245,7 +200,7 @@ public:
         std::function<void(const gsl::span<char>&)> OnResponse;
         std::function<void()> OnCompleted;
         boost::beast::http::response_parser<boost::beast::http::buffer_body> Parser;
-        HttpHeaderEndDetector HeaderEnd;
+        common::HttpHeaderEndDetector HeaderEnd;
         std::optional<size_t> RemainingContentLength;
         std::optional<common::io::HTTPChunkBasedReadHandle> ResponseParser;
     };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -22,6 +22,7 @@ Abstract:
 #include "hcs.hpp"
 #include "ContainerNameGenerator.h"
 #include "wslc/e2e/WSLCE2EHelpers.h"
+#include "HttpHeaderEndDetector.h"
 #include <nlohmann/json.hpp>
 
 using namespace std::literals::chrono_literals;
@@ -9218,6 +9219,39 @@ class WSLCTests
 
         VERIFY_ARE_EQUAL(payload.size(), output.size());
         VERIFY_IS_TRUE(payload == output);
+    }
+
+    TEST_METHOD(HttpHeaderEndDetector)
+    {
+        // Returns the index of the byte of header end, or -1 if the header never ends.
+        const auto headerEndIndex = [](std::string_view input) {
+            wsl::windows::common::HttpHeaderEndDetector detector;
+            for (size_t i = 0; i < input.size(); i++)
+            {
+                if (detector.Consume(input[i]))
+                {
+                    return static_cast<int>(i);
+                }
+            }
+
+            return -1;
+        };
+
+        VERIFY_ARE_EQUAL(3, headerEndIndex("\r\n\r\n"));
+        VERIFY_ARE_EQUAL(4, headerEndIndex("a\r\n\r\n"));
+        VERIFY_ARE_EQUAL(7, headerEndIndex("a\r\nb\r\n\r\n"));
+        VERIFY_ARE_EQUAL(4, headerEndIndex("\r\r\n\r\n"));
+        VERIFY_ARE_EQUAL(3, headerEndIndex("\r\n\r\nbody"));
+
+        VERIFY_ARE_EQUAL(-1, headerEndIndex(""));
+        VERIFY_ARE_EQUAL(-1, headerEndIndex("Header: value\r\n"));
+        VERIFY_ARE_EQUAL(-1, headerEndIndex("HTTP/1.1 200 OK\r\n"));
+        VERIFY_ARE_EQUAL(-1, headerEndIndex("\r\n\r"));
+
+        // Detection is strict.
+        VERIFY_ARE_EQUAL(-1, headerEndIndex("\n\n"));
+        VERIFY_ARE_EQUAL(-1, headerEndIndex("\r\n\n"));
+        VERIFY_ARE_EQUAL(-1, headerEndIndex("\n\r\n"));
     }
 
     WSLC_TEST_METHOD(ContainerRecoveryFromStorage)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Follow up pr for https://github.com/microsoft/WSL/pull/40849#discussion_r3444136865
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
New unit test and existing tests