### PR TITLE
Cap guest usage of host ephemeral range to half of the ports in mirrored mode

### DIFF
--- a/src/windows/service/exe/WslCoreGuestNetworkService.cpp
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.cpp
@@ -64,6 +64,9 @@ void wsl::core::networking::GuestNetworkService::CreateGuestNetworkService(
         TraceLoggingValue(m_hostUdpEphemeralPortRange.first, "udpStartPort"),
         TraceLoggingValue(m_hostUdpEphemeralPortRange.second, "udpEndPort"));
 
+    m_hostTcpEphemeralPortCap = ComputeHostEphemeralPortCap(IPPROTO_TCP);
+    m_hostUdpEphemeralPortCap = ComputeHostEphemeralPortCap(IPPROTO_UDP);
+
     hns::GuestNetworkService request{};
     request.VirtualMachineId = VmId;
     request.MirrorHostNetworking = true;
@@ -126,6 +129,11 @@ std::pair<uint16_t, uint16_t> wsl::core::networking::GuestNetworkService::Alloca
     THROW_IF_FAILED(m_allocatePortRange.value()(m_service.get(), c_ephemeralPortRangeSize, &m_reservedPortRange, &port));
 
     WI_ASSERT(m_reservedPortRange.endingPort - m_reservedPortRange.startingPort == c_ephemeralPortRangeSize);
+
+    // Count the overlap of the guest's reserved ephemeral range with the host ephemeral range
+    // and seed the in-use counters accordingly.
+    m_hostTcpEphemeralPortsInUse = ComputeHostEphemeralOverlap(IPPROTO_TCP);
+    m_hostUdpEphemeralPortsInUse = ComputeHostEphemeralOverlap(IPPROTO_UDP);
 
     // setting the port to zero as we do not expect any bind requests to be sent to wslcore for ports in this range
     m_reservedPorts.emplace(std::make_pair(HCN_PORT_PROTOCOL_TCP, static_cast<uint16_t>(0)), HcnPortReservation{port, 1});
@@ -225,6 +233,32 @@ bool wsl::core::networking::GuestNetworkService::IsPortInGuestEphemeralRange(uin
     return PortNumber >= m_reservedPortRange.startingPort && PortNumber <= m_reservedPortRange.endingPort;
 }
 
+uint32_t wsl::core::networking::GuestNetworkService::ComputeHostEphemeralPortCap(int Protocol) const noexcept
+{
+    const auto& range = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortRange : m_hostTcpEphemeralPortRange;
+    if (range.second < range.first)
+    {
+        return 0;
+    }
+
+    // Cap the guest at (at most) half of the host ephemeral range so it can't exhaust the host's ports.
+    return (static_cast<uint32_t>(range.second) - range.first + 1) / 2;
+}
+
+uint32_t wsl::core::networking::GuestNetworkService::ComputeHostEphemeralOverlap(int Protocol) const noexcept
+{
+    const auto& range = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortRange : m_hostTcpEphemeralPortRange;
+    if (range.second < range.first)
+    {
+        return 0;
+    }
+
+    // Number of guest reserved ports that fall within the host ephemeral range.
+    const uint32_t overlapStart = std::max<uint32_t>(m_reservedPortRange.startingPort, range.first);
+    const uint32_t overlapEnd = std::min<uint32_t>(m_reservedPortRange.endingPort, range.second);
+    return (overlapStart <= overlapEnd) ? (overlapEnd - overlapStart + 1) : 0;
+}
+
 int wsl::core::networking::GuestNetworkService::OnPortAllocationRequest(const SOCKADDR_INET& Address, _In_ int Protocol, _In_ bool Allocate) noexcept
 try
 {
@@ -263,21 +297,6 @@ try
 
     const auto lock = m_dataLock.lock_exclusive();
 
-    // The guest's reserved ephemeral range can overlap with the host range. Ports in
-    // the guest range are safe for the guest to use even if they fall within the host range.
-    if (IsPortInHostEphemeralRange(PortNumber, Protocol) && !IsPortInGuestEphemeralRange(PortNumber))
-    {
-        const auto& range = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortRange : m_hostTcpEphemeralPortRange;
-        WSL_LOG(
-            "GuestNetworkService::OnPortAllocationRequest - denying port in host ephemeral range",
-            TraceLoggingValue(StringAddress.c_str(), "IP address"),
-            TraceLoggingValue(Protocol == IPPROTO_TCP ? "TCP" : "UDP", "protocol"),
-            TraceLoggingValue(PortNumber, "portNumber"),
-            TraceLoggingValue(range.first, "hostEphemeralStart"),
-            TraceLoggingValue(range.second, "hostEphemeralEnd"));
-        return -LX_EADDRINUSE;
-    }
-
     if (IsPortInGuestEphemeralRange(PortNumber))
     {
         WSL_LOG(
@@ -289,6 +308,8 @@ try
             TraceLoggingValue(StringAddress.c_str(), "IP address"));
         return 0;
     }
+
+    const bool isHostEphemeralPort = IsPortInHostEphemeralRange(PortNumber, Protocol);
 
     HRESULT result = E_UNEXPECTED;
     const auto it = m_reservedPorts.find(std::make_pair(HnsProtocol, PortNumber));
@@ -305,6 +326,24 @@ try
                 TraceLoggingValue(Protocol, "Protocol"),
                 TraceLoggingValue(it->second.ReferenceCount, "ReferenceCount"));
             return 0;
+        }
+
+        // New reservation for a port in the host ephemeral range: enforce the cap.
+        if (isHostEphemeralPort)
+        {
+            const auto cap = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortCap : m_hostTcpEphemeralPortCap;
+            auto& portsInUse = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse;
+            if (portsInUse >= cap)
+            {
+                WSL_LOG(
+                    "GuestNetworkService::OnPortAllocationRequest - denying port in host ephemeral range, cap reached",
+                    TraceLoggingValue(StringAddress.c_str(), "IP address"),
+                    TraceLoggingValue(Protocol == IPPROTO_TCP ? "TCP" : "UDP", "protocol"),
+                    TraceLoggingValue(PortNumber, "portNumber"),
+                    TraceLoggingValue(portsInUse, "hostEphemeralPortsInUse"),
+                    TraceLoggingValue(cap, "hostEphemeralPortCap"));
+                return -LX_EADDRINUSE;
+            }
         }
 
         HANDLE port{nullptr};
@@ -324,6 +363,11 @@ try
         if (SUCCEEDED(result))
         {
             m_reservedPorts.emplace(std::make_pair(HnsProtocol, PortNumber), HcnPortReservation{port, 1});
+
+            if (isHostEphemeralPort)
+            {
+                ((Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse)++;
+            }
         }
         // if the port was reserved, we successfully handed over ownership
         releasePortOnError.release();
@@ -347,6 +391,16 @@ try
         {
             result = m_releasePort.value()(it->second.Handle);
             m_reservedPorts.erase(it);
+
+            if (isHostEphemeralPort)
+            {
+                auto& portsInUse = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse;
+                if (portsInUse > 0)
+                {
+                    portsInUse--;
+                }
+            }
+
             WSL_LOG(
                 "GuestNetworkService::OnPortAllocationRequest - released port",
                 TraceLoggingValue(PortNumber, "Port"),
@@ -387,6 +441,9 @@ void wsl::core::networking::GuestNetworkService::Stop() noexcept
             m_releasePort.value()(reservedPort.second.Handle);
         }
         m_reservedPorts.clear();
+
+        m_hostTcpEphemeralPortsInUse = 0;
+        m_hostUdpEphemeralPortsInUse = 0;
     }
 
     m_guestNetworkServiceCallback.reset();

--- a/src/windows/service/exe/WslCoreGuestNetworkService.cpp
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.cpp
@@ -68,9 +68,6 @@ void wsl::core::networking::GuestNetworkService::CreateGuestNetworkService(
         TraceLoggingValue(m_hostUdpEphemeralPortRange.first, "udpStartPort"),
         TraceLoggingValue(m_hostUdpEphemeralPortRange.second, "udpEndPort"));
 
-    m_hostTcpEphemeralPortCap = ComputeHostEphemeralPortCap(IPPROTO_TCP);
-    m_hostUdpEphemeralPortCap = ComputeHostEphemeralPortCap(IPPROTO_UDP);
-
     hns::GuestNetworkService request{};
     request.VirtualMachineId = VmId;
     request.MirrorHostNetworking = true;
@@ -328,7 +325,7 @@ try
         // New reservation for a port in the host ephemeral range: enforce the cap.
         if (isHostEphemeralPort)
         {
-            const auto cap = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortCap : m_hostTcpEphemeralPortCap;
+            const auto cap = ComputeHostEphemeralPortCap(Protocol);
             const auto portsInUse = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse;
             if (portsInUse >= cap)
             {

--- a/src/windows/service/exe/WslCoreGuestNetworkService.cpp
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.cpp
@@ -329,7 +329,7 @@ try
         if (isHostEphemeralPort)
         {
             const auto cap = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortCap : m_hostTcpEphemeralPortCap;
-            auto& portsInUse = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse;
+            const auto portsInUse = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse;
             if (portsInUse >= cap)
             {
                 WSL_LOG(
@@ -363,7 +363,8 @@ try
 
             if (isHostEphemeralPort)
             {
-                ((Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse)++;
+                auto& portsInUse = Protocol == IPPROTO_UDP ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse;
+                portsInUse++;
             }
         }
         // if the port was reserved, we successfully handed over ownership

--- a/src/windows/service/exe/WslCoreGuestNetworkService.cpp
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.cpp
@@ -57,6 +57,10 @@ void wsl::core::networking::GuestNetworkService::CreateGuestNetworkService(
 
     m_hostTcpEphemeralPortRange = QueryHostEphemeralPortRange(L"MSFT_NetTCPSetting");
     m_hostUdpEphemeralPortRange = QueryHostEphemeralPortRange(L"MSFT_NetUDPSetting");
+
+    WI_ASSERT(m_hostTcpEphemeralPortRange.first <= m_hostTcpEphemeralPortRange.second);
+    WI_ASSERT(m_hostUdpEphemeralPortRange.first <= m_hostUdpEphemeralPortRange.second);
+
     WSL_LOG(
         "GuestNetworkService::CreateGuestNetworkService - host ephemeral port ranges",
         TraceLoggingValue(m_hostTcpEphemeralPortRange.first, "tcpStartPort"),
@@ -233,30 +237,23 @@ bool wsl::core::networking::GuestNetworkService::IsPortInGuestEphemeralRange(uin
     return PortNumber >= m_reservedPortRange.startingPort && PortNumber <= m_reservedPortRange.endingPort;
 }
 
-uint32_t wsl::core::networking::GuestNetworkService::ComputeHostEphemeralPortCap(int Protocol) const noexcept
+uint16_t wsl::core::networking::GuestNetworkService::ComputeHostEphemeralPortCap(int Protocol) const noexcept
 {
     const auto& range = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortRange : m_hostTcpEphemeralPortRange;
-    if (range.second < range.first)
-    {
-        return 0;
-    }
 
-    // Cap the guest at (at most) half of the host ephemeral range so it can't exhaust the host's ports.
-    return (static_cast<uint32_t>(range.second) - range.first + 1) / 2;
+    // Cap the guest at half of the host ephemeral range so it can't exhaust the host's ports. The
+    // host range is always at least 255, so the cap will fit in uint16_t, no risk of overflow.
+    return static_cast<uint16_t>((range.second - range.first + 1) / 2);
 }
 
-uint32_t wsl::core::networking::GuestNetworkService::ComputeHostEphemeralOverlap(int Protocol) const noexcept
+uint16_t wsl::core::networking::GuestNetworkService::ComputeHostEphemeralOverlap(int Protocol) const noexcept
 {
     const auto& range = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortRange : m_hostTcpEphemeralPortRange;
-    if (range.second < range.first)
-    {
-        return 0;
-    }
 
     // Number of guest reserved ports that fall within the host ephemeral range.
-    const uint32_t overlapStart = std::max<uint32_t>(m_reservedPortRange.startingPort, range.first);
-    const uint32_t overlapEnd = std::min<uint32_t>(m_reservedPortRange.endingPort, range.second);
-    return (overlapStart <= overlapEnd) ? (overlapEnd - overlapStart + 1) : 0;
+    const uint16_t overlapStart = std::max<uint16_t>(m_reservedPortRange.startingPort, range.first);
+    const uint16_t overlapEnd = std::min<uint16_t>(m_reservedPortRange.endingPort, range.second);
+    return (overlapStart <= overlapEnd) ? static_cast<uint16_t>(overlapEnd - overlapStart + 1) : 0;
 }
 
 int wsl::core::networking::GuestNetworkService::OnPortAllocationRequest(const SOCKADDR_INET& Address, _In_ int Protocol, _In_ bool Allocate) noexcept
@@ -392,13 +389,14 @@ try
             result = m_releasePort.value()(it->second.Handle);
             m_reservedPorts.erase(it);
 
-            if (isHostEphemeralPort)
+            // Only decrement the in-use counter when the release actually succeeded. If the release
+            // failed the reservation may still exist on the host, and undercounting would let the
+            // guest exceed the intended cap.
+            if (isHostEphemeralPort && SUCCEEDED(result))
             {
                 auto& portsInUse = (Protocol == IPPROTO_UDP) ? m_hostUdpEphemeralPortsInUse : m_hostTcpEphemeralPortsInUse;
-                if (portsInUse > 0)
-                {
-                    portsInUse--;
-                }
+                WI_ASSERT(portsInUse > 0);
+                portsInUse--;
             }
 
             WSL_LOG(

--- a/src/windows/service/exe/WslCoreGuestNetworkService.h
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.h
@@ -90,7 +90,7 @@ private:
     uint32_t m_hostTcpEphemeralPortCap{};
     uint32_t m_hostUdpEphemeralPortCap{};
 
-    _Guarded_by_(m_dataLock) uint32_t m_hostTcpEphemeralPortsInUse{};
-    _Guarded_by_(m_dataLock) uint32_t m_hostUdpEphemeralPortsInUse{};
+    _Guarded_by_(m_dataLock) uint32_t m_hostTcpEphemeralPortsInUse {};
+    _Guarded_by_(m_dataLock) uint32_t m_hostUdpEphemeralPortsInUse {};
 };
 } // namespace wsl::core::networking

--- a/src/windows/service/exe/WslCoreGuestNetworkService.h
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.h
@@ -64,6 +64,11 @@ private:
     _Requires_lock_held_(m_dataLock)
     bool IsPortInGuestEphemeralRange(uint16_t PortNumber) const noexcept;
 
+    uint32_t ComputeHostEphemeralPortCap(int Protocol) const noexcept;
+
+    _Requires_lock_held_(m_dataLock)
+    uint32_t ComputeHostEphemeralOverlap(int Protocol) const noexcept;
+
     static std::pair<uint16_t, uint16_t> QueryHostEphemeralPortRange(LPCWSTR WmiClassName) noexcept;
 
     static std::optional<LxssDynamicFunction<decltype(HcnReserveGuestNetworkServicePortRange)>> m_allocatePortRange;
@@ -81,5 +86,11 @@ private:
     // Host ephemeral port ranges can change. They are queried once at startup, if a change occurs, the service will need to be restarted.
     std::pair<uint16_t, uint16_t> m_hostTcpEphemeralPortRange{};
     std::pair<uint16_t, uint16_t> m_hostUdpEphemeralPortRange{};
+
+    uint32_t m_hostTcpEphemeralPortCap{};
+    uint32_t m_hostUdpEphemeralPortCap{};
+
+    _Guarded_by_(m_dataLock) uint32_t m_hostTcpEphemeralPortsInUse{};
+    _Guarded_by_(m_dataLock) uint32_t m_hostUdpEphemeralPortsInUse{};
 };
 } // namespace wsl::core::networking

--- a/src/windows/service/exe/WslCoreGuestNetworkService.h
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.h
@@ -88,9 +88,6 @@ private:
     std::pair<uint16_t, uint16_t> m_hostTcpEphemeralPortRange{};
     std::pair<uint16_t, uint16_t> m_hostUdpEphemeralPortRange{};
 
-    uint16_t m_hostTcpEphemeralPortCap{};
-    uint16_t m_hostUdpEphemeralPortCap{};
-
     _Guarded_by_(m_dataLock) uint16_t m_hostTcpEphemeralPortsInUse {};
     _Guarded_by_(m_dataLock) uint16_t m_hostUdpEphemeralPortsInUse {};
 };

--- a/src/windows/service/exe/WslCoreGuestNetworkService.h
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.h
@@ -64,10 +64,10 @@ private:
     _Requires_lock_held_(m_dataLock)
     bool IsPortInGuestEphemeralRange(uint16_t PortNumber) const noexcept;
 
-    uint32_t ComputeHostEphemeralPortCap(int Protocol) const noexcept;
+    uint16_t ComputeHostEphemeralPortCap(int Protocol) const noexcept;
 
     _Requires_lock_held_(m_dataLock)
-    uint32_t ComputeHostEphemeralOverlap(int Protocol) const noexcept;
+    uint16_t ComputeHostEphemeralOverlap(int Protocol) const noexcept;
 
     static std::pair<uint16_t, uint16_t> QueryHostEphemeralPortRange(LPCWSTR WmiClassName) noexcept;
 
@@ -83,14 +83,15 @@ private:
     _Guarded_by_(m_dataLock) std::map<std::pair<HCN_PORT_PROTOCOL, USHORT>, HcnPortReservation> m_reservedPorts;
     _Guarded_by_(m_dataLock) HCN_PORT_RANGE_RESERVATION m_reservedPortRange {};
 
-    // Host ephemeral port ranges can change. They are queried once at startup, if a change occurs, the service will need to be restarted.
+    // Host ephemeral port ranges can change. They are queried once at startup, if a change occurs, the service will need to be
+    // restarted. Note: The host ephemeral range will be the same for both IPv4 and IPv6, but can be different for TCP and UDP.
     std::pair<uint16_t, uint16_t> m_hostTcpEphemeralPortRange{};
     std::pair<uint16_t, uint16_t> m_hostUdpEphemeralPortRange{};
 
-    uint32_t m_hostTcpEphemeralPortCap{};
-    uint32_t m_hostUdpEphemeralPortCap{};
+    uint16_t m_hostTcpEphemeralPortCap{};
+    uint16_t m_hostUdpEphemeralPortCap{};
 
-    _Guarded_by_(m_dataLock) uint32_t m_hostTcpEphemeralPortsInUse {};
-    _Guarded_by_(m_dataLock) uint32_t m_hostUdpEphemeralPortsInUse {};
+    _Guarded_by_(m_dataLock) uint16_t m_hostTcpEphemeralPortsInUse {};
+    _Guarded_by_(m_dataLock) uint16_t m_hostUdpEphemeralPortsInUse {};
 };
 } // namespace wsl::core::networking

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4283,66 +4283,6 @@ class MirroredTests
         VERIFY_IS_TRUE(canBindUdp);
     }
 
-    void VerifyGuestBindToHostEphemeralRangeDenied(LPCWSTR ProtocolSettingClass, LPCWSTR SocatProtocolPrefix)
-    {
-        MIRRORED_NETWORKING_TEST_ONLY();
-
-        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
-        WaitForMirroredStateInLinux();
-
-        // Query the host ephemeral port range via PowerShell.
-        auto startQuery =
-            std::wstring(L"(") + ProtocolSettingClass +
-            L" | Where-Object { $_.DynamicPortRangeStartPort -gt 0 } | Select-Object -First 1).DynamicPortRangeStartPort";
-        auto [startStr, _1] = LxsstuLaunchPowershellAndCaptureOutput(startQuery.c_str(), 0);
-        const auto hostEphemeralStart = std::stoi(startStr);
-
-        auto countQuery =
-            std::wstring(L"(") + ProtocolSettingClass +
-            L" | Where-Object { $_.DynamicPortRangeNumberOfPorts -gt 0 } | Select-Object -First 1).DynamicPortRangeNumberOfPorts";
-        auto [countStr, _2] = LxsstuLaunchPowershellAndCaptureOutput(countQuery.c_str(), 0);
-        const auto hostEphemeralEnd = hostEphemeralStart + std::stoi(countStr) - 1;
-
-        // Get the guest ephemeral port range.
-        auto [start, err1] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f1", 0);
-        start.pop_back();
-        const auto guestEphemeralRangeStart = std::stoi(start);
-
-        auto [end, err2] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f2", 0);
-        end.pop_back();
-        const auto guestEphemeralRangeEnd = std::stoi(end);
-
-        // Pick a port in the host ephemeral range but not in the guest's assigned range.
-        // The ranges may overlap
-        int testPort = 0;
-        if (hostEphemeralStart < guestEphemeralRangeStart || hostEphemeralStart > guestEphemeralRangeEnd)
-        {
-            testPort = hostEphemeralStart;
-        }
-        else if (guestEphemeralRangeEnd < hostEphemeralEnd)
-        {
-            testPort = guestEphemeralRangeEnd + 1;
-        }
-        else
-        {
-            VERIFY_FAIL(L"Guest ephemeral range fully covers the host ephemeral range, cannot find a test port");
-        }
-
-        auto socatArg = std::wstring(SocatProtocolPrefix) + std::to_wstring(testPort);
-        auto [listener, success, read] = NetworkTests::BindGuestPortHelper(socatArg);
-        VERIFY_IS_FALSE(success);
-    }
-
-    WSL2_TEST_METHOD(GuestTcpBindToHostEphemeralRangeDenied)
-    {
-        VerifyGuestBindToHostEphemeralRangeDenied(L"Get-NetTCPSetting", L"TCP4-LISTEN:");
-    }
-
-    WSL2_TEST_METHOD(GuestUdpBindToHostEphemeralRangeDenied)
-    {
-        VerifyGuestBindToHostEphemeralRangeDenied(L"Get-NetUDPSetting", L"UDP4-LISTEN:");
-    }
-
     WSL2_TEST_METHOD(NonRootNamespaceEphemeralBind)
     {
         MIRRORED_NETWORKING_TEST_ONLY();

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2132,18 +2132,19 @@ class NetworkTests
 
         // The port-0 resolution is asynchronous (deferred to a background thread).
         // Retry until the host port tracker registers the port, blocking the host bind.
-        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
-            [&assignedPort]() {
-                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
-                THROW_LAST_ERROR_IF(!sock);
+        VERIFY_NO_THROW(
+            wsl::shared::retry::RetryWithTimeout<void>(
+                [&assignedPort]() {
+                    wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                    THROW_LAST_ERROR_IF(!sock);
 
-                SOCKADDR_IN addr{};
-                addr.sin_family = AF_INET;
-                addr.sin_port = htons(assignedPort);
-                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) != SOCKET_ERROR);
-            },
-            std::chrono::seconds(1),
-            std::chrono::seconds(30)));
+                    SOCKADDR_IN addr{};
+                    addr.sin_family = AF_INET;
+                    addr.sin_port = htons(assignedPort);
+                    THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) != SOCKET_ERROR);
+                },
+                std::chrono::seconds(1),
+                std::chrono::seconds(30)));
 
         if (!verifyRelease)
         {
@@ -2154,18 +2155,19 @@ class NetworkTests
         guestProcess.reset();
 
         // Retry until the host can bind the port again, confirming it was released.
-        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
-            [&assignedPort]() {
-                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
-                THROW_LAST_ERROR_IF(!sock);
+        VERIFY_NO_THROW(
+            wsl::shared::retry::RetryWithTimeout<void>(
+                [&assignedPort]() {
+                    wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                    THROW_LAST_ERROR_IF(!sock);
 
-                SOCKADDR_IN addr{};
-                addr.sin_family = AF_INET;
-                addr.sin_port = htons(assignedPort);
-                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) == SOCKET_ERROR);
-            },
-            std::chrono::seconds(1),
-            std::chrono::minutes(2)));
+                    SOCKADDR_IN addr{};
+                    addr.sin_family = AF_INET;
+                    addr.sin_port = htons(assignedPort);
+                    THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) == SOCKET_ERROR);
+                },
+                std::chrono::seconds(1),
+                std::chrono::minutes(2)));
     }
 
     static void VerifyPortZeroRebindSucceeds()
@@ -2174,15 +2176,16 @@ class NetworkTests
         // Uses a perl one-liner to perform the entire sequence in a single process,
         // matching the semantics of a native C test (no SO_REUSEADDR, same-process rebind).
         VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"perl -MSocket -e '"
-                            L"socket(S1,AF_INET,SOCK_STREAM,0) or die;"
-                            L"bind(S1,sockaddr_in(0,INADDR_ANY)) or die;"
-                            L"my $port=(sockaddr_in(getsockname(S1)))[0];"
-                            L"close(S1);"
-                            L"socket(S2,AF_INET,SOCK_STREAM,0) or die;"
-                            L"bind(S2,sockaddr_in($port,INADDR_ANY)) or die;"
-                            L"close(S2)"
-                            L"'"),
+            LxsstuLaunchWsl(
+                L"perl -MSocket -e '"
+                L"socket(S1,AF_INET,SOCK_STREAM,0) or die;"
+                L"bind(S1,sockaddr_in(0,INADDR_ANY)) or die;"
+                L"my $port=(sockaddr_in(getsockname(S1)))[0];"
+                L"close(S1);"
+                L"socket(S2,AF_INET,SOCK_STREAM,0) or die;"
+                L"bind(S2,sockaddr_in($port,INADDR_ANY)) or die;"
+                L"close(S2)"
+                L"'"),
             0L);
     }
 
@@ -2481,8 +2484,10 @@ class NetworkTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Verify we have connectivity from the networking namespace when using ephemeral port selection.
@@ -2968,8 +2973,8 @@ class NetworkTests
             }
             else if (std::regex_search(line, match, routePattern) && match.size() >= 4)
             {
-                state.Routes.emplace_back(Route{
-                    match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
+                state.Routes.emplace_back(
+                    Route{match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
             }
         }
 
@@ -4352,12 +4357,15 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Add rule for port forwarding traffic with destination port 8080 to port 80 in the new namespace
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat PREROUTING tcp dport 8080 dnat to 192.168.15.2:80"), 0);
 
         // Start listeners in root namespace on port 8080 and new namespace on port 80
@@ -4431,8 +4439,10 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Create a listener on the Windows host on port 1234

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2132,19 +2132,18 @@ class NetworkTests
 
         // The port-0 resolution is asynchronous (deferred to a background thread).
         // Retry until the host port tracker registers the port, blocking the host bind.
-        VERIFY_NO_THROW(
-            wsl::shared::retry::RetryWithTimeout<void>(
-                [&assignedPort]() {
-                    wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
-                    THROW_LAST_ERROR_IF(!sock);
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&assignedPort]() {
+                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                THROW_LAST_ERROR_IF(!sock);
 
-                    SOCKADDR_IN addr{};
-                    addr.sin_family = AF_INET;
-                    addr.sin_port = htons(assignedPort);
-                    THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) != SOCKET_ERROR);
-                },
-                std::chrono::seconds(1),
-                std::chrono::seconds(30)));
+                SOCKADDR_IN addr{};
+                addr.sin_family = AF_INET;
+                addr.sin_port = htons(assignedPort);
+                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) != SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::seconds(30)));
 
         if (!verifyRelease)
         {
@@ -2155,19 +2154,18 @@ class NetworkTests
         guestProcess.reset();
 
         // Retry until the host can bind the port again, confirming it was released.
-        VERIFY_NO_THROW(
-            wsl::shared::retry::RetryWithTimeout<void>(
-                [&assignedPort]() {
-                    wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
-                    THROW_LAST_ERROR_IF(!sock);
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&assignedPort]() {
+                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                THROW_LAST_ERROR_IF(!sock);
 
-                    SOCKADDR_IN addr{};
-                    addr.sin_family = AF_INET;
-                    addr.sin_port = htons(assignedPort);
-                    THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) == SOCKET_ERROR);
-                },
-                std::chrono::seconds(1),
-                std::chrono::minutes(2)));
+                SOCKADDR_IN addr{};
+                addr.sin_family = AF_INET;
+                addr.sin_port = htons(assignedPort);
+                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) == SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::minutes(2)));
     }
 
     static void VerifyPortZeroRebindSucceeds()
@@ -2176,16 +2174,15 @@ class NetworkTests
         // Uses a perl one-liner to perform the entire sequence in a single process,
         // matching the semantics of a native C test (no SO_REUSEADDR, same-process rebind).
         VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(
-                L"perl -MSocket -e '"
-                L"socket(S1,AF_INET,SOCK_STREAM,0) or die;"
-                L"bind(S1,sockaddr_in(0,INADDR_ANY)) or die;"
-                L"my $port=(sockaddr_in(getsockname(S1)))[0];"
-                L"close(S1);"
-                L"socket(S2,AF_INET,SOCK_STREAM,0) or die;"
-                L"bind(S2,sockaddr_in($port,INADDR_ANY)) or die;"
-                L"close(S2)"
-                L"'"),
+            LxsstuLaunchWsl(L"perl -MSocket -e '"
+                            L"socket(S1,AF_INET,SOCK_STREAM,0) or die;"
+                            L"bind(S1,sockaddr_in(0,INADDR_ANY)) or die;"
+                            L"my $port=(sockaddr_in(getsockname(S1)))[0];"
+                            L"close(S1);"
+                            L"socket(S2,AF_INET,SOCK_STREAM,0) or die;"
+                            L"bind(S2,sockaddr_in($port,INADDR_ANY)) or die;"
+                            L"close(S2)"
+                            L"'"),
             0L);
     }
 
@@ -2484,10 +2481,8 @@ class NetworkTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Verify we have connectivity from the networking namespace when using ephemeral port selection.
@@ -2973,8 +2968,8 @@ class NetworkTests
             }
             else if (std::regex_search(line, match, routePattern) && match.size() >= 4)
             {
-                state.Routes.emplace_back(
-                    Route{match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
+                state.Routes.emplace_back(Route{
+                    match.str(2), match.str(3), {match.str(1)}, match.size() > 5 && match[5].matched ? std::stoi(match.str(5)) : 0});
             }
         }
 
@@ -4357,15 +4352,12 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Add rule for port forwarding traffic with destination port 8080 to port 80 in the new namespace
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat PREROUTING { type nat hook prerouting priority dstnat; }\""), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat PREROUTING tcp dport 8080 dnat to 192.168.15.2:80"), 0);
 
         // Start listeners in root namespace on port 8080 and new namespace on port 80
@@ -4439,10 +4431,8 @@ class MirroredTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip addr add 192.168.15.1/24 dev testbridge"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ip -n testns route add default via 192.168.15.1 dev veth-test"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add table nat"), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
-        VERIFY_ARE_EQUAL(
-            LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft \"add chain nat POSTROUTING { type nat hook postrouting priority srcnat; }\""), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"--system --user root nft add rule nat POSTROUTING ip saddr 192.168.15.0/24 oif != testbridge masquerade"), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_forward=1"), 0);
 
         // Create a listener on the Windows host on port 1234

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4283,6 +4283,147 @@ class MirroredTests
         VERIFY_IS_TRUE(canBindUdp);
     }
 
+    static std::pair<int, int> QueryHostEphemeralRange(LPCWSTR ProtocolSettingCmdlet)
+    {
+        const auto startQuery =
+            std::wstring(L"(") + ProtocolSettingCmdlet +
+            L" | Where-Object { $_.DynamicPortRangeStartPort -gt 0 } | Select-Object -First 1).DynamicPortRangeStartPort";
+        auto [startStr, _1] = LxsstuLaunchPowershellAndCaptureOutput(startQuery, 0);
+        const auto start = std::stoi(startStr);
+
+        const auto countQuery =
+            std::wstring(L"(") + ProtocolSettingCmdlet +
+            L" | Where-Object { $_.DynamicPortRangeNumberOfPorts -gt 0 } | Select-Object -First 1).DynamicPortRangeNumberOfPorts";
+        auto [countStr, _2] = LxsstuLaunchPowershellAndCaptureOutput(countQuery, 0);
+        const auto count = std::stoi(countStr);
+
+        return {start, count};
+    }
+
+    static void SetHostEphemeralRange(LPCWSTR Protocol, int Start, int NumberOfPorts)
+    {
+        // Note: setting the range for v4 also sets the same range for v6, so we only need to set one of them.
+        auto cmd = std::format(L"netsh int ipv4 set dynamicportrange {} startport={} numberofports={}", Protocol, Start, NumberOfPorts);
+        VERIFY_ARE_EQUAL(LxsstuRunCommand(cmd.data()), 0L);
+    }
+
+    // Attempt every host-ephemeral port from the guest and verify exactly the service-enforced cap
+    // (half of the host ephemeral range size) can be reserved.
+    static void VerifyHostEphemeralRangeCap(int Protocol, int HostEphemeralStart, int HostEphemeralEnd, int Cap)
+    {
+        WslKeepAlive keepAlive;
+
+        auto [guestStartStr, err1] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f1", 0);
+        guestStartStr.pop_back();
+        const auto guestStart = std::stoi(guestStartStr);
+
+        auto [guestEndStr, err2] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range | cut -f2", 0);
+        guestEndStr.pop_back();
+        const auto guestEnd = std::stoi(guestEndStr);
+
+        const int overlapStart = std::max(HostEphemeralStart, guestStart);
+        const int overlapEnd = std::min(HostEphemeralEnd, guestEnd);
+        const int overlap = (overlapStart <= overlapEnd) ? (overlapEnd - overlapStart + 1) : 0;
+
+        const int expectedSuccesses = Cap - overlap;
+        VERIFY_IS_GREATER_THAN(expectedSuccesses, 0);
+
+        // Repeat the pattern a couple of times: verify the cap, release every socket, then verify the
+        // reservations drain and the full capacity becomes available again.
+        constexpr int c_cycles = 2;
+
+        for (int cycle = 0; cycle < c_cycles; cycle++)
+        {
+            // Bind every candidate from one guest process so the test does not launch wsl.exe once per port.
+            std::wstring perlCommand = L"perl -MSocket -MErrno=EADDRINUSE -e '";
+            perlCommand += L"$|=1;";
+            perlCommand += L"my @sockets;";
+            perlCommand += L"my $candidate=0;";
+            perlCommand +=
+                L"for my $port (" + std::to_wstring(HostEphemeralStart) + L".." + std::to_wstring(HostEphemeralEnd) + L"){";
+            perlCommand += L"next if $port>=" + std::to_wstring(guestStart) + L" && $port<=" + std::to_wstring(guestEnd) + L";";
+            perlCommand += L"my $family=(($candidate++ % 2)==0) ? AF_INET : AF_INET6;";
+            perlCommand += L"socket(my $socket,$family," + std::wstring(Protocol == IPPROTO_TCP ? L"SOCK_STREAM" : L"SOCK_DGRAM") +
+                           L",0) or die \"socket port=$port: $!\\n\";";
+            perlCommand +=
+                L"my $address=$family==AF_INET ? sockaddr_in($port,INADDR_ANY) : "
+                L"Socket::sockaddr_in6($port,Socket::inet_pton(AF_INET6,\"::\"));";
+            perlCommand += L"if(bind($socket,$address)){";
+            perlCommand += L"push @sockets,$socket;";
+            perlCommand += L"}elsif($!{EADDRINUSE}){}else{die \"bind port=$port: $!\\n\";}";
+            perlCommand += L"}";
+            perlCommand += L"print \"successes=\",scalar(@sockets),\"\\nready\\n\";";
+            perlCommand += L"while(1){sleep 1000}'";
+
+            auto cmd = LxssGenerateWslCommandLine(perlCommand.data());
+            auto [readPipe, writePipe] = CreateSubprocessPipe(false, true);
+            NetworkTests::unique_kill_process process(LxsstuStartProcess(cmd.data(), nullptr, writePipe.get(), writePipe.get()));
+            writePipe.reset();
+
+            std::string output;
+            VERIFY_IS_TRUE(NetworkTests::FindSubstring(readPipe, "ready", output));
+
+            constexpr std::string_view c_successPrefix = "successes=";
+            const auto successOffset = output.find(c_successPrefix);
+            THROW_HR_IF(E_FAIL, successOffset == std::string::npos);
+            const auto successEnd = output.find('\n', successOffset);
+            THROW_HR_IF(E_FAIL, successEnd == std::string::npos);
+            const auto successes =
+                std::stoi(output.substr(successOffset + c_successPrefix.size(), successEnd - successOffset - c_successPrefix.size()));
+            VERIFY_ARE_EQUAL(expectedSuccesses, successes, L"Expected exactly the service-enforced number of reservations");
+
+            // Release every reservation so usage drops back below the cap.
+            process.reset();
+
+            // The Linux port tracker only releases a reservation c_bind_timeout_seconds (60s) after the
+            // socket is closed (see GnsPortTracker.cpp), so wait for the reservations to drain before the
+            // next iteration reserves the same ports again.
+            if (cycle + 1 < c_cycles)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(90));
+            }
+        }
+    }
+
+    WSL2_TEST_METHOD(GuestBindToHostEphemeralRangeCapped)
+    {
+        MIRRORED_NETWORKING_TEST_ONLY();
+
+        // The service caps the number of host-ephemeral ports the guest can reserve at half the host
+        // ephemeral range size, so it cannot exhaust the host's ephemeral ports. Shrink the host
+        // TCP/UDP ephemeral ranges to the smallest allowed size (255 ports) so the cap is a small,
+        // deterministic number (255 / 2 = 127), then verify the guest is denied once it reaches it.
+        constexpr int c_ephemeralRangeSize = 255;
+        constexpr int c_expectedCap = c_ephemeralRangeSize / 2;
+
+        // Save the current host ephemeral ranges so they can be restored at the end of the test.
+        int originalTcpStart = 0, originalTcpCount = 0, originalUdpStart = 0, originalUdpCount = 0;
+        std::tie(originalTcpStart, originalTcpCount) = QueryHostEphemeralRange(L"Get-NetTCPSetting");
+        std::tie(originalUdpStart, originalUdpCount) = QueryHostEphemeralRange(L"Get-NetUDPSetting");
+
+        auto restoreRanges = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
+            SetHostEphemeralRange(L"tcp", originalTcpStart, originalTcpCount);
+            SetHostEphemeralRange(L"udp", originalUdpStart, originalUdpCount);
+        });
+
+        // Use a low start port so the small host ephemeral window is less likely to overlap the
+        // guest's reserved ephemeral range, which HNS assigns from the high port space.
+        constexpr int c_hostEphemeralStart = 10000;
+        constexpr int c_hostEphemeralEnd = c_hostEphemeralStart + c_ephemeralRangeSize - 1;
+        SetHostEphemeralRange(L"tcp", c_hostEphemeralStart, c_ephemeralRangeSize);
+        SetHostEphemeralRange(L"udp", c_hostEphemeralStart, c_ephemeralRangeSize);
+
+        // Force a restart of WSL so that it queries the new host ephemeral ranges.
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+        RestartWslService();
+
+        WaitForMirroredStateInLinux();
+
+        // TCP and UDP are capped independently, but each cap is shared by IPv4 and IPv6.
+        VerifyHostEphemeralRangeCap(IPPROTO_TCP, c_hostEphemeralStart, c_hostEphemeralEnd, c_expectedCap);
+        VerifyHostEphemeralRangeCap(IPPROTO_UDP, c_hostEphemeralStart, c_hostEphemeralEnd, c_expectedCap);
+    }
+
     WSL2_TEST_METHOD(NonRootNamespaceEphemeralBind)
     {
         MIRRORED_NETWORKING_TEST_ONLY();


### PR DESCRIPTION
**Summary of the issue and fix**
https://github.com/microsoft/WSL/pull/40597/changes introduced an app-compat issue where scenarios such as Docker can happen to use ports from the host ephemeral range, which are now denied. To preserve app-compat and also prevent the container from exhausting the host ephemeral port range, add a cap for the number of ports the container can use, set to half of the size of the host ephemeral port range

**Testing:**
- New automated test that sets the host ephemeral range to a small size (255 ports), then attempts binding to all the ports in the range and confirming that only half (127) can bind

- Existing automated NetworkTests 

- [ ] **Closes:**  #40984 
