### PR TITLE
Fix flaky E2E network list test assertion

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
@@ -36,6 +36,7 @@ class WSLCE2EInspectTests
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(DebianImage.Name);
         EnsureNetworkDoesNotExist(WslcNetworkName);
+        EnsureNetworkDoesNotExist(DebianImage.Name);
         EnsureImageIsDeleted(DebianImage);
         return true;
     }
@@ -45,6 +46,7 @@ class WSLCE2EInspectTests
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(DebianImage.Name);
         EnsureNetworkDoesNotExist(WslcNetworkName);
+        EnsureNetworkDoesNotExist(DebianImage.Name);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
@@ -76,7 +76,6 @@ class WSLCE2ENetworkListTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         auto networks = FromJson<std::vector<WSLCNetworkInformation>>(result.Stdout.value().c_str());
-        VERIFY_ARE_EQUAL(2U, networks.size());
 
         std::vector<std::string> names;
         names.reserve(networks.size());

--- a/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
@@ -76,6 +76,7 @@ class WSLCE2ENetworkListTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         auto networks = FromJson<std::vector<WSLCNetworkInformation>>(result.Stdout.value().c_str());
+        VERIFY_ARE_EQUAL(2U, networks.size());
 
         std::vector<std::string> names;
         names.reserve(networks.size());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add missing network cleanup for DebianImage.Name in WSLCE2EInspectTests to prevent leaked networks from causing flaky count assertions in WSLCE2E_Network_List_JsonFormat.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The `WSLCE2E_Network_List_JsonFormat` test intermittently fails with `Values (2, 3)` because `WSLCE2E_Inspect_Image_PriorityOverNetwork` creates a network named "debian" (DebianImage.Name) that isn't covered
by InspectTests' MethodSetup/ClassCleanup.
When the test process terminates abnormally (or scope_exit doesn't run), this network persists in Docker. On the next session start,
WSLCSession::RecoverExistingNetworks() re-imports any docker network with the wslc managed label, causing network list to return 3 instead of 2.

Fix: Add EnsureNetworkDoesNotExist(DebianImage.Name) to InspectTests'
MethodSetup and ClassCleanup, matching the existing pattern for
WslcNetworkName.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified the test passes locally with the fix applied