### PR TITLE
Add --format option to wslc version command

### DIFF
--- a/src/windows/wslc/commands/VersionCommand.cpp
+++ b/src/windows/wslc/commands/VersionCommand.cpp
@@ -43,18 +43,6 @@ void VersionCommand::PrintVersion()
     wsl::windows::common::wslutil::PrintMessage(std::format(L"{} {}", s_ExecutableName, WSL_PACKAGE_VERSION));
 }
 
-void VersionCommand::ValidateArgumentsInternal(const ArgMap& execArgs) const
-{
-    if (execArgs.Contains(ArgType::Format))
-    {
-        auto format = execArgs.Get<ArgType::Format>();
-        if (!IsEqual(format, L"json") && !IsEqual(format, L"table"))
-        {
-            throw CommandException(Localization::WSLCCLI_InvalidFormatError());
-        }
-    }
-}
-
 void VersionCommand::ExecuteInternal(CLIExecutionContext& context) const
 {
     FormatType format = FormatType::Table;

--- a/src/windows/wslc/commands/VersionCommand.cpp
+++ b/src/windows/wslc/commands/VersionCommand.cpp
@@ -12,11 +12,22 @@ Abstract:
 
 --*/
 #include "VersionCommand.h"
+#include "ArgumentValidation.h"
+#include "JsonUtils.h"
 
 using namespace wsl::shared;
+using namespace wsl::shared::string;
 using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::models;
 
 namespace wsl::windows::wslc {
+std::vector<Argument> VersionCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::Format),
+    };
+}
+
 std::wstring VersionCommand::ShortDescription() const
 {
     return Localization::WSLCCLI_VersionDesc();
@@ -32,9 +43,40 @@ void VersionCommand::PrintVersion()
     wsl::windows::common::wslutil::PrintMessage(std::format(L"{} {}", s_ExecutableName, WSL_PACKAGE_VERSION));
 }
 
+void VersionCommand::ValidateArgumentsInternal(const ArgMap& execArgs) const
+{
+    if (execArgs.Contains(ArgType::Format))
+    {
+        auto format = execArgs.Get<ArgType::Format>();
+        if (!IsEqual(format, L"json") && !IsEqual(format, L"table"))
+        {
+            throw CommandException(Localization::WSLCCLI_InvalidFormatError());
+        }
+    }
+}
+
 void VersionCommand::ExecuteInternal(CLIExecutionContext& context) const
 {
-    UNREFERENCED_PARAMETER(context);
-    PrintVersion();
+    FormatType format = FormatType::Table;
+    if (context.Args.Contains(ArgType::Format))
+    {
+        format = validation::GetFormatTypeFromString(context.Args.Get<ArgType::Format>());
+    }
+
+    switch (format)
+    {
+    case FormatType::Json:
+    {
+        nlohmann::json root;
+        root["Client"]["Version"] = WSL_PACKAGE_VERSION;
+        wsl::windows::common::wslutil::PrintMessage(MultiByteToWide(root.dump(c_jsonPrettyPrintIndent)));
+        break;
+    }
+    case FormatType::Table:
+        PrintVersion();
+        break;
+    default:
+        THROW_HR(E_UNEXPECTED);
+    }
 }
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/VersionCommand.cpp
+++ b/src/windows/wslc/commands/VersionCommand.cpp
@@ -56,7 +56,7 @@ void VersionCommand::ExecuteInternal(CLIExecutionContext& context) const
     case FormatType::Json:
     {
         nlohmann::json root;
-        root["Client"]["Version"] = std::wstring{WSL_PACKAGE_VERSION};
+        root["Client"]["Version"] = std::string{WSL_PACKAGE_VERSION};
         wsl::windows::common::wslutil::PrintMessage(MultiByteToWide(root.dump(c_jsonPrettyPrintIndent)));
         break;
     }

--- a/src/windows/wslc/commands/VersionCommand.cpp
+++ b/src/windows/wslc/commands/VersionCommand.cpp
@@ -12,11 +12,22 @@ Abstract:
 
 --*/
 #include "VersionCommand.h"
+#include "ArgumentValidation.h"
+#include "JsonUtils.h"
 
 using namespace wsl::shared;
+using namespace wsl::shared::string;
 using namespace wsl::windows::wslc::execution;
+using namespace wsl::windows::wslc::models;
 
 namespace wsl::windows::wslc {
+std::vector<Argument> VersionCommand::GetArguments() const
+{
+    return {
+        Argument::Create(ArgType::Format),
+    };
+}
+
 std::wstring VersionCommand::ShortDescription() const
 {
     return Localization::WSLCCLI_VersionDesc();
@@ -34,7 +45,26 @@ void VersionCommand::PrintVersion()
 
 void VersionCommand::ExecuteInternal(CLIExecutionContext& context) const
 {
-    UNREFERENCED_PARAMETER(context);
-    PrintVersion();
+    FormatType format = FormatType::Table;
+    if (context.Args.Contains(ArgType::Format))
+    {
+        format = validation::GetFormatTypeFromString(context.Args.Get<ArgType::Format>());
+    }
+
+    switch (format)
+    {
+    case FormatType::Json:
+    {
+        nlohmann::json root;
+        root["Client"]["Version"] = WSL_PACKAGE_VERSION;
+        wsl::windows::common::wslutil::PrintMessage(MultiByteToWide(root.dump(c_jsonPrettyPrintIndent)));
+        break;
+    }
+    case FormatType::Table:
+        PrintVersion();
+        break;
+    default:
+        THROW_HR(E_UNEXPECTED);
+    }
 }
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/VersionCommand.cpp
+++ b/src/windows/wslc/commands/VersionCommand.cpp
@@ -56,7 +56,7 @@ void VersionCommand::ExecuteInternal(CLIExecutionContext& context) const
     case FormatType::Json:
     {
         nlohmann::json root;
-        root["Client"]["Version"] = WSL_PACKAGE_VERSION;
+        root["Client"]["Version"] = std::wstring{WSL_PACKAGE_VERSION};
         wsl::windows::common::wslutil::PrintMessage(MultiByteToWide(root.dump(c_jsonPrettyPrintIndent)));
         break;
     }

--- a/src/windows/wslc/commands/VersionCommand.h
+++ b/src/windows/wslc/commands/VersionCommand.h
@@ -22,6 +22,7 @@ struct VersionCommand final : public Command
     {
     }
     static void PrintVersion();
+    std::vector<Argument> GetArguments() const override;
     std::wstring ShortDescription() const override;
     std::wstring LongDescription() const override;
 

--- a/src/windows/wslc/commands/VersionCommand.h
+++ b/src/windows/wslc/commands/VersionCommand.h
@@ -22,10 +22,12 @@ struct VersionCommand final : public Command
     {
     }
     static void PrintVersion();
+    std::vector<Argument> GetArguments() const override;
     std::wstring ShortDescription() const override;
     std::wstring LongDescription() const override;
 
 protected:
+    void ValidateArgumentsInternal(const ArgMap& source) const override;
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/commands/VersionCommand.h
+++ b/src/windows/wslc/commands/VersionCommand.h
@@ -27,7 +27,6 @@ struct VersionCommand final : public Command
     std::wstring LongDescription() const override;
 
 protected:
-    void ValidateArgumentsInternal(const ArgMap& source) const override;
     void ExecuteInternal(CLIExecutionContext& context) const override;
 };
 } // namespace wsl::windows::wslc

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -300,6 +300,9 @@ COMMAND_LINE_TEST_CASE(L"image rm cont1 cont2 cont3 --force --no-prune", L"remov
 // Version command tests
 COMMAND_LINE_TEST_CASE(L"version", L"version", true)
 COMMAND_LINE_TEST_CASE(L"version --help", L"version", true)
+COMMAND_LINE_TEST_CASE(L"version --format json", L"version", true)
+COMMAND_LINE_TEST_CASE(L"version --format table", L"version", true)
+COMMAND_LINE_TEST_CASE(L"version --format invalid", L"version", false)
 COMMAND_LINE_TEST_CASE(L"version extraarg", L"version", false)
 // Settings command
 COMMAND_LINE_TEST_CASE(L"settings", L"settings", true)

--- a/test/windows/wslc/WSLCCLICommandUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLICommandUnitTests.cpp
@@ -162,13 +162,21 @@ class WSLCCLICommandUnitTests
         VERIFY_ARE_EQUAL(0u, cmd.GetCommands().size());
     }
 
-    // Test: Verify VersionCommand has no arguments (only the auto-added --help)
-    TEST_METHOD(VersionCommand_HasNoArguments)
+    // Test: Verify VersionCommand exposes the --format argument (plus the auto-added --help)
+    TEST_METHOD(VersionCommand_HasFormatArgument)
     {
         auto cmd = VersionCommand(L"wslc");
-        VERIFY_ARE_EQUAL(0u, cmd.GetArguments().size());
-        // Test out that auto added help command is the only one
-        VERIFY_ARE_EQUAL(1u, cmd.GetAllArguments().size());
+
+        auto args = cmd.GetArguments();
+        VERIFY_ARE_EQUAL(1u, args.size());
+
+        const auto& format = args[0];
+        VERIFY_ARE_EQUAL(ArgType::Format, format.Type());
+        VERIFY_ARE_EQUAL(Kind::Value, format.Kind());
+        VERIFY_IS_FALSE(format.Required());
+
+        // GetAllArguments also includes the auto-added --help.
+        VERIFY_ARE_EQUAL(2u, cmd.GetAllArguments().size());
     }
 
     // Test: Verify RootCommand contains VersionCommand as a subcommand

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -119,7 +119,7 @@ class WSLCE2EGlobalTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
         VERIFY_IS_TRUE(result.Stdout.has_value());
         const auto root = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(result.Stdout.value()));
-        VERIFY_ARE_EQUAL(wsl::shared::string::WideToMultiByte(WSL_PACKAGE_VERSION), root["Client"]["Version"].get<std::string>());
+        VERIFY_ARE_EQUAL(std::string{WSL_PACKAGE_VERSION}, root["Client"]["Version"].get<std::string>());
     }
 
     WSLC_TEST_METHOD(WSLCE2E_VersionCommand_FormatTable)

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -115,7 +115,11 @@ class WSLCE2EGlobalTests
 
     WSLC_TEST_METHOD(WSLCE2E_VersionCommand_FormatJson)
     {
-        RunWslcAndVerify(L"version --format json", {.Stdout = GetVersionJsonMessage(), .Stderr = L"", .ExitCode = 0});
+        auto result = RunWslc(L"version --format json");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(result.Stdout.has_value());
+        const auto root = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(result.Stdout.value()));
+        VERIFY_ARE_EQUAL(wsl::shared::string::WideToMultiByte(WSL_PACKAGE_VERSION), root["Client"]["Version"].get<std::string>());
     }
 
     WSLC_TEST_METHOD(WSLCE2E_VersionCommand_FormatTable)

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -113,6 +113,24 @@ class WSLCE2EGlobalTests
         RunWslcAndVerify(L"--version", {.Stdout = GetVersionMessage(), .Stderr = L"", .ExitCode = 0});
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_VersionCommand_FormatJson)
+    {
+        RunWslcAndVerify(L"version --format json", {.Stdout = GetVersionJsonMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_VersionCommand_FormatTable)
+    {
+        // Explicit table format matches the default plain-text output.
+        RunWslcAndVerify(L"version --format table", {.Stdout = GetVersionMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_VersionCommand_InvalidFormat)
+    {
+        auto result = RunWslc(L"version --format yaml");
+        VERIFY_ARE_NOT_EQUAL(0u, result.ExitCode.value_or(0));
+        VERIFY_IS_TRUE(result.StderrContainsSubstring(L"Supported format types are: json, table"));
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Session_DefaultElevated)
     {
         // Run container list to create the default elevated session
@@ -576,6 +594,13 @@ private:
     std::wstring GetVersionMessage() const
     {
         return std::format(L"wslc {}\r\n", WSL_PACKAGE_VERSION);
+    }
+
+    // The pretty-printed JSON emitted by `version --format json`. Internal '\n' from the JSON
+    // serializer and the trailing newline are translated to '\r\n' by the text-mode stdout.
+    std::wstring GetVersionJsonMessage() const
+    {
+        return std::format(L"{{\r\n  \"Client\": {{\r\n    \"Version\": \"{}\"\r\n  }}\r\n}}\r\n", WSL_PACKAGE_VERSION);
     }
 };
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -588,6 +588,7 @@ private:
     {
         return std::format(L"wslc {}\r\n", WSL_PACKAGE_VERSION);
     }
+
     std::wstring GetVersionJsonMessage() const
     {
         return std::format(L"{{\r\n  \"Client\": {{\r\n    \"Version\": \"{}\"\r\n  }}\r\n}}\r\n", WSL_PACKAGE_VERSION);

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -113,6 +113,17 @@ class WSLCE2EGlobalTests
         RunWslcAndVerify(L"--version", {.Stdout = GetVersionMessage(), .Stderr = L"", .ExitCode = 0});
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_VersionCommand_FormatJson)
+    {
+        RunWslcAndVerify(L"version --format json", {.Stdout = GetVersionJsonMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_VersionCommand_FormatTable)
+    {
+        // Explicit table format matches the default plain-text output.
+        RunWslcAndVerify(L"version --format table", {.Stdout = GetVersionMessage(), .Stderr = L"", .ExitCode = 0});
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Session_DefaultElevated)
     {
         // Run container list to create the default elevated session
@@ -576,6 +587,10 @@ private:
     std::wstring GetVersionMessage() const
     {
         return std::format(L"wslc {}\r\n", WSL_PACKAGE_VERSION);
+    }
+    std::wstring GetVersionJsonMessage() const
+    {
+        return std::format(L"{{\r\n  \"Client\": {{\r\n    \"Version\": \"{}\"\r\n  }}\r\n}}\r\n", WSL_PACKAGE_VERSION);
     }
 };
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -595,9 +595,6 @@ private:
     {
         return std::format(L"wslc {}\r\n", WSL_PACKAGE_VERSION);
     }
-
-    // The pretty-printed JSON emitted by `version --format json`. Internal '\n' from the JSON
-    // serializer and the trailing newline are translated to '\r\n' by the text-mode stdout.
     std::wstring GetVersionJsonMessage() const
     {
         return std::format(L"{{\r\n  \"Client\": {{\r\n    \"Version\": \"{}\"\r\n  }}\r\n}}\r\n", WSL_PACKAGE_VERSION);

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -592,10 +592,5 @@ private:
     {
         return std::format(L"wslc {}\r\n", WSL_PACKAGE_VERSION);
     }
-
-    std::wstring GetVersionJsonMessage() const
-    {
-        return std::format(L"{{\r\n  \"Client\": {{\r\n    \"Version\": \"{}\"\r\n  }}\r\n}}\r\n", WSL_PACKAGE_VERSION);
-    }
 };
 } // namespace WSLCE2ETests


### PR DESCRIPTION
This pull request adds support for a `--format` argument to the `version` command, allowing users to choose between JSON and table (plain text) output formats. It also introduces validation for the argument, updates the command execution logic to handle both formats, and adds comprehensive end-to-end tests for the new functionality.

**New argument and validation for `version` command:**

- Added a `--format` argument to the `VersionCommand`, enabling output in either `json` or `table` format. The argument is validated to accept only these two formats; otherwise, an error is thrown. [[1]](diffhunk://#diff-6e7f2513cd59d813fa697bb559e7898d6716e1bcb7d3b0eca10189c0578a4df7R15-R30) [[2]](diffhunk://#diff-6e7f2513cd59d813fa697bb559e7898d6716e1bcb7d3b0eca10189c0578a4df7R46-R80) [[3]](diffhunk://#diff-be827ddad3991855117bca45081cf426c40035bb05852330cdc4a8547c150121R25-R30)

**Command execution logic enhancements:**

- Updated the `ExecuteInternal` method to output the version information as pretty-printed JSON when `--format json` is specified, or as plain text for `--format table` (or by default).

**End-to-end test coverage:**

- Added new E2E tests to verify correct behavior for `version --format json`, `version --format table`, and invalid format values, ensuring robust validation and output.
- Added a helper method to generate the expected JSON output for testing.Support `wslc version --format json`, which prints the version as pretty-printed JSON of the form {"Client":{"Version":"..."}}. The default and explicit `table` format keep the existing plain-text output. Invalid format values are rejected with a localized error.

Add end-to-end tests covering the json, table, and invalid-format paths.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
