### PR TITLE
Improve WSL2 guest memory reclaim

### DIFF
--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3505,71 +3505,102 @@ int ProcessCreateProcessMessage(wsl::shared::Transaction& Transaction, gsl::span
 
 #define RECLAIM_PATH CGROUP_MOUNTPOINT "/memory.reclaim"
 
-static long long int GetUserCpuTime()
+static bool ReadCpuBusyIdle(unsigned long long& Busy, unsigned long long& Idle)
 
 /*++
 
 Routine Description:
 
-    This routine parses /proc/stat to query a summary of all user CPU time.
+    This routine parses the aggregate "cpu" line of /proc/stat and splits the cumulative jiffies into
+    busy and idle buckets. Idle time is idle + iowait; everything else (user, nice, system, irq,
+    softirq, steal) counts as busy, so kernel-bound work keeps the VM out of the idle state rather than
+    looking at user time alone.
 
 Arguments:
 
-    None.
+    Busy - Receives the cumulative busy jiffies across all cores.
+
+    Idle - Receives the cumulative idle jiffies (idle + iowait) across all cores.
 
 Return Value:
 
-    The current user CPU counter for all cores.
+    true on success, false on failure.
 
 --*/
 
 {
-    wil::unique_fd Fd{open("/proc/stat", O_RDONLY)};
-    if (!Fd)
+    wil::unique_fd fd{TEMP_FAILURE_RETRY(open("/proc/stat", O_RDONLY | O_CLOEXEC))};
+    if (!fd)
     {
-        LOG_ERROR("open failed {}", errno);
-        return -1;
+        LOG_ERROR("open(/proc/stat) failed {}", errno);
+        return false;
     }
 
-    char Buffer[32];
-    int Result = TEMP_FAILURE_RETRY(read(Fd.get(), Buffer, (sizeof(Buffer) - 1)));
-    if (Result <= 0)
+    char buffer[256];
+    const ssize_t result = TEMP_FAILURE_RETRY(read(fd.get(), buffer, sizeof(buffer) - 1));
+    if (result <= 0)
     {
-        LOG_ERROR("read failed {}", errno);
-        return -1;
+        LOG_ERROR("read(/proc/stat) failed {}", errno);
+        return false;
     }
 
+    buffer[result] = '\0';
+
     //
-    // Parse the first line of /proc/stat which is in the format
-    // "cpu  <counter>".
+    // Format: "cpu  user nice system idle iowait irq softirq steal ...". Fields after steal are ignored.
     //
 
-    Buffer[Result] = '\0';
-    char* Sp1;
-    char* Info = strtok_r(Buffer, " \n", &Sp1);
-    if (Info == nullptr)
+    if (strncmp(buffer, "cpu ", 4) != 0)
     {
         LOG_ERROR("/proc/stat first line missing cpu label");
-        return -1;
+        return false;
     }
 
-    Info = strtok_r(nullptr, " \n", &Sp1);
-    if (Info == nullptr)
+    unsigned long long fields[8] = {};
+    const char* cursor = buffer + 3;
+    int parsed = 0;
+    for (; parsed < static_cast<int>(COUNT_OF(fields)); parsed += 1)
     {
-        LOG_ERROR("/proc/stat first line missing cpu counter");
-        return -1;
+        char* end = nullptr;
+        const unsigned long long value = strtoull(cursor, &end, 10);
+        if (end == cursor)
+        {
+            break;
+        }
+
+        fields[parsed] = value;
+        cursor = end;
     }
 
-    return strtoll(Info, nullptr, 10);
+    if (parsed < 5)
+    {
+        LOG_ERROR("failed to parse /proc/stat cpu line (parsed {})", parsed);
+        return false;
+    }
+
+    Idle = fields[3] + fields[4];
+    Busy = 0;
+    for (int index = 0; index < parsed; index += 1)
+    {
+        if (index != 3 && index != 4)
+        {
+            Busy += fields[index];
+        }
+    }
+
+    return true;
 }
 
-static ssize_t GetMemoryInUse()
+static long long GetReclaimableCacheBytes()
 
 /*++
 
 Routine Description:
 
-    This routine returns the amount memory in use in bytes.
+    This routine returns the amount of reclaimable file-backed page cache (in bytes) by parsing
+    /proc/meminfo. It counts only memory that cache reclaim can actually return to the host:
+    Active(file) + Inactive(file) + SReclaimable. Anonymous memory is excluded because reclaim of clean
+    cache cannot free it.
 
 Arguments:
 
@@ -3577,17 +3608,92 @@ Arguments:
 
 Return Value:
 
-    Total memory - Free memory. Includes that used by cache and buffers.
+    Reclaimable cache in bytes, or -1 on failure.
 
 --*/
 
-try
 {
-    struct sysinfo Info = {};
-    THROW_LAST_ERROR_IF(sysinfo(&Info) < 0);
-    return (Info.totalram - Info.freeram) * Info.mem_unit;
+    std::ifstream memInfo("/proc/meminfo");
+    if (!memInfo)
+    {
+        LOG_ERROR("failed to open /proc/meminfo");
+        return -1;
+    }
+
+    // /proc/meminfo values are in kB.
+    long long totalKb = 0;
+    bool foundCounter = false;
+    std::string line;
+    while (std::getline(memInfo, line))
+    {
+        std::istringstream stream(line);
+        std::string name;
+        long long value = 0;
+        if (!(stream >> name >> value))
+        {
+            continue;
+        }
+
+        if (name == "Active(file):" || name == "Inactive(file):" || name == "SReclaimable:")
+        {
+            foundCounter = true;
+            totalKb += value;
+        }
+    }
+
+    if (memInfo.bad())
+    {
+        LOG_ERROR("failed to read /proc/meminfo");
+        return -1;
+    }
+
+    if (!foundCounter)
+    {
+        LOG_ERROR("failed to find reclaimable cache counters in /proc/meminfo");
+        return -1;
+    }
+
+    return totalKb * 1024;
 }
-CATCH_RETURN_ERRNO()
+
+static bool RequestReclaim(long long Bytes)
+
+/*++
+
+Routine Description:
+
+    Best-effort write of a byte count to the cgroup memory.reclaim knob. EAGAIN is an expected outcome
+    (the kernel freed some, but not all, of the requested pages) and is treated as success without
+    logging, so the long-lived reduction thread does not error out every interval. A transient failure
+    never throws.
+
+Arguments:
+
+    Bytes - Supplies the number of bytes to request the kernel reclaim.
+
+Return Value:
+
+    true if pages were reclaimed (full success or EAGAIN), false otherwise.
+
+--*/
+
+{
+    wil::unique_fd fd{TEMP_FAILURE_RETRY(open(RECLAIM_PATH, O_WRONLY | O_CLOEXEC))};
+    if (!fd)
+    {
+        LOG_ERROR("open({}) failed {}", RECLAIM_PATH, errno);
+        return false;
+    }
+
+    const std::string request = std::to_string(Bytes) + " swappiness=0";
+    if (UtilWriteStringView(fd.get(), request) == static_cast<ssize_t>(request.size()) || errno == EAGAIN)
+    {
+        return true;
+    }
+
+    LOG_ERROR("write({}, {}) failed {}", RECLAIM_PATH, request, errno);
+    return false;
+}
 
 void StartMemoryReductionThread(LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode)
 
@@ -3595,8 +3701,14 @@ void StartMemoryReductionThread(LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode)
 
 Routine Description:
 
-    This routine starts a background thread that performs memory compaction and optional cache/memory
-    reclaim when the VM is idle. This ensures that the maximum number of pages can be discarded to the host.
+    This routine starts a background thread that reclaims cold page cache and compacts free pages while
+    the VM is idle, so the maximum number of pages can be discarded back to the host.
+
+    Reclaim is gated on CPU idle (measured over each interval using all non-idle CPU time, not just user
+    time) so it never competes with real work. Gradual mode reclaims cold file-backed page cache above a
+    small floor via the cgroup memory.reclaim knob, falling back to drop_caches when the knob is
+    unavailable. DropCache mode uses drop_caches directly. Freed pages are compacted so free-page
+    reporting can hand back large blocks.
 
 Arguments:
 
@@ -3610,129 +3722,167 @@ Return Value:
 
 try
 {
-    std::thread([Mode = Mode]() mutable {
+    if (Mode == LxMiniInitMemoryReclaimModeDisabled)
+    {
+        return;
+    }
+
+    std::thread([Mode]() {
         try
         {
             //
-            // Set the thread's scheduling policy to idle.
+            // Run at idle scheduling priority so reclaim never competes with real work.
             //
 
-            sched_param Parameter{};
-            Parameter.sched_priority = 0;
-            const int Result = pthread_setschedparam(pthread_self(), SCHED_IDLE, &Parameter);
-            THROW_ERRNO_IF(Result, Result != 0);
+            sched_param parameter{};
+            parameter.sched_priority = 0;
+            const int result = pthread_setschedparam(pthread_self(), SCHED_IDLE, &parameter);
+            THROW_ERRNO_IF(result, result != 0);
 
             //
-            // Periodically check if the machine is idle by querying procfs for CPU usage.
-            // Memory compaction will occur if both of the following conditions are true:
-            //     1. The CPU time since the last check is greater than the idle threshold.
-            //     2. The current CPU usage is below the idle threshold. This is measured by taking two readings one second apart.
+            // Gradual mode uses cgroup memory.reclaim and falls back to drop_caches when unavailable.
             //
 
-            double MemoryLow = 1024 * 1024 * 1024;
-            double MemoryHigh = 1.1 * 1024.0 * 1024.0 * 1024.0;
-            const int IdleThreshold = get_nprocs(); // Change math to adjust if sysconf(_SC_CLK_TCK) != 100? Is 1%
-            long long int Start, Stop = 0;
-            auto constexpr SleepDuration = std::chrono::seconds(30);
-            size_t ReclaimIndex = 0;
-            long long int const ReclaimThreshold = (get_nprocs() * sysconf(_SC_CLK_TCK) * SleepDuration / std::chrono::seconds(1)) / 200; // 0.5%
-            long long int ReclaimWindow[20] = {}; // 10 minutes
-            long long int ReclaimWindowLength = COUNT_OF(ReclaimWindow);
-            bool ReclaimIdling = false;
-
-            //
-            // Fall back to drop cache if the required cgroup path is not present.
-            //
-
-            if (Mode == LxMiniInitMemoryReclaimModeGradual && access(RECLAIM_PATH, W_OK) < 0)
+            bool useReclaim = Mode != LxMiniInitMemoryReclaimModeDropCache;
+            if (useReclaim && access(RECLAIM_PATH, W_OK) < 0)
             {
                 LOG_WARNING("access({}, W_OK) failed {}, falling back to drop_caches", RECLAIM_PATH, errno);
-                Mode = LxMiniInitMemoryReclaimModeDropCache;
+                useReclaim = false;
             }
 
-            if (Mode == LxMiniInitMemoryReclaimModeGradual)
+            constexpr auto c_pollInterval = std::chrono::seconds(10);
+
+            // An interval is idle when busy CPU is at most this fraction (per-mille) of total CPU time.
+            constexpr unsigned long long c_busyThresholdPerMille = 5; // 0.5%
+
+            // Reclaimable cache below this floor is always retained to protect a minimal working set.
+            constexpr long long c_floorBytes = 128ll * 1024 * 1024;
+
+            // Compact immediately on idle, but preserve the cache during normal pauses between commands.
+            constexpr int c_reclaimIdleIntervals = 12; // 2 minutes
+
+            // Scale reclaim requests with the VM size while keeping individual operations bounded.
+            constexpr long long c_minReclaimBytes = 256ll * 1024 * 1024;
+            constexpr long long c_maxReclaimBytes = 1024ll * 1024 * 1024;
+
+            struct sysinfo info = {};
+            THROW_LAST_ERROR_IF(sysinfo(&info) < 0);
+
+            long long reclaimStepBytes = (static_cast<long long>(info.totalram) * info.mem_unit) / 32;
+            if (reclaimStepBytes < c_minReclaimBytes)
             {
-                static_assert(COUNT_OF(ReclaimWindow) >= 6);
-                ReclaimWindowLength = 6; // Set to 3 minutes.
+                reclaimStepBytes = c_minReclaimBytes;
             }
-
-            for (auto i = 1; i < ReclaimWindowLength; i++)
+            else if (reclaimStepBytes > c_maxReclaimBytes)
             {
-                ReclaimWindow[i] = LLONG_MIN;
+                reclaimStepBytes = c_maxReclaimBytes;
             }
 
-            std::this_thread::sleep_for(SleepDuration);
+            unsigned long long previousBusy = 0;
+            unsigned long long previousIdle = 0;
+            bool havePreviousSample = false;
+            int idleIntervals = 0;
+
+            bool droppedThisIdlePeriod = false;
+            bool compactedThisIdlePeriod = false;
+
             for (;;)
             {
-                auto const Target = std::chrono::steady_clock::now() + SleepDuration;
-                Start = GetUserCpuTime();
-                THROW_LAST_ERROR_IF(Start == -1);
+                std::this_thread::sleep_for(c_pollInterval);
 
-                if (Mode != LxMiniInitMemoryReclaimModeDisabled)
+                unsigned long long busy = 0;
+                unsigned long long idle = 0;
+                if (!ReadCpuBusyIdle(busy, idle))
                 {
-                    //
-                    // Ensure that utilization is below 0.5% from the last 30 seconds, and last n minutes, of usage.
-                    //
+                    continue;
+                }
 
-                    size_t const LastIndex = (ReclaimIndex + 1) % ReclaimWindowLength;
-                    if ((ReclaimWindow[LastIndex] > Start - ReclaimThreshold * (ReclaimWindowLength + 1)) &&
-                        (ReclaimWindow[ReclaimIndex] > Start - ReclaimThreshold))
-                    {
-                        if (Mode == LxMiniInitMemoryReclaimModeGradual)
-                        {
-                            double MemorySize = GetMemoryInUse();
-                            THROW_LAST_ERROR_IF(MemorySize < 0);
-
-                            if (MemorySize > MemoryHigh)
-                            {
-                                ReclaimIdling = false;
-                            }
-
-                            if (!ReclaimIdling && MemorySize > MemoryLow)
-                            {
-                                double MemoryTargetSize = MemorySize * 0.97;
-                                std::string MemoryToFree = std::to_string(size_t(MemorySize - MemoryTargetSize));
-                                // EAGAIN Means that it attempted, but was unable to evict sufficient pages.
-                                THROW_LAST_ERROR_IF(WriteToFile(RECLAIM_PATH, MemoryToFree.c_str()) < 0 && errno != EAGAIN);
-
-                                if (MemoryTargetSize < MemoryLow)
-                                {
-                                    ReclaimIdling = true;
-                                }
-                            }
-                        }
-                        else if (!ReclaimIdling)
-                        {
-                            ReclaimIdling = true;
-                            THROW_LAST_ERROR_IF(WriteToFile("/proc/sys/vm/drop_caches", "1\n") < 0);
-                        }
-                    }
-                    else
-                    {
-                        ReclaimIdling = false;
-                    }
-
-                    ReclaimIndex = LastIndex;
-                    ReclaimWindow[ReclaimIndex] = Start;
+                if (!havePreviousSample)
+                {
+                    previousBusy = busy;
+                    previousIdle = idle;
+                    havePreviousSample = true;
+                    continue;
                 }
 
                 //
-                // Perform memory compaction if the VM is idle.
-                // This coalesces free pages into larger blocks for more efficient page reporting.
+                // Guard against non-monotonic counters (should not happen, but resample if it does).
                 //
 
-                if ((Start - Stop) > IdleThreshold)
+                if (busy < previousBusy || idle < previousIdle)
                 {
-                    std::this_thread::sleep_for(std::chrono::seconds(1));
-                    Stop = GetUserCpuTime();
-                    THROW_LAST_ERROR_IF(Stop == -1);
-                    if ((Stop - Start) < IdleThreshold)
+                    previousBusy = busy;
+                    previousIdle = idle;
+                    continue;
+                }
+
+                const unsigned long long busyDelta = busy - previousBusy;
+                const unsigned long long totalDelta = busyDelta + (idle - previousIdle);
+                previousBusy = busy;
+                previousIdle = idle;
+
+                const bool intervalIdle = (totalDelta == 0) || (busyDelta * 1000 <= totalDelta * c_busyThresholdPerMille);
+                if (!intervalIdle)
+                {
+                    idleIntervals = 0;
+                    droppedThisIdlePeriod = false;
+                    compactedThisIdlePeriod = false;
+                    continue;
+                }
+
+                idleIntervals += 1;
+
+                //
+                // The VM is idle: reclaim cold cache and compact.
+                //
+
+                bool reclaimed = false;
+                if (idleIntervals >= c_reclaimIdleIntervals && useReclaim)
+                {
+                    const long long cache = GetReclaimableCacheBytes();
+                    if (cache > c_floorBytes)
                     {
-                        THROW_LAST_ERROR_IF(WriteToFile("/proc/sys/vm/compact_memory", "1\n") < 0);
+                        long long bytes = cache - c_floorBytes;
+                        if (bytes > reclaimStepBytes)
+                        {
+                            bytes = reclaimStepBytes;
+                        }
+
+                        reclaimed = RequestReclaim(bytes);
+                    }
+                }
+                else if (idleIntervals >= c_reclaimIdleIntervals && !useReclaim && !droppedThisIdlePeriod)
+                {
+                    if (WriteToFile("/proc/sys/vm/drop_caches", "1\n") == 0)
+                    {
+                        droppedThisIdlePeriod = true;
+                        reclaimed = true;
                     }
                 }
 
-                std::this_thread::sleep_until(Target);
+                //
+                // Coalesce freed pages into larger blocks for efficient page reporting.
+                //
+
+                bool memoryOperation = reclaimed;
+                if (!compactedThisIdlePeriod || reclaimed)
+                {
+                    if (WriteToFile("/proc/sys/vm/compact_memory", "1\n") == 0)
+                    {
+                        compactedThisIdlePeriod = true;
+                        memoryOperation = true;
+                    }
+                }
+
+                //
+                // Exclude the reclaim/compaction work from the next utilization interval so it does not
+                // restart the grace period itself.
+                //
+
+                if (memoryOperation)
+                {
+                    ReadCpuBusyIdle(previousBusy, previousIdle);
+                }
             }
         }
         CATCH_LOG()


### PR DESCRIPTION
## Summary

- replace the user-CPU ring buffer with aggregate busy/idle CPU sampling
- compact once when the VM becomes idle and after each successful reclaim
- preserve page cache for two minutes before reclaiming to protect short-pause resume performance
- use `memory.reclaim` with `swappiness=0`, a 128 MB floor, and RAM-scaled 256 MB to 1 GB requests in Gradual mode
- preserve explicit DropCache behavior and fall back to it when `memory.reclaim` is unavailable
- parse `/proc/stat` and `/proc/meminfo` robustly without allowing malformed entries to terminate the reduction thread

## Benchmark results

Measured with two clean 16-way Linux kernel builds, two read-heavy source archive runs, and three warm-cache reuse runs per configuration.

| Metric | Existing DropCache | New DropCache |
|---|---:|---:|
| Kernel build: 50% host working-set reduction | 591s | 177s |
| Source archive: 50% host working-set reduction | 542s | 142s |
| Warm reread after 60 seconds idle | 0.233s | 0.220s |
| Kernel workload working set after 15 minutes | 2.14 GiB | 2.12 GiB |

Gradual mode with the same grace period reaches a lower sustained footprint by continuing to reclaim cache toward the floor.

## Validation

- `cmake --build . --config Debug -- -m`
- built and deployed the generated MSI
- verified `memory.reclaim` `swappiness=0` support on the WSL 6.18 kernel
- collected host `vmmemWSL`, guest memory, reclaim, compaction, and workload timing data