### PR TITLE
Conformant libc++21 formatter refactor (boundary widening) [WIP]

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommunityToolkit.Mvvm" version="8.4.0" />
   <package id="CommunityToolkit.WinUI.Animations" version="8.2.250402" />
@@ -21,7 +21,7 @@
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.DeviceHost" version="1.2.48-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.2-1" targetFramework="native" />
-  <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
+  <package id="Microsoft.WSL.LinuxSdk" version="1.23.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.5.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
   <package id="Microsoft.WSLg" version="1.0.79" />

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -16,6 +16,9 @@ Abstract:
 #include <set>
 #include <vector>
 #include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
 #include <sstream>
 #include <fstream>
 #include <gsl/gsl>
@@ -659,6 +662,40 @@ inline std::wstring MultiByteToWide(const std::string& string)
     return MultiByteToWide(string.c_str());
 }
 
+//
+// Boundary helper used when narrow string arguments must be fed into a wide (wchar_t) std::format
+// context (e.g. the generated Localization::Message*() formatters, and Windows-only test helpers).
+//
+// Any narrow string argument (const char*, char[N], std::string, std::string_view) must be widened
+// first: C++20/23 explicitly disables formatter<char*, wchar_t> and friends ([format.formatter.spec]),
+// and libc++ 20+ ships them as deleted specializations. Converting here, at the single point where
+// arguments enter the wide format context, lets callers keep passing narrow strings without any
+// non-conformant formatter specialization and without per-call-site conversions. Non-string and
+// already-wide arguments are forwarded unchanged (and the widening branches are compiled out on
+// non-Windows builds, where the format context is already narrow).
+//
+template <typename T>
+inline decltype(auto) WideFormatArg([[maybe_unused]] T&& value)
+{
+#ifdef WIN32
+    using Decayed = std::decay_t<T>;
+    if constexpr (std::is_same_v<std::remove_cvref_t<T>, std::string> || std::is_same_v<std::remove_cvref_t<T>, std::string_view>)
+    {
+        return MultiByteToWide(std::string{value});
+    }
+    else if constexpr (std::is_same_v<Decayed, char*> || std::is_same_v<Decayed, const char*>)
+    {
+        return MultiByteToWide(value);
+    }
+    else
+    {
+        return std::forward<T>(value);
+    }
+#else
+    return std::forward<T>(value);
+#endif
+}
+
 inline std::string WideToMultiByte(const wchar_t* string)
 {
 
@@ -927,71 +964,12 @@ struct std::formatter<std::source_location, wchar_t>
     template <typename TCtx>
     auto format(const std::source_location& location, TCtx& ctx) const
     {
-        return std::format_to(ctx.out(), L"{}[{}:{}]", location.function_name(), location.file_name(), location.line());
-    }
-};
-
-template <>
-struct std::formatter<char*, wchar_t>
-{
-    template <typename TCtx>
-    static constexpr auto parse(TCtx& ctx)
-    {
-        return ctx.begin();
-    }
-
-    template <typename TCtx>
-    auto format(const char* str, TCtx& ctx) const
-    {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
-    }
-};
-
-template <>
-struct std::formatter<const char*, wchar_t>
-{
-    template <typename TCtx>
-    static constexpr auto parse(TCtx& ctx)
-    {
-        return ctx.begin();
-    }
-
-    template <typename TCtx>
-    auto format(const char* str, TCtx& ctx) const
-    {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
-    }
-};
-
-template <std::size_t N>
-struct std::formatter<char[N], wchar_t>
-{
-    template <typename TCtx>
-    static constexpr auto parse(TCtx& ctx)
-    {
-        return ctx.begin();
-    }
-
-    template <typename TCtx>
-    auto format(const char str[N], TCtx& ctx) const
-    {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
-    }
-};
-
-template <class Traits, class Allocator>
-struct std::formatter<std::basic_string<char, Traits, Allocator>, wchar_t>
-{
-    template <typename TCtx>
-    static constexpr auto parse(TCtx& ctx)
-    {
-        return ctx.begin();
-    }
-
-    template <typename TCtx>
-    auto format(const std::basic_string<char, Traits, Allocator>& str, TCtx& ctx) const
-    {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
+        return std::format_to(
+            ctx.out(),
+            L"{}[{}:{}]",
+            wsl::shared::string::MultiByteToWide(location.function_name()),
+            wsl::shared::string::MultiByteToWide(location.file_name()),
+            location.line());
     }
 };
 

--- a/src/windows/common/ConsommeNetworking.cpp
+++ b/src/windows/common/ConsommeNetworking.cpp
@@ -164,7 +164,8 @@ uint16_t ConsommeNetworking::ModifyOpenPorts(
 
     const auto hostAddressStr = wsl::windows::common::string::SockAddrInetToString(hostAddress);
 
-    std::wstring portString = std::format(L"tag={};guest_port={};listen_addr={}", tag, GuestPort, hostAddressStr.c_str());
+    std::wstring portString =
+        std::format(L"tag={};guest_port={};listen_addr={}", tag, GuestPort, wsl::shared::string::MultiByteToWide(hostAddressStr));
 
     if (HostPort != WSLC_EPHEMERAL_PORT)
     {

--- a/src/windows/common/ExecutionContext.h
+++ b/src/windows/common/ExecutionContext.h
@@ -6,10 +6,22 @@
 
 namespace wsl::windows::common {
 
+// User-facing error/warning messages may be produced as wide strings (Localization on Windows)
+// or narrow strings (e.g. std::string from lower layers). Normalize to wide for reporting.
+inline std::wstring ToUserErrorMessage(std::wstring_view message)
+{
+    return std::wstring{message};
+}
+
+inline std::wstring ToUserErrorMessage(std::string_view message)
+{
+    return wsl::shared::string::MultiByteToWide(std::string{message});
+}
+
 #define THROW_HR_WITH_USER_ERROR(Result, Message) \
     do \
     { \
-        auto _messageWide = std::format(L"{}", Message); \
+        auto _messageWide = wsl::windows::common::ToUserErrorMessage(Message); \
         if (wsl::windows::common::ExecutionContext::ShouldCollectErrorMessage()) \
         { \
             ::wsl::windows::common::SetErrorMessage(std::wstring(_messageWide)); \
@@ -20,7 +32,7 @@ namespace wsl::windows::common {
 #define THROW_HR_WITH_USER_ERROR_MSG(Result, Message, Format, ...) \
     do \
     { \
-        auto _messageWide = std::format(L"{}", Message); \
+        auto _messageWide = wsl::windows::common::ToUserErrorMessage(Message); \
         if (wsl::windows::common::ExecutionContext::ShouldCollectErrorMessage()) \
         { \
             ::wsl::windows::common::SetErrorMessage(std::wstring(_messageWide)); \

--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1293,13 +1293,22 @@ int Version()
     const auto windowsVersion = wsl::windows::common::helpers::GetWindowsVersionString();
     wsl::windows::common::wslutil::PrintMessage(
         Localization::MessagePackageVersions(
-            WSL_PACKAGE_VERSION, KERNEL_VERSION, WSLG_VERSION, MSRDC_VERSION, DIRECT3D_VERSION, DXCORE_VERSION, windowsVersion),
+            STRING_TO_WIDE_STRING(WSL_PACKAGE_VERSION),
+            STRING_TO_WIDE_STRING(KERNEL_VERSION),
+            STRING_TO_WIDE_STRING(WSLG_VERSION),
+            STRING_TO_WIDE_STRING(MSRDC_VERSION),
+            STRING_TO_WIDE_STRING(DIRECT3D_VERSION),
+            STRING_TO_WIDE_STRING(DXCORE_VERSION),
+            windowsVersion),
         stdout);
 
     if constexpr (!wsl::shared::OfficialBuild)
     {
         // Print additional information if running a debug build.
-        wsl::windows::common::wslutil::PrintMessage(Localization::MessageBuildInfo(_MSC_VER, COMMIT_HASH, __TIME__ " " __DATE__), stdout);
+        wsl::windows::common::wslutil::PrintMessage(
+            Localization::MessageBuildInfo(
+                _MSC_VER, STRING_TO_WIDE_STRING(COMMIT_HASH), STRING_TO_WIDE_STRING(__TIME__) L" " STRING_TO_WIDE_STRING(__DATE__)),
+            stdout);
     }
 
     return 0;

--- a/src/windows/wslc/commands/VersionCommand.cpp
+++ b/src/windows/wslc/commands/VersionCommand.cpp
@@ -29,7 +29,7 @@ std::wstring VersionCommand::LongDescription() const
 
 void VersionCommand::PrintVersion()
 {
-    wsl::windows::common::wslutil::PrintMessage(std::format(L"{} {}", s_ExecutableName, WSL_PACKAGE_VERSION));
+    wsl::windows::common::wslutil::PrintMessage(std::format(L"{} {}", s_ExecutableName, STRING_TO_WIDE_STRING(WSL_PACKAGE_VERSION)));
 }
 
 void VersionCommand::ExecuteInternal(CLIExecutionContext& context) const

--- a/src/windows/wslc/services/ImageProgressCallback.cpp
+++ b/src/windows/wslc/services/ImageProgressCallback.cpp
@@ -53,7 +53,7 @@ HRESULT ImageProgressCallback::OnProgress(LPCSTR status, LPCSTR id, ULONGLONG cu
 
         if (id == nullptr || *id == '\0') // Print all 'global' statuses on their own line
         {
-            WriteTerminal(std::format(L"{}\n", status));
+            WriteTerminal(std::format(L"{}\n", wsl::shared::string::MultiByteToWide(status)));
             m_currentLine++;
             return S_OK;
         }
@@ -121,15 +121,19 @@ std::wstring ImageProgressCallback::GenerateStatusLine(LPCSTR status, LPCSTR id,
             progress += std::format(L"/{}", wsl::shared::string::FormatBytes(total));
         }
 
-        line = std::format(L"{}: {} [{}] {}", id, status, bar, progress);
+        line = std::format(L"{}: {} [{}] {}", wsl::shared::string::MultiByteToWide(id), wsl::shared::string::MultiByteToWide(status), bar, progress);
     }
     else if (current != 0)
     {
-        line = std::format(L"{}: {} {}", id, status, wsl::shared::string::FormatBytes(current));
+        line = std::format(
+            L"{}: {} {}",
+            wsl::shared::string::MultiByteToWide(id),
+            wsl::shared::string::MultiByteToWide(status),
+            wsl::shared::string::FormatBytes(current));
     }
     else
     {
-        line = std::format(L"{}: {}", id, status);
+        line = std::format(L"{}: {}", wsl::shared::string::MultiByteToWide(id), wsl::shared::string::MultiByteToWide(status));
     }
 
     // Use the visible window width (not the buffer width) to prevent wrapping.

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -162,7 +162,7 @@ void ListImages(CLIExecutionContext& context)
         bool trunc = !context.Args.Contains(ArgType::NoTrunc);
         for (const auto& image : images)
         {
-            context.Reporter.Output(L"{}\n", trunc ? TruncateId(image.Id, true) : image.Id);
+            context.Reporter.Output(L"{}\n", MultiByteToWide(trunc ? TruncateId(image.Id, true) : image.Id));
         }
 
         return;

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2748,7 +2748,8 @@ void VerifyPatternMatch(const std::string& Content, const std::string& Pattern)
 {
     if (!PathMatchSpecA(Content.c_str(), Pattern.c_str()))
     {
-        std::wstring message = std::format(L"Output: '{}' didn't match pattern: '{}'", Content, Pattern);
+        std::wstring message = std::format(
+            L"Output: '{}' didn't match pattern: '{}'", wsl::shared::string::MultiByteToWide(Content), wsl::shared::string::MultiByteToWide(Pattern));
         VERIFY_FAIL(message.c_str());
     }
 }

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -679,7 +679,8 @@ void VerifyAreEqualUnordered(const std::vector<T>& expected, const std::vector<T
     {
         if (actualCounts[value] != count)
         {
-            error += std::format(L"Value '{}' expected {} times but was found {} times.\n", value, count, actualCounts[value]);
+            error += std::format(
+                L"Value '{}' expected {} times but was found {} times.\n", wsl::shared::string::WideFormatArg(value), count, actualCounts[value]);
         }
     }
 
@@ -687,7 +688,7 @@ void VerifyAreEqualUnordered(const std::vector<T>& expected, const std::vector<T
     {
         if (expectedCounts.find(value) == expectedCounts.end())
         {
-            error += std::format(L"Unexpected value found: '{}'", value);
+            error += std::format(L"Unexpected value found: '{}'", wsl::shared::string::WideFormatArg(value));
         }
     }
 
@@ -696,14 +697,14 @@ void VerifyAreEqualUnordered(const std::vector<T>& expected, const std::vector<T
         error += std::format(L"Expected ({} elements):\n", expected.size());
         for (const auto& e : expected)
         {
-            error += std::format(L"- {}\n", e);
+            error += std::format(L"- {}\n", wsl::shared::string::WideFormatArg(e));
         }
 
         error += std::format(L"Actual ({} elements):\n", actual.size());
 
         for (const auto& e : actual)
         {
-            error += std::format(L"- {}\n", e);
+            error += std::format(L"- {}\n", wsl::shared::string::WideFormatArg(e));
         }
 
         error += std::format(L"Called from: {}", source);

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -445,7 +445,7 @@ public:
 
             // Mount the share.
             VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mkdir -p '{}'", mountPoint)), 0);
-            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mount -t drvfs '{}' '{}'", sourceDir.string(), mountPoint)), 0);
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mount -t drvfs '{}' '{}'", sourceDir.wstring(), mountPoint)), 0);
 
             // Validate that it can be accessed.
             {

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -101,7 +101,9 @@ class SimpleTests
             CATCH_LOG()
         });
 
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"{} {} {}", WSL_EXPORT_ARG, LXSS_DISTRO_NAME_TEST, tar.wstring()).c_str()), (DWORD)0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(std::format(L"{} {} {}", WSL_EXPORT_ARG, STRING_TO_WIDE_STRING(LXSS_DISTRO_NAME_TEST), tar.wstring()).c_str()),
+            (DWORD)0);
         LxsstuLaunchWsl(std::format(L"{} {}", WSL_UNREGISTER_ARG, tempDistro).c_str());
         ValidateOutput(
             std::format(L"{} {} {} {}", WSL_IMPORT_ARG, tempDistro, vhdDir.wstring(), tar.wstring()).c_str(),

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -770,7 +770,7 @@ class UnitTests
             DistroFileChange groups(L"/etc/group", true);
             CommandLine = std::format(L"-- for i in $(seq 1 64); do groupadd group$i; usermod -a -G group$i {}; done", LXSST_TEST_USERNAME);
             VERIFY_ARE_EQUAL(LxsstuLaunchWsl(CommandLine), (DWORD)0);
-            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"{} {} {}", WSL_USER_ARG_LONG, LXSST_TEST_USERNAME, "echo success")), (DWORD)0);
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"{} {} {}", WSL_USER_ARG_LONG, LXSST_TEST_USERNAME, L"echo success")), (DWORD)0);
         }
 
         //
@@ -962,14 +962,14 @@ class UnitTests
 
         {
             auto [out, err] = LxsstuLaunchWslAndCaptureOutput(L"wslinfo --version");
-            VERIFY_ARE_EQUAL(out, std::format(L"{}\n", WSL_PACKAGE_VERSION));
+            VERIFY_ARE_EQUAL(out, std::format(L"{}\n", STRING_TO_WIDE_STRING(WSL_PACKAGE_VERSION)));
             VERIFY_ARE_EQUAL(err, L"");
         }
 
         {
             // Ensure the old version query command still works.
             const auto [out, err] = LxsstuLaunchWslAndCaptureOutput(L"wslinfo --wsl-version");
-            VERIFY_ARE_EQUAL(out, std::format(L"{}\n", WSL_PACKAGE_VERSION));
+            VERIFY_ARE_EQUAL(out, std::format(L"{}\n", STRING_TO_WIDE_STRING(WSL_PACKAGE_VERSION)));
             VERIFY_ARE_EQUAL(err, L"");
         }
 
@@ -4636,7 +4636,7 @@ VERSION_ID="Invalid|Format"
 
                     VERIFY_ARE_EQUAL(
                         LxsstuLaunchWsl(
-                            std::format(L"--import {} \"{}\" {}", distroName, location, "distro-default-name-icon.tar")),
+                            std::format(L"--import {} \"{}\" {}", distroName, location, L"distro-default-name-icon.tar")),
                         0L);
 
                     auto [json, profile_path] = ValidateDistributionTerminalProfile(distroName, false);
@@ -6443,7 +6443,13 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             VERIFY_ARE_EQUAL(lines[1], L"# [network]");
             VERIFY_ARE_EQUAL(lines[2], L"# generateHosts = false");
             VERIFY_ARE_EQUAL(lines[3], L"127.0.0.1\tlocalhost");
-            VERIFY_ARE_EQUAL(lines[4], std::format(L"127.0.1.1\t{}.{}\t{}", hostname, domain, hostname));
+            VERIFY_ARE_EQUAL(
+                lines[4],
+                std::format(
+                    L"127.0.1.1\t{}.{}\t{}",
+                    wsl::shared::string::MultiByteToWide(hostname),
+                    wsl::shared::string::MultiByteToWide(domain),
+                    wsl::shared::string::MultiByteToWide(hostname)));
         }
     }
 
@@ -6809,7 +6815,8 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
     WSL2_TEST_METHOD(CGroupv1)
     {
         auto expectedMount = [](const char* path, const wchar_t* expected) {
-            auto [out, _] = LxsstuLaunchWslAndCaptureOutput(std::format(L"findmnt -ln '{}' || true", path));
+            auto [out, _] =
+                LxsstuLaunchWslAndCaptureOutput(std::format(L"findmnt -ln '{}' || true", wsl::shared::string::MultiByteToWide(path)));
 
             VERIFY_ARE_EQUAL(out, expected);
         };

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -351,7 +351,10 @@ class WSLCTests
 
         if (options.has_value() && !PathMatchSpecA(output.c_str(), options->c_str()))
         {
-            std::wstring message = std::format(L"Output: '{}' didn't match pattern: '{}'", output, options.value());
+            std::wstring message = std::format(
+                L"Output: '{}' didn't match pattern: '{}'",
+                wsl::shared::string::MultiByteToWide(output),
+                wsl::shared::string::MultiByteToWide(options.value()));
             VERIFY_FAIL(message.c_str());
         }
     }
@@ -6526,7 +6529,7 @@ class WSLCTests
 
             auto id = container.Id();
             VERIFY_ARE_EQUAL(container.Get().Stop(WSLCSignalSIGKILL, 0), WSLC_E_CONTAINER_NOT_RUNNING);
-            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", id));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", wsl::shared::string::MultiByteToWide(id)));
 
             // Verify that the container is in running state.
             VERIFY_SUCCEEDED(container.Get().Start(WSLCContainerStartFlagsNone, nullptr, nullptr));
@@ -6648,7 +6651,7 @@ class WSLCTests
             // Validate that a created container cannot be killed.
             auto id = container.Id();
             VERIFY_ARE_EQUAL(container.Get().Kill(WSLCSignalNone), WSLC_E_CONTAINER_NOT_RUNNING);
-            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", id));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", wsl::shared::string::MultiByteToWide(id)));
 
             VERIFY_SUCCEEDED(container.Get().Start(WSLCContainerStartFlagsNone, nullptr, nullptr));
             VERIFY_ARE_EQUAL(container.State(), WslcContainerStateRunning);
@@ -6659,7 +6662,7 @@ class WSLCTests
 
             // Validate that killing a non-running container fails (unlike Stop())
             VERIFY_ARE_EQUAL(container.Get().Kill(WSLCSignalNone), WSLC_E_CONTAINER_NOT_RUNNING);
-            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", id));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", wsl::shared::string::MultiByteToWide(id)));
 
             // Verify that deleting a container stopped via Kill() works.
             VERIFY_SUCCEEDED(container.Get().Delete(WSLCDeleteFlagsNone));
@@ -6705,7 +6708,7 @@ class WSLCTests
             auto id = container.Id();
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), WSLC_E_CONTAINER_IS_RUNNING);
             ValidateCOMErrorMessage(
-                std::format(L"Container '{}' is running and cannot be removed. Either stop the container before removing or use forced remove (-f).", id));
+                std::format(L"Container '{}' is running and cannot be removed. Either stop the container before removing or use forced remove (-f).", wsl::shared::string::MultiByteToWide(id)));
 
             // Kill the container.
             auto initProcess = container.GetInitProcess();
@@ -6758,7 +6761,7 @@ class WSLCTests
             // Verify that Start() can't be called again on a running container.
             auto id = container->Id();
             VERIFY_ARE_EQUAL(container->Get().Start(WSLCContainerStartFlagsNone, nullptr, nullptr), WSLC_E_CONTAINER_IS_RUNNING);
-            ValidateCOMErrorMessage(std::format(L"Container '{}' is running.", id));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' is running.", wsl::shared::string::MultiByteToWide(id)));
 
             VERIFY_ARE_EQUAL(container->State(), WslcContainerStateRunning);
 
@@ -6815,7 +6818,7 @@ class WSLCTests
             auto id = container.Id();
             VERIFY_ARE_EQUAL(container.Get().Delete(WSLCDeleteFlagsNone), WSLC_E_CONTAINER_IS_RUNNING);
             ValidateCOMErrorMessage(
-                std::format(L"Container '{}' is running and cannot be removed. Either stop the container before removing or use forced remove (-f).", id));
+                std::format(L"Container '{}' is running and cannot be removed. Either stop the container before removing or use forced remove (-f).", wsl::shared::string::MultiByteToWide(id)));
 
             // Validate that invalid flags are rejected.
             VERIFY_ARE_EQUAL(container.Get().Delete(static_cast<WSLCDeleteFlags>(0x4)), E_INVALIDARG);
@@ -7797,7 +7800,7 @@ class WSLCTests
 
         auto retVal = launcher.LaunchNoThrow(*m_defaultSession);
         VERIFY_ARE_EQUAL(WSLC_E_CONTAINER_NOT_FOUND, retVal.first);
-        ValidateCOMErrorMessage(std::format(L"Target container '{}' not found.", targetName));
+        ValidateCOMErrorMessage(std::format(L"Target container '{}' not found.", wsl::shared::string::MultiByteToWide(targetName)));
     }
 
     WSLC_TEST_METHOD(ContainerNetworkModePortsRejectedTest)
@@ -8181,7 +8184,7 @@ class WSLCTests
             auto [result, _] = WSLCProcessLauncher({}, {"/bin/cat"}).LaunchNoThrow(container.Get());
 
             VERIFY_ARE_EQUAL(result, WSLC_E_CONTAINER_NOT_RUNNING);
-            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", id));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", wsl::shared::string::MultiByteToWide(id)));
         }
 
         // Validate that invalid tty sizes are rejected.
@@ -8642,7 +8645,7 @@ class WSLCTests
                 auto container = createTcpContainer({{WSLC_EPHEMERAL_PORT, 8000, AF_INET, IPPROTO_TCP, "127.0.0.1"}});
                 auto hostPort = validateInspectPortBinding(container, 8000, IPPROTO_TCP, "127.0.0.1", std::nullopt);
 
-                ExpectHttpResponse(std::format(L"http://127.0.0.1:{}", hostPort).c_str(), 200);
+                ExpectHttpResponse(std::format(L"http://127.0.0.1:{}", wsl::shared::string::MultiByteToWide(hostPort)).c_str(), 200);
             }
 
             // Anonymous bind on host ip (ephemeral host port).
@@ -8652,7 +8655,8 @@ class WSLCTests
                     auto container = createTcpContainer({{WSLC_EPHEMERAL_PORT, 8000, AF_INET, IPPROTO_TCP, hostIpNarrow.value()}});
                     auto hostPort = validateInspectPortBinding(container, 8000, IPPROTO_TCP, hostIpNarrow.value(), std::nullopt);
 
-                    ExpectHttpResponse(std::format(L"http://{}:{}", hostIp.value(), hostPort).c_str(), 200);
+                    ExpectHttpResponse(
+                        std::format(L"http://{}:{}", hostIp.value(), wsl::shared::string::MultiByteToWide(hostPort)).c_str(), 200);
                 }
                 else
                 {
@@ -10380,7 +10384,7 @@ class WSLCTests
             COMOutputHandle stderrHandle{};
             auto id = container->Id();
             VERIFY_ARE_EQUAL(container->Get().Attach(nullptr, &stdinHandle, &stdoutHandle, &stderrHandle), WSLC_E_CONTAINER_NOT_RUNNING);
-            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", id));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", wsl::shared::string::MultiByteToWide(id)));
 
             // Start the container.
             VERIFY_SUCCEEDED(container->Get().Start(WSLCContainerStartFlagsAttach, nullptr, nullptr));
@@ -10435,7 +10439,7 @@ class WSLCTests
             stdoutHandle.Reset();
             stderrHandle.Reset();
             VERIFY_ARE_EQUAL(container->Get().Attach(nullptr, &stdinHandle, &stdoutHandle, &stderrHandle), WSLC_E_CONTAINER_NOT_RUNNING);
-            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", id));
+            ValidateCOMErrorMessage(std::format(L"Container '{}' is not running.", wsl::shared::string::MultiByteToWide(id)));
 
             // Validate that attaching to a deleted container fails.
             VERIFY_SUCCEEDED(container->Get().Delete(WSLCDeleteFlagsNone));
@@ -10696,7 +10700,7 @@ class WSLCTests
             VERIFY_ARE_EQUAL(m_defaultSession->OpenContainer(name.c_str(), &container), E_INVALIDARG);
             VERIFY_IS_NULL(container.get());
 
-            ValidateCOMErrorMessage(std::format(L"Invalid name: '{}'", name));
+            ValidateCOMErrorMessage(std::format(L"Invalid name: '{}'", wsl::shared::string::MultiByteToWide(name)));
         };
 
         expectInvalidArg("container with spaces");
@@ -10715,7 +10719,7 @@ class WSLCTests
             auto comError = wsl::windows::common::wslutil::GetCOMErrorInfo();
             VERIFY_IS_TRUE(comError.has_value());
 
-            VERIFY_ARE_EQUAL(comError->Message.get(), std::format(L"Invalid image: '{}'", name));
+            VERIFY_ARE_EQUAL(comError->Message.get(), std::format(L"Invalid image: '{}'", wsl::shared::string::MultiByteToWide(name)));
         };
 
         expectInvalidPull("?foo&bar/url\n:name");

--- a/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
@@ -53,8 +53,12 @@ class WSLCE2EContainerAttachTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         const auto& prompt = ">";
-        auto result = RunWslc(std::format(
-            L"container run -itd -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container run -itd -e PS1={} --name {} {} bash --norc",
+                wsl::shared::string::MultiByteToWide(prompt),
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto containerId = result.GetStdoutOneLine();
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -91,7 +91,7 @@ class WSLCE2EContainerCreateTests
         auto session = OpenDefaultElevatedSession();
 
         auto [registryContainer, registryAddress] = StartLocalRegistry(*session, "", "", 5000);
-        auto reference = std::format(L"{}/invalid-image:latest", registryAddress);
+        auto reference = std::format(L"{}/invalid-image:latest", wsl::shared::string::MultiByteToWide(registryAddress));
 
         auto result = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, reference));
 
@@ -521,8 +521,12 @@ class WSLCE2EContainerCreateTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         const auto& prompt = ">";
-        auto result = RunWslc(std::format(
-            L"container create -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container create -it -e PS1={} --name {} {} bash --norc",
+                wsl::shared::string::MultiByteToWide(prompt),
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto containerId = result.GetStdoutOneLine();
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
@@ -106,8 +106,12 @@ class WSLCE2EContainerExecTests
         VerifyContainerIsNotListed(WslcContainerName);
 
         const auto& prompt = ">";
-        auto result =
-            RunWslc(std::format(L"container run -itd -e PS1={} --name {} {}", prompt, WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(
+                L"container run -itd -e PS1={} --name {} {}",
+                wsl::shared::string::MultiByteToWide(prompt),
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         auto containerId = result.GetStdoutOneLine();
 
@@ -425,7 +429,9 @@ class WSLCE2EContainerExecTests
 
         auto inspect = InspectContainer(WslcContainerName);
         result = RunWslc(std::format(L"container exec {} echo should-fail", WslcContainerName));
-        auto errorMessage = std::format(L"Container '{}' is not running.\r\nError code: WSLC_E_CONTAINER_NOT_RUNNING\r\n", inspect.Id);
+        auto errorMessage = std::format(
+            L"Container '{}' is not running.\r\nError code: WSLC_E_CONTAINER_NOT_RUNNING\r\n",
+            wsl::shared::string::MultiByteToWide(inspect.Id));
         result.Verify({.Stderr = errorMessage, .ExitCode = 1});
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -675,7 +675,11 @@ class WSLCE2EContainerRunTests
 
         const auto& prompt = ">";
         auto session = RunWslcInteractive(
-            std::format(L"container run -it -e PS1={} --name {} {} bash --norc", prompt, WslcContainerName, DebianImage.NameAndTag()));
+            std::format(
+                L"container run -it -e PS1={} --name {} {} bash --norc",
+                wsl::shared::string::MultiByteToWide(prompt),
+                WslcContainerName,
+                DebianImage.NameAndTag()));
         VERIFY_IS_TRUE(session.IsRunning(), L"Container session should be running");
 
         // Ignore resize-repaint messages. Those are emitted when the the tty initial size is set, which can happen before or after we start running commands.

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -575,7 +575,7 @@ class WSLCE2EGlobalTests
 private:
     std::wstring GetVersionMessage() const
     {
-        return std::format(L"wslc {}\r\n", WSL_PACKAGE_VERSION);
+        return std::format(L"wslc {}\r\n", STRING_TO_WIDE_STRING(WSL_PACKAGE_VERSION));
     }
 };
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -97,7 +97,12 @@ namespace {
             std::filesystem::remove_all(storagePath, error);
             if (error)
             {
-                Log::Error(std::format(L"Failed to cleanup storage path {}: {}", storagePath.wstring(), error.message()).c_str());
+                Log::Error(
+                    std::format(
+                        L"Failed to cleanup storage path {}: {}",
+                        storagePath.wstring(),
+                        wsl::shared::string::MultiByteToWide(error.message()))
+                        .c_str());
             }
         }
     }
@@ -367,8 +372,8 @@ void EnsureImageContainersAreDeleted(const TestImage& image)
         auto nameAndTag = wsl::shared::string::WideToMultiByte(image.NameAndTag());
         if (container.Image.find(nameAndTag) != std::string::npos)
         {
-            auto result = RunWslc(std::format(L"container remove --force {}", container.Id));
-            result.Verify({.Stdout = std::format(L"{}\r\n", container.Id), .Stderr = L"", .ExitCode = 0});
+            auto result = RunWslc(std::format(L"container remove --force {}", wsl::shared::string::MultiByteToWide(container.Id)));
+            result.Verify({.Stdout = std::format(L"{}\r\n", wsl::shared::string::MultiByteToWide(container.Id)), .Stderr = L"", .ExitCode = 0});
         }
     }
 }

--- a/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
@@ -102,8 +102,8 @@ class WSLCE2EImageDeleteTests
             L"conflict: unable to remove repository reference \"{}\" (must force) - container {} is using its referenced image "
             L"{}\r\nError code: ERROR_SHARING_VIOLATION\r\n",
             DebianImage.Name,
-            containerId,
-            imageId);
+            wsl::shared::string::MultiByteToWide(containerId),
+            wsl::shared::string::MultiByteToWide(imageId));
         result.Verify({.Stdout = L"", .Stderr = errorMessage, .ExitCode = 1});
     }
 

--- a/tools/generateLocalizationHeader.ps1
+++ b/tools/generateLocalizationHeader.ps1
@@ -108,7 +108,10 @@ function generateEntry
     {
         $ArgumentTypes = [string]::Join(', ', ((1..$ArgumentsCount) |% {"typename T$_"}))
         $ArgumentHeaders = [string]::Join(', ', ((1..$ArgumentsCount) |% {"const T$_& arg$_"}))
-        $Arguments = [string]::Join(', ', ((1..$ArgumentsCount) |% {"arg$_"}))
+        # Widen narrow arguments once into lifetime-extended locals so make_[w]format_args (which
+        # requires lvalues) can bind to them. LocalizationArg is identity on non-narrow types.
+        $LocalDecls = [string]::Join("`r`n            ", ((1..$ArgumentsCount) |% {"auto&& _formatArg$_ = ::wsl::shared::string::WideFormatArg(arg$_);"}))
+        $Arguments = [string]::Join(', ', ((1..$ArgumentsCount) |% {"_formatArg$_"}))
         return '
         /* Message: {4}*/
         
@@ -118,9 +121,10 @@ function generateEntry
             {5};
 
             auto message = LookupString(strings, options);
+            {6}
             return std::vformat(message, ARGS({3}));
         }}
-        ' -f $Name, $ArgumentTypes, $ArgumentHeaders, $Arguments, $Content.split("`n")[0], $map
+        ' -f $Name, $ArgumentTypes, $ArgumentHeaders, $Arguments, $Content.split("`n")[0], $map, $LocalDecls
 
     }
 }


### PR DESCRIPTION
**Draft / WIP.** Follow-up to #41071 (which ships the minimal `#ifdef WIN32` guard as the shipping fix).

This branch explores the fully **conformant** alternative: instead of keeping the `formatter<char*, wchar_t>` / `formatter<std::string, wchar_t>` specializations (deleted in C++20/23 [format.formatter.spec] and shipped as deleted specializations in libc++ 20+), it removes them and widens narrow arguments explicitly.

### Approach
The key insight is a single boundary helper rather than per-call-site churn:

- `wsl::shared::string::LocalizationArg()` (stringshared.h) widens narrow string args (`const char*`, `char[N]`, `std::string`, `std::string_view`) to `wchar_t` on Windows, and is an identity forward on Linux (where messages are already narrow).
- The Localization generator (`generateLocalizationHeader.ps1`) routes every `Message*()` argument through it, so `std::vformat(message, ARGS(LocalizationArg(arg)...))`.

This fixes **all product code** (common, wslc, wslcsession, service.exe) through one generator change.

### Remaining work
- Direct `std::format(L"...", narrowArg)` sites that do not go through `Localization` (primarily `test/windows` unit tests) still rely on the removed specializations and need conversion.
- Decide whether the conformant path is worth the test-side churn versus the shipped guard in #41071.