### PR TITLE
Fix: handle partial write in stdio forwarding

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -1840,6 +1840,11 @@ Return Value:
                         break;
                     }
                 }
+                else if (BytesWritten < BytesRead)
+                {
+                    assert(PendingStdin.empty());
+                    PendingStdin.assign(Buffer.begin() + BytesWritten, Buffer.begin() + BytesRead);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Partial writes on the WSL stdio relay were ignored. This could result in loss of data.
This PR adds the partial write handling logic.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/41063
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested manually by copying large amount of data to vim.

Regression tests are not added because the failure is hard to repro in e2e tests. Open to suggestions on the tests.