### PR TITLE
Fix potential use-after-free on the container deletion path

### DIFF
--- a/src/windows/common/COMImplClass.h
+++ b/src/windows/common/COMImplClass.h
@@ -24,6 +24,7 @@ class COMImplClass
 public:
     void Initialize(TPointer impl)
     {
+        std::unique_lock lock(m_lock);
         m_impl = std::move(impl);
     }
 

--- a/src/windows/common/COMImplClass.h
+++ b/src/windows/common/COMImplClass.h
@@ -22,9 +22,6 @@ template <typename TImpl, typename TPointer = TImpl*>
 class COMImplClass
 {
 public:
-    // Stores the pointer to the underlying impl. Kept separate from the constructor so that the
-    // std::weak_ptr specialization can be initialized after the impl is owned by a std::shared_ptr
-    // (e.g. via std::enable_shared_from_this::weak_from_this()).
     void Initialize(TPointer impl)
     {
         m_impl = std::move(impl);
@@ -42,7 +39,7 @@ public:
             return m_callers.empty() || m_callers.size() == 1 && *m_callers.begin() == std::this_thread::get_id();
         });
 
-        ResetImpl();
+        m_impl = {};
     }
 
 protected:
@@ -68,9 +65,6 @@ protected:
     }
     CATCH_RETURN();
 
-    // Returns a usable pointer to the impl for the current call: the raw pointer for the TImpl*
-    // specialization, or a strong std::shared_ptr locked from the weak_ptr otherwise.
-    // Must be called with m_lock held.
     auto GetPointer()
     {
         if constexpr (std::is_same_v<TPointer, TImpl*>)
@@ -85,10 +79,6 @@ protected:
 
     [[nodiscard]] auto LockImpl()
     {
-        // Obtain a usable reference to the impl and add ourselves to the list of callers.
-        // For the std::weak_ptr specialization, GetPointer() returns a strong std::shared_ptr that
-        // keeps the impl alive for the full duration of the call, even if the owning container map
-        // entry is erased concurrently on another thread.
         auto impl = [this] {
             std::unique_lock lock{m_lock};
 
@@ -114,19 +104,6 @@ protected:
     }
 
 private:
-    // Clears the impl pointer so subsequent LockImpl() calls fail with RPC_E_DISCONNECTED.
-    // Must be called with m_lock held.
-    void ResetImpl() noexcept
-    {
-        if constexpr (std::is_same_v<TPointer, TImpl*>)
-        {
-            m_impl = nullptr;
-        }
-        else
-        {
-            m_impl.reset();
-        }
-    }
 
     std::mutex m_lock;
     std::condition_variable m_cv;

--- a/src/windows/common/COMImplClass.h
+++ b/src/windows/common/COMImplClass.h
@@ -18,12 +18,16 @@ Abstract:
 
 namespace wsl::windows::service::wslc {
 
-template <typename TImpl>
+template <typename TImpl, typename TPointer = TImpl*>
 class COMImplClass
 {
 public:
-    COMImplClass(TImpl* impl) : m_impl(impl)
+    // Stores the pointer to the underlying impl. Kept separate from the constructor so that the
+    // std::weak_ptr specialization can be initialized after the impl is owned by a std::shared_ptr
+    // (e.g. via std::enable_shared_from_this::weak_from_this()).
+    void Initialize(TPointer impl)
     {
+        m_impl = std::move(impl);
     }
 
     void Disconnect() noexcept
@@ -38,8 +42,7 @@ public:
             return m_callers.empty() || m_callers.size() == 1 && *m_callers.begin() == std::this_thread::get_id();
         });
 
-        WI_ASSERT(m_impl != nullptr);
-        m_impl = nullptr;
+        ResetImpl();
     }
 
 protected:
@@ -48,7 +51,7 @@ protected:
     try
     {
         auto [lock, impl] = LockImpl();
-        (impl->*routine)(std::forward<Args>(args)...);
+        ((*impl).*routine)(std::forward<Args>(args)...);
 
         return S_OK;
     }
@@ -59,22 +62,44 @@ protected:
     try
     {
         auto [lock, impl] = LockImpl();
-        (impl->*routine)(std::forward<Args>(args)...);
+        ((*impl).*routine)(std::forward<Args>(args)...);
 
         return S_OK;
     }
     CATCH_RETURN();
 
+    // Returns a usable pointer to the impl for the current call: the raw pointer for the TImpl*
+    // specialization, or a strong std::shared_ptr locked from the weak_ptr otherwise.
+    // Must be called with m_lock held.
+    auto GetPointer()
+    {
+        if constexpr (std::is_same_v<TPointer, TImpl*>)
+        {
+            return m_impl;
+        }
+        else
+        {
+            return m_impl.lock();
+        }
+    }
+
     [[nodiscard]] auto LockImpl()
     {
-        // Check if m_impl is available and add ourselves to the list of callers if that's the case.
-        {
+        // Obtain a usable reference to the impl and add ourselves to the list of callers.
+        // For the std::weak_ptr specialization, GetPointer() returns a strong std::shared_ptr that
+        // keeps the impl alive for the full duration of the call, even if the owning container map
+        // entry is erased concurrently on another thread.
+        auto impl = [this] {
             std::unique_lock lock{m_lock};
-            THROW_HR_IF(RPC_E_DISCONNECTED, m_impl == nullptr);
+
+            auto pointer = GetPointer();
+            THROW_HR_IF(RPC_E_DISCONNECTED, !pointer);
 
             auto [_, inserted] = m_callers.insert(std::this_thread::get_id());
             WI_ASSERT(inserted);
-        }
+
+            return pointer;
+        }();
 
         auto release = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [this]() {
             std::unique_lock lock{m_lock};
@@ -85,14 +110,28 @@ protected:
             m_cv.notify_one();
         });
 
-        return std::make_pair(std::move(release), m_impl);
+        return std::make_pair(std::move(release), std::move(impl));
     }
 
 private:
+    // Clears the impl pointer so subsequent LockImpl() calls fail with RPC_E_DISCONNECTED.
+    // Must be called with m_lock held.
+    void ResetImpl() noexcept
+    {
+        if constexpr (std::is_same_v<TPointer, TImpl*>)
+        {
+            m_impl = nullptr;
+        }
+        else
+        {
+            m_impl.reset();
+        }
+    }
+
     std::mutex m_lock;
     std::condition_variable m_cv;
     _Guarded_by_(m_lock) std::unordered_set<std::thread::id> m_callers;
-    TImpl* m_impl = nullptr;
+    TPointer m_impl{};
 };
 
 } // namespace wsl::windows::service::wslc

--- a/src/windows/common/COMImplClass.h
+++ b/src/windows/common/COMImplClass.h
@@ -104,7 +104,6 @@ protected:
     }
 
 private:
-
     std::mutex m_lock;
     std::condition_variable m_cv;
     _Guarded_by_(m_lock) std::unordered_set<std::thread::id> m_callers;

--- a/src/windows/service/exe/WSLCSessionManager.cpp
+++ b/src/windows/service/exe/WSLCSessionManager.cpp
@@ -544,8 +544,9 @@ HRESULT WSLCSessionManagerImpl::CheckTokenAccess(const SessionEntry& Entry, cons
     return S_OK;
 }
 
-WSLCSessionManager::WSLCSessionManager(WSLCSessionManagerImpl* Impl) : COMImplClass<WSLCSessionManagerImpl>(Impl)
+WSLCSessionManager::WSLCSessionManager(WSLCSessionManagerImpl* Impl)
 {
+    Initialize(Impl);
 }
 
 HRESULT WSLCSessionManager::GetVersion(_Out_ WSLCVersion* Version)

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -619,7 +619,7 @@ WSLCContainerImpl::~WSLCContainerImpl()
 
 void WSLCContainerImpl::Initialize()
 {
-    // N.B. this must be done here because weak_from_this() is only valid after the constructor returns. 
+    // N.B. this must be done here because weak_from_this() is only valid after the constructor returns.
     m_comWrapper->Initialize(weak_from_this());
 }
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -619,8 +619,7 @@ WSLCContainerImpl::~WSLCContainerImpl()
 
 void WSLCContainerImpl::Initialize()
 {
-    // Store a weak_ptr to this impl in the COM wrapper so that in-flight COM calls (via LockImpl)
-    // keep the impl alive for their full duration, independent of the owning container map entry.
+    // N.B. this must be done here because weak_from_this() is only valid after the constructor returns. 
     m_comWrapper->Initialize(weak_from_this());
 }
 

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -559,7 +559,7 @@ WSLCContainerImpl::WSLCContainerImpl(
     m_volumes(Volumes),
     m_mappedPorts(std::move(ports)),
     m_labels(std::move(labels)),
-    m_comWrapper(wil::MakeOrThrow<WSLCContainer>(this, wslcSession, std::move(onDeleted))),
+    m_comWrapper(wil::MakeOrThrow<WSLCContainer>(wslcSession, std::move(onDeleted))),
     m_dockerClient(DockerClient),
     m_eventTracker(EventTracker),
     m_ioRelay(Relay),
@@ -615,6 +615,13 @@ WSLCContainerImpl::~WSLCContainerImpl()
         auto lock = m_lock.lock_exclusive();
         wrapper = ReleaseResources();
     }
+}
+
+void WSLCContainerImpl::Initialize()
+{
+    // Store a weak_ptr to this impl in the COM wrapper so that in-flight COM calls (via LockImpl)
+    // keep the impl alive for their full duration, independent of the owning container map entry.
+    m_comWrapper->Initialize(weak_from_this());
 }
 
 void WSLCContainerImpl::SetExitCode(int ExitCode) noexcept
@@ -1384,7 +1391,7 @@ WslcInspectContainer WSLCContainerImpl::BuildInspectContainer(const DockerInspec
     return wslcInspect;
 }
 
-std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
+std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
     const WSLCContainerOptions& containerOptions,
     const std::string& containerName,
     WSLCSession& wslcSession,
@@ -1777,7 +1784,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         namedVolumes.emplace_back(containerOptions.NamedVolumes[i].Name);
     }
 
-    auto container = std::make_unique<WSLCContainerImpl>(
+    auto container = std::make_shared<WSLCContainerImpl>(
         wslcSession,
         virtualMachine,
         pluginNotifier,
@@ -1799,11 +1806,13 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         containerOptions.InitProcessOptions.Flags,
         containerOptions.Flags);
 
+    container->Initialize();
+
     deleteOnFailure.release();
     return container;
 }
 
-std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
+std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
     const common::docker_schema::ContainerInfo& dockerContainer,
     WSLCSession& wslcSession,
     WSLCVirtualMachine& virtualMachine,
@@ -1869,7 +1878,7 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
         }
     }
 
-    auto container = std::make_unique<WSLCContainerImpl>(
+    auto container = std::make_shared<WSLCContainerImpl>(
         wslcSession,
         virtualMachine,
         pluginNotifier,
@@ -1890,6 +1899,8 @@ std::unique_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
         static_cast<std::uint64_t>(dockerContainer.Created),
         metadata.InitProcessFlags,
         metadata.Flags);
+
+    container->Initialize();
 
     // Restore the state change timestamp from Docker inspect data.
     try
@@ -2179,8 +2190,8 @@ __requires_lock_held(m_lock) void WSLCContainerImpl::Transition(WSLCContainerSta
     m_stateChangedAt = stateChangedAt.value_or(static_cast<std::uint64_t>(std::time(nullptr)));
 }
 
-WSLCContainer::WSLCContainer(WSLCContainerImpl* impl, WSLCSession& session, std::function<void(const WSLCContainerImpl*)>&& OnDeleted) :
-    COMImplClass<WSLCContainerImpl>(impl), m_session(session), m_onDeleted(std::move(OnDeleted))
+WSLCContainer::WSLCContainer(WSLCSession& session, std::function<void(const WSLCContainerImpl*)>&& OnDeleted) :
+    m_session(session), m_onDeleted(std::move(OnDeleted))
 {
 }
 
@@ -2325,7 +2336,7 @@ try
     auto [lock, impl] = LockImpl();
 
     impl->Delete(Flags);
-    m_onDeleted(impl);
+    m_onDeleted(impl.get());
 
     return S_OK;
 }

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -94,8 +94,6 @@ public:
 
     ~WSLCContainerImpl();
 
-    // Completes two-phase construction by wiring the COM wrapper to a std::weak_ptr of this impl.
-    // Must be called after the impl is owned by a std::shared_ptr (see Create()/Open()).
     void Initialize();
 
     void Start(WSLCContainerStartFlags Flags, const WSLCProcessStartOptions* StartOptions);

--- a/src/windows/wslcsession/WSLCContainer.h
+++ b/src/windows/wslcsession/WSLCContainer.h
@@ -64,7 +64,7 @@ struct ContainerPortMapping
     uint16_t ContainerPort{};
 };
 
-class WSLCContainerImpl
+class WSLCContainerImpl : public std::enable_shared_from_this<WSLCContainerImpl>
 {
 public:
     NON_COPYABLE(WSLCContainerImpl);
@@ -93,6 +93,10 @@ public:
         WSLCContainerFlags ContainerFlags);
 
     ~WSLCContainerImpl();
+
+    // Completes two-phase construction by wiring the COM wrapper to a std::weak_ptr of this impl.
+    // Must be called after the impl is owned by a std::shared_ptr (see Create()/Open()).
+    void Initialize();
 
     void Start(WSLCContainerStartFlags Flags, const WSLCProcessStartOptions* StartOptions);
     void Attach(LPCSTR DetachKeys, WSLCHandle* Stdin, WSLCHandle* Stdout, WSLCHandle* Stderr) const;
@@ -129,7 +133,7 @@ public:
         return m_containerFlags;
     }
 
-    static std::unique_ptr<WSLCContainerImpl> Create(
+    static std::shared_ptr<WSLCContainerImpl> Create(
         const WSLCContainerOptions& Options,
         const std::string& Name,
         WSLCSession& wslcSession,
@@ -142,7 +146,7 @@ public:
         DockerHTTPClient& DockerClient,
         IORelay& Relay);
 
-    static std::unique_ptr<WSLCContainerImpl> Open(
+    static std::shared_ptr<WSLCContainerImpl> Open(
         const common::docker_schema::ContainerInfo& DockerContainer,
         WSLCSession& wslcSession,
         WSLCVirtualMachine& virtualMachine,
@@ -224,11 +228,11 @@ private:
 
 class DECLSPEC_UUID("B1F1C4E3-C225-4CAE-AD8A-34C004DE1AE4") WSLCContainer
     : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IWSLCContainer, IWSLCCompatContainer, IFastRundown, ISupportErrorInfo>,
-      public COMImplClass<WSLCContainerImpl>
+      public COMImplClass<WSLCContainerImpl, std::weak_ptr<WSLCContainerImpl>>
 {
 
 public:
-    WSLCContainer(WSLCContainerImpl* impl, WSLCSession& session, std::function<void(const WSLCContainerImpl*)>&& OnDeleted);
+    WSLCContainer(WSLCSession& session, std::function<void(const WSLCContainerImpl*)>&& OnDeleted);
 
     IFACEMETHOD(Attach)(_In_opt_ LPCSTR DetachKeys, _Out_ WSLCHandle* Stdin, _Out_ WSLCHandle* Stdout, _Out_ WSLCHandle* Stderr) override;
     IFACEMETHOD(Stop)(_In_ WSLCSignal Signal, _In_ LONG TimeoutSeconds) override;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -3405,7 +3405,11 @@ void WSLCSession::OnContainerDeleted(const WSLCContainerImpl* Container)
     auto lock = m_lock.lock_shared();
     std::lock_guard containersLock(m_containersLock);
 
-    WI_VERIFY(m_containers.erase(Container->ID()) == 1);
+    // The container may already have been removed from the map by a concurrent purge (erase_if of
+    // WslcContainerStateDeleted entries in OpenContainer/ListContainers, or PruneContainers) while
+    // this Delete() was in flight, so an erase count of 0 is expected. The impl itself remains alive
+    // for the duration of the call via the shared_ptr held by WSLCContainer::Delete's LockImpl().
+    m_containers.erase(Container->ID());
 }
 
 HRESULT WSLCSession::GetState(_Out_ WSLCSessionState* State)

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -3405,10 +3405,8 @@ void WSLCSession::OnContainerDeleted(const WSLCContainerImpl* Container)
     auto lock = m_lock.lock_shared();
     std::lock_guard containersLock(m_containersLock);
 
-    // The container may already have been removed from the map by a concurrent purge (erase_if of
-    // WslcContainerStateDeleted entries in OpenContainer/ListContainers, or PruneContainers) while
-    // this Delete() was in flight, so an erase count of 0 is expected. The impl itself remains alive
-    // for the duration of the call via the shared_ptr held by WSLCContainer::Delete's LockImpl().
+    // N.B. once a container transitions to a 'Deleted' state, a call to ListContainers() can remove it from m_containers.
+    // Therefore it's possible that the container is already removed when the callback from Delete() is invoked.
     m_containers.erase(Container->ID());
 }
 

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -315,7 +315,7 @@ private:
     // This allows independent operations to proceed while container bookkeeping remains synchronized.
     // WSLCVolumes has its own internal srwlock and does not require m_lock.
     std::mutex m_containersLock;
-    std::unordered_map<std::string, std::unique_ptr<WSLCContainerImpl>> m_containers;
+    std::unordered_map<std::string, std::shared_ptr<WSLCContainerImpl>> m_containers;
     std::optional<WSLCVolumes> m_volumes;
     std::mutex m_networksLock;
     std::unordered_map<std::string, NetworkEntry> m_networks;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -6779,7 +6779,7 @@ class WSLCTests
 
         const std::string containerName = "wslc-list-delete-stress";
 
-        unsigned int failures = 0;
+        std::atomic<unsigned int> failures = 0;
 
         // One thread repeatedly creates a container and then deletes it.
         std::thread thread([&]() {
@@ -6846,7 +6846,7 @@ class WSLCTests
 
         thread.join();
 
-        VERIFY_ARE_EQUAL(failures, 0u);
+        VERIFY_ARE_EQUAL(failures.load(), 0u);
     }
 
     WSLC_TEST_METHOD(ContainerNetwork)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -6773,6 +6773,83 @@ class WSLCTests
         }
     }
 
+    WSLC_TEST_METHOD(ContainerListDeleteStressTest)
+    {
+        constexpr auto c_iterations = 50;
+
+        const std::string containerName = "wslc-list-delete-stress";
+
+        unsigned int failures = 0;
+
+
+        // One thread repeatedly creates a container and then deletes it.
+        std::thread thread([&]() {
+            for (unsigned int i = 0; i < c_iterations; ++i)
+            {
+                WSLCContainerLauncher launcher("debian:latest", containerName, {"sleep", "99999"});
+
+                auto [hrCreate, container] = launcher.CreateNoThrow(*m_defaultSession);
+                if (FAILED(hrCreate))
+                {
+                    LogError("CreateContainer(%hs) unexpected HR: 0x%08x", containerName.c_str(), hrCreate);
+                    ++failures;
+                    continue;
+                }
+
+                if (i % 2 == 0)
+                {
+                    auto result = container->Get().Start(WSLCContainerStartFlagsNone, nullptr, nullptr);
+                    if (FAILED(result))
+                    {
+                        LogError("Start(%hs) failed: 0x%08x", containerName.c_str(), result);
+                        ++failures;
+                    }
+
+                    if (i % 4 == 0)
+                    {
+                        result = container->Get().Stop(WSLCSignalSIGKILL, 0);
+                        if (FAILED(result))
+                        {
+                            LogError("Stop(%hs) failed: 0x%08x", containerName.c_str(), result);
+                            ++failures;
+                        }
+                    }
+                }
+
+                HRESULT result = container->Get().Delete(WSLCDeleteFlagsForce);
+                if (FAILED(result))
+                {
+                    LogError("Delete(%hs) failed: 0x%08x", containerName.c_str(), result);
+                    ++failures;
+                }
+                else
+                {
+                    container->SetDeleteOnClose(false);
+                }
+            }
+        });
+
+        while (WaitForSingleObject(thread.native_handle(), 0) == WAIT_TIMEOUT)
+        {
+            WSLCListContainersOptions options{};
+            options.Flags = WSLCListContainersFlagsAll;
+
+            wil::unique_cotaskmem_array_ptr<WSLCContainerEntry> containers;
+            wil::unique_cotaskmem_array_ptr<WSLCContainerPortMapping> ports;
+            HRESULT hrList = m_defaultSession->ListContainers(
+                &options, &containers, containers.size_address<ULONG>(), &ports, ports.size_address<ULONG>());
+            if (FAILED(hrList))
+            {
+                LogError("ListContainers unexpected HR: 0x%08x", hrList);
+                ++failures;
+            }
+        }
+
+        thread.join();
+
+        VERIFY_ARE_EQUAL(failures, 0u);
+    }
+
     WSLC_TEST_METHOD(ContainerNetwork)
     {
         auto expectContainerList = [&](const std::vector<std::tuple<std::string, std::string, WSLCContainerState>>& expectedContainers) {

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -6781,7 +6781,6 @@ class WSLCTests
 
         unsigned int failures = 0;
 
-
         // One thread repeatedly creates a container and then deletes it.
         std::thread thread([&]() {
             for (unsigned int i = 0; i < c_iterations; ++i)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

There are two ways a container can be removed from `m_containers`: 

1) The container transitions to the `Deleted` state, and a later call that enumerates `m_containers` deletes it

2) The callback from WSLCContainer::Delete() 

If 1) happens while 2) is in progress, the callback from 2) will operate on a pointer that's been deleted. 

This change solves the issue by switching 2) to use a `std::weak_ptr` instead of a raw pointer, which guarantees that the pointer will be valid until released.

This change also adds a stress test to protect from regressions on this path.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
