### PR TITLE
Improve WSL2 guest memory reclaim

### DIFF
--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3505,71 +3505,102 @@ int ProcessCreateProcessMessage(wsl::shared::Transaction& Transaction, gsl::span
 
 #define RECLAIM_PATH CGROUP_MOUNTPOINT "/memory.reclaim"
 
-static long long int GetUserCpuTime()
+static bool ReadCpuBusyIdle(unsigned long long& Busy, unsigned long long& Idle)
 
 /*++
 
 Routine Description:
 
-    This routine parses /proc/stat to query a summary of all user CPU time.
+    This routine parses the aggregate "cpu" line of /proc/stat and splits the cumulative jiffies into
+    busy and idle buckets. Idle time is idle + iowait; everything else (user, nice, system, irq,
+    softirq, steal) counts as busy, so kernel-bound work keeps the VM out of the idle state rather than
+    looking at user time alone.
 
 Arguments:
 
-    None.
+    Busy - Receives the cumulative busy jiffies across all cores.
+
+    Idle - Receives the cumulative idle jiffies (idle + iowait) across all cores.
 
 Return Value:
 
-    The current user CPU counter for all cores.
+    true on success, false on failure.
 
 --*/
 
 {
-    wil::unique_fd Fd{open("/proc/stat", O_RDONLY)};
-    if (!Fd)
+    wil::unique_fd fd{TEMP_FAILURE_RETRY(open("/proc/stat", O_RDONLY | O_CLOEXEC))};
+    if (!fd)
     {
-        LOG_ERROR("open failed {}", errno);
-        return -1;
+        LOG_ERROR("open(/proc/stat) failed {}", errno);
+        return false;
     }
 
-    char Buffer[32];
-    int Result = TEMP_FAILURE_RETRY(read(Fd.get(), Buffer, (sizeof(Buffer) - 1)));
-    if (Result <= 0)
+    char buffer[256];
+    const ssize_t result = TEMP_FAILURE_RETRY(read(fd.get(), buffer, sizeof(buffer) - 1));
+    if (result <= 0)
     {
-        LOG_ERROR("read failed {}", errno);
-        return -1;
+        LOG_ERROR("read(/proc/stat) failed {}", errno);
+        return false;
     }
 
+    buffer[result] = '\0';
+
     //
-    // Parse the first line of /proc/stat which is in the format
-    // "cpu  <counter>".
+    // Format: "cpu  user nice system idle iowait irq softirq steal ...". Fields after steal are ignored.
     //
 
-    Buffer[Result] = '\0';
-    char* Sp1;
-    char* Info = strtok_r(Buffer, " \n", &Sp1);
-    if (Info == nullptr)
+    if (strncmp(buffer, "cpu ", 4) != 0)
     {
         LOG_ERROR("/proc/stat first line missing cpu label");
-        return -1;
+        return false;
     }
 
-    Info = strtok_r(nullptr, " \n", &Sp1);
-    if (Info == nullptr)
+    unsigned long long fields[8] = {};
+    const char* cursor = buffer + 3;
+    int parsed = 0;
+    for (; parsed < static_cast<int>(COUNT_OF(fields)); parsed += 1)
     {
-        LOG_ERROR("/proc/stat first line missing cpu counter");
-        return -1;
+        char* end = nullptr;
+        const unsigned long long value = strtoull(cursor, &end, 10);
+        if (end == cursor)
+        {
+            break;
+        }
+
+        fields[parsed] = value;
+        cursor = end;
     }
 
-    return strtoll(Info, nullptr, 10);
+    if (parsed < 5)
+    {
+        LOG_ERROR("failed to parse /proc/stat cpu line (parsed {})", parsed);
+        return false;
+    }
+
+    Idle = fields[3] + fields[4];
+    Busy = 0;
+    for (int index = 0; index < parsed; index += 1)
+    {
+        if (index != 3 && index != 4)
+        {
+            Busy += fields[index];
+        }
+    }
+
+    return true;
 }
 
-static ssize_t GetMemoryInUse()
+static long long GetReclaimableCacheBytes()
 
 /*++
 
 Routine Description:
 
-    This routine returns the amount memory in use in bytes.
+    This routine returns the amount of reclaimable file-backed page cache (in bytes) by parsing
+    /proc/meminfo. It counts only memory that cache reclaim can actually return to the host:
+    Active(file) + Inactive(file) + SReclaimable. Anonymous memory is excluded because reclaim of clean
+    cache cannot free it.
 
 Arguments:
 
@@ -3577,17 +3608,92 @@ Arguments:
 
 Return Value:
 
-    Total memory - Free memory. Includes that used by cache and buffers.
+    Reclaimable cache in bytes, or -1 on failure.
 
 --*/
 
-try
 {
-    struct sysinfo Info = {};
-    THROW_LAST_ERROR_IF(sysinfo(&Info) < 0);
-    return (Info.totalram - Info.freeram) * Info.mem_unit;
+    std::ifstream memInfo("/proc/meminfo");
+    if (!memInfo)
+    {
+        LOG_ERROR("failed to open /proc/meminfo");
+        return -1;
+    }
+
+    // /proc/meminfo values are in kB.
+    long long totalKb = 0;
+    bool foundCounter = false;
+    std::string line;
+    while (std::getline(memInfo, line))
+    {
+        std::istringstream stream(line);
+        std::string name;
+        long long value = 0;
+        if (!(stream >> name >> value))
+        {
+            continue;
+        }
+
+        if (name == "Active(file):" || name == "Inactive(file):" || name == "SReclaimable:")
+        {
+            foundCounter = true;
+            totalKb += value;
+        }
+    }
+
+    if (memInfo.bad())
+    {
+        LOG_ERROR("failed to read /proc/meminfo");
+        return -1;
+    }
+
+    if (!foundCounter)
+    {
+        LOG_ERROR("failed to find reclaimable cache counters in /proc/meminfo");
+        return -1;
+    }
+
+    return totalKb * 1024;
 }
-CATCH_RETURN_ERRNO()
+
+static bool RequestReclaim(long long Bytes)
+
+/*++
+
+Routine Description:
+
+    Best-effort write of a byte count to the cgroup memory.reclaim knob. EAGAIN is an expected outcome
+    (the kernel freed some, but not all, of the requested pages) and is treated as success without
+    logging, so the long-lived reduction thread does not error out every interval. A transient failure
+    never throws.
+
+Arguments:
+
+    Bytes - Supplies the number of bytes to request the kernel reclaim.
+
+Return Value:
+
+    true if pages were reclaimed (full success or EAGAIN), false otherwise.
+
+--*/
+
+{
+    wil::unique_fd fd{TEMP_FAILURE_RETRY(open(RECLAIM_PATH, O_WRONLY | O_CLOEXEC))};
+    if (!fd)
+    {
+        LOG_ERROR("open({}) failed {}", RECLAIM_PATH, errno);
+        return false;
+    }
+
+    const std::string request = std::to_string(Bytes) + " swappiness=0";
+    if (UtilWriteStringView(fd.get(), request) == static_cast<ssize_t>(request.size()) || errno == EAGAIN)
+    {
+        return true;
+    }
+
+    LOG_ERROR("write({}, {}) failed {}", RECLAIM_PATH, request, errno);
+    return false;
+}
 
 void StartMemoryReductionThread(LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode)
 
@@ -3595,8 +3701,14 @@ void StartMemoryReductionThread(LX_MINI_INIT_MEMORY_RECLAIM_MODE Mode)
 
 Routine Description:
 
-    This routine starts a background thread that performs memory compaction and optional cache/memory
-    reclaim when the VM is idle. This ensures that the maximum number of pages can be discarded to the host.
+    This routine starts a background thread that reclaims cold page cache and compacts free pages while
+    the VM is idle, so the maximum number of pages can be discarded back to the host.
+
+    Reclaim is gated on CPU idle (measured over each interval using all non-idle CPU time, not just user
+    time) so it never competes with real work. Gradual mode reclaims cold file-backed page cache above a
+    small floor via the cgroup memory.reclaim knob, falling back to drop_caches when the knob is
+    unavailable. DropCache mode uses drop_caches directly. Freed pages are compacted so free-page
+    reporting can hand back large blocks.
 
 Arguments:
 
@@ -3610,129 +3722,167 @@ Return Value:
 
 try
 {
-    std::thread([Mode = Mode]() mutable {
+    if (Mode == LxMiniInitMemoryReclaimModeDisabled)
+    {
+        return;
+    }
+
+    std::thread([Mode]() {
         try
         {
             //
-            // Set the thread's scheduling policy to idle.
+            // Run at idle scheduling priority so reclaim never competes with real work.
             //
 
-            sched_param Parameter{};
-            Parameter.sched_priority = 0;
-            const int Result = pthread_setschedparam(pthread_self(), SCHED_IDLE, &Parameter);
-            THROW_ERRNO_IF(Result, Result != 0);
+            sched_param parameter{};
+            parameter.sched_priority = 0;
+            const int result = pthread_setschedparam(pthread_self(), SCHED_IDLE, &parameter);
+            THROW_ERRNO_IF(result, result != 0);
 
             //
-            // Periodically check if the machine is idle by querying procfs for CPU usage.
-            // Memory compaction will occur if both of the following conditions are true:
-            //     1. The CPU time since the last check is greater than the idle threshold.
-            //     2. The current CPU usage is below the idle threshold. This is measured by taking two readings one second apart.
+            // Gradual mode uses cgroup memory.reclaim and falls back to drop_caches when unavailable.
             //
 
-            double MemoryLow = 1024 * 1024 * 1024;
-            double MemoryHigh = 1.1 * 1024.0 * 1024.0 * 1024.0;
-            const int IdleThreshold = get_nprocs(); // Change math to adjust if sysconf(_SC_CLK_TCK) != 100? Is 1%
-            long long int Start, Stop = 0;
-            auto constexpr SleepDuration = std::chrono::seconds(30);
-            size_t ReclaimIndex = 0;
-            long long int const ReclaimThreshold = (get_nprocs() * sysconf(_SC_CLK_TCK) * SleepDuration / std::chrono::seconds(1)) / 200; // 0.5%
-            long long int ReclaimWindow[20] = {}; // 10 minutes
-            long long int ReclaimWindowLength = COUNT_OF(ReclaimWindow);
-            bool ReclaimIdling = false;
-
-            //
-            // Fall back to drop cache if the required cgroup path is not present.
-            //
-
-            if (Mode == LxMiniInitMemoryReclaimModeGradual && access(RECLAIM_PATH, W_OK) < 0)
+            bool useReclaim = Mode != LxMiniInitMemoryReclaimModeDropCache;
+            if (useReclaim && access(RECLAIM_PATH, W_OK) < 0)
             {
                 LOG_WARNING("access({}, W_OK) failed {}, falling back to drop_caches", RECLAIM_PATH, errno);
-                Mode = LxMiniInitMemoryReclaimModeDropCache;
+                useReclaim = false;
             }
 
-            if (Mode == LxMiniInitMemoryReclaimModeGradual)
+            constexpr auto c_pollInterval = std::chrono::seconds(10);
+
+            // An interval is idle when busy CPU is at most this fraction (per-mille) of total CPU time.
+            constexpr unsigned long long c_busyThresholdPerMille = 5; // 0.5%
+
+            // Reclaimable cache below this floor is always retained to protect a minimal working set.
+            constexpr long long c_floorBytes = 128ll * 1024 * 1024;
+
+            // Compact immediately on idle, but preserve the cache during normal pauses between commands.
+            constexpr int c_reclaimIdleIntervals = 12; // 2 minutes
+
+            // Scale reclaim requests with the VM size while keeping individual operations bounded.
+            constexpr long long c_minReclaimBytes = 256ll * 1024 * 1024;
+            constexpr long long c_maxReclaimBytes = 1024ll * 1024 * 1024;
+
+            struct sysinfo info = {};
+            THROW_LAST_ERROR_IF(sysinfo(&info) < 0);
+
+            long long reclaimStepBytes = (static_cast<long long>(info.totalram) * info.mem_unit) / 32;
+            if (reclaimStepBytes < c_minReclaimBytes)
             {
-                static_assert(COUNT_OF(ReclaimWindow) >= 6);
-                ReclaimWindowLength = 6; // Set to 3 minutes.
+                reclaimStepBytes = c_minReclaimBytes;
             }
-
-            for (auto i = 1; i < ReclaimWindowLength; i++)
+            else if (reclaimStepBytes > c_maxReclaimBytes)
             {
-                ReclaimWindow[i] = LLONG_MIN;
+                reclaimStepBytes = c_maxReclaimBytes;
             }
 
-            std::this_thread::sleep_for(SleepDuration);
+            unsigned long long previousBusy = 0;
+            unsigned long long previousIdle = 0;
+            bool havePreviousSample = false;
+            int idleIntervals = 0;
+
+            bool droppedThisIdlePeriod = false;
+            bool compactedThisIdlePeriod = false;
+
             for (;;)
             {
-                auto const Target = std::chrono::steady_clock::now() + SleepDuration;
-                Start = GetUserCpuTime();
-                THROW_LAST_ERROR_IF(Start == -1);
+                std::this_thread::sleep_for(c_pollInterval);
 
-                if (Mode != LxMiniInitMemoryReclaimModeDisabled)
+                unsigned long long busy = 0;
+                unsigned long long idle = 0;
+                if (!ReadCpuBusyIdle(busy, idle))
                 {
-                    //
-                    // Ensure that utilization is below 0.5% from the last 30 seconds, and last n minutes, of usage.
-                    //
+                    continue;
+                }
 
-                    size_t const LastIndex = (ReclaimIndex + 1) % ReclaimWindowLength;
-                    if ((ReclaimWindow[LastIndex] > Start - ReclaimThreshold * (ReclaimWindowLength + 1)) &&
-                        (ReclaimWindow[ReclaimIndex] > Start - ReclaimThreshold))
-                    {
-                        if (Mode == LxMiniInitMemoryReclaimModeGradual)
-                        {
-                            double MemorySize = GetMemoryInUse();
-                            THROW_LAST_ERROR_IF(MemorySize < 0);
-
-                            if (MemorySize > MemoryHigh)
-                            {
-                                ReclaimIdling = false;
-                            }
-
-                            if (!ReclaimIdling && MemorySize > MemoryLow)
-                            {
-                                double MemoryTargetSize = MemorySize * 0.97;
-                                std::string MemoryToFree = std::to_string(size_t(MemorySize - MemoryTargetSize));
-                                // EAGAIN Means that it attempted, but was unable to evict sufficient pages.
-                                THROW_LAST_ERROR_IF(WriteToFile(RECLAIM_PATH, MemoryToFree.c_str()) < 0 && errno != EAGAIN);
-
-                                if (MemoryTargetSize < MemoryLow)
-                                {
-                                    ReclaimIdling = true;
-                                }
-                            }
-                        }
-                        else if (!ReclaimIdling)
-                        {
-                            ReclaimIdling = true;
-                            THROW_LAST_ERROR_IF(WriteToFile("/proc/sys/vm/drop_caches", "1\n") < 0);
-                        }
-                    }
-                    else
-                    {
-                        ReclaimIdling = false;
-                    }
-
-                    ReclaimIndex = LastIndex;
-                    ReclaimWindow[ReclaimIndex] = Start;
+                if (!havePreviousSample)
+                {
+                    previousBusy = busy;
+                    previousIdle = idle;
+                    havePreviousSample = true;
+                    continue;
                 }
 
                 //
-                // Perform memory compaction if the VM is idle.
-                // This coalesces free pages into larger blocks for more efficient page reporting.
+                // Guard against non-monotonic counters (should not happen, but resample if it does).
                 //
 
-                if ((Start - Stop) > IdleThreshold)
+                if (busy < previousBusy || idle < previousIdle)
                 {
-                    std::this_thread::sleep_for(std::chrono::seconds(1));
-                    Stop = GetUserCpuTime();
-                    THROW_LAST_ERROR_IF(Stop == -1);
-                    if ((Stop - Start) < IdleThreshold)
+                    previousBusy = busy;
+                    previousIdle = idle;
+                    continue;
+                }
+
+                const unsigned long long busyDelta = busy - previousBusy;
+                const unsigned long long totalDelta = busyDelta + (idle - previousIdle);
+                previousBusy = busy;
+                previousIdle = idle;
+
+                const bool intervalIdle = (totalDelta == 0) || (busyDelta * 1000 <= totalDelta * c_busyThresholdPerMille);
+                if (!intervalIdle)
+                {
+                    idleIntervals = 0;
+                    droppedThisIdlePeriod = false;
+                    compactedThisIdlePeriod = false;
+                    continue;
+                }
+
+                idleIntervals += 1;
+
+                //
+                // The VM is idle: reclaim cold cache and compact.
+                //
+
+                bool reclaimed = false;
+                if (idleIntervals >= c_reclaimIdleIntervals && useReclaim)
+                {
+                    const long long cache = GetReclaimableCacheBytes();
+                    if (cache > c_floorBytes)
                     {
-                        THROW_LAST_ERROR_IF(WriteToFile("/proc/sys/vm/compact_memory", "1\n") < 0);
+                        long long bytes = cache - c_floorBytes;
+                        if (bytes > reclaimStepBytes)
+                        {
+                            bytes = reclaimStepBytes;
+                        }
+
+                        reclaimed = RequestReclaim(bytes);
+                    }
+                }
+                else if (idleIntervals >= c_reclaimIdleIntervals && !useReclaim && !droppedThisIdlePeriod)
+                {
+                    if (WriteToFile("/proc/sys/vm/drop_caches", "1\n") == 0)
+                    {
+                        droppedThisIdlePeriod = true;
+                        reclaimed = true;
                     }
                 }
 
-                std::this_thread::sleep_until(Target);
+                //
+                // Coalesce freed pages into larger blocks for efficient page reporting.
+                //
+
+                bool memoryOperation = reclaimed;
+                if (!compactedThisIdlePeriod || reclaimed)
+                {
+                    if (WriteToFile("/proc/sys/vm/compact_memory", "1\n") == 0)
+                    {
+                        compactedThisIdlePeriod = true;
+                        memoryOperation = true;
+                    }
+                }
+
+                //
+                // Exclude the reclaim/compaction work from the next utilization interval so it does not
+                // restart the grace period itself.
+                //
+
+                if (memoryOperation)
+                {
+                    ReadCpuBusyIdle(previousBusy, previousIdle);
+                }
             }
         }
         CATCH_LOG()

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3681,8 +3681,12 @@ Return Value:
     }
 
     // /proc/meminfo values are in kB.
-    long long totalKb = 0;
-    bool foundCounter = false;
+    long long activeFileKb = 0;
+    long long inactiveFileKb = 0;
+    long long reclaimableSlabKb = 0;
+    bool foundActiveFile = false;
+    bool foundInactiveFile = false;
+    bool foundReclaimableSlab = false;
     std::string line;
     while (std::getline(memInfo, line))
     {
@@ -3694,10 +3698,20 @@ Return Value:
             continue;
         }
 
-        if (name == "Active(file):" || name == "Inactive(file):" || name == "SReclaimable:")
+        if (name == "Active(file):")
         {
-            foundCounter = true;
-            totalKb += value;
+            activeFileKb = value;
+            foundActiveFile = true;
+        }
+        else if (name == "Inactive(file):")
+        {
+            inactiveFileKb = value;
+            foundInactiveFile = true;
+        }
+        else if (name == "SReclaimable:")
+        {
+            reclaimableSlabKb = value;
+            foundReclaimableSlab = true;
         }
     }
 
@@ -3707,13 +3721,13 @@ Return Value:
         return -1;
     }
 
-    if (!foundCounter)
+    if (!foundActiveFile || !foundInactiveFile || !foundReclaimableSlab)
     {
         LOG_ERROR("failed to find reclaimable cache counters in /proc/meminfo");
         return -1;
     }
 
-    return totalKb * 1024;
+    return (activeFileKb + inactiveFileKb + reclaimableSlabKb) * 1024;
 }
 
 static bool RequestReclaim(long long Bytes)
@@ -3945,7 +3959,13 @@ try
 
                 if (memoryOperation)
                 {
-                    ReadCpuBusyIdle(previousBusy, previousIdle);
+                    if (!ReadCpuBusyIdle(previousBusy, previousIdle))
+                    {
+                        havePreviousSample = false;
+                        idleTracker.Reset();
+                        droppedThisIdlePeriod = false;
+                        compactedThisIdlePeriod = false;
+                    }
                 }
             }
         }

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3505,6 +3505,66 @@ int ProcessCreateProcessMessage(wsl::shared::Transaction& Transaction, gsl::span
 
 #define RECLAIM_PATH CGROUP_MOUNTPOINT "/memory.reclaim"
 
+namespace {
+
+class CpuIdleTracker
+{
+public:
+    struct State
+    {
+        bool IntervalIdle;
+        bool WindowIdle;
+    };
+
+    State AddSample(unsigned long long Busy, unsigned long long Total)
+    {
+        m_windowBusy -= m_busyWindow[m_windowIndex];
+        m_windowTotal -= m_totalWindow[m_windowIndex];
+        m_busyWindow[m_windowIndex] = Busy;
+        m_totalWindow[m_windowIndex] = Total;
+        m_windowBusy += Busy;
+        m_windowTotal += Total;
+        m_windowIndex = (m_windowIndex + 1) % c_windowIntervals;
+        if (m_windowSamples < c_windowIntervals)
+        {
+            m_windowSamples += 1;
+        }
+
+        return {
+            .IntervalIdle = IsIdle(Busy, Total),
+            .WindowIdle = m_windowSamples == c_windowIntervals && IsIdle(m_windowBusy, m_windowTotal),
+        };
+    }
+
+    void Reset()
+    {
+        m_busyWindow.fill(0);
+        m_totalWindow.fill(0);
+        m_windowBusy = 0;
+        m_windowTotal = 0;
+        m_windowIndex = 0;
+        m_windowSamples = 0;
+    }
+
+private:
+    static bool IsIdle(unsigned long long Busy, unsigned long long Total)
+    {
+        return Total == 0 || Busy * 1000 <= Total * c_busyThresholdPerMille;
+    }
+
+    static constexpr size_t c_windowIntervals = 12;                  // 2 minutes
+    static constexpr unsigned long long c_busyThresholdPerMille = 5; // 0.5%
+
+    std::array<unsigned long long, c_windowIntervals> m_busyWindow{};
+    std::array<unsigned long long, c_windowIntervals> m_totalWindow{};
+    unsigned long long m_windowBusy = 0;
+    unsigned long long m_windowTotal = 0;
+    size_t m_windowIndex = 0;
+    size_t m_windowSamples = 0;
+};
+
+} // namespace
+
 static bool ReadCpuBusyIdle(unsigned long long& Busy, unsigned long long& Idle)
 
 /*++
@@ -3686,7 +3746,8 @@ Return Value:
     }
 
     const std::string request = std::to_string(Bytes) + " swappiness=0";
-    if (UtilWriteStringView(fd.get(), request) == static_cast<ssize_t>(request.size()) || errno == EAGAIN)
+    const ssize_t result = UtilWriteStringView(fd.get(), request);
+    if (result == static_cast<ssize_t>(request.size()) || (result < 0 && errno == EAGAIN))
     {
         return true;
     }
@@ -3704,11 +3765,10 @@ Routine Description:
     This routine starts a background thread that reclaims cold page cache and compacts free pages while
     the VM is idle, so the maximum number of pages can be discarded back to the host.
 
-    Reclaim is gated on CPU idle (measured over each interval using all non-idle CPU time, not just user
-    time) so it never competes with real work. Gradual mode reclaims cold file-backed page cache above a
-    small floor via the cgroup memory.reclaim knob, falling back to drop_caches when the knob is
-    unavailable. DropCache mode uses drop_caches directly. Freed pages are compacted so free-page
-    reporting can hand back large blocks.
+    Reclaim is gated on CPU idle using a rolling window of all non-idle CPU time, not just user time.
+    Gradual mode reclaims cold file-backed page cache above a small floor via the cgroup memory.reclaim
+    knob, falling back to drop_caches when the knob is unavailable. DropCache mode uses drop_caches
+    directly. Freed pages are compacted so free-page reporting can hand back large blocks.
 
 Arguments:
 
@@ -3752,14 +3812,8 @@ try
 
             constexpr auto c_pollInterval = std::chrono::seconds(10);
 
-            // An interval is idle when busy CPU is at most this fraction (per-mille) of total CPU time.
-            constexpr unsigned long long c_busyThresholdPerMille = 5; // 0.5%
-
             // Reclaimable cache below this floor is always retained to protect a minimal working set.
             constexpr long long c_floorBytes = 128ll * 1024 * 1024;
-
-            // Compact immediately on idle, but preserve the cache during normal pauses between commands.
-            constexpr int c_reclaimIdleIntervals = 12; // 2 minutes
 
             // Scale reclaim requests with the VM size while keeping individual operations bounded.
             constexpr long long c_minReclaimBytes = 256ll * 1024 * 1024;
@@ -3781,7 +3835,8 @@ try
             unsigned long long previousBusy = 0;
             unsigned long long previousIdle = 0;
             bool havePreviousSample = false;
-            int idleIntervals = 0;
+
+            CpuIdleTracker idleTracker;
 
             bool droppedThisIdlePeriod = false;
             bool compactedThisIdlePeriod = false;
@@ -3813,6 +3868,9 @@ try
                 {
                     previousBusy = busy;
                     previousIdle = idle;
+                    idleTracker.Reset();
+                    droppedThisIdlePeriod = false;
+                    compactedThisIdlePeriod = false;
                     continue;
                 }
 
@@ -3821,23 +3879,29 @@ try
                 previousBusy = busy;
                 previousIdle = idle;
 
-                const bool intervalIdle = (totalDelta == 0) || (busyDelta * 1000 <= totalDelta * c_busyThresholdPerMille);
-                if (!intervalIdle)
+                const auto idleState = idleTracker.AddSample(busyDelta, totalDelta);
+                if (!idleState.WindowIdle)
                 {
-                    idleIntervals = 0;
                     droppedThisIdlePeriod = false;
                     compactedThisIdlePeriod = false;
                     continue;
                 }
 
-                idleIntervals += 1;
+                //
+                // A short burst blocks this tick but does not discard the preceding idle history.
+                //
+
+                if (!idleState.IntervalIdle)
+                {
+                    continue;
+                }
 
                 //
                 // The VM is idle: reclaim cold cache and compact.
                 //
 
                 bool reclaimed = false;
-                if (idleIntervals >= c_reclaimIdleIntervals && useReclaim)
+                if (useReclaim)
                 {
                     const long long cache = GetReclaimableCacheBytes();
                     if (cache > c_floorBytes)
@@ -3851,7 +3915,7 @@ try
                         reclaimed = RequestReclaim(bytes);
                     }
                 }
-                else if (idleIntervals >= c_reclaimIdleIntervals && !useReclaim && !droppedThisIdlePeriod)
+                else if (!droppedThisIdlePeriod)
                 {
                     if (WriteToFile("/proc/sys/vm/drop_caches", "1\n") == 0)
                     {


### PR DESCRIPTION
## What this changes

This replaces the existing memory reduction loop with a shared idle detector and simpler reclaim policy.

- CPU idle detection uses aggregate busy time instead of user time only.
- Free pages are compacted when the VM enters idle and after every reclaim operation.
- Cache reclaim waits for two minutes of sustained idle, protecting normal pauses between commands.
- Reclaim and compaction CPU are excluded from the next idle sample so the thread does not reset its own grace period.

### Modes

| Mode | Behavior after two minutes idle |
|---|---|
| Disabled | No memory reduction thread |
| DropCache | Run `drop_caches` once for the idle period |
| Gradual | Reclaim cold cache toward a 128 MB floor using RAM-scaled 256 MB to 1 GB steps |

Gradual uses `memory.reclaim` with `swappiness=0`, which prevents proactive reclaim from swapping anonymous memory. If `memory.reclaim` is unavailable, it falls back to DropCache.

The default remains DropCache.

## Why

The current implementation waits approximately ten minutes before dropping cache and only measures user CPU time. This leaves `vmmemWSL` elevated long after real workloads finish and can treat kernel or I/O work as idle.

The new policy returns memory sooner while preserving cache during short user pauses.

## DropCache results

Measured with two clean 16-way Linux kernel builds, two read-heavy source archive runs, and three warm-cache reuse runs per configuration.

| Metric | Existing DropCache | New DropCache |
|---|---:|---:|
| Kernel build: 50% working-set reduction | 591s | 177s |
| Source archive: 50% working-set reduction | 542s | 142s |
| Warm reread after 60 seconds idle | 0.233s | 0.220s |
| Kernel working set after 15 minutes | 2.14 GiB | 2.12 GiB |
| Source archive working set after 15 minutes | 1.99 GiB | 1.98 GiB |

The new DropCache policy reaches the existing eventual footprint roughly seven minutes sooner without affecting the 60-second warm-cache case.

## Gradual results

A focused test using the same two-minute grace period showed:

- warm rereads after 60 seconds remained at 0.22-0.23 seconds
- 1.83 GiB of reclaimable cache remained intact through 120 seconds
- reclaim began at approximately 129 seconds
- cache fell to 0.14 GiB by 140 seconds
- `vmmemWSL` fell from 3.23 GiB to 1.63 GiB by 150 seconds

Gradual reaches a lower sustained footprint because it continues reclaiming regrown cache toward the floor. DropCache remains the default for compatibility and Gradual remains available for users who prioritize minimum memory usage.

## Validation

- `cmake --build . --config Debug -- -m`
- built and deployed the generated MSI
- verified `memory.reclaim` `swappiness=0` support on the WSL 6.18 kernel
- collected host `vmmemWSL`, guest memory, reclaim, compaction, workload timing, and warm-cache reuse data