### PR TITLE
Update validate-line-endings.py to not depend on pip packages

### DIFF
--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -104,9 +104,6 @@ stages:
           pool: ${{ parameters.pool }}
 
         steps:
-          - script: pip install --user -r tools/devops/requirements.txt --break-system-packages
-            displayName: Install dependencies
-
           - script: python tools/devops/validate-localization.py
             displayName: Validate localization resources
 

--- a/tools/devops/validate-line-endings.py
+++ b/tools/devops/validate-line-endings.py
@@ -47,7 +47,7 @@ def main(path: str, fix: bool):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Validate that source files use CRLF line endings.')
-    parser.add_argument('path', help='Path to the repository root.')
+    parser.add_argument('path', help='Path to validate (must be inside the repo).')
     parser.add_argument('--fix', action='store_true', help='Convert mismatching files to CRLF line endings.')
     args = parser.parse_args()
 

--- a/tools/devops/validate-line-endings.py
+++ b/tools/devops/validate-line-endings.py
@@ -35,7 +35,7 @@ def main(path: str, fix: bool):
                 fd.write(to_crlf(content))
 
     if not mismatches:
-        print('All files use CRLF line endings')
+        print(f'All {len(source_files)} files use CRLF line endings')
         return
 
     listed = '\n'.join(mismatches)
@@ -50,8 +50,5 @@ if __name__ == '__main__':
     parser.add_argument('path', help='Path to the repository root.')
     parser.add_argument('--fix', action='store_true', help='Convert mismatching files to CRLF line endings.')
     args = parser.parse_args()
-
-    if not os.path.exists(args.path):
-        parser.error(f"Path '{args.path}' does not exist.")
 
     main(args.path, args.fix)

--- a/tools/devops/validate-line-endings.py
+++ b/tools/devops/validate-line-endings.py
@@ -1,6 +1,6 @@
-import click
+import argparse
 import os.path
-from git import Repo
+import subprocess
 
 EXTENSIONS = ['.c', '.cpp', '.h', '.hpp', '.idl', '.resw']
 
@@ -16,14 +16,10 @@ def to_crlf(content: bytes) -> bytes:
     # Normalize every line ending (CRLF, lone CR, lone LF) to a single CRLF.
     return content.replace(b'\r\n', b'\n').replace(b'\r', b'\n').replace(b'\n', b'\r\n')
 
-@click.command()
-@click.argument('path', required=True, type=click.Path(exists=True))
-@click.option('--fix', is_flag=True, help='Convert mismatching files to CRLF line endings.')
 def main(path: str, fix: bool):
-    repo = Repo(path, search_parent_directories=True)
-
-    tracked = repo.git.ls_files('-z').split('\0')
-    source_files = [os.path.join(repo.working_tree_dir, e) for e in tracked if e and is_source_file(e)]
+    tracked = subprocess.run(
+        ['git', '-C', path, 'ls-files', '-z'], check=True, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\0')
+    source_files = [os.path.join(path, e) for e in tracked if e and is_source_file(e)]
 
     mismatches = []
     for e in source_files:
@@ -39,15 +35,23 @@ def main(path: str, fix: bool):
                 fd.write(to_crlf(content))
 
     if not mismatches:
-        click.secho('All files use CRLF line endings', fg='green')
+        print('All files use CRLF line endings')
         return
 
     listed = '\n'.join(mismatches)
     if fix:
-        click.secho(f'Converted {len(mismatches)} files to CRLF:\n{listed}', fg='yellow')
+        print(f'Converted {len(mismatches)} files to CRLF:\n{listed}')
     else:
-        click.secho(f'{len(mismatches)} files have non-CRLF line endings:\n{listed}', fg='red')
+        print(f'{len(mismatches)} files have non-CRLF line endings:\n{listed}')
         raise SystemExit(1)
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description='Validate that source files use CRLF line endings.')
+    parser.add_argument('path', help='Path to the repository root.')
+    parser.add_argument('--fix', action='store_true', help='Convert mismatching files to CRLF line endings.')
+    args = parser.parse_args()
+
+    if not os.path.exists(args.path):
+        parser.error(f"Path '{args.path}' does not exist.")
+
+    main(args.path, args.fix)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates `validate-line-endings.py` to not have pip dependencies, which fail to install in the nightly & release pipelines. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
