### PR TITLE
Cap storage hw queue count to 4

### DIFF
--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -39,6 +39,8 @@ using wsl::windows::common::helpers::LaunchWslRelayFlags;
 constexpr auto c_WslSupportInterfaceKey = L"Software\\Classes\\Interface\\{46f3c96d-ffa3-42f0-b052-52f5e7ecbb08}";
 constexpr auto c_WslSupportInterfaceName = L"IWslSupport";
 
+constexpr ULONG c_MaxStorageHwQueues = 4;
+
 namespace {
 
 class ProcessLauncher
@@ -762,7 +764,8 @@ try
 }
 CATCH_LOG()
 
-void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ ULONG64 swiotlbSizeBytes)
+void wsl::windows::common::helpers::AppendCommonKernelCommandLine(
+    _Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ ULONG64 swiotlbSizeBytes, _In_ ULONG cpuCount)
 {
     // Enable timesync workaround to sync on resume from sleep in modern standby.
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
@@ -777,6 +780,12 @@ void wsl::windows::common::helpers::AppendCommonKernelCommandLine(_Inout_ std::w
     if (swiotlbSizeBytes != 0)
     {
         kernelCmdLine += std::format(L" swiotlb=force hv_pci_swiotlb={}", swiotlbSizeBytes);
+    }
+
+    // Cap the storage hw queue count. Default is CPU count.
+    if (cpuCount > c_MaxStorageHwQueues)
+    {
+        kernelCmdLine += std::format(L" hv_storvsc.storvsc_max_hw_queues={}", c_MaxStorageHwQueues);
     }
 }
 

--- a/src/windows/common/helpers.cpp
+++ b/src/windows/common/helpers.cpp
@@ -767,6 +767,9 @@ CATCH_LOG()
 void wsl::windows::common::helpers::AppendCommonKernelCommandLine(
     _Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ ULONG64 swiotlbSizeBytes, _In_ ULONG cpuCount)
 {
+    // Set number of processors.
+    kernelCmdLine += std::format(L" nr_cpus={}", cpuCount);
+
     // Enable timesync workaround to sync on resume from sleep in modern standby.
     kernelCmdLine += L" hv_utils.timesync_implicit=1";
 

--- a/src/windows/common/helpers.hpp
+++ b/src/windows/common/helpers.hpp
@@ -205,7 +205,7 @@ bool TryAttachConsole();
 
 void RegisterWithDcat(_In_ bool IncludeVersionNumber = true);
 
-void AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ ULONG64 swiotlbSizeBytes);
+void AppendCommonKernelCommandLine(_Inout_ std::wstring& kernelCmdLine, _In_ int pageReportingOrder, _In_ ULONG64 swiotlbSizeBytes, _In_ ULONG cpuCount);
 
 UINT64 ComputeDefaultSwiotlbConfig(_In_ UINT64 memoryBytes);
 

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -166,7 +166,6 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
 
     // Initialize kernel command line.
     std::wstring kernelCmdLine = L"initrd=\\" LXSS_VM_MODE_INITRD_NAME L" " TEXT(WSLC_ROOT_INIT_ENV) L"=1 panic=-1";
-    kernelCmdLine += std::format(L" nr_cpus={}", Settings->CpuCount);
     helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder, swiotlbSizeBytes, Settings->CpuCount);
 
     // Setup dmesg collector with optional DmesgOutput handle.

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -30,7 +30,6 @@ using helpers::WindowsBuildNumbers;
 using wsl::windows::service::wslc::HcsVirtualMachine;
 
 constexpr auto MAX_VM_CRASH_FILES = 3;
-constexpr ULONG MAX_STORAGE_HW_QUEUES = 4;
 constexpr auto SAVED_STATE_FILE_EXTENSION = L".vmrs";
 constexpr auto SAVED_STATE_FILE_PREFIX = L"saved-state-";
 
@@ -168,13 +167,7 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     // Initialize kernel command line.
     std::wstring kernelCmdLine = L"initrd=\\" LXSS_VM_MODE_INITRD_NAME L" " TEXT(WSLC_ROOT_INIT_ENV) L"=1 panic=-1";
     kernelCmdLine += std::format(L" nr_cpus={}", Settings->CpuCount);
-    helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder, swiotlbSizeBytes);
-
-    // Cap the storage hw queue count. Default is CPU count.
-    if (Settings->CpuCount > MAX_STORAGE_HW_QUEUES)
-    {
-        kernelCmdLine += std::format(L" hv_storvsc.storvsc_max_hw_queues={}", MAX_STORAGE_HW_QUEUES);
-    }
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder, swiotlbSizeBytes, Settings->CpuCount);
 
     // Setup dmesg collector with optional DmesgOutput handle.
     // TODO: move dmesg collector to user session process.

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -30,6 +30,7 @@ using helpers::WindowsBuildNumbers;
 using wsl::windows::service::wslc::HcsVirtualMachine;
 
 constexpr auto MAX_VM_CRASH_FILES = 3;
+constexpr auto MAX_STORAGE_HW_QUEUES = 4;
 constexpr auto SAVED_STATE_FILE_EXTENSION = L".vmrs";
 constexpr auto SAVED_STATE_FILE_PREFIX = L"saved-state-";
 
@@ -168,6 +169,12 @@ HcsVirtualMachine::HcsVirtualMachine(_In_ const WSLCSessionSettings* Settings)
     std::wstring kernelCmdLine = L"initrd=\\" LXSS_VM_MODE_INITRD_NAME L" " TEXT(WSLC_ROOT_INIT_ENV) L"=1 panic=-1";
     kernelCmdLine += std::format(L" nr_cpus={}", Settings->CpuCount);
     helpers::AppendCommonKernelCommandLine(kernelCmdLine, pageReportingOrder, swiotlbSizeBytes);
+
+    // Cap the storage hw queue count. Default is CPU count.
+    if (Settings->CpuCount > MAX_STORAGE_HW_QUEUES)
+    {
+        kernelCmdLine += std::format(L" hv_storvsc.storvsc_max_hw_queues={}", MAX_STORAGE_HW_QUEUES);
+    }
 
     // Setup dmesg collector with optional DmesgOutput handle.
     // TODO: move dmesg collector to user session process.

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -30,7 +30,7 @@ using helpers::WindowsBuildNumbers;
 using wsl::windows::service::wslc::HcsVirtualMachine;
 
 constexpr auto MAX_VM_CRASH_FILES = 3;
-constexpr auto MAX_STORAGE_HW_QUEUES = 4;
+constexpr ULONG MAX_STORAGE_HW_QUEUES = 4;
 constexpr auto SAVED_STATE_FILE_EXTENSION = L".vmrs";
 constexpr auto SAVED_STATE_FILE_PREFIX = L"saved-state-";
 

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1579,7 +1579,7 @@ std::wstring WslCoreVm::GenerateConfigJson()
     kernelCmdLine += std::format(L" nr_cpus={}", m_vmConfig.ProcessorCount);
 
     // Append common kernel parameters shared between WSL2 and WSLC.
-    helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder, m_vmConfig.SwiotlbSizeBytes);
+    helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder, m_vmConfig.SwiotlbSizeBytes, m_vmConfig.ProcessorCount);
 
     if (m_vmConfig.EnableVirtio && helpers::IsVirtioSerialConsoleSupported())
     {

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -1575,9 +1575,6 @@ std::wstring WslCoreVm::GenerateConfigJson()
     // Initialize kernel command line.
     std::wstring kernelCmdLine = L"initrd=\\" LXSS_VM_MODE_INITRD_NAME L" " TEXT(WSL_ROOT_INIT_ENV) L"=1 panic=-1";
 
-    // Set number of processors.
-    kernelCmdLine += std::format(L" nr_cpus={}", m_vmConfig.ProcessorCount);
-
     // Append common kernel parameters shared between WSL2 and WSLC.
     helpers::AppendCommonKernelCommandLine(kernelCmdLine, m_pageReportingOrder, m_vmConfig.SwiotlbSizeBytes, m_vmConfig.ProcessorCount);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Cap the hv_storvsc.storvsc_max_hw_queues to 4 to reduce memory overhead on CPUs with high core counts.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

### Test platform
CPU: 13900, 32 logical cores.
Drive backing the vhd: WDC SN810 1T
### RAM overhead comparison
RAM overhead measured with wsl-benchmarking. VM RAM = 2G, vhd size = 100G. Noise (std) ~= 5 - 10
<img width="1053" height="751" alt="image" src="https://github.com/user-attachments/assets/a088fa3f-0284-467a-a3da-f3b68fb875a0" />


### IO performance comparison
IO performance measured with fio-bench. --numjobs = 32. VM CPU count = 32.
| queue count | random read/IOps | random write/IOps | sequential read/MBps | random read p99/ms |
| - | - | - | - | - |
| 1 | 255800 | 262900 | 6174 | 8.2 |
| 2 | 433900 | 231200 | 6343 | 4.2 |
| 4 | 437700 | 234300 | 6354 | 4.3 |
| 8 | 431900 | 238700 | 6367 | 4.1 |
| 16 | 443300 | 229200 | 6246 | 4.1 |
| 32 | 432300 | 232800 | 6299 | 4.5 |