### PR TITLE
Use throwing overloads in SetupTestDirectory

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -139,12 +139,8 @@ void WriteTestFileContent(const std::filesystem::path& filePath, const std::stri
 // Sets up a clean test directory and returns a scope_exit to remove it.
 inline auto SetupTestDirectory(const std::filesystem::path& directory)
 {
-    std::error_code ec;
-    std::filesystem::remove_all(directory, ec);
-    THROW_HR_IF_MSG(E_FAIL, ec.value() != 0 && std::filesystem::exists(directory), "%hs", ec.message().c_str());
-
-    std::filesystem::create_directories(directory, ec);
-    THROW_HR_IF_MSG(E_FAIL, ec.value() != 0 || !std::filesystem::exists(directory), "%hs", ec.message().c_str());
+    std::filesystem::remove_all(directory);
+    std::filesystem::create_directories(directory);
 
     return wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [directory]() {
         std::error_code removeError;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Use throwing std::filesystem overloads. Addresses code review feedback.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
