### PR TITLE
Bump Kali to 2026.2

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -121,12 +121,12 @@
                 "FriendlyName": "Kali Linux Rolling",
                 "Default": true,
                 "Amd64Url": {
-                    "Url": "https://kali.download/wsl-images/kali-2026.1/kali-linux-2026.1-wsl-rootfs-amd64.wsl",
-                    "Sha256": "55c295400603a592d5ccf6a4046bb965f04d2509a62d1752cb2fe586c65deded"
+                    "Url": "https://kali.download/wsl-images/kali-2026.2/kali-linux-2026.2-wsl-rootfs-amd64.wsl",
+                    "Sha256": "1b172389e9109e9bb0c3d1fa18eda078271484dbcef8dbee4aab8b1f369466c6"
                 },
                 "Arm64Url": {
-                    "Url": "https://kali.download/wsl-images/kali-2026.1/kali-linux-2026.1-wsl-rootfs-arm64.wsl",
-                    "Sha256": "6ecd31844e9c1f0f77c052480ac40aeca24036846428676fa9137b003ab1b8e5"
+                    "Url": "https://kali.download/wsl-images/kali-2026.2/kali-linux-2026.2-wsl-rootfs-arm64.wsl",
+                    "Sha256": "0ebc7b7ed93b20ed787b27e217e408179f6b816be505e56dd0db65ce5e73f5f0"
                 }
             }
         ],


### PR DESCRIPTION
Release notes: https://www.kali.org/blog/kali-linux-2026-2-release/