### PR TITLE
Fix: Update plan9 registration with the new default uid after OOBE

### DIFF
--- a/src/windows/common/Redirector.cpp
+++ b/src/windows/common/Redirector.cpp
@@ -226,14 +226,14 @@ void ConnectionTargetManager::AddConnectionTarget(
     if (!Contains(security.LogonId))
     {
         redirector::AddConnectionTarget(m_name, security.LogonId, aname, uid, unixSocketPath, instanceId, port);
-        m_logonIds.push_back(security.LogonId);
+        m_targets.emplace_back(security.LogonId, std::string(aname), uid, std::wstring(unixSocketPath), instanceId, port);
     }
 
     // Checking the list also catches the case where the logon ID and linked logon ID are equal.
     if (!Contains(security.LinkedLogonId))
     {
         redirector::AddConnectionTarget(m_name, security.LinkedLogonId, aname, uid, unixSocketPath, instanceId, port);
-        m_logonIds.push_back(security.LinkedLogonId);
+        m_targets.emplace_back(security.LinkedLogonId, std::string(aname), uid, std::wstring(unixSocketPath), instanceId, port);
     }
 }
 
@@ -241,20 +241,41 @@ void ConnectionTargetManager::AddConnectionTarget(
 void ConnectionTargetManager::RemoveAll()
 {
     auto lock = m_lock.lock_exclusive();
-    for (const auto logonId : m_logonIds)
+    for (const auto& target : m_targets)
     {
-        RemoveConnectionTarget(m_name, logonId);
+        RemoveConnectionTarget(m_name, target.logonId);
     }
 
-    m_logonIds.clear();
+    m_targets.clear();
 }
 
 // Checks whether the list of logon IDs contains the specified ID.
 bool ConnectionTargetManager::Contains(LUID luid) const
 {
-    const auto it = std::find_if(m_logonIds.begin(), m_logonIds.end(), [&luid](auto& item) { return RtlEqualLuid(&luid, &item); });
+    const auto it =
+        std::find_if(m_targets.begin(), m_targets.end(), [&luid](auto& item) { return RtlEqualLuid(&luid, &item.logonId); });
 
-    return it != m_logonIds.end();
+    return it != m_targets.end();
+}
+
+// Re-add all connection targets with the new UID.
+void ConnectionTargetManager::UpdateUid(LX_UID_T uid)
+{
+    auto lock = m_lock.lock_exclusive();
+
+    for (auto& target : m_targets)
+    {
+        if (target.uid == uid)
+        {
+            continue;
+        }
+
+        redirector::RemoveConnectionTarget(m_name, target.logonId);
+        redirector::AddConnectionTarget(
+            m_name, target.logonId, target.aname, uid, target.unixSocketPath, target.instanceId, target.port);
+
+        target.uid = uid;
+    }
 }
 
 } // namespace wsl::windows::common::redirector

--- a/src/windows/common/Redirector.cpp
+++ b/src/windows/common/Redirector.cpp
@@ -249,7 +249,7 @@ void ConnectionTargetManager::RemoveAll()
     m_targets.clear();
 }
 
-// Checks whether the list of logon IDs contains the specified ID.
+// Checks whether the list of targets contains the specified ID.
 bool ConnectionTargetManager::Contains(LUID luid) const
 {
     const auto it =

--- a/src/windows/common/Redirector.h
+++ b/src/windows/common/Redirector.h
@@ -26,11 +26,23 @@ public:
 
     void RemoveAll();
 
+    void UpdateUid(LX_UID_T uid);
+
 private:
+    struct ConnectionTarget
+    {
+        LUID logonId;
+        std::string aname;
+        LX_UID_T uid;
+        std::wstring unixSocketPath;
+        GUID instanceId;
+        ULONG port;
+    };
+
     bool Contains(LUID luid) const;
 
     std::wstring_view m_name;
-    std::vector<LUID> m_logonIds;
+    std::vector<ConnectionTarget> m_targets;
     wil::srwlock m_lock;
 };
 

--- a/src/windows/service/exe/LxssInstance.cpp
+++ b/src/windows/service/exe/LxssInstance.cpp
@@ -425,6 +425,12 @@ void LxssInstance::Stop()
 
 void LxssInstance::RegisterPlan9ConnectionTarget(_In_ HANDLE userToken)
 {
+    // m_defaultUid is not set before OOBE is complete.
+    if (m_configuration.RunOOBE)
+    {
+        return;
+    }
+
     const auto path = m_configuration.BasePath / LXSS_PLAN9_UNIX_SOCKET;
     using unique_unicode_string = wil::unique_struct<UNICODE_STRING, decltype(RtlFreeUnicodeString), RtlFreeUnicodeString>;
     unique_unicode_string socketPath;
@@ -577,6 +583,8 @@ wil::unique_handle LxssInstance::_CreateLxProcess(
                             registration.Write(wsl::windows::service::Property::DefaultUid, static_cast<int>(OobeResult->DefaultUid));
                             m_defaultUid = static_cast<int>(OobeResult->DefaultUid);
                         }
+
+                        RegisterPlan9ConnectionTarget(m_userToken.get());
                     }
                 }
                 CATCH_LOG()

--- a/src/windows/service/exe/LxssInstance.cpp
+++ b/src/windows/service/exe/LxssInstance.cpp
@@ -425,12 +425,6 @@ void LxssInstance::Stop()
 
 void LxssInstance::RegisterPlan9ConnectionTarget(_In_ HANDLE userToken)
 {
-    // m_defaultUid is not set before OOBE is complete.
-    if (m_configuration.RunOOBE)
-    {
-        return;
-    }
-
     const auto path = m_configuration.BasePath / LXSS_PLAN9_UNIX_SOCKET;
     using unique_unicode_string = wil::unique_struct<UNICODE_STRING, decltype(RtlFreeUnicodeString), RtlFreeUnicodeString>;
     unique_unicode_string socketPath;
@@ -584,7 +578,7 @@ wil::unique_handle LxssInstance::_CreateLxProcess(
                             m_defaultUid = static_cast<int>(OobeResult->DefaultUid);
                         }
 
-                        RegisterPlan9ConnectionTarget(m_userToken.get());
+                        m_redirectorConnectionTargets.UpdateUid(m_defaultUid);
                     }
                 }
                 CATCH_LOG()

--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -309,6 +309,8 @@ void WslCoreInstance::ReadOOBEResult(wil::unique_socket&& Socket, wsl::windows::
             registration.Write(wsl::windows::service::Property::DefaultUid, static_cast<int>(oobeResult->DefaultUid));
             m_defaultUid = static_cast<int>(oobeResult->DefaultUid);
         }
+
+        RegisterPlan9ConnectionTarget(m_userToken.get());
     }
 }
 
@@ -530,6 +532,12 @@ void WslCoreInstance::Stop()
 
 void WslCoreInstance::RegisterPlan9ConnectionTarget(_In_ HANDLE userToken)
 {
+    // m_defaultUid is not set before OOBE is complete.
+    if (m_configuration.RunOOBE)
+    {
+        return;
+    }
+
     // If Plan 9 is running, add a connection target to the P9Rdr driver.
     if (m_plan9Port != LX_INIT_UTILITY_VM_INVALID_PORT)
     {

--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -310,7 +310,7 @@ void WslCoreInstance::ReadOOBEResult(wil::unique_socket&& Socket, wsl::windows::
             m_defaultUid = static_cast<int>(oobeResult->DefaultUid);
         }
 
-        RegisterPlan9ConnectionTarget(m_userToken.get());
+        m_redirectorConnectionTargets.UpdateUid(m_defaultUid);
     }
 }
 
@@ -532,12 +532,6 @@ void WslCoreInstance::Stop()
 
 void WslCoreInstance::RegisterPlan9ConnectionTarget(_In_ HANDLE userToken)
 {
-    // m_defaultUid is not set before OOBE is complete.
-    if (m_configuration.RunOOBE)
-    {
-        return;
-    }
-
     // If Plan 9 is running, add a connection target to the P9Rdr driver.
     if (m_plan9Port != LX_INIT_UTILITY_VM_INVALID_PORT)
     {

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -4441,15 +4441,6 @@ VERSION_ID="Invalid|Format"
 
             TerminateDistribution();
 
-            // The distro's files should not be exposed via \\wsl.localhost before OOBE is completed.
-            const std::wstring testFilePathLinux = L"/tmp/oobe_file_test";
-            const std::wstring testFilePathWindows = L"\\\\wsl.localhost\\" LXSS_DISTRO_NAME_TEST_L L"\\tmp\\oobe_file_test";
-            {
-                const wil::unique_hfile file(CreateFile(
-                    testFilePathWindows.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
-                VERIFY_IS_FALSE(file.is_valid());
-            }
-
             validateOutput(nullptr, L"OOBE\n");
             VERIFY_ARE_EQUAL(runOOBE.Get(), 0);
 
@@ -4457,13 +4448,14 @@ VERSION_ID="Invalid|Format"
             validateOutput(L"id -u", L"1010\n");
             VERIFY_ARE_EQUAL(defaultUid.Get(), 1010);
 
-            // The distro's files should now be exposed. And new file should be created with the correct uid.
-            {
-                const wil::unique_hfile file(CreateFile(
-                    testFilePathWindows.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
-                VERIFY_IS_TRUE(file.is_valid());
-                validateOutput(std::format(L"stat -c %u {}", testFilePathLinux).c_str(), L"1010\n");
-            }
+            // New file should be created with the correct uid.
+            const std::wstring testFilePathLinux = L"/tmp/oobe_file_test";
+            const std::wstring testFilePathWindows = L"\\\\wsl.localhost\\" LXSS_DISTRO_NAME_TEST_L L"\\tmp\\oobe_file_test";
+
+            const wil::unique_hfile file(CreateFile(
+                testFilePathWindows.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+            VERIFY_IS_TRUE(file.is_valid());
+            validateOutput(std::format(L"stat -c %u {}", testFilePathLinux).c_str(), L"1010\n");
         }
 
         // Verify that the default UID isn't changed if it's not present in wsl-distribution.conf.

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -4441,12 +4441,29 @@ VERSION_ID="Invalid|Format"
 
             TerminateDistribution();
 
+            // The distro's files should not be exposed via \\wsl.localhost before OOBE is completed.
+            const std::wstring testFilePathLinux = L"/tmp/oobe_file_test";
+            const std::wstring testFilePathWindows = L"\\\\wsl.localhost\\" LXSS_DISTRO_NAME_TEST_L L"\\tmp\\oobe_file_test";
+            {
+                const wil::unique_hfile file(CreateFile(
+                    testFilePathWindows.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+                VERIFY_IS_FALSE(file.is_valid());
+            }
+
             validateOutput(nullptr, L"OOBE\n");
             VERIFY_ARE_EQUAL(runOOBE.Get(), 0);
 
             // Validate that DefaultUid was set
             validateOutput(L"id -u", L"1010\n");
             VERIFY_ARE_EQUAL(defaultUid.Get(), 1010);
+
+            // The distro's files should now be exposed. And new file should be created with the correct uid.
+            {
+                const wil::unique_hfile file(CreateFile(
+                    testFilePathWindows.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+                VERIFY_IS_TRUE(file.is_valid());
+                validateOutput(std::format(L"stat -c %u {}", testFilePathLinux).c_str(), L"1010\n");
+            }
         }
 
         // Verify that the default UID isn't changed if it's not present in wsl-distribution.conf.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Currently, after a fresh distro installation, operations in the linux plan9 share will use the uid 0. Because the uid was cached before the OOBE is complete. And this only recovers after a distro termination.
This PR updates the plan9 registration after the OOBE completes with the new default uid.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/40941
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Updated the test UnitTests::UnitTests::ModernOOBE to verify this change.