### PR TITLE
Remove hard-coded password from C# API docs

### DIFF
--- a/doc/docs/api-reference/csharp/core-classes/session.md
+++ b/doc/docs/api-reference/csharp/core-classes/session.md
@@ -181,7 +181,7 @@ Authenticates to a registry and returns an identity token string.
 string token = session.Authenticate(
     new Uri("https://registry.example.com"),
     "user1",
-    Environment.GetEnvironmentVariable("REGISTRY_PASSWORD")!);
+    "password");
 ```
 
 ## Session.GetImages()

--- a/doc/docs/api-reference/csharp/core-classes/session.md
+++ b/doc/docs/api-reference/csharp/core-classes/session.md
@@ -181,7 +181,7 @@ Authenticates to a registry and returns an identity token string.
 string token = session.Authenticate(
     new Uri("https://registry.example.com"),
     "user1",
-    "p@ssw0rd");
+    Environment.GetEnvironmentVariable("REGISTRY_PASSWORD")!);
 ```
 
 ## Session.GetImages()


### PR DESCRIPTION
## Summary
- replace the CredScan-triggering sample password with a neutral documentation placeholder
- prevent the Guardian CSCAN-MSFT0090 failure

## Validation
- py -m mkdocs build -f doc\mkdocs.yml