### PR TITLE
Follow up to the cgroup PR #40519

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1200,7 +1200,7 @@ See recovery instructions on: https://aka.ms/wsldiskmountrecovery</value>
   </data>
   <data name="MessageCgroupV1IncompatibleWithDistroIsolation" xml:space="preserve">
     <value>Cgroup v1 is incompatible with per-distribution cgroup isolation. To use cgroup v1, set isolateDistroCgroup=false under [wsl2] in .wslconfig, then run wsl --shutdown.</value>
-    <comment>{Locked="--shutdown."}{Locked=".wslconfig"}Command line arguments, file names and string inserts should not be translated. {Locked="[wsl2]"}{Locked="isolateDistroCgroup=false"}{Locked="Cgroup v1"}{Locked="cgroup v1"}Configuration keys and commands should not be translated.</comment>
+    <comment>{Locked="--shutdown"}{Locked=".wslconfig"}Command line arguments, file names and string inserts should not be translated. {Locked="[wsl2]"}{Locked="isolateDistroCgroup=false"}{Locked="Cgroup v1"}{Locked="cgroup v1"}Configuration keys and commands should not be translated.</comment>
   </data>
   <data name="Settings_ErrorTryAgainLater.Text" xml:space="preserve">
     <value>Something went wrong. Try again later.</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1198,6 +1198,10 @@ See recovery instructions on: https://aka.ms/wsldiskmountrecovery</value>
     <value>Failed to translate '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageCgroupV1IncompatibleWithDistroIsolation" xml:space="preserve">
+    <value>Cgroup v1 is incompatible with per-distribution cgroup isolation. To use cgroup v1, set isolateDistroCgroup=false under [wsl2] in .wslconfig, then run wsl --shutdown.</value>
+    <comment>{Locked="Cgroup v1"}{Locked="cgroup v1"}{Locked="isolateDistroCgroup=false"}{Locked="[wsl2]"}{Locked=".wslconfig"}{Locked="wsl --shutdown"}Configuration keys, file paths, and commands should not be translated.</comment>
+  </data>
   <data name="Settings_ErrorTryAgainLater.Text" xml:space="preserve">
     <value>Something went wrong. Try again later.</value>
   </data>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1200,7 +1200,7 @@ See recovery instructions on: https://aka.ms/wsldiskmountrecovery</value>
   </data>
   <data name="MessageCgroupV1IncompatibleWithDistroIsolation" xml:space="preserve">
     <value>Cgroup v1 is incompatible with per-distribution cgroup isolation. To use cgroup v1, set isolateDistroCgroup=false under [wsl2] in .wslconfig, then run wsl --shutdown.</value>
-    <comment>{Locked="--shutdown"}{Locked=".wslconfig"}Command line arguments, file names and string inserts should not be translated. {Locked="[wsl2]"}{Locked="isolateDistroCgroup=false"}{Locked="Cgroup v1"}{Locked="cgroup v1"}Configuration keys and commands should not be translated.</comment>
+    <comment>{Locked="Cgroup v1"}{Locked="cgroup v1"}{Locked="isolateDistroCgroup=false"}{Locked="[wsl2]"}{Locked="--shutdown."}{Locked=".wslconfig"}Command line arguments, file names and string inserts should not be translated.</comment>
   </data>
   <data name="Settings_ErrorTryAgainLater.Text" xml:space="preserve">
     <value>Something went wrong. Try again later.</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -1200,7 +1200,7 @@ See recovery instructions on: https://aka.ms/wsldiskmountrecovery</value>
   </data>
   <data name="MessageCgroupV1IncompatibleWithDistroIsolation" xml:space="preserve">
     <value>Cgroup v1 is incompatible with per-distribution cgroup isolation. To use cgroup v1, set isolateDistroCgroup=false under [wsl2] in .wslconfig, then run wsl --shutdown.</value>
-    <comment>{Locked="Cgroup v1"}{Locked="cgroup v1"}{Locked="isolateDistroCgroup=false"}{Locked="[wsl2]"}{Locked=".wslconfig"}{Locked="wsl --shutdown"}Configuration keys, file paths, and commands should not be translated.</comment>
+    <comment>{Locked="--shutdown."}{Locked=".wslconfig"}Command line arguments, file names and string inserts should not be translated. {Locked="[wsl2]"}{Locked="isolateDistroCgroup=false"}{Locked="Cgroup v1"}{Locked="cgroup v1"}Configuration keys and commands should not be translated.</comment>
   </data>
   <data name="Settings_ErrorTryAgainLater.Text" xml:space="preserve">
     <value>Something went wrong. Try again later.</value>

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -1841,6 +1841,11 @@ try
             }
         }
 
+        if (Config.CGroup == WslDistributionConfig::CGroupVersion::v1 && getenv(LX_WSL2_DISTRO_CGROUP_PATH) != nullptr)
+        {
+            EMIT_USER_WARNING(wsl::shared::Localization::MessageCgroupV1IncompatibleWithDistroIsolation());
+        }
+
         if (Config.CGroup == WslDistributionConfig::CGroupVersion::v1)
         {
             THROW_LAST_ERROR_IF(mount("tmpfs", CGROUP_MOUNTPOINT, "tmpfs", (MS_NOSUID | MS_NODEV | MS_NOEXEC), "mode=755") < 0);

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1462,7 +1462,7 @@ std::wstring LxssWriteWslConfig(const std::wstring& Content)
 // writes distro specific settings /etc/wsl.conf
 std::string LxssWriteWslDistroConfig(const std::string& Content, LPCWSTR DistributionName)
 {
-    std::string path = std::format("\\\\wsl.localhost\\{}\\etc\\wsl.conf", wsl::shared::string::WideToMultiByte(DistributionName));
+    std::string path = std::format("\\\\wsl.localhost\\{}\\etc\\wsl.conf", DistributionName);
 
     std::ifstream distroConfigRead(path);
     auto previousContent = std::string{std::istreambuf_iterator<char>(distroConfigRead), {}};


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR serves as a follow up to comments in #40519
1. Remove the redundant string encoding conversion in std::format.
2. Add user warning when cgroup v1 is enabled and point the user to the correct .wslconfig setting.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
