### PR TITLE
CLI: Make container id required for stop command

### DIFF
--- a/src/windows/wslc/commands/ContainerStopCommand.cpp
+++ b/src/windows/wslc/commands/ContainerStopCommand.cpp
@@ -27,7 +27,7 @@ namespace wsl::windows::wslc {
 std::vector<Argument> ContainerStopCommand::GetArguments() const
 {
     return {
-        Argument::Create(ArgType::ContainerId, std::nullopt, NO_LIMIT),
+        Argument::Create(ArgType::ContainerId, true, NO_LIMIT),
         Argument::Create(ArgType::Signal),
         Argument::Create(ArgType::Time),
     };

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -95,7 +95,8 @@ COMMAND_LINE_TEST_CASE(L"container run ubuntu", L"run", true)
 COMMAND_LINE_TEST_CASE(L"container run --cidfile C:\\temp\\cidfile ubuntu", L"run", true)
 COMMAND_LINE_TEST_CASE(L"container run -it --name foo ubuntu", L"run", true)
 COMMAND_LINE_TEST_CASE(L"container run --rm -it --name foo ubuntu", L"run", true)
-COMMAND_LINE_TEST_CASE(L"stop", L"stop", true)
+COMMAND_LINE_TEST_CASE(L"stop", L"stop", false)           // Missing required container-id positional
+COMMAND_LINE_TEST_CASE(L"container stop", L"stop", false) // Missing required container-id positional
 COMMAND_LINE_TEST_CASE(L"container stop cont1 --signal 9", L"stop", true)
 COMMAND_LINE_TEST_CASE(L"container stop cont1 --signal SIGALRM", L"stop", true)
 COMMAND_LINE_TEST_CASE(L"container stop cont1 --signal sigkill", L"stop", true)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changes the 'container stop' command to require at least one container id.

This is consistent with Docker CLI's container stop command, which also requires at least one.
Reference: [https://docs.docker.com/reference/cli/docker/container/stop](https://docs.docker.com/reference/cli/docker/container/stop)
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Set the container id to be required.
Updated command line tests to verify fail if it is not provided.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
