### PR TITLE
CLI: Route wslc warnings through Reporter

### DIFF
--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -41,9 +41,10 @@ static void SetContainerArguments(WSLCProcessOptions& options, std::vector<const
     options.CommandLine = {.Values = argsStorage.data(), .Count = static_cast<ULONG>(argsStorage.size())};
 }
 
-static wsl::windows::common::RunningWSLCContainer CreateInternal(
-    Reporter& reporter, Session& session, const std::string& image, const ContainerOptions& options, IWarningCallback* warningCallback = nullptr)
+static wsl::windows::common::RunningWSLCContainer CreateInternal(Reporter& reporter, Session& session, const std::string& image, const ContainerOptions& options)
 {
+    WarningCallback warningCallback(reporter);
+
     auto processFlags = WSLCProcessFlagsNone;
     WI_SetFlagIf(processFlags, WSLCProcessFlagsStdin, options.Interactive);
     WI_SetFlagIf(processFlags, WSLCProcessFlagsTty, options.TTY);
@@ -243,7 +244,7 @@ static wsl::windows::common::RunningWSLCContainer CreateInternal(
         containerLauncher.AddLabel(key, value);
     }
 
-    auto [result, runningContainer] = containerLauncher.CreateNoThrow(*session.Get(), warningCallback);
+    auto [result, runningContainer] = containerLauncher.CreateNoThrow(*session.Get(), &warningCallback);
     if (result == WSLC_E_IMAGE_NOT_FOUND)
     {
         {
@@ -252,9 +253,9 @@ static wsl::windows::common::RunningWSLCContainer CreateInternal(
             ImageProgressCallback callback(reporter, Reporter::Level::Info);
             reporter.Info(L"{}\n", Localization::WSLCCLI_ImageNotFoundPulling(wsl::shared::string::MultiByteToWide(image)));
             ImageService imageService;
-            imageService.Pull(session, image, &callback);
+            imageService.Pull(reporter, session, image, &callback);
         }
-        return containerLauncher.Create(*session.Get(), warningCallback);
+        return containerLauncher.Create(*session.Get(), &warningCallback);
     }
 
     THROW_IF_FAILED(result);
@@ -431,10 +432,9 @@ int ContainerService::Run(Reporter& reporter, Session& session, const std::strin
     // container isn't created when the caller-requested path can't be written. The file is
     // removed automatically if we don't reach Commit() below.
     CidFile cidFile(runOptions.CidFile);
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
 
     // Create the container
-    auto runningContainer = CreateInternal(reporter, session, image, runOptions, warningCallback.Get());
+    auto runningContainer = CreateInternal(reporter, session, image, runOptions);
     auto& container = runningContainer.Get();
 
     WSLCContainerId containerId{};
@@ -456,7 +456,8 @@ int ContainerService::Run(Reporter& reporter, Session& session, const std::strin
         startOptions.TtyColumns = size.X;
     }
 
-    THROW_IF_FAILED(container.Start(startFlags, &startOptions, warningCallback.Get())); // TODO: detach keys
+    WarningCallback warningCallback(reporter);
+    THROW_IF_FAILED(container.Start(startFlags, &startOptions, &warningCallback)); // TODO: detach keys
 
     // Disable auto-delete only after successful start
     runningContainer.SetDeleteOnClose(false);
@@ -475,8 +476,7 @@ int ContainerService::Run(Reporter& reporter, Session& session, const std::strin
 CreateContainerResult ContainerService::Create(Reporter& reporter, Session& session, const std::string& image, ContainerOptions runOptions)
 {
     CidFile cidFile(runOptions.CidFile);
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
-    auto runningContainer = CreateInternal(reporter, session, image, runOptions, warningCallback.Get());
+    auto runningContainer = CreateInternal(reporter, session, image, runOptions);
     runningContainer.SetDeleteOnClose(false);
     auto& container = runningContainer.Get();
     WSLCContainerId id{};
@@ -490,7 +490,6 @@ int ContainerService::Start(Reporter& reporter, Session& session, const std::str
     wil::com_ptr<IWSLCContainer> container;
     THROW_IF_FAILED(session.Get()->OpenContainer(id.c_str(), &container));
     WSLCContainerStartFlags flags = attach ? WSLCContainerStartFlagsAttach : WSLCContainerStartFlagsNone;
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
 
     wsl::windows::common::ConsoleState console;
     WSLCProcessStartOptions startOptions{};
@@ -498,7 +497,8 @@ int ContainerService::Start(Reporter& reporter, Session& session, const std::str
     startOptions.TtyRows = size.Y;
     startOptions.TtyColumns = size.X;
 
-    THROW_IF_FAILED_EXCEPT(container->Start(flags, &startOptions, warningCallback.Get()), WSLC_E_CONTAINER_IS_RUNNING);
+    WarningCallback warningCallback(reporter);
+    THROW_IF_FAILED_EXCEPT(container->Start(flags, &startOptions, &warningCallback), WSLC_E_CONTAINER_IS_RUNNING);
 
     if (!attach)
     {

--- a/src/windows/wslc/services/ContainerService.h
+++ b/src/windows/wslc/services/ContainerService.h
@@ -16,6 +16,7 @@ Abstract:
 #include "ContainerModel.h"
 #include "Reporter.h"
 #include <docker_schema.h>
+#include <wslc.h>
 #include <wslc_schema.h>
 
 namespace wsl::windows::wslc::services {

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -231,24 +231,20 @@ std::vector<ImageInformation> ImageService::List(
     return result;
 }
 
-void ImageService::Load(wsl::windows::wslc::models::Session& session, const std::wstring& input, IImageLoadCallback* callback)
+void ImageService::Load(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::wstring& input, IImageLoadCallback* callback)
 {
+    WarningCallback warningCallback(reporter);
     auto source = OpenImageInput(input);
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
-    THROW_IF_FAILED(session.Get()->LoadImage(ToCOMInputHandle(source.Handle.Get()), source.ContentLength, warningCallback.Get(), callback));
+    THROW_IF_FAILED(session.Get()->LoadImage(ToCOMInputHandle(source.Handle.Get()), source.ContentLength, &warningCallback, callback));
 }
 
-std::string ImageService::Import(wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName)
+std::string ImageService::Import(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName)
 {
+    WarningCallback warningCallback(reporter);
     auto source = OpenImageInput(input);
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
     wil::unique_cotaskmem_ansistring imageId;
     THROW_IF_FAILED(session.Get()->ImportImage(
-        ToCOMInputHandle(source.Handle.Get()),
-        imageName.empty() ? nullptr : imageName.c_str(),
-        source.ContentLength,
-        warningCallback.Get(),
-        &imageId));
+        ToCOMInputHandle(source.Handle.Get()), imageName.empty() ? nullptr : imageName.c_str(), source.ContentLength, &warningCallback, &imageId));
     return imageId.get() ? std::string(imageId.get()) : std::string();
 }
 
@@ -271,12 +267,12 @@ void ImageService::Delete(wsl::windows::wslc::models::Session& session, const st
     THROW_IF_FAILED(session.Get()->DeleteImage(&options, &deletedImages, deletedImages.size_address<ULONG>()));
 }
 
-void ImageService::Pull(wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback)
+void ImageService::Pull(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback)
 {
+    WarningCallback warningCallback(reporter);
     auto server = GetServerFromImage(image);
     auto auth = RegistryService::Get(server);
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
-    THROW_IF_FAILED(session.Get()->PullImage(image.c_str(), auth.c_str(), callback, warningCallback.Get()));
+    THROW_IF_FAILED(session.Get()->PullImage(image.c_str(), auth.c_str(), callback, &warningCallback));
 }
 
 void ImageService::Tag(wsl::windows::wslc::models::Session& session, const std::string& sourceImage, const std::string& targetImage)
@@ -303,12 +299,12 @@ InspectImage ImageService::Inspect(wsl::windows::wslc::models::Session& session,
     return wsl::shared::FromJson<InspectImage>(inspectData.get());
 }
 
-void ImageService::Push(wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback)
+void ImageService::Push(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback)
 {
+    WarningCallback warningCallback(reporter);
     auto server = GetServerFromImage(image);
     auto auth = RegistryService::Get(server);
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
-    THROW_IF_FAILED(session.Get()->PushImage(image.c_str(), auth.c_str(), callback, warningCallback.Get()));
+    THROW_IF_FAILED(session.Get()->PushImage(image.c_str(), auth.c_str(), callback, &warningCallback));
 }
 
 void ImageService::Save(wsl::windows::wslc::models::Session& session, const std::vector<std::string>& images, const std::wstring& output, HANDLE cancelEvent)

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -15,6 +15,7 @@ Abstract:
 
 #include "SessionModel.h"
 #include "ImageModel.h"
+#include "Reporter.h"
 #include <wslc_schema.h>
 
 namespace wsl::windows::wslc::services {
@@ -35,12 +36,12 @@ public:
 
     static std::vector<wsl::windows::wslc::models::ImageInformation> List(
         wsl::windows::wslc::models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
-    static void Load(wsl::windows::wslc::models::Session& session, const std::wstring& input, IImageLoadCallback* callback = nullptr);
-    static std::string Import(wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName);
+    static void Load(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::wstring& input, IImageLoadCallback* callback = nullptr);
+    static std::string Import(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName);
     static void Delete(wsl::windows::wslc::models::Session& session, const std::string& image, bool force, bool noPrune);
     static wsl::windows::common::wslc_schema::InspectImage Inspect(wsl::windows::wslc::models::Session& session, const std::string& image);
-    static void Pull(wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback);
-    static void Push(wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback);
+    static void Pull(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback);
+    static void Push(Reporter& reporter, wsl::windows::wslc::models::Session& session, const std::string& image, IProgressCallback* callback);
     static void Save(wsl::windows::wslc::models::Session& session, const std::vector<std::string>& images, const std::wstring& output, HANDLE cancelEvent = nullptr);
     static void Save(wsl::windows::wslc::models::Session& session, const std::vector<std::string>& images, HANDLE outputHandle, HANDLE cancelEvent = nullptr);
     static void Tag(wsl::windows::wslc::models::Session& session, const std::string& sourceImage, const std::string& targetImage);

--- a/src/windows/wslc/services/NetworkService.cpp
+++ b/src/windows/wslc/services/NetworkService.cpp
@@ -22,8 +22,9 @@ using namespace wsl::windows::common::wslutil;
 
 namespace wsl::windows::wslc::services {
 
-void NetworkService::Create(models::Session& session, const models::CreateNetworkOptions& createOptions)
+void NetworkService::Create(Reporter& reporter, models::Session& session, const models::CreateNetworkOptions& createOptions)
 {
+    WarningCallback warningCallback(reporter);
     WSLCNetworkOptions options{};
     options.Name = createOptions.Name.c_str();
     if (createOptions.Driver.has_value())
@@ -61,8 +62,7 @@ void NetworkService::Create(models::Session& session, const models::CreateNetwor
         options.Gateway = createOptions.Gateway->c_str();
     }
 
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
-    THROW_IF_FAILED(session.Get()->CreateNetwork(&options, warningCallback.Get()));
+    THROW_IF_FAILED(session.Get()->CreateNetwork(&options, &warningCallback));
 }
 
 void NetworkService::Delete(models::Session& session, const std::string& name)

--- a/src/windows/wslc/services/NetworkService.h
+++ b/src/windows/wslc/services/NetworkService.h
@@ -15,12 +15,14 @@ Abstract:
 
 #include "SessionModel.h"
 #include "NetworkModel.h"
+#include "Reporter.h"
+#include <wslc.h>
 #include <wslc_schema.h>
 
 namespace wsl::windows::wslc::services {
 struct NetworkService
 {
-    static void Create(models::Session& session, const models::CreateNetworkOptions& createOptions);
+    static void Create(Reporter& reporter, models::Session& session, const models::CreateNetworkOptions& createOptions);
     static void Delete(models::Session& session, const std::string& name);
     static std::vector<WSLCNetworkInformation> List(models::Session& session);
     static wsl::windows::common::wslc_schema::Network Inspect(models::Session& session, const std::string& name);

--- a/src/windows/wslc/services/SessionService.cpp
+++ b/src/windows/wslc/services/SessionService.cpp
@@ -52,14 +52,14 @@ Session SessionService::OpenDefaultSession()
     return OpenSessionByName(CreateSessionManager(), nullptr);
 }
 
-Session SessionService::OpenOrCreateDefaultSession()
+Session SessionService::OpenOrCreateDefaultSession(Reporter& reporter)
 {
+    WarningCallback warningCallback(reporter);
     auto manager = CreateSessionManager();
 
     // Null Settings = default session with server-determined name and settings.
     wil::com_ptr<IWSLCSession> session;
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
-    THROW_IF_FAILED(manager->CreateSession(nullptr, WSLCSessionFlagsNone, warningCallback.Get(), &session));
+    THROW_IF_FAILED(manager->CreateSession(nullptr, WSLCSessionFlagsNone, &warningCallback, &session));
     wsl::windows::common::security::ConfigureForCOMImpersonation(session.get());
     return Session(std::move(session));
 }
@@ -123,11 +123,11 @@ int SessionService::Enter(Reporter& reporter, const std::wstring& storagePath, c
     THROW_HR_IF(E_INVALIDARG, storagePath.empty());
     THROW_HR_IF(E_INVALIDARG, displayName.empty());
 
+    WarningCallback warningCallback(reporter);
     auto sessionManager = CreateSessionManager();
 
     wil::com_ptr<IWSLCSession> session;
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
-    THROW_IF_FAILED(sessionManager->EnterSession(displayName.c_str(), storagePath.c_str(), warningCallback.Get(), &session));
+    THROW_IF_FAILED(sessionManager->EnterSession(displayName.c_str(), storagePath.c_str(), &warningCallback, &session));
     wsl::windows::common::security::ConfigureForCOMImpersonation(session.get());
     reporter.Info(L"{}\n", Localization::MessageWslcCreatedSession(displayName));
 

--- a/src/windows/wslc/services/SessionService.h
+++ b/src/windows/wslc/services/SessionService.h
@@ -35,7 +35,7 @@ struct SessionService
     // Opens the default session. Throws WSLC_E_SESSION_NOT_FOUND if no default session exists.
     static wsl::windows::wslc::models::Session OpenDefaultSession();
     // Opens or creates the default session.
-    static wsl::windows::wslc::models::Session OpenOrCreateDefaultSession();
+    static wsl::windows::wslc::models::Session OpenOrCreateDefaultSession(Reporter& reporter);
     // Runs the given command and arguments in a session without a TTY, resolving the executable from PATH.
     static int Run(Reporter& reporter, const wsl::windows::wslc::models::Session& session, const std::vector<std::string>& arguments);
     static int TerminateSession(Reporter& reporter, const wsl::windows::wslc::models::Session& session);

--- a/src/windows/wslc/services/VolumeService.cpp
+++ b/src/windows/wslc/services/VolumeService.cpp
@@ -83,8 +83,10 @@ wsl::windows::common::wslc_schema::InspectVolume VolumeService::Inspect(models::
     return FromJson<wsl::windows::common::wslc_schema::InspectVolume>(output.get());
 }
 
-models::PruneVolumesResult VolumeService::Prune(models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters)
+models::PruneVolumesResult VolumeService::Prune(
+    Reporter& reporter, models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters)
 {
+    WarningCallback warningCallback(reporter);
     const bool hasExplicitAll = std::any_of(filters.begin(), filters.end(), [](const auto& f) { return f.first == "all"; });
 
     std::vector<WSLCFilter> filterEntries;
@@ -99,13 +101,12 @@ models::PruneVolumesResult VolumeService::Prune(models::Session& session, bool a
         filterEntries.push_back({.Key = key.c_str(), .Value = value.c_str()});
     }
 
-    auto warningCallback = Microsoft::WRL::Make<WarningCallback>();
     wil::unique_cotaskmem_array_ptr<WSLCVolumeName> volumes;
     ULONGLONG spaceReclaimed = 0;
     THROW_IF_FAILED(session.Get()->PruneVolumes(
         filterEntries.empty() ? nullptr : filterEntries.data(),
         static_cast<ULONG>(filterEntries.size()),
-        warningCallback.Get(),
+        &warningCallback,
         &volumes,
         volumes.size_address<ULONG>(),
         &spaceReclaimed));

--- a/src/windows/wslc/services/VolumeService.h
+++ b/src/windows/wslc/services/VolumeService.h
@@ -15,6 +15,8 @@ Abstract:
 
 #include "SessionModel.h"
 #include "VolumeModel.h"
+#include "Reporter.h"
+#include <wslc.h>
 #include <wslc_schema.h>
 
 namespace wsl::windows::wslc::services {
@@ -24,6 +26,7 @@ struct VolumeService
     static void Delete(models::Session& session, const std::string& name);
     static std::vector<WSLCVolumeInformation> List(models::Session& session);
     static wsl::windows::common::wslc_schema::InspectVolume Inspect(models::Session& session, const std::string& name);
-    static models::PruneVolumesResult Prune(models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters = {});
+    static models::PruneVolumesResult Prune(
+        Reporter& reporter, models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters = {});
 };
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/services/WarningCallback.h
+++ b/src/windows/wslc/services/WarningCallback.h
@@ -2,23 +2,37 @@
 
 #pragma once
 
+#include "Reporter.h"
 #include <wslc.h>
 #include <wslutil.h>
 
 namespace wsl::windows::wslc::services {
 
+// Adapts the service IWarningCallback COM sink onto the CLI Reporter so the CLI, not the
+// service, decides how warnings are presented (mirrors ImageProgressCallback).
 class DECLSPEC_UUID("A7E3F8B2-4D19-4C6A-9E5B-8F2A1D3C7E90") WarningCallback
     : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, IWarningCallback, IFastRundown>
 {
 public:
+    explicit WarningCallback(Reporter& reporter) : m_reporter(reporter)
+    {
+    }
+
     HRESULT OnWarning(LPCWSTR Message) override
     {
         WI_ASSERT(Message);
-        // The message already includes the "wsl: " prefix and a trailing newline (added by
-        // EmitUserWarning), so write it directly. This matches how wsl.exe surfaces its warnings.
-        fputws(Message, stderr);
+        if (Message != nullptr)
+        {
+            // Message already carries the "wsl: " prefix and trailing newline from EmitUserWarning;
+            // Warn writes it verbatim, adding color only on a VT console.
+            m_reporter.Warn(L"{}", Message);
+        }
+
         return S_OK;
     }
+
+private:
+    Reporter& m_reporter;
 };
 
 } // namespace wsl::windows::wslc::services

--- a/src/windows/wslc/services/WarningCallback.h
+++ b/src/windows/wslc/services/WarningCallback.h
@@ -20,15 +20,19 @@ public:
 
     HRESULT OnWarning(LPCWSTR Message) override
     {
-        WI_ASSERT(Message);
-        if (Message != nullptr)
+        try
         {
-            // Message already carries the "wsl: " prefix and trailing newline from EmitUserWarning;
-            // Warn writes it verbatim, adding color only on a VT console.
-            m_reporter.Warn(L"{}", Message);
-        }
+            WI_ASSERT(Message);
+            if (Message != nullptr)
+            {
+                // Message already carries the "wsl: " prefix and trailing newline from EmitUserWarning;
+                // Warn writes it verbatim, adding color only on a VT console.
+                m_reporter.Warn(L"{}", Message);
+            }
 
-        return S_OK;
+            return S_OK;
+        }
+        CATCH_RETURN();
     }
 
 private:

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -226,7 +226,7 @@ void PullImage(CLIExecutionContext& context)
     auto& imageId = context.Args.Get<ArgType::ImageId>();
 
     ImageProgressCallback callback(context.Reporter, Reporter::Level::Output);
-    services::ImageService::Pull(session, WideToMultiByte(imageId), &callback);
+    services::ImageService::Pull(context.Reporter, session, WideToMultiByte(imageId), &callback);
 }
 
 void PushImage(CLIExecutionContext& context)
@@ -237,7 +237,7 @@ void PushImage(CLIExecutionContext& context)
     auto& imageId = context.Args.Get<ArgType::ImageId>();
 
     ImageProgressCallback callback(context.Reporter, Reporter::Level::Output);
-    services::ImageService::Push(session, WideToMultiByte(imageId), &callback);
+    services::ImageService::Push(context.Reporter, session, WideToMultiByte(imageId), &callback);
 }
 
 void DeleteImage(CLIExecutionContext& context)
@@ -262,7 +262,7 @@ void LoadImage(CLIExecutionContext& context)
     {
         auto& input = context.Args.Get<ArgType::Input>();
         auto callback = wil::MakeOrThrow<WSLCImageLoadCallback>(context.Reporter);
-        services::ImageService::Load(session, input, callback.Get());
+        services::ImageService::Load(context.Reporter, session, input, callback.Get());
         return;
     }
 
@@ -283,7 +283,7 @@ void ImportImage(CLIExecutionContext& context)
     }
 
     auto& input = context.Args.Get<ArgType::ImportFile>();
-    auto imageId = services::ImageService::Import(session, input, imageName);
+    auto imageId = services::ImageService::Import(context.Reporter, session, input, imageName);
     if (!imageId.empty())
     {
         bool trunc = !context.Args.Contains(ArgType::NoTrunc);

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -107,7 +107,7 @@ void CreateNetwork(CLIExecutionContext& context)
         options.Gateway = WideToMultiByte(context.Args.Get<ArgType::Gateway>());
     }
 
-    NetworkService::Create(context.Data.Get<Data::Session>(), options);
+    NetworkService::Create(context.Reporter, context.Data.Get<Data::Session>(), options);
     context.Reporter.Output(L"{}\n", MultiByteToWide(options.Name));
 }
 

--- a/src/windows/wslc/tasks/SessionTasks.cpp
+++ b/src/windows/wslc/tasks/SessionTasks.cpp
@@ -46,7 +46,7 @@ void OpenOrCreateDefaultSession(CLIExecutionContext& context)
 {
     if (!context.Data.Contains(Data::Session))
     {
-        context.Data.Add<Data::Session>(SessionService::OpenOrCreateDefaultSession());
+        context.Data.Add<Data::Session>(SessionService::OpenOrCreateDefaultSession(context.Reporter));
     }
 }
 

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -213,7 +213,7 @@ void PruneVolumes(CLIExecutionContext& context)
         filters.push_back(validation::ParseFilter(value));
     }
 
-    auto result = VolumeService::Prune(session, all, filters);
+    auto result = VolumeService::Prune(context.Reporter, session, all, filters);
 
     for (const auto& volumeName : result.PrunedVolumes)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Follows up on #41010 (which routed all non-help wslc output through `Reporter`) by
routing service-layer **warnings** through the same `Reporter` sink. Previously the
warning callback wrote directly to `stderr`, bypassing `Reporter` and its
`no-color` / output-level handling. With this change warnings are now routed as warnings to stderr, colored yellow where supported, and non-colored when not supported or color is disabled.

<img width="481" height="173" alt="image" src="https://github.com/user-attachments/assets/6ef48eab-96bf-40e9-88a2-9d3bbc769666" />
<img width="527" height="99" alt="image" src="https://github.com/user-attachments/assets/5a1f7c67-5ec4-411d-8430-56925aa0bf5a" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- **`WarningCallback` is now a Reporter adapter.** It takes a `Reporter&` in its
  constructor and its `OnWarning` forwards the message to `m_reporter.Warn(...)`
  (verbatim, with color added only on a VT console, and a null-guard), instead of
  `fputws(Message, stderr)`.
- **Services build the callback internally from a `Reporter&`.** The methods that
  surface warnings now take a `Reporter&` and construct `WarningCallback` locally,
  replacing the `Microsoft::WRL::Make<WarningCallback>()` COM object that was
  created and passed around:
  - `ContainerService` — `Run` / `Create` / `Start` (via `CreateInternal`)
  - `ImageService` — `Load` / `Import` / `Pull` / `Push`
  - `NetworkService` — `Create`
  - `SessionService` — `OpenOrCreateDefaultSession` / `Enter`
  - `VolumeService` — `Prune`
- **Call sites simplified.** Tasks pass `context.Reporter`; the floating
  `IWarningCallback*` parameter is gone.

### Why
- `Reporter` becomes the single output sink for warnings too, so warnings honor
  `no-color` (SGR stripping) and level-based routing consistently with all other
  CLI output.
- Removes a floating callback pointer threaded through the task/service layers in
  favor of a `Reporter&`, cleaning up call sites.

### Notes
- No public/SDK ABI surface is affected — these are internal CLI service helpers.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Forced a test warning and did some manual validation of the output with its expected color, no-color, and redirected output, confirmed it looks as-expected (this is the attached images)
- The E2E tests have WarningCallback for session warnings explicitly tested, which should verify no regressions with the warning plumbing, and these tests passed locally.