### PR TITLE
Fix "WSLCCreateContainer" telemetry event

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1933,7 +1933,8 @@ try
         TraceLoggingValue(WSL_PACKAGE_VERSION, "wslVersion"),
         TraceLoggingValue(containerOptions->Image, "Image"),
         TraceLoggingValue(m_displayName.c_str(), "SessionName"),
-        TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess"));
+        TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess")),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO));
 
     return result;
 }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1933,7 +1933,7 @@ try
         TraceLoggingValue(WSL_PACKAGE_VERSION, "wslVersion"),
         TraceLoggingValue(containerOptions->Image, "Image"),
         TraceLoggingValue(m_displayName.c_str(), "SessionName"),
-        TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess")),
+        TraceLoggingValue(m_creatorProcessName.c_str(), "CreatorProcess"),
         TraceLoggingLevel(WINEVENT_LEVEL_INFO));
 
     return result;


### PR DESCRIPTION
"WSLCCreateContainer" event isn't coming through properly. Looking at the code it seems like it is missing a required line when compared to the "CreateSession" and "ExecCritical" events. 

This PR adds it so that it can report out the telemetry. 