### PR TITLE
Start the plan9 server on WSL2 even when automount and mountFsTab are…

### DIFF
--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -845,21 +845,16 @@ try
     }
 
     //
-//
--    // Run the Plan 9 server. This requires a DrvFs mount for the socket file,
--    // so either fstab or automount must be enabled to have a chance for the
--    // mount to be available.
-+    // Run the Plan 9 server. On WSL1 this requires a DrvFs mount for the socket
-+    // file, so either fstab or automount must be enabled to have a chance for
-+    // the mount to be available. WSL2 serves over an hvsocket and has no such
-+    // dependency.
-     //
-     // N.B. Failure to start the server is non-fatal.
-     //
-     unsigned int Plan9Port = LX_INIT_UTILITY_VM_INVALID_PORT;
-     if ((WI_IsFlagClear(Config.FeatureFlags.value(), LxInitFeatureDisable9pServer)) && (Config.Plan9Enabled) &&
--        (Config.AutoMount || Config.MountFsTab))
-+        (UtilIsUtilityVm() || Config.AutoMount || Config.MountFsTab))
+    // Run the Plan 9 server. On WSL1 this requires a DrvFs mount for the socket
+    // file, so either fstab or automount must be enabled to have a chance for
+    // the mount to be available. WSL2 serves over an hvsocket and has no such
+    // dependency.
+    //
+    // N.B. Failure to start the server is non-fatal.
+    //
+    unsigned int Plan9Port = LX_INIT_UTILITY_VM_INVALID_PORT;
+    if ((WI_IsFlagClear(Config.FeatureFlags.value(), LxInitFeatureDisable9pServer)) && (Config.Plan9Enabled) &&
+        (UtilIsUtilityVm() || Config.AutoMount || Config.MountFsTab))
     {
         std::tie(Plan9Port, Config.Plan9ControlChannel) = StartPlan9Server(Plan9SocketPath, Config);
     }

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -845,16 +845,21 @@ try
     }
 
     //
-    // Run the Plan 9 server. This requires a DrvFs mount for the socket file,
-    // so either fstab or automount must be enabled to have a chance for the
-    // mount to be available.
-    //
-    // N.B. Failure to start the server is non-fatal.
-    //
-
-    unsigned int Plan9Port = LX_INIT_UTILITY_VM_INVALID_PORT;
-    if ((WI_IsFlagClear(Config.FeatureFlags.value(), LxInitFeatureDisable9pServer)) && (Config.Plan9Enabled) &&
-        (Config.AutoMount || Config.MountFsTab))
+//
+-    // Run the Plan 9 server. This requires a DrvFs mount for the socket file,
+-    // so either fstab or automount must be enabled to have a chance for the
+-    // mount to be available.
++    // Run the Plan 9 server. On WSL1 this requires a DrvFs mount for the socket
++    // file, so either fstab or automount must be enabled to have a chance for
++    // the mount to be available. WSL2 serves over an hvsocket and has no such
++    // dependency.
+     //
+     // N.B. Failure to start the server is non-fatal.
+     //
+     unsigned int Plan9Port = LX_INIT_UTILITY_VM_INVALID_PORT;
+     if ((WI_IsFlagClear(Config.FeatureFlags.value(), LxInitFeatureDisable9pServer)) && (Config.Plan9Enabled) &&
+-        (Config.AutoMount || Config.MountFsTab))
++        (UtilIsUtilityVm() || Config.AutoMount || Config.MountFsTab))
     {
         std::tie(Plan9Port, Config.Plan9ControlChannel) = StartPlan9Server(Plan9SocketPath, Config);
     }


### PR DESCRIPTION
Fixes #41056

On WSL2, when `/etc/wsl.conf` has both `automount.enabled = false` and
`automount.mountFsTab = false`, init never starts the plan9 file server, so
`\\wsl.localhost\<distro>` / `\\wsl$\<distro>` are inaccessible.

The guard in `ConfigInitializeInstance()` requires
`(Config.AutoMount || Config.MountFsTab)` because the server "requires a DrvFs
mount for the socket file". That rationale only applies to WSL1: on WSL2,
`StartPlan9Server()` binds an hvsocket (`UtilBindVsockAnyPort`) and never uses
the socket path — the initialize message carries an empty `Plan9SocketOffset`
(see the trace excerpt in #41056).

This change exempts WSL2 (`UtilIsUtilityVm()`) from the mount requirement:

- WSL1 behavior is unchanged.
- WSL2 with this configuration now takes exactly the same code path as the
  default configuration (where automount is enabled and the server starts).
- Anyone intentionally relying on this option combination to disable the 9p
  server can use the dedicated setting (`Config.Plan9Enabled`) instead.

**Testing:** verified by code inspection and the ETW trace attached to #41056
(`LxInitMessageInitializeResponse` carries
`Plan9Port = LX_INIT_UTILITY_VM_INVALID_PORT` while `FeatureFlags = 0`). I
don't currently have a local build environment, so this has not been build- or
runtime-tested on my side — happy to add a regression test if you can point me
at the right harness.