### PR TITLE
Fix: string conversion pointer advancement, DNS send loop infinite loop, interface stack traversal, and thread-safety annotation errors

### DIFF
--- a/src/linux/init/DnsServer.cpp
+++ b/src/linux/init/DnsServer.cpp
@@ -131,6 +131,12 @@ try
     {
         int bytesSent = Syscall(
             sendto, m_udpSocket.get(), dnsBuffer.data() + totalBytesSent, bufferSize - totalBytesSent, 0, reinterpret_cast<sockaddr*>(&remoteAddr), sizeof(remoteAddr));
+        // Guard against infinite loop: if sendto returns 0 or a negative value, break out
+        if (bytesSent <= 0)
+        {
+            GNS_LOG_ERROR("UDP DNS sendto failed or returned 0, aborting send loop. bytesSent: {}", bytesSent);
+            break;
+        }
         totalBytesSent += bytesSent;
     }
 }
@@ -166,6 +172,12 @@ try
     while (totalBytesSent < bufferSize)
     {
         int bytesSent = Syscall(write, tcpConnection, dnsBuffer.data() + totalBytesSent, bufferSize - totalBytesSent);
+        // Guard against infinite loop: if write returns 0 or a negative value, break out
+        if (bytesSent <= 0)
+        {
+            GNS_LOG_ERROR("TCP DNS write failed or returned 0, aborting send loop. bytesSent: {}", bytesSent);
+            break;
+        }
         totalBytesSent += bytesSent;
     }
 }

--- a/src/linux/init/DnsServer.cpp
+++ b/src/linux/init/DnsServer.cpp
@@ -131,11 +131,11 @@ try
     {
         int bytesSent = Syscall(
             sendto, m_udpSocket.get(), dnsBuffer.data() + totalBytesSent, bufferSize - totalBytesSent, 0, reinterpret_cast<sockaddr*>(&remoteAddr), sizeof(remoteAddr));
-        // Guard against infinite loop: if sendto returns 0 or a negative value, break out
-        if (bytesSent <= 0)
+        // Syscall() throws on negative return; guard against the unexpected "no progress" case to avoid an infinite loop.
+        if (bytesSent == 0)
         {
-            GNS_LOG_ERROR("UDP DNS sendto failed or returned 0, aborting send loop. bytesSent: {}", bytesSent);
-            break;
+            GNS_LOG_ERROR("UDP DNS sendto returned 0 bytes; aborting send loop. UDP request id: {}", dnsClientIdentifier.DnsClientId);
+            return;
         }
         totalBytesSent += bytesSent;
     }
@@ -172,11 +172,13 @@ try
     while (totalBytesSent < bufferSize)
     {
         int bytesSent = Syscall(write, tcpConnection, dnsBuffer.data() + totalBytesSent, bufferSize - totalBytesSent);
-        // Guard against infinite loop: if write returns 0 or a negative value, break out
-        if (bytesSent <= 0)
+        // Syscall() throws on negative return; if write returns 0, treat the connection as broken
+        // and remove it from tracking to avoid repeated writes to a dead fd.
+        if (bytesSent == 0)
         {
-            GNS_LOG_ERROR("TCP DNS write failed or returned 0, aborting send loop. bytesSent: {}", bytesSent);
-            break;
+            GNS_LOG_ERROR("TCP DNS write returned 0 bytes; closing connection. TCP connection id: {}", dnsClientIdentifier.DnsClientId);
+            m_tcpConnectionContexts.erase(it);
+            return;
         }
         totalBytesSent += bytesSent;
     }

--- a/src/linux/init/DnsServer.h
+++ b/src/linux/init/DnsServer.h
@@ -113,11 +113,11 @@ private:
 
     // Unique id that is incremented for each TCP connection. In case the value reaches MAX_UINT and is reset to 0,
     // it's assumed previous connections with id's 0, 1, ... were closed in the meantime and the id can be reused.
-    // _Guarded_by_(m_udpLock)
+    // _Guarded_by_(m_tcpLock)
     uint32_t m_currentTcpConnectionId = 0;
 
     // Mapping TCP connection unique id to connection context
-    // _Guarded_by_(m_udpLock)
+    // _Guarded_by_(m_tcpLock)
     std::map<uint32_t, std::unique_ptr<TcpConnectionContext>> m_tcpConnectionContexts;
 
     // Pipe used to stop m_serverThread.

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -639,7 +639,9 @@ inline std::wstring MultiByteToWide(const char* string)
     }
 
     std::mbstate_t state{};
-    size_t size = std::mbsrtowcs(nullptr, &string, 0, &state);
+    // Use a temporary pointer for the length calculation since mbsrtowcs advances the source pointer
+    const char* src = string;
+    size_t size = std::mbsrtowcs(nullptr, &src, 0, &state);
     THROW_LAST_ERROR_IF(size == -1);
 
     if (size == 0)
@@ -648,7 +650,9 @@ inline std::wstring MultiByteToWide(const char* string)
     }
 
     std::wstring buffer(size, L'\0');
-    std::mbsrtowcs(buffer.data(), &string, size, &state);
+    // Reset the source pointer for the actual conversion
+    src = string;
+    std::mbsrtowcs(buffer.data(), &src, size, &state);
     return buffer;
 
 #endif // WIN32
@@ -675,7 +679,9 @@ inline std::string WideToMultiByte(const wchar_t* string)
     }
 
     std::mbstate_t state{};
-    size_t size = std::wcsrtombs(nullptr, &string, 0, &state);
+    // Use a temporary pointer for the length calculation since wcsrtombs advances the source pointer
+    const wchar_t* src = string;
+    size_t size = std::wcsrtombs(nullptr, &src, 0, &state);
     THROW_LAST_ERROR_IF(size == -1);
 
     if (size == 0)
@@ -684,7 +690,9 @@ inline std::string WideToMultiByte(const wchar_t* string)
     }
 
     std::string buffer(size, '\0');
-    std::wcsrtombs(buffer.data(), &string, size, &state);
+    // Reset the source pointer for the actual conversion
+    src = string;
+    std::wcsrtombs(buffer.data(), &src, size, &state);
     return buffer;
 
 #endif // WIN32

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -650,9 +650,13 @@ inline std::wstring MultiByteToWide(const char* string)
     }
 
     std::wstring buffer(size, L'\0');
-    // Reset the source pointer for the actual conversion
+    // Reset the source pointer and conversion state for the actual conversion pass.
+    // The mbstate_t must be reset because stateful encodings may have left residual shift state
+    // from the length-calculation pass.
     src = string;
-    std::mbsrtowcs(buffer.data(), &src, size, &state);
+    state = std::mbstate_t{};
+    size_t result = std::mbsrtowcs(buffer.data(), &src, size, &state);
+    THROW_LAST_ERROR_IF(result == static_cast<size_t>(-1));
     return buffer;
 
 #endif // WIN32
@@ -690,9 +694,13 @@ inline std::string WideToMultiByte(const wchar_t* string)
     }
 
     std::string buffer(size, '\0');
-    // Reset the source pointer for the actual conversion
+    // Reset the source pointer and conversion state for the actual conversion pass.
+    // The mbstate_t must be reset because stateful encodings may have left residual shift state
+    // from the length-calculation pass.
     src = string;
-    std::wcsrtombs(buffer.data(), &src, size, &state);
+    state = std::mbstate_t{};
+    size_t result = std::wcsrtombs(buffer.data(), &src, size, &state);
+    THROW_LAST_ERROR_IF(result == static_cast<size_t>(-1));
     return buffer;
 
 #endif // WIN32

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -642,7 +642,7 @@ inline std::wstring MultiByteToWide(const char* string)
     // Use a temporary pointer for the length calculation since mbsrtowcs advances the source pointer
     const char* src = string;
     size_t size = std::mbsrtowcs(nullptr, &src, 0, &state);
-    THROW_LAST_ERROR_IF(size == -1);
+    THROW_LAST_ERROR_IF(size == static_cast<size_t>(-1));
 
     if (size == 0)
     {
@@ -686,7 +686,7 @@ inline std::string WideToMultiByte(const wchar_t* string)
     // Use a temporary pointer for the length calculation since wcsrtombs advances the source pointer
     const wchar_t* src = string;
     size_t size = std::wcsrtombs(nullptr, &src, 0, &state);
-    THROW_LAST_ERROR_IF(size == -1);
+    THROW_LAST_ERROR_IF(size == static_cast<size_t>(-1));
 
     if (size == 0)
     {

--- a/src/windows/common/WslCoreNetworkingSupport.cpp
+++ b/src/windows/common/WslCoreNetworkingSupport.cpp
@@ -41,7 +41,9 @@ static bool FindInterfacesForNetworkAdapter(
     // Find the IP interface(s) in the adapter's interface stack.
     std::vector<IF_INDEX> ipInterfaces{};
     std::queue<IF_INDEX> interfaceStack{};
+    std::unordered_set<IF_INDEX> visitedInterfaces{};
     interfaceStack.push(interfaceIndex);
+    visitedInterfaces.insert(interfaceIndex);
     while (!interfaceStack.empty())
     {
         IF_INDEX currInterfaceIndex = interfaceStack.front();
@@ -51,7 +53,12 @@ static bool FindInterfacesForNetworkAdapter(
         {
             if (interfaceStackTable.get()->Table[i].LowerLayerInterfaceIndex == currInterfaceIndex)
             {
-                interfaceStack.push(interfaceStackTable.get()->Table[i].HigherLayerInterfaceIndex);
+                IF_INDEX higherLayer = interfaceStackTable.get()->Table[i].HigherLayerInterfaceIndex;
+                // Guard against circular references in the interface stack table
+                if (visitedInterfaces.insert(higherLayer).second)
+                {
+                    interfaceStack.push(higherLayer);
+                }
             }
         }
 


### PR DESCRIPTION
## Overview

This PR fixes 4 defects found in the WSL codebase across shared string utilities, Linux DNS tunneling server, and Windows networking support code.

## Fixes

### 1. Fix string conversion pointer advancement bug in `stringshared.h` (Critical)

**Issue**: The `MultiByteToWide` and `WideToMultiByte` functions on Linux use `mbsrtowcs`/`wcsrtombs` for string conversion. These functions advance the source pointer (second parameter) after the call. After the first pass (length calculation), the source pointer has been advanced to the end of the string. The second pass (actual conversion) then operates on an empty string, resulting in an empty conversion result.

**Impact**: All non-empty string wide-character conversions on the Linux side return empty strings.

**Fix**: Use a temporary pointer variable `src` for the length calculation to avoid modifying the original pointer. Reset `src` to the original string before the second conversion pass. Also reset `mbstate_t` to support stateful encodings, and check the return value for conversion errors.

### 2. Fix infinite loop risk in DNS UDP/TCP send loops in `DnsServer.cpp` (Critical)

**Issue**: The send loops in `HandleUdpDnsResponse` and `HandleTcpDnsResponse` do not exit when `sendto`/`write` returns 0, causing an infinite loop.

**Impact**: The DNS server could hang permanently.

**Fix**: Add a `bytesSent == 0` guard. For UDP, use `return` to make the failure explicit. For TCP, remove the broken connection from `m_tcpConnectionContexts` to avoid subsequent writes to a dead file descriptor.

### 3. Fix interface stack traversal infinite loop in `WslCoreNetworkingSupport.cpp` (Critical)

**Issue**: The BFS traversal of the network interface stack does not maintain a visited set. If circular references exist in the interface stack table, this leads to an infinite loop and CPU exhaustion.

**Fix**: Add `std::unordered_set<IF_INDEX> visitedInterfaces` to track visited interfaces and skip already-visited ones before enqueueing.

### 4. Fix thread-safety annotation errors in `DnsServer.h`

**Issue**: `m_currentTcpConnectionId` and `m_tcpConnectionContexts` are TCP-related members protected by `m_tcpLock`, but their `_Guarded_by_` annotations incorrectly reference `m_udpLock`.

**Impact**: Static analysis tools produce false positives; maintainers may misunderstand lock protection scope.

**Fix**: Change `_Guarded_by_(m_udpLock)` to `_Guarded_by_(m_tcpLock)`.

## Files Changed

- `src/shared/inc/stringshared.h` — String conversion function fix
- `src/linux/init/DnsServer.cpp` — DNS send loop guard
- `src/linux/init/DnsServer.h` — Thread-safety annotation correction
- `src/windows/common/WslCoreNetworkingSupport.cpp` — Interface stack traversal safety