### PR TITLE
test(drvfs): add O_APPEND ftruncate coverage, skip on virtiofs

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -19,6 +19,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
+  <!-- TODO: Bump to an updated Microsoft.WSL.DeviceHost that includes the virtiofs O_APPEND ftruncate (EACCES) fix, then remove the virtiofs skip on the ftruncate check in test/linux/unit_tests/drvfs.c (DrvFsTestBasic). See microsoft/WSL#40987. -->
   <package id="Microsoft.WSL.DeviceHost" version="1.2.39-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.2-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />

--- a/test/linux/unit_tests/drvfs.c
+++ b/test/linux/unit_tests/drvfs.c
@@ -1070,6 +1070,32 @@ Return Value:
     LxtCheckEqual(Stat.st_size, 11, "%lld");
 
     //
+    // Verify ftruncate succeeds on a descriptor opened with O_APPEND | O_WRONLY.
+    // Regression test for a virtiofs bug where ftruncate returned EACCES on an
+    // append-mode descriptor (GitHub issue #40987).
+    //
+    // TODO: Remove the virtiofs skip once the wsldevicehost fix ships (the
+    // Windows lxutil file server strips FILE_WRITE_DATA for O_APPEND, causing
+    // SetEndOfFile to fail with access denied).
+    //
+
+    if (g_LxtFsInfo.FsType == LxtFsTypeVirtioFs)
+    {
+        LxtLogInfo("Skipping O_APPEND ftruncate test on virtiofs (see GitHub issue #40987).");
+    }
+    else
+    {
+        LxtCheckErrno(Fd = open(DRVFS_BASIC_PREFIX "/test", O_WRONLY | O_APPEND, 0666));
+        LxtCheckErrno(Size = write(Fd, "hello", 5));
+        LxtCheckEqual(Size, 5, "%ld");
+        LxtCheckErrnoZeroSuccess(ftruncate(Fd, 0));
+        LxtCheckErrnoZeroSuccess(ftruncate(Fd, 1));
+        LxtCheckClose(Fd);
+        LxtCheckErrnoZeroSuccess(stat(DRVFS_BASIC_PREFIX "/test", &Stat));
+        LxtCheckEqual(Stat.st_size, 1, "%lld");
+    }
+
+    //
     // Creating/removing items relative to the current working directory.
     //
 


### PR DESCRIPTION
## Summary

Adds an `ftruncate`-on-`O_APPEND` regression check to the drvfs `Basic` unit test. This scenario (`open(O_APPEND | O_WRONLY)` → `write` → `ftruncate`) was previously uncovered, and it currently fails on **virtiofs** with `EACCES`, breaking real-world workloads (see microsoft/WSL#40987).

Root cause is in the Windows lxutil file server (wsldevicehost): opening with `O_APPEND` strips `FILE_WRITE_DATA` from the NT access mask to enforce append-only writes, but the truncate path is issued on that same handle, so `SetEndOfFile` is denied. plan9 is unaffected because it doesn't map append semantics to a reduced NT access mask.

## Changes

- **`test/linux/unit_tests/drvfs.c`** — new `ftruncate`-on-`O_APPEND` coverage in `DrvFsTestBasic`. It runs on plan9 and is skipped on virtiofs (gated on `g_LxtFsInfo.FsType == LxtFsTypeVirtioFs`) with a `LxtLogInfo` note, since the backend fix hasn't shipped yet.
- **`packages.config`** — TODO above `Microsoft.WSL.DeviceHost` to bump the package to a build containing the virtiofs fix and then remove the virtiofs skip.

## Validation

Built Debug and ran locally:

| Test | Transport | Result |
|------|-----------|--------|
| `WSL2VirtioFs::DrvFs` | virtiofs | Passed (ftruncate check skipped, logs issue reference) |
| `WSL2Plan9::DrvFs` | plan9 | Passed (ftruncate check runs) |

Without the skip, `WSL2VirtioFs::DrvFs` fails with `ftruncate(Fd, 0) failed: errno 13 (Permission denied)`, confirming the test reproduces the bug. clang-format clean.

Once an updated `Microsoft.WSL.DeviceHost` with the fix is consumed, the virtiofs skip should be removed so the check runs on both transports.
