### PR TITLE
Bump Linux SDK to 1.23.0 and guard char->wide formatters to Windows

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -21,7 +21,7 @@
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.DeviceHost" version="1.2.48-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.2-1" targetFramework="native" />
-  <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
+  <package id="Microsoft.WSL.LinuxSdk" version="1.23.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.5.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
   <package id="Microsoft.WSLg" version="1.0.79" />

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -931,6 +931,11 @@ struct std::formatter<std::source_location, wchar_t>
     }
 };
 
+// char -> wchar_t formatting is only used by the Windows components. libc++ (used to
+// build the Linux components) now provides these as deleted specializations per C++23
+// [format.formatter.spec], which would collide, so restrict them to Windows.
+#ifdef WIN32
+
 template <>
 struct std::formatter<char*, wchar_t>
 {
@@ -994,6 +999,8 @@ struct std::formatter<std::basic_string<char, Traits, Allocator>, wchar_t>
         return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
     }
 };
+
+#endif // WIN32
 
 template <>
 struct std::formatter<std::filesystem::path, wchar_t>


### PR DESCRIPTION
## Summary

The new Linux SDK (1.23.0) ships libc++ 21, which now provides *deleted* `std::formatter` specializations for `char` -> `wchar_t` cross-encoding formatting per C++23 [format.formatter.spec]. Our own char->wide specializations in `stringshared.h` collide with those when building the Linux components, causing redefinition errors.

These specializations are only used by the Windows components (MSVC leaves the primary formatter template deleted-but-undefined, so our specializations are legal there and are relied upon). This change restricts them to `#ifdef WIN32`, which resolves the collision on Linux while leaving Windows behavior unchanged.

## Changes

- Bump `Microsoft.WSL.LinuxSdk` 1.20.0 -> 1.23.0
- Guard the char->wchar_t `std::formatter` specializations behind `WIN32`
