### PR TITLE
Fix cgmanifest.json hash format and add type:git entries for NOTICE generation

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -81,7 +81,7 @@
                     "name": "nlohmann::json",
                     "version": "3.12.0",
                     "downloadUrl": "https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz",
-                    "hash": "sha256:42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa"
+                    "hash": "sha1:48c2c76de06fde8cf36faf039509b38b3ae90b5b"
                 }
             }
         }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -53,13 +53,30 @@
         },
         {
             "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/jbeder/yaml-cpp",
+                    "commitHash": "56e3bb550c91fd7005566f19c079cb7a503223cf"
+                }
+            }
+        },
+        {
+            "component": {
                 "type": "other",
                 "other": {
                     "name": "yaml-cpp",
                     "version": "0.9.0",
                     "downloadUrl": "https://github.com/jbeder/yaml-cpp/releases/download/yaml-cpp-0.9.0/yaml-cpp-yaml-cpp-0.9.0.tar.gz",
                     "hash": "sha1:a7bf36bd4d48eac9341fd56e3e044dd81b04c25a"
-
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/microsoft/GSL",
+                    "commitHash": "a3534567187d2edc428efd3f13466ff75fe5805c"
                 }
             }
         },
@@ -71,6 +88,15 @@
                     "version": "4.0.0",
                     "downloadUrl": "https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.tar.gz",
                     "hash": "sha1:909c9540a76fe4b4f71dbbd24126cab3925fb78e"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/nlohmann/json",
+                    "commitHash": "55f93686c01528224f448c19128836e7df245f72"
                 }
             }
         },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -47,7 +47,7 @@
                     "name": "boost",
                     "version": "1.90.0",
                     "downloadUrl": "https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.gz",
-                    "hash": "sha256:5e93d582aff26868d581a52ae78c7d8edf3f3064742c6e77901a1f18a437eea9"
+                    "hash": "sha1:44500f8d6b279ec314a4cdce1290ddc30f530ed7"
                 }
             }
         },
@@ -58,7 +58,7 @@
                     "name": "yaml-cpp",
                     "version": "0.9.0",
                     "downloadUrl": "https://github.com/jbeder/yaml-cpp/releases/download/yaml-cpp-0.9.0/yaml-cpp-yaml-cpp-0.9.0.tar.gz",
-                    "hash": "sha256:298593d9c440fd9034b8b193d96318b76d49bc97c6ceadb7b0836edf0b6d7539"
+                    "hash": "sha1:a7bf36bd4d48eac9341fd56e3e044dd81b04c25a"
 
                 }
             }
@@ -70,7 +70,7 @@
                     "name": "GSL",
                     "version": "4.0.0",
                     "downloadUrl": "https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.tar.gz",
-                    "hash": "sha256:f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9"
+                    "hash": "sha1:909c9540a76fe4b4f71dbbd24126cab3925fb78e"
                 }
             }
         },


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix Component Governance registration failures for 4 OSS components (nlohmann::json, GSL, yaml-cpp, boost) by converting their hash format from sha256 to sha1, and add  type: "git"  entries for yaml-cpp, GSL, and nlohmann::json so the notice pipeline can resolve their licenses.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The  wsl-github-notice  pipeline was silently rejecting 4  type: "other"  cgmanifest entries during CG registration with:
The provided user input is not valid. Parameter name: 'Hash'.
Root cause: CG's server does not accept sha256:  prefixed hashes for type: "other" registrations, only sha1:  works (as evidenced by the libarchive entry which was already using sha1 and being accepted).
Changes:
1. Converted hash format from sha256:  to sha1:  for boost, yaml-cpp, GSL, and nlohmann::json, fixing the registration rejection.
2. Added type: "git" entries (with repositoryUrl + commitHash) for yaml-cpp, GSL, and nlohmann::json, same dual-registration pattern libarchive and boost already use. This gives notice@0 a coordinate it can resolve directly in ClearlyDefined.

Result: Registrations went from 35 accepted (4 rejected) → 44 accepted (0 rejected). GSL and nlohmann::json now appear in the generated NOTICE.txt. yaml-cpp and boost will appear once their ClearlyDefined harvests complete (~2 weeks, already triggered).
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Pushed branch  user/beenachauhan/fix-cgmanifest-hash  and ran  wsl-github-notice  pipeline manually (run #20260707.8, commit  107e2571 ).
2. Confirmed "Submitted 44 registrations" with zero  Parameter name: 'Hash'  warnings.
3. Downloaded NOTICE.txt artifact (83,498 bytes, up from 78,779) and verified:
•  microsoft/gsl a3534567... - MIT license present
•  nlohmann/json 55f93686... - MIT license present 
4. Confirmed yaml-cpp appears in "Not harvested in ClearlyDefined" (expected - harvest pending, no code fix needed).