### PR TITLE
Bump DeviceHost to 1.2.48-0 and enable virtiofs O_APPEND ftruncate test

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.39-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.48-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.2-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.4.0" />

--- a/test/linux/unit_tests/drvfs.c
+++ b/test/linux/unit_tests/drvfs.c
@@ -1074,26 +1074,15 @@ Return Value:
     // Regression test for a virtiofs bug where ftruncate returned EACCES on an
     // append-mode descriptor (GitHub issue #40987).
     //
-    // TODO: Remove the virtiofs skip once the wsldevicehost fix ships (the
-    // Windows lxutil file server strips FILE_WRITE_DATA for O_APPEND, causing
-    // SetEndOfFile to fail with access denied).
-    //
 
-    if (g_LxtFsInfo.FsType == LxtFsTypeVirtioFs)
-    {
-        LxtLogInfo("Skipping O_APPEND ftruncate test on virtiofs (see GitHub issue #40987).");
-    }
-    else
-    {
-        LxtCheckErrno(Fd = open(DRVFS_BASIC_PREFIX "/test", O_WRONLY | O_APPEND, 0666));
-        LxtCheckErrno(Size = write(Fd, "hello", 5));
-        LxtCheckEqual(Size, 5, "%ld");
-        LxtCheckErrnoZeroSuccess(ftruncate(Fd, 0));
-        LxtCheckErrnoZeroSuccess(ftruncate(Fd, 1));
-        LxtCheckClose(Fd);
-        LxtCheckErrnoZeroSuccess(stat(DRVFS_BASIC_PREFIX "/test", &Stat));
-        LxtCheckEqual(Stat.st_size, 1, "%lld");
-    }
+    LxtCheckErrno(Fd = open(DRVFS_BASIC_PREFIX "/test", O_WRONLY | O_APPEND, 0666));
+    LxtCheckErrno(Size = write(Fd, "hello", 5));
+    LxtCheckEqual(Size, 5, "%ld");
+    LxtCheckErrnoZeroSuccess(ftruncate(Fd, 0));
+    LxtCheckErrnoZeroSuccess(ftruncate(Fd, 1));
+    LxtCheckClose(Fd);
+    LxtCheckErrnoZeroSuccess(stat(DRVFS_BASIC_PREFIX "/test", &Stat));
+    LxtCheckEqual(Stat.st_size, 1, "%lld");
 
     //
     // Creating/removing items relative to the current working directory.


### PR DESCRIPTION
Bumps `Microsoft.WSL.DeviceHost` to 1.2.48-0, which contains the wsldevicehost fix for the O_APPEND `ftruncate` EACCES bug on virtiofs (GitHub issue #40987).

With the fix shipping, this also removes the virtiofs skip in the drvfs unit test so the O_APPEND `ftruncate` regression test now runs on all filesystems.

## Validation
- Full build with DeviceHost 1.2.48-0
- `test.bat /name:*WSL2VirtioFs::DrvFs` passed (Total=1, Passed=1, Failed=0)