### PR TITLE
CLI: Add quiet support to pull and align with Docker

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3020,6 +3020,13 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_PublishAllArgDescription" xml:space="preserve">
     <value>Publish all exposed ports to random host ports</value>
   </data>
+  <data name="WSLCCLI_PullQuietArgDescription" xml:space="preserve">
+    <value>Suppress verbose output</value>
+  </data>
+  <data name="WSLCCLI_PullUsingDefaultTag" xml:space="preserve">
+    <value>Using default tag: {}</value>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name="WSLCCLI_QuietArgDescription" xml:space="preserve">
     <value>Outputs the container IDs only</value>
   </data>

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1437,15 +1437,23 @@ std::string wsl::windows::common::wslutil::GetCanonicalImageReference(const std:
 {
     // Mirror the Docker CLI's client-side reference normalization so the final line matches `docker pull` exactly.
     // See github.com/distribution/reference (normalize.go, reference.go) and github.com/docker/cli
-    // (cli/command/image/pull.go). A digest takes precedence over a tag here, consistent with ParseImage.
-    EnumReferenceFormat format = EnumReferenceFormatNone;
-    auto [repo, tagOrDigest] = ParseImage(input, &format);
-    auto [domain, path] = NormalizeRepo(repo);
+    // (cli/command/image/pull.go). Unlike ParseImage -- which collapses to a single tag-or-digest field with digest
+    // precedence -- Docker's canonical string keeps both a tag and a digest when both are present, so compose the
+    // reference directly from the parsed name, tag and digest groups.
+    static const auto regex = BuildImageReferenceRegex();
+    std::smatch match;
+    if (!std::regex_match(input, match, regex))
+    {
+        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, wsl::shared::Localization::MessageWslcInvalidImage(input.c_str()));
+    }
 
-    // A digest is joined with '@', a tag with ':'; a name-only reference defaults to the ":latest" tag.
-    const std::string_view separator = (format == EnumReferenceFormatDigest) ? "@" : ":";
-    const std::string_view reference = (format == EnumReferenceFormatNone) ? "latest" : std::string_view{tagOrDigest.value()};
-    return std::format("{}/{}{}{}", domain, path, separator, reference);
+    auto [domain, path] = NormalizeRepo(match[1].str());
+
+    // A tag joins with ':' and a digest with '@'. A name-only reference (no tag and no digest) defaults to ":latest";
+    // a digest-only reference is not name-only, so it keeps no tag (matching Docker's TagNameOnly).
+    const std::string tag = match[2].matched ? std::format(":{}", match[2].str()) : (match[3].matched ? "" : ":latest");
+    const std::string digest = match[3].matched ? std::format("@{}", match[3].str()) : "";
+    return std::format("{}/{}{}{}", domain, path, tag, digest);
 }
 
 void wsl::windows::common::wslutil::PrintSystemError(_In_ HRESULT result, _Inout_ FILE* const stream)

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1433,6 +1433,21 @@ std::pair<std::string, std::optional<std::string>> wsl::windows::common::wslutil
     return {repo.str(), std::move(tagOrDigest)};
 }
 
+std::string wsl::windows::common::wslutil::GetCanonicalImageReference(const std::string& input)
+{
+    // Mirror the Docker CLI's client-side reference normalization so the final line matches `docker pull` exactly.
+    // See github.com/distribution/reference (normalize.go, reference.go) and github.com/docker/cli
+    // (cli/command/image/pull.go). A digest takes precedence over a tag here, consistent with ParseImage.
+    EnumReferenceFormat format = EnumReferenceFormatNone;
+    auto [repo, tagOrDigest] = ParseImage(input, &format);
+    auto [domain, path] = NormalizeRepo(repo);
+
+    // A digest is joined with '@', a tag with ':'; a name-only reference defaults to the ":latest" tag.
+    const std::string_view separator = (format == EnumReferenceFormatDigest) ? "@" : ":";
+    const std::string_view reference = (format == EnumReferenceFormatNone) ? "latest" : std::string_view{tagOrDigest.value()};
+    return std::format("{}/{}{}{}", domain, path, separator, reference);
+}
+
 void wsl::windows::common::wslutil::PrintSystemError(_In_ HRESULT result, _Inout_ FILE* const stream)
 {
     fwprintf(stream, L"%ls\n", GetSystemErrorString(result).c_str());

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -222,6 +222,10 @@ ErrorStrings ErrorToString(const Error& error);
 
 std::filesystem::path GetBasePath();
 
+// Returns the fully-qualified canonical image reference for the given input, matching the string
+// printed by `docker pull` (e.g. "ubuntu" -> "docker.io/library/ubuntu:latest").
+std::string GetCanonicalImageReference(const std::string& input);
+
 std::optional<COMErrorInfo> GetCOMErrorInfo();
 
 DWORD GetDefaultVersion(void);

--- a/src/windows/wslc/commands/ImagePullCommand.cpp
+++ b/src/windows/wslc/commands/ImagePullCommand.cpp
@@ -28,6 +28,7 @@ std::vector<Argument> ImagePullCommand::GetArguments() const
 {
     return {
         Argument::Create(ArgType::ImageId, true),
+        Argument::Create(ArgType::Quiet, std::nullopt, std::nullopt, Localization::WSLCCLI_PullQuietArgDescription()),
         // Argument::Create(ArgType::Scheme),
         // Argument::Create(ArgType::Progress),
     };

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -223,10 +223,26 @@ void PullImage(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Session));
     WI_ASSERT(context.Args.Contains(ArgType::ImageId));
     auto& session = context.Data.Get<Data::Session>();
-    auto& imageId = context.Args.Get<ArgType::ImageId>();
+    const auto image = WideToMultiByte(context.Args.Get<ArgType::ImageId>());
+    const bool quiet = context.Args.Contains(ArgType::Quiet);
 
+    // Match `docker pull`: for a name-only reference (no tag or digest) the tag defaults to "latest". Unless quiet,
+    // the client reports this on stdout before contacting the registry.
+    EnumReferenceFormat format = EnumReferenceFormatNone;
+    ParseImage(image, &format);
+    if (!quiet && format == EnumReferenceFormatNone)
+    {
+        context.Reporter.Output(L"{}\n", Localization::WSLCCLI_PullUsingDefaultTag(L"latest"));
+    }
+
+    // Match `docker pull`: in quiet mode, suppress progress output by passing no progress callback. Warnings are
+    // unaffected because the warning callback is built internally by ImageService::Pull from the Reporter.
     ImageProgressCallback callback(context.Reporter, Reporter::Level::Output);
-    services::ImageService::Pull(context.Reporter, session, WideToMultiByte(imageId), &callback);
+    IProgressCallback* progress = quiet ? nullptr : &callback;
+    services::ImageService::Pull(context.Reporter, session, image, progress);
+
+    // Match `docker pull`: always print the resolved canonical image reference as the final line.
+    context.Reporter.Output(L"{}\n", MultiByteToWide(GetCanonicalImageReference(image)));
 }
 
 void PushImage(CLIExecutionContext& context)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -11599,10 +11599,10 @@ class WSLCTests
             "ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
             "docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
 
-        // A digest takes precedence over a tag, consistent with ParseImage.
+        // A tag and digest are both preserved when both are present, matching Docker's canonical reference.
         Validate(
             "ubuntu:22.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
-            "docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
+            "docker.io/library/ubuntu:22.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
     }
 
     WSLC_TEST_METHOD(ElevatedTokenCanOpenNonElevatedHandles)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -11594,6 +11594,9 @@ class WSLCTests
         Validate("myregistry.io:5000/myimage", "myregistry.io:5000/myimage:latest");
         Validate("localhost:5000/myimage:latest", "localhost:5000/myimage:latest");
 
+        // A mixed-case registry domain is preserved verbatim, matching Docker (which never lowercases the domain).
+        Validate("Example.COM/owner/repo", "Example.COM/owner/repo:latest");
+
         // Digest references are preserved.
         Validate(
             "ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -11573,6 +11573,38 @@ class WSLCTests
             "2001:0db8:85a3:0000:0000:8a2e:0370:7334:80/path", "2001:0db8:85a3:0000:0000:8a2e:0370:7334:80", "path");
     }
 
+    TEST_METHOD(CanonicalImageReference)
+    {
+        using wsl::windows::common::wslutil::GetCanonicalImageReference;
+
+        auto Validate = [](const std::string& input, const std::string& expected) {
+            VERIFY_ARE_EQUAL(GetCanonicalImageReference(input), expected);
+        };
+
+        // Name-only references default to ":latest" and the docker.io/library prefix (matches `docker pull` output).
+        Validate("ubuntu", "docker.io/library/ubuntu:latest");
+        Validate("ubuntu:22.04", "docker.io/library/ubuntu:22.04");
+        Validate("library/ubuntu", "docker.io/library/ubuntu:latest");
+        Validate("pytorch/pytorch", "docker.io/pytorch/pytorch:latest");
+        Validate("docker.io/ubuntu", "docker.io/library/ubuntu:latest");
+        Validate("index.docker.io/library/ubuntu:latest", "docker.io/library/ubuntu:latest");
+
+        // Custom registries keep their domain and path.
+        Validate("ghcr.io/owner/repo:sha-abc123", "ghcr.io/owner/repo:sha-abc123");
+        Validate("myregistry.io:5000/myimage", "myregistry.io:5000/myimage:latest");
+        Validate("localhost:5000/myimage:latest", "localhost:5000/myimage:latest");
+
+        // Digest references are preserved.
+        Validate(
+            "ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
+            "docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
+
+        // A digest takes precedence over a tag, consistent with ParseImage.
+        Validate(
+            "ubuntu:22.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
+            "docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
+    }
+
     WSLC_TEST_METHOD(ElevatedTokenCanOpenNonElevatedHandles)
     {
         wil::com_ptr<IWSLCSession> nonElevatedSession;

--- a/test/windows/wslc/CommandLineTestCases.h
+++ b/test/windows/wslc/CommandLineTestCases.h
@@ -294,6 +294,8 @@ COMMAND_LINE_TEST_CASE(L"image list --verbose", L"list", true)
 COMMAND_LINE_TEST_CASE(L"image list -q", L"list", true)
 COMMAND_LINE_TEST_CASE(L"image pull ubuntu", L"pull", true)
 COMMAND_LINE_TEST_CASE(L"pull ubuntu", L"pull", true)
+COMMAND_LINE_TEST_CASE(L"pull ubuntu --quiet", L"pull", true)
+COMMAND_LINE_TEST_CASE(L"pull ubuntu -q", L"pull", true)
 COMMAND_LINE_TEST_CASE(L"image rm cont1 --force --no-prune", L"remove", true)
 COMMAND_LINE_TEST_CASE(L"image rm cont1 cont2 cont3 --force --no-prune", L"remove", true)
 

--- a/test/windows/wslc/e2e/WSLCE2EPushPullTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EPushPullTests.cpp
@@ -93,6 +93,35 @@ class WSLCE2EPushPullTests
         }
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Image_Pull_QuietOption)
+    {
+        const auto& debianImage = DebianTestImage();
+        EnsureImageIsLoaded(debianImage);
+
+        auto session = OpenDefaultElevatedSession();
+
+        {
+            auto [registryContainer, registryAddress] = StartLocalRegistry(*session, "", "", 15004);
+            auto registryAddressW = string::MultiByteToWide(registryAddress);
+
+            // Tag and push the image so it can be pulled back from the registry.
+            auto registryImage = TagImageForRegistry(debianImage.NameAndTag(), registryAddressW);
+            auto tagCleanup = wil::scope_exit([&]() { RunWslc(std::format(L"image delete --force {}", registryImage)); });
+
+            RunWslcAndVerify(std::format(L"push {}", registryImage), {.Stderr = L"", .ExitCode = 0});
+
+            // Delete the local copy so the pull actually fetches from the registry.
+            RunWslcAndVerify(std::format(L"image delete --force {}", registryImage), {.ExitCode = 0});
+
+            // Quiet pull (Docker parity): progress is suppressed and stdout is exactly the resolved canonical
+            // reference. The registry image is already fully-qualified, so it equals the printed reference.
+            // GetStdoutOneLine() also asserts there is exactly one output line, proving progress was suppressed.
+            auto result = RunWslc(std::format(L"pull --quiet {}", registryImage));
+            result.Verify({.Stderr = L"", .ExitCode = 0});
+            VERIFY_ARE_EQUAL(registryImage, result.GetStdoutOneLine());
+        }
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Image_Push_NonExistentImage)
     {
         auto result = RunWslc(L"push does-not-exist:latest");
@@ -107,6 +136,16 @@ class WSLCE2EPushPullTests
             L"pull access denied for does-not-exist, repository does not exist or may require 'docker login': denied: requested "
             L"access to the resource is denied\r\nError code: WSLC_E_IMAGE_NOT_FOUND\r\n";
         result.Verify({.Stdout = L"", .Stderr = errorMessage, .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_Pull_NameOnlyDefaultsTag)
+    {
+        auto result = RunWslc(L"pull does-not-exist");
+        result.Verify({.ExitCode = 1});
+        VERIFY_IS_TRUE(result.StdoutContainsLine(L"Using default tag: latest"));
+
+        // Quiet mode suppresses the "Using default tag" line, leaving stdout empty on failure.
+        RunWslcAndVerify(L"pull -q does-not-exist", {.Stdout = L"", .ExitCode = 1});
     }
 };
 } // namespace WSLCE2ETests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Add a `--quiet` / `-q` option to `wslc pull` with output behavior that matches `docker pull` exactly. In quiet mode, layer/progress output is suppressed and only the final canonical image reference is printed. As part of matching Docker's client-side behavior, `wslc pull` now also prints `Using default tag: latest` for name-only references and always prints the fully-qualified canonical reference as the final line.

This is an entirely client-side change (no IDL/service changes); the behavior was verified line-by-line against Docker's `cli/command/image/pull.go`.

<img width="723" height="152" alt="image" src="https://github.com/user-attachments/assets/76270ab1-a1da-4021-8e1a-6df8d3058f14" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
`wslc pull` now mirrors the Docker CLI's `runPull` flow:

- **`--quiet` / `-q`** — suppresses progress output by passing a null progress callback to `ImageService::Pull` (the COM `IProgressCallback*` is already `[in, unique]`/nullable). Warnings are unaffected because the warning callback is built internally from the `Reporter`. Help text is "Suppress verbose output", matching Docker.
- **`Using default tag: latest`** — for a name-only reference (no tag or digest), the tag defaults to `latest` and, unless quiet, the client reports this on stdout before contacting the registry (exactly as Docker does).
- **Canonical reference always printed** — the resolved fully-qualified reference is always printed as the final line, in both quiet and non-quiet modes (e.g. `docker.io/library/ubuntu:latest`). Previously `wslc pull` did not print this line; this closes a Docker-parity gap.

A new helper, `wsl::windows::common::wslutil::GetCanonicalImageReference`, mirrors the client-side normalization in `github.com/distribution/reference` (`ParseNormalizedNamed` adds the `docker.io` default domain and `library/` prefix; `TagNameOnly` defaults a name-only reference to `:latest`) and produces the reference string printed by `docker pull`, preserving a tag and digest together when both are present.

**Example behavior (matches Docker):**

- `wslc pull ubuntu:latest -q` prints `docker.io/library/ubuntu:latest` (single line, no progress)
- `wslc pull alpine:latest` prints progress on stdout, then `docker.io/library/alpine:latest`
- `wslc pull ubuntu` prints `Using default tag: latest` first, then progress + canonical reference
- `wslc pull ubuntu:22.04@sha256:...` prints `docker.io/library/ubuntu:22.04@sha256:...` (both tag and digest preserved)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* New tests ran and pass
* Existing pull tests pass
* Manual verification from deployed local build