### PR TITLE
Pre-download socat to avoid test failing due to connectivity issues

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -23,7 +23,7 @@
   <package id="Microsoft.WSL.DeviceHost" version="1.2.39-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.2-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
-  <package id="Microsoft.WSL.TestData" version="0.4.0" />
+  <package id="Microsoft.WSL.TestData" version="0.5.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
   <package id="Microsoft.WSLg" version="1.0.79" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -651,6 +651,8 @@ void VerifyPatternMatch(const std::string& Content, const std::string& Pattern);
 
 std::filesystem::path GetTestImagePath(std::string_view imageName);
 
+std::filesystem::path GetTestDataPath();
+
 void LoadTestImage(IWSLCSession& session, std::string_view imageName);
 
 void ExpectHttpResponse(LPCWSTR Url, std::optional<int> expectedCode, bool retry = false);

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -651,8 +651,6 @@ void VerifyPatternMatch(const std::string& Content, const std::string& Pattern);
 
 std::filesystem::path GetTestImagePath(std::string_view imageName);
 
-std::filesystem::path GetTestDataPath();
-
 void LoadTestImage(IWSLCSession& session, std::string_view imageName);
 
 void ExpectHttpResponse(LPCWSTR Url, std::optional<int> expectedCode, bool retry = false);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3412,7 +3412,8 @@ class WSLCTests
         {
             constexpr auto c_mountPoint = "/testdata";
             VERIFY_SUCCEEDED(session->MountWindowsFolder(g_testDataPath.c_str(), c_mountPoint, true));
-            auto unmount = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { session->UnmountWindowsFolder(c_mountPoint); });
+            auto unmount =
+                wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_FAILED(session->UnmountWindowsFolder(c_mountPoint)); });
 
             const auto installCommand = std::format("tdnf install -y --disablerepo='*' --nogpgcheck {}/packages/*.rpm", c_mountPoint);
             auto installSocat = WSLCProcessLauncher("/bin/sh", {"/bin/sh", "-c", installCommand}).Launch(*session);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3408,11 +3408,16 @@ class WSLCTests
         auto createNewSession = networkingMode != m_defaultSessionSettings.NetworkingMode;
         auto session = createNewSession ? CreateSession(settings) : m_defaultSession;
 
-        // Install socat in the container.
-        //
-        // TODO: revisit this in the future to avoid pulling packages from the network.
-        auto installSocat = WSLCProcessLauncher("/bin/sh", {"/bin/sh", "-c", "tdnf install socat -y"}).Launch(*session);
-        ValidateProcessOutput(installSocat, {}, 0, 300 * 1000);
+        // Install socat in the VM.
+        {
+            constexpr auto c_mountPoint = "/testdata";
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(g_testDataPath.c_str(), c_mountPoint, true));
+            auto unmount = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { session->UnmountWindowsFolder(c_mountPoint); });
+
+            const auto installCommand = std::format("tdnf install -y --disablerepo='*' --nogpgcheck {}/packages/*.rpm", c_mountPoint);
+            auto installSocat = WSLCProcessLauncher("/bin/sh", {"/bin/sh", "-c", installCommand}).Launch(*session);
+            ValidateProcessOutput(installSocat, {}, 0, 120 * 1000);
+        }
 
         auto listen = [&](short port, const char* content, bool ipv6) {
             auto cmd = std::format("echo -n '{}' | /usr/bin/socat -dd TCP{}-LISTEN:{},reuseaddr -", content, ipv6 ? "6" : "", port);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3411,7 +3411,9 @@ class WSLCTests
         // Install socat in the VM.
         {
             constexpr auto c_mountPoint = "/testdata";
-            VERIFY_SUCCEEDED(session->MountWindowsFolder(g_testDataPath.c_str(), c_mountPoint, true));
+            auto mountSource = std::filesystem::absolute(g_testDataPath);
+
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(mountSource.c_str(), c_mountPoint, true));
             auto unmount =
                 wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { LOG_IF_FAILED(session->UnmountWindowsFolder(c_mountPoint)); });
 

--- a/tools/test/download-test-data-rpms.ps1
+++ b/tools/test/download-test-data-rpms.ps1
@@ -2,8 +2,7 @@
 [CmdletBinding(PositionalBinding = $False)]
 param (
     [Parameter(Mandatory = $true)][string]$Target,
-    [string]$BaseUrl = "https://packages.microsoft.com/azurelinux/3.0/prod/base",
-    [switch]$Force
+    [string]$BaseUrl = "https://packages.microsoft.com/azurelinux/3.0/prod/base"
 )
 
 $ErrorActionPreference = "Stop"
@@ -32,7 +31,7 @@ function Get-LatestRpmUrl {
         throw "Failed to list packages at $listingUrl"
     }
 
-    $pattern = 'href="(?<file>' + [regex]::Escape($Package) + '-(?<ver>[0-9][0-9.]*)-(?<rel>[0-9]+)\.azl3\.' + $Arch + '\.rpm)"'
+    $pattern = 'href="(?<file>' + [regex]::Escape($Package) + '-(?<ver>[0-9][0-9.]*)-(?<rel>[0-9]+)\.azl[0-9]+\.' + $Arch + '\.rpm)"'
     $matches = [regex]::Matches($listing, $pattern)
     if ($matches.Count -eq 0) {
         throw "No '$Package' rpm found for '$Arch' at $listingUrl"

--- a/tools/test/download-test-data-rpms.ps1
+++ b/tools/test/download-test-data-rpms.ps1
@@ -26,7 +26,7 @@ function Get-LatestRpmUrl {
     $letter = $Package.Substring(0, 1).ToLowerInvariant()
     $listingUrl = "$RepoUrl/$Arch/Packages/$letter/"
 
-    $listing = curl.exe -sSL $listingUrl
+    $listing = curl.exe --fail -sSL $listingUrl
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to list packages at $listingUrl"
     }

--- a/tools/test/download-test-data-rpms.ps1
+++ b/tools/test/download-test-data-rpms.ps1
@@ -65,7 +65,7 @@ foreach ($archEntry in $archMap.GetEnumerator()) {
         $destination = Join-Path $packagesDir $fileName
 
         Write-Output "[$nugetArch] Downloading $url"
-        curl.exe -sSL -o $destination $url
+        curl.exe --fail -sSL -o $destination $url
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to download $url"
         }

--- a/tools/test/download-test-data-rpms.ps1
+++ b/tools/test/download-test-data-rpms.ps1
@@ -1,0 +1,74 @@
+
+[CmdletBinding(PositionalBinding = $False)]
+param (
+    [Parameter(Mandatory = $true)][string]$Target,
+    [string]$BaseUrl = "https://packages.microsoft.com/azurelinux/3.0/prod/base",
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$ProgressPreference = "SilentlyContinue"
+
+$archMap = @{
+    "x64"   = "x86_64"
+    "arm64" = "aarch64"
+}
+
+$packages = @("socat", "readline", "ncurses-libs")
+
+function Get-LatestRpmUrl {
+    param (
+        [string]$RepoUrl,
+        [string]$Arch,
+        [string]$Package
+    )
+
+    $letter = $Package.Substring(0, 1).ToLowerInvariant()
+    $listingUrl = "$RepoUrl/$Arch/Packages/$letter/"
+
+    $listing = curl.exe -sSL $listingUrl
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to list packages at $listingUrl"
+    }
+
+    $pattern = 'href="(?<file>' + [regex]::Escape($Package) + '-(?<ver>[0-9][0-9.]*)-(?<rel>[0-9]+)\.azl3\.' + $Arch + '\.rpm)"'
+    $matches = [regex]::Matches($listing, $pattern)
+    if ($matches.Count -eq 0) {
+        throw "No '$Package' rpm found for '$Arch' at $listingUrl"
+    }
+
+    $latest = $matches |
+        Sort-Object -Property `
+            @{ Expression = { [version]$_.Groups["ver"].Value } }, `
+            @{ Expression = { [int]$_.Groups["rel"].Value } } |
+        Select-Object -Last 1
+
+    return "$listingUrl$($latest.Groups['file'].Value)"
+}
+
+foreach ($archEntry in $archMap.GetEnumerator()) {
+    $nugetArch = $archEntry.Key
+    $repoArch = $archEntry.Value
+
+    $archInput = Join-Path $Target $nugetArch
+    if (-not (Test-Path -Path $archInput -PathType Container)) {
+        Write-Warning "Skipping '$nugetArch': '$archInput' does not exist."
+        continue
+    }
+
+    $packagesDir = Join-Path $archInput "packages"
+    New-Item -ItemType Directory -Path $packagesDir -Force | Out-Null
+
+    foreach ($package in $packages) {
+        $url = Get-LatestRpmUrl -RepoUrl $BaseUrl -Arch $repoArch -Package $package
+        $fileName = Split-Path -Path $url -Leaf
+        $destination = Join-Path $packagesDir $fileName
+
+        Write-Output "[$nugetArch] Downloading $url"
+        curl.exe -sSL -o $destination $url
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to download $url"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds logic to pre-download the rpms for socat and its dependencies so we don't download it from the internet while the tests run. We've seen this causing a test failure in the past.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
