### PR TITLE
Simplify e2e build-test image cleanup with per-test RAII ownership

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -403,6 +403,9 @@ void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix)
     {
         if (image.Repository && image.Tag && image.Repository->starts_with(prefix))
         {
+            // No container cleanup here: the images this prunes are only ever built and inspected, never used to 
+            // create containers, so image delete --force is sufficient. If a future test containerizes a built
+            // image, remove its container in that test's cleanup rather than broadening this prefix-based safety net.
             const auto nameAndTag = wsl::shared::string::MultiByteToWide(std::format("{}:{}", *image.Repository, *image.Tag));
             RunWslc(std::format(L"image delete --force {}", nameAndTag)).Verify({.Stderr = L"", .ExitCode = 0});
         }

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -392,6 +392,23 @@ void EnsureImageIsDeleted(const TestImage& image)
     }
 }
 
+void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix)
+{
+    auto result = RunWslc(L"image list --format json");
+    result.Verify({.Stderr = L"", .ExitCode = 0});
+
+    const auto images = wsl::shared::FromJson<std::vector<wsl::windows::wslc::models::ImageInformation>>(result.Stdout.value().c_str());
+    const auto prefix = wsl::shared::string::WideToMultiByte(repositoryPrefix);
+    for (const auto& image : images)
+    {
+        if (image.Repository && image.Tag && image.Repository->starts_with(prefix))
+        {
+            const auto nameAndTag = wsl::shared::string::MultiByteToWide(std::format("{}:{}", *image.Repository, *image.Tag));
+            RunWslc(std::format(L"image delete --force {}", nameAndTag)).Verify({.Stderr = L"", .ExitCode = 0});
+        }
+    }
+}
+
 void EnsureNoUntaggedImages()
 {
     auto result = RunWslc(L"image list --format json --filter dangling=true");

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -403,7 +403,7 @@ void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix)
     {
         if (image.Repository && image.Tag && image.Repository->starts_with(prefix))
         {
-            // No container cleanup here: the images this prunes are only ever built and inspected, never used to 
+            // No container cleanup here: the images this prunes are only ever built and inspected, never used to
             // create containers, so image delete --force is sufficient. If a future test containerizes a built
             // image, remove its container in that test's cleanup rather than broadening this prefix-based safety net.
             const auto nameAndTag = wsl::shared::string::MultiByteToWide(std::format("{}:{}", *image.Repository, *image.Tag));

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -127,6 +127,7 @@ std::vector<wsl::windows::wslc::models::ContainerInformation> ListAllContainers(
 void EnsureContainerDoesNotExist(const std::wstring& containerName);
 void EnsureImageIsLoaded(const TestImage& image, const std::wstring& sessionName = L"");
 void EnsureImageIsDeleted(const TestImage& image);
+void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix);
 void EnsureImageContainersAreDeleted(const TestImage& image);
 void EnsureNoUntaggedImages();
 void EnsureSessionIsTerminated(const std::wstring& sessionName = L"");

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -24,32 +24,40 @@ class WSLCE2EImageBuildTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        DeleteAllBuiltImages();
+        DeleteImagesWithRepositoryPrefix(c_builtImagePrefix);
         EnsureImageIsLoaded(DebianTestImage());
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        DeleteAllBuiltImages();
+        DeleteImagesWithRepositoryPrefix(c_builtImagePrefix);
         EnsureImageIsDeleted(DebianTestImage());
         return true;
     }
 
-    TEST_METHOD_SETUP(MethodSetup)
-    {
-        DeleteAllBuiltImages();
-        return true;
-    }
+    // Each test owns and cleans up exactly the image(s) it builds via DeleteImageOnExit, so there is
+    // no per-method sweep. DeleteImagesWithRepositoryPrefix in the class setup/cleanup above is only a
+    // safety net for images left behind by a crashed run.
+    static constexpr auto c_builtImagePrefix = L"wslc-e2e-build-";
 
-    TEST_METHOD_CLEANUP(MethodCleanup)
+    // Returns an RAII guard that best-effort deletes the given image when it goes out of scope. It is
+    // deliberately non-throwing (no VERIFY) because it may run while the stack unwinds after a test
+    // failure; the class-level prune is the authoritative cleanup.
+    static auto DeleteImageOnExit(const TestImage& image)
     {
-        DeleteAllBuiltImages();
-        return true;
+        return wil::scope_exit([image]() {
+            try
+            {
+                RunWslc(std::format(L"image delete --force {}", image.NameAndTag()));
+            }
+            CATCH_LOG()
+        });
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_EmptyContextDirectory_Success)
     {
+        auto imageCleanup = DeleteImageOnExit(BuiltImage);
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-empty-context";
         auto cleanup = SetupTestDirectory(testRoot);
 
@@ -73,6 +81,8 @@ class WSLCE2EImageBuildTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_BuildArgsFileAndMultipleTags_Success)
     {
+        auto imageCleanup1 = DeleteImageOnExit(BuiltImageTag1);
+        auto imageCleanup2 = DeleteImageOnExit(BuiltImageTag2);
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-args-tags";
         auto cleanup = SetupTestDirectory(testRoot);
 
@@ -124,6 +134,7 @@ class WSLCE2EImageBuildTests
     {
         SKIP_TEST_UNSTABLE(); // TODO: Enable when a private image source is available.
 
+        auto imageCleanup = DeleteImageOnExit(BuiltImagePull);
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-pull";
         auto cleanup = SetupTestDirectory(testRoot);
 
@@ -148,6 +159,7 @@ class WSLCE2EImageBuildTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Target_Success)
     {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageTarget);
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-target";
         auto cleanup = SetupTestDirectory(testRoot);
 
@@ -184,6 +196,7 @@ class WSLCE2EImageBuildTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Label_Success)
     {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageLabel);
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-label";
         auto cleanup = SetupTestDirectory(testRoot);
 
@@ -219,6 +232,7 @@ class WSLCE2EImageBuildTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_LabelOverridesDockerfile_Success)
     {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageLabelOverride);
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-label-override";
         auto cleanup = SetupTestDirectory(testRoot);
 
@@ -249,11 +263,13 @@ class WSLCE2EImageBuildTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_DockerfileInContextDir_Success)
     {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageDockerfile);
         BuildFromContextFile(L"Dockerfile", BuiltImageDockerfile);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_ContainerfileInContextDir_Success)
     {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageContainerfile);
         BuildFromContextFile(L"Containerfile", BuiltImageContainerfile);
     }
 
@@ -307,6 +323,7 @@ class WSLCE2EImageBuildTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_NoCache_Success)
     {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageNoCache);
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-no-cache";
         auto cleanup = SetupTestDirectory(testRoot);
 
@@ -371,20 +388,6 @@ private:
         VERIFY_IS_TRUE(inspectData.RepoTags.has_value());
         VERIFY_ARE_EQUAL(1u, inspectData.RepoTags.value().size());
         VERIFY_ARE_EQUAL(image.NameAndTag(), wsl::shared::string::MultiByteToWide(inspectData.RepoTags.value()[0]));
-    }
-
-    void DeleteAllBuiltImages()
-    {
-        EnsureImageIsDeleted(BuiltImage);
-        EnsureImageIsDeleted(BuiltImageTag1);
-        EnsureImageIsDeleted(BuiltImageTag2);
-        EnsureImageIsDeleted(BuiltImagePull);
-        EnsureImageIsDeleted(BuiltImageTarget);
-        EnsureImageIsDeleted(BuiltImageDockerfile);
-        EnsureImageIsDeleted(BuiltImageContainerfile);
-        EnsureImageIsDeleted(BuiltImageNoCache);
-        EnsureImageIsDeleted(BuiltImageLabel);
-        EnsureImageIsDeleted(BuiltImageLabelOverride);
     }
 };
 } // namespace WSLCE2ETests


### PR DESCRIPTION
This pull request refactors the image cleanup logic in the `WSLCE2EImageBuildTests` end-to-end test suite to be more robust and maintainable. It introduces a new helper function for bulk image deletion by repository prefix, replaces per-method sweeping with targeted per-test cleanup, and removes the old manual deletion code. The changes improve test reliability, especially in the presence of test failures or crashes.

**Test cleanup improvements:**

* Added a new helper function `DeleteImagesWithRepositoryPrefix` that deletes all images whose repository names start with a given prefix, making bulk cleanup more reliable and less error-prone. [[1]](diffhunk://#diff-b059d674da3f0bd3ae09f294da4ae6ea4ee1bf5adc1a8b8605b7602168d5eb87R395-R411) [[2]](diffhunk://#diff-3257a3f10828a45a583e55686d0fb0e66a58767b39aa7ecc58c7a3f9c00bf845R130)
* Updated class-level setup and cleanup in `WSLCE2EImageBuildTests` to use the new prefix-based image deletion helper, ensuring any leftover images from previous runs are removed.
* Removed per-method sweeping (`DeleteAllBuiltImages`) in favor of using an RAII-style `DeleteImageOnExit` guard for each test, which ensures only images created by a test are cleaned up, even if the test fails. [[1]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02L27-R60) [[2]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02R84-R85) [[3]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02R137) [[4]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02R162) [[5]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02R199) [[6]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02R235) [[7]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02R266-R272) [[8]](diffhunk://#diff-9106e97e128d77fe50409f84ff2f91f40316566ce084de12ce1b11496c090a02R326)
* Removed the now-unnecessary `DeleteAllBuiltImages` method and its invocations, simplifying the codebase.
* Updated test documentation and comments to clarify the new cleanup strategy and its rationale.Replace the hand-maintained DeleteAllBuiltImages() static list (run in both TEST_METHOD_SETUP and TEST_METHOD_CLEANUP, sweeping every built image twice per test and flooding the log with VERIFY lines) with:

- A per-test DeleteImageOnExit() RAII guard so each test owns and cleans up exactly the image(s) it builds. It is best-effort and non-throwing (no VERIFY) since it may run during stack unwinding after a failure.
- A single class-level DeleteImagesWithRepositoryPrefix() prune in ClassSetup and ClassCleanup as the authoritative safety net for images left behind by a crashed run.

This removes the per-method sweeps, the static image list, and the excessive per-field VERIFY logging that dominated test output.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
