### PR TITLE
fixed title error visibility

### DIFF
--- a/src/windows/common/WslClient.cpp
+++ b/src/windows/common/WslClient.cpp
@@ -1525,7 +1525,14 @@ int WslMain(_In_ std::wstring_view commandLine)
     // Call the MSI package if we're in an MSIX context
     if (wsl::windows::common::wslutil::IsRunningInMsix())
     {
-        return wsl::windows::common::install::CallMsiPackage();
+        const bool launchedViaAppActivation = winrt::Windows::ApplicationModel::AppInstance::GetActivatedEventArgs() != nullptr;
+        const auto exitCode = wsl::windows::common::install::CallMsiPackage();
+        if (launchedViaAppActivation && exitCode == -1)
+        {
+            g_promptBeforeExit = true;
+        }
+
+        return exitCode;
     }
 
     // Use exit code -1 so invokers of wsl.exe can distinguish between a Linux


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The Start menu launches the MSIX `wsl.exe`, which forwards the command to the installed MSI `wsl.exe`. The inner process prints the actual error, but only the outer MSIX process retains the App activation context and owns the console window. Previously, the outer process returned immediately when the inner process failed.

The outer process now detects an App-activated launch and prompts before exiting when the inner process returns WSL's client failure code (`-1`). Linux command exit codes are not affected.

## PR Checklist
- [x] **Closes:** Closes #41112
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
The MSIX `wsl.exe` owns the Start menu console, while the forwarded MSI `wsl.exe` prints the actual startup error. This change keeps the outer process open when the inner process returns WSL's client failure code (`-1`), without affecting Linux exit codes or  terminal launches.

## Validation Steps Performed
 - Clean-built `wsl.exe` and the signed glue MSIX.
 - Triggered a deterministic startup failure through the real Start menu entry.
 - Verified the official build closed immediately, while the patched build kept the error window open.
 - Verified normal terminal invocations and exit codes were unchanged.