### PR TITLE
Don't use an overlay for the gpu libraries if the inbox folder isn't present

### DIFF
--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -1185,8 +1185,8 @@ void WSLCVirtualMachine::MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_
     std::optional<std::string> inboxLibMountPoint;
     if (std::filesystem::is_directory(inboxLibPath))
     {
-        inboxLibMountPoint = std::format("{}/inbox", LibrariesMountPoint);
-        THROW_IF_FAILED(MountWindowsFolderImpl(inboxLibPath.c_str(), inboxLibMountPoint->c_str(), WSLCMountFlagsReadOnly));
+        // inboxLibMountPoint = std::format("{}/inbox", LibrariesMountPoint);
+        // THROW_IF_FAILED(MountWindowsFolderImpl(inboxLibPath.c_str(), inboxLibMountPoint->c_str(), WSLCMountFlagsReadOnly));
     }
 
     // Mount the packaged libraries.
@@ -1200,19 +1200,26 @@ void WSLCVirtualMachine::MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_
 
 #endif
 
-    auto packagedLibMountPoint = std::format("{}/packaged", LibrariesMountPoint);
-    THROW_IF_FAILED(MountWindowsFolderImpl(packagedLibPath.c_str(), packagedLibMountPoint.c_str(), WSLCMountFlagsReadOnly));
-
-    // Mount an overlay containing both inbox and packaged libraries (the packaged mount takes precedence).
-    std::string options = "lowerdir=" + packagedLibMountPoint;
     if (inboxLibMountPoint.has_value())
     {
-        options += ":" + inboxLibMountPoint.value();
+        // Mount an overlay containing both inbox and packaged libraries (the packaged mount takes precedence).
+        auto packagedLibMountPoint = std::format("{}/packaged", LibrariesMountPoint);
+        THROW_IF_FAILED(MountWindowsFolderImpl(packagedLibPath.c_str(), packagedLibMountPoint.c_str(), WSLCMountFlagsReadOnly));
+
+        Mount(
+            m_initChannel,
+            "none",
+            LibrariesMountPoint,
+            "overlay",
+            std::format("lowerdir={}:{}", packagedLibMountPoint, inboxLibMountPoint.value()).c_str(),
+            0);
     }
-
-    Mount(m_initChannel, "none", LibrariesMountPoint, "overlay", options.c_str(), 0);
+    else
+    {
+        // If the inbox libraries are not present, mount the packaged libraries directly at final location (no overlay needed).
+        THROW_IF_FAILED(MountWindowsFolderImpl(packagedLibPath.c_str(), LibrariesMountPoint, WSLCMountFlagsReadOnly));
+    }
 }
-
 void WSLCVirtualMachine::OnProcessReleased(int Pid)
 {
     std::lock_guard lock{m_trackedProcessesLock};

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -1185,8 +1185,8 @@ void WSLCVirtualMachine::MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_
     std::optional<std::string> inboxLibMountPoint;
     if (std::filesystem::is_directory(inboxLibPath))
     {
-        // inboxLibMountPoint = std::format("{}/inbox", LibrariesMountPoint);
-        // THROW_IF_FAILED(MountWindowsFolderImpl(inboxLibPath.c_str(), inboxLibMountPoint->c_str(), WSLCMountFlagsReadOnly));
+        inboxLibMountPoint = std::format("{}/inbox", LibrariesMountPoint);
+        THROW_IF_FAILED(MountWindowsFolderImpl(inboxLibPath.c_str(), inboxLibMountPoint->c_str(), WSLCMountFlagsReadOnly));
     }
 
     // Mount the packaged libraries.


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the GPU mounting logic to skip the overlayfs part if C:\Windows\System32\lxss\lib doesn't exist (otherwise the overlay will fail to mount, since there would be no upper).

Unfortunately the inbox folder cannot be easily modified in the tests, so this change doesn't include test coverage

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #40959 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
