### PR TITLE
Refine CODEOWNERS for WSLC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,6 @@
 /src/windows/common/WSLC*          @microsoft/wsl-maintainers @microsoft/wslc-team
 /src/windows/service/exe/WSLC*     @microsoft/wsl-maintainers @microsoft/wslc-team
 /src/windows/service/inc/wslc.idl  @microsoft/wsl-maintainers @microsoft/wslc-team
+/src/windows/service/inc/WSLC*.idl @microsoft/wsl-maintainers @microsoft/wslc-team
 /src/windows/inc/wslc_schema.h     @microsoft/wsl-maintainers @microsoft/wslc-team
 /src/linux/init/WSLC*              @microsoft/wsl-maintainers @microsoft/wslc-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,15 @@
-# File containing policy for file ownership
-
-# Reviewers for all files in the repository
+# Default ownership
 * @microsoft/wsl-maintainers
-* @microsoft/wslc-team
+
+# WSLC
+/src/windows/wslc/         @microsoft/wsl-maintainers @microsoft/wslc-team
+/src/windows/wslcsession/  @microsoft/wsl-maintainers @microsoft/wslc-team
+/src/windows/WslcSDK/      @microsoft/wsl-maintainers @microsoft/wslc-team
+/test/windows/wslc/        @microsoft/wsl-maintainers @microsoft/wslc-team
+
+# WSLC surfaces in shared components
+/src/windows/common/WSLC*          @microsoft/wsl-maintainers @microsoft/wslc-team
+/src/windows/service/exe/WSLC*     @microsoft/wsl-maintainers @microsoft/wslc-team
+/src/windows/service/inc/wslc.idl  @microsoft/wsl-maintainers @microsoft/wslc-team
+/src/windows/inc/wslc_schema.h     @microsoft/wsl-maintainers @microsoft/wslc-team
+/src/linux/init/WSLC*              @microsoft/wsl-maintainers @microsoft/wslc-team


### PR DESCRIPTION
Restore WSL maintainers as the default owners and scope WSLC team ownership to WSLC-specific components and tests.