### PR TITLE
Fix various issues in the virtionet tests

### DIFF
--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "precomp.h"
 #include "Common.h"
 #include "LxssDynamicFunction.h"
+#include "WslCoreNetworkEndpointSettings.h"
 #include <tlhelp32.h>
 #include <werapi.h>
 #include <Dbghelp.h>
@@ -3041,53 +3042,15 @@ void ExpectHttpResponse(LPCWSTR Url, std::optional<int> expectedCode, bool retry
     }
 }
 
-std::optional<std::string> GetHostAdapterIpv4()
+std::optional<std::wstring> GetHostAdapterIpv4()
 {
-    ULONG bufferSize = 0;
-    constexpr ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
-    auto result = GetAdaptersAddresses(AF_INET, flags, nullptr, nullptr, &bufferSize);
-    if (result != ERROR_BUFFER_OVERFLOW)
+    auto endpoint = wsl::core::networking::GetHostEndpointSettings();
+    if (!endpoint)
     {
-        return std::nullopt;
+        return {};
     }
 
-    std::vector<BYTE> buffer(bufferSize);
-    auto* adapters = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
-    result = GetAdaptersAddresses(AF_INET, flags, nullptr, adapters, &bufferSize);
-    if (result != ERROR_SUCCESS)
-    {
-        return std::nullopt;
-    }
-
-    for (auto* adapter = adapters; adapter != nullptr; adapter = adapter->Next)
-    {
-        if (adapter->OperStatus != IfOperStatusUp || adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK || adapter->IfType == IF_TYPE_TUNNEL)
-        {
-            continue;
-        }
-
-        for (auto* addr = adapter->FirstUnicastAddress; addr != nullptr; addr = addr->Next)
-        {
-            if (addr->Address.lpSockaddr->sa_family != AF_INET)
-            {
-                continue;
-            }
-
-            auto& ipv4 = reinterpret_cast<sockaddr_in*>(addr->Address.lpSockaddr)->sin_addr;
-
-            // Skip APIPA (169.254.x.x) addresses.
-            if ((ntohl(ipv4.s_addr) & 0xFFFF0000) == 0xA9FE0000)
-            {
-                continue;
-            }
-
-            char buf[INET_ADDRSTRLEN];
-            VERIFY_IS_NOT_NULL(inet_ntop(AF_INET, &ipv4, buf, sizeof(buf)));
-            return std::string(buf);
-        }
-    }
-
-    return std::nullopt;
+    return endpoint->PreferredIpAddress.AddressString;
 }
 
 void SetPathAccess(const std::filesystem::path& path, DWORD Permissions, ACCESS_MODE Mode)

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -3045,7 +3045,7 @@ void ExpectHttpResponse(LPCWSTR Url, std::optional<int> expectedCode, bool retry
 std::optional<std::wstring> GetHostAdapterIpv4()
 {
     auto endpoint = wsl::core::networking::GetHostEndpointSettings();
-    if (!endpoint)
+    if (!endpoint || endpoint->PreferredIpAddress.AddressString.empty())
     {
         return {};
     }

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -655,7 +655,7 @@ void LoadTestImage(IWSLCSession& session, std::string_view imageName);
 
 void ExpectHttpResponse(LPCWSTR Url, std::optional<int> expectedCode, bool retry = false);
 
-std::optional<std::string> GetHostAdapterIpv4();
+std::optional<std::wstring> GetHostAdapterIpv4();
 
 template <typename T>
 void VerifyAreEqualUnordered(const std::vector<T>& expected, const std::vector<T>& actual, const std::source_location& source = std::source_location::current())

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8141,6 +8141,11 @@ class WSLCTests
         auto [restore, session] = SetupPortMappingsTest(WSLCNetworkingModeConsomme);
 
         auto hostIp = GetHostAdapterIpv4();
+        std::optional<std::string> hostIpNarrow;
+        if (hostIp.has_value())
+        {
+            hostIpNarrow = wsl::shared::string::WideToMultiByte(hostIp.value());
+        }
 
         struct PortMapping
         {
@@ -8152,7 +8157,7 @@ class WSLCTests
         };
 
         auto runCustomBindingTests = [&](const std::string& containerNetworkType) {
-            LogInfo("Container network type: %s", containerNetworkType.c_str());
+            LogInfo("Container network type: %hs", containerNetworkType.c_str());
 
             auto createTcpContainer = [&](const std::vector<PortMapping>& ports) {
                 static int containerIndex = 0;
@@ -8217,7 +8222,7 @@ class WSLCTests
                 // Verify reachable via host adapter IP to confirm wildcard semantics.
                 if (hostIp.has_value())
                 {
-                    auto url = std::format(L"http://{}:1261", wsl::shared::string::MultiByteToWide(hostIp.value()));
+                    auto url = std::format(L"http://{}:1261", hostIp.value());
                     ExpectHttpResponse(url.c_str(), 200);
                 }
                 else
@@ -8230,10 +8235,10 @@ class WSLCTests
             {
                 if (hostIp.has_value())
                 {
-                    auto container = createTcpContainer({{1262, 8000, AF_INET, IPPROTO_TCP, hostIp.value()}});
-                    validateInspectPortBinding(container, 8000, IPPROTO_TCP, hostIp.value(), 1262);
+                    auto container = createTcpContainer({{1262, 8000, AF_INET, IPPROTO_TCP, hostIpNarrow.value()}});
+                    validateInspectPortBinding(container, 8000, IPPROTO_TCP, hostIpNarrow.value(), 1262);
 
-                    auto url = std::format(L"http://{}:1262", wsl::shared::string::MultiByteToWide(hostIp.value()));
+                    auto url = std::format(L"http://{}:1262", hostIp.value());
                     ExpectHttpResponse(url.c_str(), 200);
                 }
                 else
@@ -8254,8 +8259,8 @@ class WSLCTests
             {
                 if (hostIp.has_value())
                 {
-                    auto container = createTcpContainer({{WSLC_EPHEMERAL_PORT, 8000, AF_INET, IPPROTO_TCP, hostIp.value()}});
-                    auto hostPort = validateInspectPortBinding(container, 8000, IPPROTO_TCP, hostIp.value(), std::nullopt);
+                    auto container = createTcpContainer({{WSLC_EPHEMERAL_PORT, 8000, AF_INET, IPPROTO_TCP, hostIpNarrow.value()}});
+                    auto hostPort = validateInspectPortBinding(container, 8000, IPPROTO_TCP, hostIpNarrow.value(), std::nullopt);
 
                     ExpectHttpResponse(std::format(L"http://{}:{}", hostIp.value(), hostPort).c_str(), 200);
                 }

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -633,7 +633,7 @@ class WSLCE2EContainerRunTests
         auto portBindings = inspectContainer.Ports[portKey];
         VERIFY_ARE_EQUAL(1u, portBindings.size());
         VERIFY_ARE_EQUAL(std::to_string(HostTestPort1), portBindings[0].HostPort);
-        VERIFY_ARE_EQUAL(*hostIp, portBindings[0].HostIp);
+        VERIFY_ARE_EQUAL(wsl::shared::string::WideToMultiByte(*hostIp), portBindings[0].HostIp);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_Port_TCP)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves two issues with the virtionet tests:

- The host IP address logic doesn't match the product logic, and so it sometimes mismatches (especially if Hyper-V is running)
- A broken "%s" string outputs garbage 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [Xd] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
