### PR TITLE
Add support for wslc container restart command

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2127,7 +2127,7 @@ Usage:
   </data>
   <data name="MessageWslcContainerRestartAutoRemove" xml:space="preserve">
     <value>Container '{}' was created with --rm and cannot be restarted.</value>
-    <comment>{FixedPlaceholder="{}"}{Locked="--rm"}Command line arguments, file names and string inserts should not be translated</comment>
+    <comment>{FixedPlaceholder="{}"}{Locked="--rm "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageWslcContainerIsRunning" xml:space="preserve">
     <value>Container '{}' is running.</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2125,6 +2125,10 @@ Usage:
     <value>Container '{}' is not running.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcContainerRestartAutoRemove" xml:space="preserve">
+    <value>Container '{}' was created with --rm and cannot be restarted.</value>
+    <comment>{FixedPlaceholder="{}"}{Locked="--rm"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="MessageWslcContainerIsRunning" xml:space="preserve">
     <value>Container '{}' is running.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
@@ -2514,6 +2518,12 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   </data>
   <data name="WSLCCLI_ContainerRemoveLongDesc" xml:space="preserve">
     <value>Removes containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerRestartDesc" xml:space="preserve">
+    <value>Restart containers.</value>
+  </data>
+  <data name="WSLCCLI_ContainerRestartLongDesc" xml:space="preserve">
+    <value>Restarts one or more containers. Running containers are stopped and started again; stopped containers are started.</value>
   </data>
   <data name="WSLCCLI_ContainerRunDesc" xml:space="preserve">
     <value>Run a container.</value>

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -492,6 +492,7 @@ interface IWSLCContainer : IUnknown
     HRESULT Stats([out] LPSTR* Output);
     HRESULT ConnectToNetwork([in] const WSLCNetworkConnectionOptions* Options);
     HRESULT DisconnectFromNetwork([in] LPCSTR NetworkName);
+    HRESULT Restart([in] WSLCSignal Signal, [in] LONG TimeoutSeconds, [in, unique] IWarningCallback* WarningCallback);
 }
 
 typedef struct _WSLCDeletedImageInformation

--- a/src/windows/wslc/commands/ContainerCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCommand.cpp
@@ -32,6 +32,7 @@ std::vector<std::unique_ptr<Command>> ContainerCommand::GetCommands() const
     commands.push_back(std::make_unique<ContainerListCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerPruneCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerRemoveCommand>(FullName()));
+    commands.push_back(std::make_unique<ContainerRestartCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerRunCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerStartCommand>(FullName()));
     commands.push_back(std::make_unique<ContainerStatsCommand>(FullName()));

--- a/src/windows/wslc/commands/ContainerCommand.h
+++ b/src/windows/wslc/commands/ContainerCommand.h
@@ -168,6 +168,21 @@ protected:
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
 
+// Restart Command
+struct ContainerRestartCommand final : public Command
+{
+    constexpr static std::wstring_view CommandName = L"restart";
+    ContainerRestartCommand(const std::wstring& parent) : Command(CommandName, parent)
+    {
+    }
+    std::vector<Argument> GetArguments() const override;
+    std::wstring ShortDescription() const override;
+    std::wstring LongDescription() const override;
+
+protected:
+    void ExecuteInternal(CLIExecutionContext& context) const override;
+};
+
 // Run Command
 struct ContainerRunCommand final : public Command
 {

--- a/src/windows/wslc/commands/ContainerRestartCommand.cpp
+++ b/src/windows/wslc/commands/ContainerRestartCommand.cpp
@@ -1,0 +1,54 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ContainerRestartCommand.cpp
+
+Abstract:
+
+    Implementation of command execution logic.
+
+--*/
+
+#include "ContainerCommand.h"
+#include "CLIExecutionContext.h"
+#include "ContainerTasks.h"
+#include "SessionTasks.h"
+#include "Task.h"
+
+using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::task;
+using namespace wsl::shared;
+
+namespace wsl::windows::wslc {
+// Container Restart Command
+std::vector<Argument> ContainerRestartCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::ContainerId, std::nullopt, NO_LIMIT),
+        Argument::Create(ArgType::Signal),
+        Argument::Create(ArgType::Time),
+    };
+}
+
+std::wstring ContainerRestartCommand::ShortDescription() const
+{
+    return Localization::WSLCCLI_ContainerRestartDesc();
+}
+
+std::wstring ContainerRestartCommand::LongDescription() const
+{
+    return Localization::WSLCCLI_ContainerRestartLongDesc();
+}
+
+// clang-format off
+void ContainerRestartCommand::ExecuteInternal(CLIExecutionContext& context) const
+{
+    context
+        << ResolveSession
+        << RestartContainers;
+}
+// clang-format on
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -492,6 +492,14 @@ void ContainerService::Stop(Session& session, const std::string& id, StopContain
     THROW_IF_FAILED_EXCEPT(container->Stop(options.Signal, options.Timeout), WSLC_E_CONTAINER_NOT_RUNNING);
 }
 
+void ContainerService::Restart(Session& session, const std::string& id, StopContainerOptions options)
+{
+    wil::com_ptr<IWSLCContainer> container;
+    THROW_IF_FAILED(session.Get()->OpenContainer(id.c_str(), &container));
+    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
+    THROW_IF_FAILED(container->Restart(options.Signal, options.Timeout, warningCallback.Get()));
+}
+
 void ContainerService::Kill(Session& session, const std::string& id, WSLCSignal signal)
 {
     wil::com_ptr<IWSLCContainer> container;

--- a/src/windows/wslc/services/ContainerService.h
+++ b/src/windows/wslc/services/ContainerService.h
@@ -28,6 +28,7 @@ struct ContainerService
     static models::CreateContainerResult Create(models::Session& session, const std::string& image, models::ContainerOptions options);
     static int Start(models::Session& session, const std::string& id, bool attach = false);
     static void Stop(models::Session& session, const std::string& id, models::StopContainerOptions options);
+    static void Restart(models::Session& session, const std::string& id, models::StopContainerOptions options);
     static void Kill(models::Session& session, const std::string& id, WSLCSignal signal = WSLCSignalSIGKILL);
     static void Delete(models::Session& session, const std::string& id, bool force);
     static std::vector<models::ContainerInformation> List(

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -767,6 +767,29 @@ void StopContainers(CLIExecutionContext& context)
     }
 }
 
+void RestartContainers(CLIExecutionContext& context)
+{
+    WI_ASSERT(context.Data.Contains(Data::Session));
+    auto& session = context.Data.Get<Data::Session>();
+    auto containersToRestart = context.Args.GetAll<ArgType::ContainerId>();
+    StopContainerOptions options;
+    if (context.Args.Contains(ArgType::Signal))
+    {
+        options.Signal = validation::GetWSLCSignalFromString(context.Args.Get<ArgType::Signal>());
+    }
+
+    if (context.Args.Contains(ArgType::Time))
+    {
+        options.Timeout = validation::GetIntegerFromString<LONG>(context.Args.Get<ArgType::Time>());
+    }
+
+    for (const auto& id : containersToRestart)
+    {
+        ContainerService::Restart(session, WideToMultiByte(id), options);
+        PrintMessage(id);
+    }
+}
+
 void ViewContainerLogs(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Data.Contains(Data::Session));

--- a/src/windows/wslc/tasks/ContainerTasks.h
+++ b/src/windows/wslc/tasks/ContainerTasks.h
@@ -39,6 +39,7 @@ void KillContainers(CLIExecutionContext& context);
 void ListContainers(CLIExecutionContext& context);
 void PruneContainers(CLIExecutionContext& context);
 void RemoveContainers(CLIExecutionContext& context);
+void RestartContainers(CLIExecutionContext& context);
 void RunContainer(CLIExecutionContext& context);
 void SetContainerOptionsFromArgs(CLIExecutionContext& context);
 void ShowContainerStats(CLIExecutionContext& context);

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -2524,6 +2524,40 @@ void WSLCContainerImpl::DisconnectFromNetwork(LPCSTR NetworkName)
         TraceLoggingValue(NetworkName, "NetworkName"));
 }
 
+void WSLCContainerImpl::Restart(WSLCSignal Signal, LONG TimeoutSeconds)
+{
+    // N.B. Snapshot under a brief shared lock and release before composing Stop/Start.
+    // m_lock is a non-recursive srwlock; Stop and Start each take it exclusively.
+    WSLCContainerState snapshotState{};
+    WSLCContainerFlags snapshotFlags{};
+    {
+        auto lock = m_lock.lock_shared();
+        snapshotState = m_state;
+        snapshotFlags = m_containerFlags;
+    }
+
+    // Refuse --rm before stopping: Stop -> OnStopped would delete the container.
+    THROW_HR_WITH_USER_ERROR_IF(
+        HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
+        Localization::MessageWslcContainerRestartAutoRemove(m_id),
+        WI_IsFlagSet(snapshotFlags, WSLCContainerFlagsRm));
+
+    THROW_HR_IF_MSG(
+        HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
+        snapshotState != WslcContainerStateRunning && snapshotState != WslcContainerStateExited && snapshotState != WslcContainerStateCreated,
+        "Cannot restart container '%hs', state %i",
+        m_id.c_str(),
+        snapshotState);
+
+    if (snapshotState == WslcContainerStateRunning)
+    {
+        // N.B. If the container exits on its own before Stop acquires m_lock, Stop no-ops on Exited.
+        Stop(Signal, TimeoutSeconds, /*Kill*/ false);
+    }
+
+    Start(WSLCContainerStartFlagsNone, nullptr);
+}
+
 HRESULT WSLCContainer::GetLabels(WSLCLabelInformation** Labels, ULONG* Count)
 try
 {
@@ -2550,6 +2584,15 @@ try
 {
     COMServiceExecutionContext context;
     return CallImpl(&WSLCContainerImpl::DisconnectFromNetwork, NetworkName);
+}
+CATCH_RETURN();
+
+HRESULT WSLCContainer::Restart(_In_ WSLCSignal Signal, _In_ LONG TimeoutSeconds, _In_opt_ IWarningCallback* WarningCallback)
+try
+{
+    // N.B. WarningCallback is ambient here so EMIT_USER_WARNING reaches the client from both the Stop and Start phases.
+    WSLCExecutionContext context(&m_session, WarningCallback);
+    return CallImpl(&WSLCContainerImpl::Restart, Signal, TimeoutSeconds);
 }
 CATCH_RETURN();
 

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -110,6 +110,7 @@ public:
     void GetLabels(WSLCLabelInformation** Labels, ULONG* Count) const;
     void ConnectToNetwork(const WSLCNetworkConnectionOptions* Options);
     void DisconnectFromNetwork(LPCSTR NetworkName);
+    void Restart(WSLCSignal Signal, LONG TimeoutSeconds);
 
     void CopyTo(IWSLCContainer** Container) const;
 
@@ -247,6 +248,7 @@ public:
     IFACEMETHOD(Stats)(_Out_ LPSTR* Output) override;
     IFACEMETHOD(ConnectToNetwork)(_In_ const WSLCNetworkConnectionOptions* Options) override;
     IFACEMETHOD(DisconnectFromNetwork)(_In_ LPCSTR NetworkName) override;
+    IFACEMETHOD(Restart)(_In_ WSLCSignal Signal, _In_ LONG TimeoutSeconds, _In_opt_ IWarningCallback* WarningCallback) override;
 
     // IWSLCCompatContainer.
     IFACEMETHOD(Start)(_In_ WSLCContainerStartFlags Flags) override;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -6192,6 +6192,63 @@ class WSLCTests
         }
     }
 
+    WSLC_TEST_METHOD(ContainerRestart)
+    {
+        // Restart a running container.
+        {
+            WSLCContainerLauncher launcher("debian:latest", "test-restart-running", {"sleep", "99999"});
+            auto container = launcher.Launch(*m_defaultSession);
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+
+            VERIFY_SUCCEEDED(container.Get().Restart(WSLCSignalSIGKILL, 0, nullptr));
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+        }
+
+        // Restart of an exited container just starts it.
+        {
+            WSLCContainerLauncher launcher("debian:latest", "test-restart-exited", {"sleep", "99999"});
+            auto container = launcher.Launch(*m_defaultSession);
+            VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateExited);
+
+            VERIFY_SUCCEEDED(container.Get().Restart(WSLCSignalSIGKILL, 0, nullptr));
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+        }
+
+        // Restart of a created (never-started) container starts it.
+        {
+            WSLCContainerLauncher launcher("debian:latest", "test-restart-created", {"sleep", "99999"});
+            auto container = launcher.Create(*m_defaultSession);
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateCreated);
+
+            VERIFY_SUCCEEDED(container.Get().Restart(WSLCSignalSIGKILL, 0, nullptr));
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+        }
+
+        // --rm containers are refused; Stop is not invoked so the container stays Running.
+        {
+            WSLCContainerLauncher launcher("debian:latest", "test-restart-autorm", {"sleep", "99999"});
+            launcher.SetContainerFlags(WSLCContainerFlagsRm);
+            auto container = launcher.Launch(*m_defaultSession);
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+
+            auto id = container.Id();
+            VERIFY_ARE_EQUAL(container.Get().Restart(WSLCSignalSIGKILL, 0, nullptr), HRESULT_FROM_WIN32(ERROR_INVALID_STATE));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' was created with --rm and cannot be restarted.", id));
+            VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
+        }
+
+        // Deleted containers can't be restarted.
+        {
+            WSLCContainerLauncher launcher("debian:latest", "test-restart-deleted", {"sleep", "99999"});
+            auto container = launcher.Launch(*m_defaultSession);
+            VERIFY_SUCCEEDED(container.Get().Stop(WSLCSignalSIGKILL, 0));
+            VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
+
+            VERIFY_ARE_EQUAL(container.Get().Restart(WSLCSignalSIGKILL, 0, nullptr), RPC_E_DISCONNECTED);
+        }
+    }
+
     WSLC_TEST_METHOD(OpenContainer)
     {
         auto expectOpen = [&](const char* Id, HRESULT expectedResult = S_OK) {

--- a/test/windows/wslc/e2e/WSLCE2EContainerRestartTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRestartTests.cpp
@@ -1,0 +1,224 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WSLCE2EContainerRestartTests.cpp
+
+Abstract:
+
+    This file contains end-to-end tests for WSLC.
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCExecutor.h"
+#include "WSLCE2EHelpers.h"
+
+namespace WSLCE2ETests {
+using namespace wsl::shared;
+
+class WSLCE2EContainerRestartTests
+{
+    WSLC_TEST_CLASS(WSLCE2EContainerRestartTests)
+
+    TEST_CLASS_SETUP(ClassSetup)
+    {
+        EnsureImageIsLoaded(DebianImage);
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(ClassCleanup)
+    {
+        EnsureContainerDoesNotExist(WslcContainerName);
+        EnsureContainerDoesNotExist(WslcContainerName2);
+        EnsureImageIsDeleted(DebianImage);
+        return true;
+    }
+
+    TEST_METHOD_SETUP(TestMethodSetup)
+    {
+        EnsureContainerDoesNotExist(WslcContainerName);
+        EnsureContainerDoesNotExist(WslcContainerName2);
+        return true;
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_HelpCommand)
+    {
+        auto result = RunWslc(L"container restart --help");
+        result.Verify({.Stdout = GetHelpMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_RunningContainer)
+    {
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto containerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(containerId.empty());
+
+        VerifyContainerIsListed(containerId, L"running");
+
+        result = RunWslc(std::format(L"container restart {} -t 0", containerId));
+        result.Verify({.Stdout = std::format(L"{}\r\n", containerId), .Stderr = L"", .ExitCode = 0});
+
+        // Should be running again after restart.
+        VerifyContainerIsListed(containerId, L"running");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_StoppedContainer)
+    {
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto containerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(containerId.empty());
+
+        result = RunWslc(std::format(L"container stop {} -t 0", containerId));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VerifyContainerIsListed(containerId, L"exited");
+
+        // Restart of a stopped container should just start it.
+        result = RunWslc(std::format(L"container restart {} -t 0", containerId));
+        result.Verify({.Stdout = std::format(L"{}\r\n", containerId), .Stderr = L"", .ExitCode = 0});
+        VerifyContainerIsListed(containerId, L"running");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_ByName)
+    {
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto containerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(containerId.empty());
+
+        VerifyContainerIsListed(containerId, L"running");
+
+        result = RunWslc(std::format(L"container restart {} -t 0", WslcContainerName));
+        result.Verify({.Stdout = std::format(L"{}\r\n", WslcContainerName), .Stderr = L"", .ExitCode = 0});
+
+        VerifyContainerIsListed(containerId, L"running");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_NotFound)
+    {
+        VerifyContainerIsNotListed(WslcContainerName);
+
+        auto result = RunWslc(std::format(L"container restart {} -t 0", WslcContainerName));
+        result.Verify(
+            {.Stderr = std::format(L"Container '{}' not found.\r\nError code: WSLC_E_CONTAINER_NOT_FOUND\r\n", WslcContainerName),
+             .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_TargetedContainerOnly)
+    {
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto firstContainerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(firstContainerId.empty());
+
+        result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName2, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto secondContainerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(secondContainerId.empty());
+
+        VerifyContainerIsListed(firstContainerId, L"running");
+        VerifyContainerIsListed(secondContainerId, L"running");
+
+        // Restart only the first container.
+        result = RunWslc(std::format(L"container restart {} -t 0", firstContainerId));
+        result.Verify({.Stdout = std::format(L"{}\r\n", firstContainerId), .Stderr = L"", .ExitCode = 0});
+
+        VerifyContainerIsListed(firstContainerId, L"running");
+        VerifyContainerIsListed(secondContainerId, L"running");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_AutoRemoveRefused)
+    {
+        // --rm containers cannot be restarted (Stop would delete them).
+        auto result =
+            RunWslc(std::format(L"container run -d --rm --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto containerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(containerId.empty());
+
+        VerifyContainerIsListed(containerId, L"running");
+
+        result = RunWslc(std::format(L"container restart {} -t 0", containerId));
+        const auto expectedStderr =
+            std::format(L"Container '{}' was created with --rm and cannot be restarted.\r\nError code: ERROR_INVALID_STATE\r\n", containerId);
+        result.Verify({.Stderr = expectedStderr, .ExitCode = 1});
+
+        // Container should still be running after the refusal.
+        VerifyContainerIsListed(containerId, L"running");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_InvalidSignal)
+    {
+        auto result = RunWslc(std::format(L"container run --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        result = RunWslc(std::format(L"container restart {} -s 0 -t 0", WslcContainerName));
+        result.Verify({.Stderr = L"Invalid signal value: 0 is out of valid range (1-31).\r\n", .ExitCode = 1});
+
+        result = RunWslc(std::format(L"container restart {} -s 32 -t 0", WslcContainerName));
+        result.Verify({.Stderr = L"Invalid signal value: 32 is out of valid range (1-31).\r\n", .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Restart_InvalidTimeout)
+    {
+        auto result = RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto containerId = result.GetStdoutOneLine();
+        VERIFY_IS_FALSE(containerId.empty());
+
+        result = RunWslc(std::format(L"container restart {} -t abc", containerId));
+        result.Verify({.Stderr = L"Invalid time argument value: abc\r\n", .ExitCode = 1});
+
+        // Container is unaffected by the parse failure.
+        VerifyContainerIsListed(containerId, L"running");
+    }
+
+private:
+    const std::wstring WslcContainerName = L"wslc-test-container";
+    const std::wstring WslcContainerName2 = L"wslc-test-container-2";
+    const TestImage& DebianImage = DebianTestImage();
+
+    std::wstring GetHelpMessage() const
+    {
+        std::wstringstream output;
+        output << GetWslcHeader()        //
+               << GetDescription()       //
+               << GetUsage()             //
+               << GetAvailableCommands() //
+               << GetAvailableOptions();
+        return output.str();
+    }
+
+    std::wstring GetDescription() const
+    {
+        return Localization::WSLCCLI_ContainerRestartLongDesc() + L"\r\n\r\n";
+    }
+
+    std::wstring GetUsage() const
+    {
+        return L"Usage: wslc container restart [<options>] [<container-id>]\r\n\r\n";
+    }
+
+    std::wstring GetAvailableCommands() const
+    {
+        std::wstringstream commands;
+        commands << L"The following arguments are available:\r\n" << L"  container-id    Container ID\r\n" << L"\r\n";
+        return commands.str();
+    }
+
+    std::wstring GetAvailableOptions() const
+    {
+        std::wstringstream options;
+        options << L"The following options are available:\r\n"
+                << L"  -s,--signal     Signal to send\r\n"
+                << L"  -t,--time       Time in seconds to wait before executing (default 5)\r\n"
+                << L"  -?,--help       Shows help about the selected command\r\n"
+                << L"\r\n";
+        return options.str();
+    }
+};
+} // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerTests.cpp
@@ -79,6 +79,7 @@ private:
             {L"list", Localization::WSLCCLI_ContainerListDesc()},
             {L"prune", Localization::WSLCCLI_ContainerPruneDesc()},
             {L"remove", Localization::WSLCCLI_ContainerRemoveDesc()},
+            {L"restart", Localization::WSLCCLI_ContainerRestartDesc()},
             {L"run", Localization::WSLCCLI_ContainerRunDesc()},
             {L"start", Localization::WSLCCLI_ContainerStartDesc()},
             {L"stats", Localization::WSLCCLI_ContainerStatsDesc()},


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds wslc container restart which stops and then starts a container, matching Docker CLI semantics. Supports `--signal` and `--time` options (defaults: SIGTERM, 5s timeout).
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [X] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
**Behavior:**
- Running container: sends signal, waits for timeout, then starts.
- Stopped/Exited container: skips stop phase, starts directly.
- Created (never-started) container: starts directly.
- `--rm` container: refused with `ERROR_INVALID_STATE` — Stop would trigger auto-delete via `OnStopped`, destroying the container.
- Not-found container: returns `WSLC_E_CONTAINER_NOT_FOUND`.

**Implementation path:** `ContainerRestartCommand` → `ContainerTasks::RestartContainers` → `ContainerService::Restart` → `IWSLCContainer::Restart` → `WSLCContainerImpl::Restart`.

**N.B. Lock design:** `WSLCContainerImpl::Restart` snapshots state/flags under a shared lock, then releases before calling `Stop` and `Start` (which each take the lock exclusively). This is intentional - `m_lock` is a non-recursive `wil::srwlock`. If the container self-exits between the snapshot and Stop, Stop no-ops on the Exited state.

**Follow-up:** To achieve full Docker parity for `--rm` containers (Docker allows restart on `--rm` by suppressing auto-remove during the restart window), a follow-up PR will add a member flag `m_restartInProgress` guarded by `wil::scope_exit` and checked in `OnStopped`. This closes the race where a natural container exit between Stop and Start would trigger auto-delete. Shipping the `--rm` guard (refuse) now is the safe default; the member-flag approach needs its own review and dedicated tests for the self-exit race.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
**Unit tests** (`test/windows/WSLCTests.cpp` — `ContainerRestart`):
- Restart running container → stops then starts, state returns to Running
- Restart exited container → starts, state returns to Running
- Restart created container → starts, state returns to Running
- Restart `--rm` container → refused with `ERROR_INVALID_STATE` and exact localized message
- Restart on already-deleted COM object → fails with RPC_E_DISCONNECTED (object disconnected after delete)

**E2E tests** (`test/windows/wslc/e2e/WSLCE2EContainerRestartTests.cpp`):
- `--help` output
- Restart running container (by ID)
- Restart stopped container
- Restart by name
- Container not found
- Only targeted container restarted (multi-container)
- `--rm` container refused with exact error + HRESULT
- Invalid signal (0, 32)
- Invalid timeout (non-numeric)

**Manual validation:**

- wslc container run -d --name test debian:latest sleep infinity
- wslc container restart test -t 0
- wslc container ls # confirms running
- wslc container stop test -t 0
- wslc container restart test -t 0
- wslc container ls # confirms running again