### PR TITLE
Read /etc/locale.conf when configuring the distro locale

### DIFF
--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -53,6 +53,7 @@ Abstract:
 #define HOSTS_FILE_PATH ETC_FOLDER "hosts"
 #define LANG_ENV "LANG"
 #define LOCALE_FILE_PATH ETC_DEFAULT_FOLDER "locale"
+#define LOCALE_CONF_FILE_PATH ETC_FOLDER "locale.conf"
 #define PATH_ENV "PATH"
 #define RESOLV_CONF_DIRECTORY_MODE 0755
 #define RESOLV_CONF_FILE_MODE 0644
@@ -2514,8 +2515,13 @@ void ConfigUpdateLanguage(EnvironmentBlock& Environment)
 
 Routine Description:
 
-    This routine queries the contents of the /etc/default/locale text file and
+    This routine queries the contents of the locale configuration file and
     if present updates the $LANG environment variable in the environment block.
+
+    Different distributions store this file in different locations:
+        - /etc/default/locale
+        - /etc/locale.conf
+    Both share the same "LANG=" line format, so the first file that exists is used.
 
 Arguments:
 
@@ -2530,22 +2536,33 @@ Return Value:
 try
 {
     //
-    // Attempt to open the /etc/default/locale file. If the file does not exist
-    // then the $LANG environment variable will not be updated.
+    // Attempt to open the locale configuration file, trying each known path in turn.
+    // If none of the files exist then the $LANG environment variable will not be updated.
     //
-    // N.B. This file is being opened by root. The only user-visible content
+    // N.B. These files are being opened by root. The only user-visible content
     //      will be the contents of the last line of the file that contains
     //      "LANG=".
     //
 
-    wil::unique_file LocaleFile{fopen(LOCALE_FILE_PATH, "r")};
-    if (!LocaleFile)
+    constexpr const char* LocaleFilePaths[] = {LOCALE_FILE_PATH, LOCALE_CONF_FILE_PATH};
+
+    wil::unique_file LocaleFile;
+    for (const auto* Path : LocaleFilePaths)
     {
-        if (errno != ENOENT)
+        LocaleFile.reset(fopen(Path, "r"));
+        if (LocaleFile)
         {
-            LOG_ERROR("fopen({}) failed {}", LOCALE_FILE_PATH, errno);
+            break;
         }
 
+        if (errno != ENOENT)
+        {
+            LOG_ERROR("fopen({}) failed {}", Path, errno);
+        }
+    }
+
+    if (!LocaleFile)
+    {
         return;
     }
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -516,6 +516,46 @@ class UnitTests
         }
     }
 
+    WSL2_TEST_METHOD(ConfigUpdateLanguage)
+    {
+        // Validates that init populates $LANG from the distro locale configuration file.
+        // ConfigUpdateLanguage reads /etc/default/locale first, then /etc/locale.conf, and uses
+        // the first file that exists. See ConfigUpdateLanguage in src/linux/init/config.cpp.
+
+        DistroFileChange defaultLocale(L"/etc/default/locale", LxsstuLaunchWsl(L"test -f /etc/default/locale") == 0);
+        DistroFileChange localeConf(L"/etc/locale.conf", LxsstuLaunchWsl(L"test -f /etc/locale.conf") == 0);
+
+        const auto readLang = []() { return LxsstuLaunchWslAndCaptureOutput(L"echo $LANG").first; };
+
+        // Only /etc/default/locale is present (Debian/Ubuntu).
+        {
+            defaultLocale.Delete();
+            localeConf.Delete();
+            defaultLocale.SetContent(L"LANG=de_DE.UTF-8\n");
+            TerminateDistribution();
+            VERIFY_ARE_EQUAL(readLang(), L"de_DE.UTF-8\n");
+        }
+
+        // Only /etc/locale.conf is present (Fedora, Arch, openSUSE, ...).
+        {
+            defaultLocale.Delete();
+            localeConf.Delete();
+            localeConf.SetContent(L"LANG=fr_FR.UTF-8\n");
+            TerminateDistribution();
+            VERIFY_ARE_EQUAL(readLang(), L"fr_FR.UTF-8\n");
+        }
+
+        // Both files are present: /etc/default/locale takes precedence because it is read first.
+        {
+            defaultLocale.Delete();
+            localeConf.Delete();
+            defaultLocale.SetContent(L"LANG=ja_JP.UTF-8\n");
+            localeConf.SetContent(L"LANG=en_US.UTF-8\n");
+            TerminateDistribution();
+            VERIFY_ARE_EQUAL(readLang(), L"ja_JP.UTF-8\n");
+        }
+    }
+
     TEST_METHOD(Dup)
     {
         VERIFY_NO_THROW(LxsstuRunTest(L"/data/test/wsl_unit_tests dup", L"Dup"));


### PR DESCRIPTION
## Summary of the Pull Request
`init` populates the distro's `$LANG` environment variable from
`/etc/default/locale`, but that was the only path checked. `/etc/default/locale`
is the Debian/Ubuntu convention; systemd-based distributions (Fedora, Arch,
openSUSE, ...) store the locale in `/etc/locale.conf` instead. On those distros
`$LANG` was never propagated from the distro's configuration.

This change makes `ConfigUpdateLanguage` check both locations and use the first
one that exists.

## PR Checklist
- [x] **Closes:** Link to issue #13207
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
- Added `LOCALE_CONF_FILE_PATH` (`/etc/locale.conf`).
- `ConfigUpdateLanguage` now tries `/etc/default/locale` then `/etc/locale.conf`,
  opening the first file that exists.
- Both files use the same `KEY=value` format with a `LANG=` line, so the existing
  line-parsing logic is reused unchanged.
- Behavior is preserved:
  - `/etc/default/locale` takes precedence when both files exist.
  - A missing file (`ENOENT`) is skipped silently; other `fopen` errors are still
    logged.
  - If neither file exists, `$LANG` is left unchanged.

## Validation Steps Performed
- Built the Linux `init` target (cross-compiled via the in-tree clang/LINUXSDK
  toolchain) — compiles cleanly.
- Verified on **Ubuntu** (uses `/etc/default/locale`): existing behavior is
  preserved — `$LANG` is still propagated correctly.
- Verified on **Arch Linux** (uses `/etc/locale.conf`): `$LANG` is now correctly
  propagated from the distro's locale configuration.