### PR TITLE
WSLC: Add UDP and IPv6 support for exposed image ports

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3492,6 +3492,9 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="MessageWslcSwapInitFailed" xml:space="preserve">
     <value>Failed to initialize swap</value>
   </data>
+  <data name="MessageWslcPublishAllUdpNotSupported" xml:space="preserve">
+    <value>UDP ports exposed by the image were not published because UDP port forwarding is not supported in the current networking mode</value>
+  </data>
   <data name="MessageWslcContainerTimestampRecoveryFailed" xml:space="preserve">
     <value>Failed to restore timestamp for container '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1820,9 +1820,26 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
 
         if (imageInfo.Config.has_value() && imageInfo.Config->ExposedPorts.has_value())
         {
+            // The userspace wslrelay port relay only forwards TCP. When it's active, adding a UDP
+            // mapping would fail the whole container (MapPort throws ERROR_NOT_SUPPORTED), so skip
+            // UDP exposed ports and warn once. UDP is published normally on the virtioNet path.
+            const bool relayForwarding = virtualMachine.UseWslRelayPortForwarding();
+            bool warnedUdpSkipped = false;
+
             for (const auto& [portKey, _] : imageInfo.Config->ExposedPorts.value())
             {
                 auto [port, protocol] = ParseExposedPortKey(portKey);
+
+                if (relayForwarding && protocol == IPPROTO_UDP)
+                {
+                    if (!warnedUdpSkipped)
+                    {
+                        EMIT_USER_WARNING(Localization::MessageWslcPublishAllUdpNotSupported());
+                        warnedUdpSkipped = true;
+                    }
+
+                    continue;
+                }
 
                 // Exposed ports carry only a port and protocol (tcp/udp), never an address family.
                 // Mirror Docker's dual-stack default by publishing each exposed port on both the IPv4

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -310,7 +310,10 @@ std::vector<ContainerPortMapping> BuildPortMappings(std::vector<_WSLCPortMapping
     const bool allocateVmPorts = NetworkModeAllocatesVmPorts(primary);
     for (auto& e : requestedPorts)
     {
-        if (e.HostPort == WSLC_EPHEMERAL_PORT && vm.NetworkingMode() == WSLCNetworkingModeNAT)
+        // Pre-allocate a concrete host port whenever the wslrelay relay path will be used: that path
+        // maps the host port verbatim and has no ephemeral writeback (unlike the virtioNet path), so
+        // an unresolved WSLC_EPHEMERAL_PORT (0) would otherwise be mapped as port 0 and fail.
+        if (e.HostPort == WSLC_EPHEMERAL_PORT && vm.UseWslRelayPortForwarding())
         {
             e.HostPort = AllocateEphemeralPort(e.Family, e.BindingAddress);
         }

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1824,18 +1824,18 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
             {
                 auto [port, protocol] = ParseExposedPortKey(portKey);
 
-                // Only TCP localhost mappings are currently supported by the relay path.
-                if (protocol != IPPROTO_TCP)
+                // Exposed ports carry only a port and protocol (tcp/udp), never an address family.
+                // Mirror Docker's dual-stack default by publishing each exposed port on both the IPv4
+                // and IPv6 loopback, while keeping wslc's loopback-only default binding convention.
+                for (const auto& [family, address] : {std::pair{AF_INET, "127.0.0.1"}, std::pair{AF_INET6, "::1"}})
                 {
-                    continue;
+                    auto& createdPort = ports.emplace_back();
+                    createdPort.HostPort = WSLC_EPHEMERAL_PORT;
+                    createdPort.Family = family;
+                    createdPort.ContainerPort = port;
+                    createdPort.Protocol = protocol;
+                    strcpy_s(createdPort.BindingAddress, address);
                 }
-
-                auto& createdPort = ports.emplace_back();
-                createdPort.HostPort = WSLC_EPHEMERAL_PORT;
-                createdPort.Family = AF_INET;
-                createdPort.ContainerPort = port;
-                createdPort.Protocol = protocol;
-                strcpy_s(createdPort.BindingAddress, "127.0.0.1");
             }
         }
     }

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -188,10 +188,12 @@ public:
 
     WSLCNetworkingMode NetworkingMode() const;
 
+    // True when port forwarding goes through the userspace wslrelay path (NAT mode, or Consomme with
+    // the wslrelay feature flag). That relay only supports TCP localhost mappings.
+    bool UseWslRelayPortForwarding() const;
+
 private:
     void MapRelayPort(_In_ int Family, _In_ unsigned short WindowsPort, _In_ unsigned short LinuxPort, _In_ bool Remove);
-
-    bool UseWslRelayPortForwarding() const;
 
     // Initial setup during Connect()
     void ConfigureNetworking();

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8817,8 +8817,9 @@ class WSLCTests
             // Verify the second exposed port got a dual-stack mapping too.
             auto ports9090 = getDualStackHostPorts(inspectData.Ports["9090/tcp"]);
 
-            // The two exposed ports must map to different host ports.
+            // Each exposed port must map to distinct host ports on both loopback families.
             VERIFY_ARE_NOT_EQUAL(ports8080.ipv4, ports9090.ipv4);
+            VERIFY_ARE_NOT_EQUAL(ports8080.ipv6, ports9090.ipv6);
         }
     }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8778,19 +8778,40 @@ class WSLCTests
             VERIFY_IS_TRUE(inspectData.Ports.contains("8080/tcp"));
             VERIFY_IS_TRUE(inspectData.Ports.contains("9090/tcp"));
 
-            // Verify we can connect to the 8080 exposed port from the host.
-            auto portBindings8080 = inspectData.Ports["8080/tcp"];
-            VERIFY_ARE_EQUAL(1u, portBindings8080.size());
-            auto hostPort8080 = std::stoi(portBindings8080[0].HostPort);
-            VERIFY_IS_TRUE(hostPort8080 > 0);
+            // Each exposed port is published dual-stack: one IPv4 (127.0.0.1) and one IPv6 (::1)
+            // loopback binding. Verify both are present and return the IPv4 host port.
+            auto getDualStackIpv4HostPort = [](const auto& bindings) -> int {
+                VERIFY_ARE_EQUAL(2u, bindings.size());
 
+                int ipv4HostPort = 0;
+                bool foundIpv4 = false;
+                bool foundIpv6 = false;
+                for (const auto& binding : bindings)
+                {
+                    auto hostPort = std::stoi(binding.HostPort);
+                    VERIFY_IS_TRUE(hostPort > 0);
+                    if (binding.HostIp == "127.0.0.1")
+                    {
+                        ipv4HostPort = hostPort;
+                        foundIpv4 = true;
+                    }
+                    else if (binding.HostIp == "::1")
+                    {
+                        foundIpv6 = true;
+                    }
+                }
+
+                VERIFY_IS_TRUE(foundIpv4);
+                VERIFY_IS_TRUE(foundIpv6);
+                return ipv4HostPort;
+            };
+
+            // Verify we can connect to the 8080 exposed port from the host.
+            auto hostPort8080 = getDualStackIpv4HostPort(inspectData.Ports["8080/tcp"]);
             ExpectHttpResponse(std::format(L"http://127.0.0.1:{}", hostPort8080).c_str(), 200);
 
             // Verify the second exposed port got a mapping too.
-            auto portBindings9090 = inspectData.Ports["9090/tcp"];
-            VERIFY_ARE_EQUAL(1u, portBindings9090.size());
-            auto hostPort9090 = std::stoi(portBindings9090[0].HostPort);
-            VERIFY_IS_TRUE(hostPort9090 > 0);
+            auto hostPort9090 = getDualStackIpv4HostPort(inspectData.Ports["9090/tcp"]);
 
             // The two host ports must be different.
             VERIFY_ARE_NOT_EQUAL(hostPort8080, hostPort9090);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8779,42 +8779,46 @@ class WSLCTests
             VERIFY_IS_TRUE(inspectData.Ports.contains("9090/tcp"));
 
             // Each exposed port is published dual-stack: one IPv4 (127.0.0.1) and one IPv6 (::1)
-            // loopback binding. Verify both are present and return the IPv4 host port.
-            auto getDualStackIpv4HostPort = [](const auto& bindings) -> int {
+            // loopback binding. Verify both are present and return both host ports.
+            struct DualStackHostPorts
+            {
+                int ipv4 = 0;
+                int ipv6 = 0;
+            };
+
+            auto getDualStackHostPorts = [](const auto& bindings) -> DualStackHostPorts {
                 VERIFY_ARE_EQUAL(2u, bindings.size());
 
-                int ipv4HostPort = 0;
-                bool foundIpv4 = false;
-                bool foundIpv6 = false;
+                DualStackHostPorts ports;
                 for (const auto& binding : bindings)
                 {
                     auto hostPort = std::stoi(binding.HostPort);
                     VERIFY_IS_TRUE(hostPort > 0);
                     if (binding.HostIp == "127.0.0.1")
                     {
-                        ipv4HostPort = hostPort;
-                        foundIpv4 = true;
+                        ports.ipv4 = hostPort;
                     }
                     else if (binding.HostIp == "::1")
                     {
-                        foundIpv6 = true;
+                        ports.ipv6 = hostPort;
                     }
                 }
 
-                VERIFY_IS_TRUE(foundIpv4);
-                VERIFY_IS_TRUE(foundIpv6);
-                return ipv4HostPort;
+                VERIFY_IS_TRUE(ports.ipv4 > 0);
+                VERIFY_IS_TRUE(ports.ipv6 > 0);
+                return ports;
             };
 
-            // Verify we can connect to the 8080 exposed port from the host.
-            auto hostPort8080 = getDualStackIpv4HostPort(inspectData.Ports["8080/tcp"]);
-            ExpectHttpResponse(std::format(L"http://127.0.0.1:{}", hostPort8080).c_str(), 200);
+            // Verify we can reach the 8080 exposed port over both IPv4 and IPv6 loopback.
+            auto ports8080 = getDualStackHostPorts(inspectData.Ports["8080/tcp"]);
+            ExpectHttpResponse(std::format(L"http://127.0.0.1:{}", ports8080.ipv4).c_str(), 200);
+            ExpectHttpResponse(std::format(L"http://[::1]:{}", ports8080.ipv6).c_str(), 200);
 
-            // Verify the second exposed port got a mapping too.
-            auto hostPort9090 = getDualStackIpv4HostPort(inspectData.Ports["9090/tcp"]);
+            // Verify the second exposed port got a dual-stack mapping too.
+            auto ports9090 = getDualStackHostPorts(inspectData.Ports["9090/tcp"]);
 
-            // The two host ports must be different.
-            VERIFY_ARE_NOT_EQUAL(hostPort8080, hostPort9090);
+            // The two exposed ports must map to different host ports.
+            VERIFY_ARE_NOT_EQUAL(ports8080.ipv4, ports9090.ipv4);
         }
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1379,6 +1379,73 @@ class WSLCE2EContainerCreateTests
         VERIFY_ARE_EQUAL("127.0.0.1", bindings[0].HostIp);
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Container_Create_PublishAll_DualStack)
+    {
+        // Remove the container and built image on exit. Both helpers are idempotent, so this is safe
+        // to arm before either resource exists.
+        auto cleanup = wil::scope_exit([&] {
+            EnsureContainerDoesNotExist(WslcContainerName);
+            EnsureImageIsDeleted(PublishAllImage);
+        });
+
+        // Build an image that exposes both a TCP and a UDP port so publish-all has something to map.
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-publish-all";
+        auto cleanupDir = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(
+            dockerfilePath,
+            std::format(
+                "FROM {}\n"
+                "EXPOSE 8080/tcp\n"
+                "EXPOSE 9090/udp\n",
+                string::WideToMultiByte(DebianImage.NameAndTag())));
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {}", contextDir.wstring(), dockerfilePath.wstring(), PublishAllImage.NameAndTag()));
+        buildResult.Verify({.Stdout = L"", .ExitCode = 0});
+
+        // Port bindings only show up in inspect after start, so create then start before inspecting.
+        auto result = RunWslc(std::format(L"container create --name {} -P {} sleep 5", WslcContainerName, PublishAllImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        result = RunWslc(std::format(L"container start {}", WslcContainerName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        // Each exposed port (tcp and udp) must be published dual-stack: one IPv4 loopback and one IPv6
+        // loopback binding, each on an ephemeral host port.
+        const auto inspect = InspectContainer(WslcContainerName);
+        for (const auto& portKey : {std::string{"8080/tcp"}, std::string{"9090/udp"}})
+        {
+            VERIFY_IS_TRUE(inspect.Ports.contains(portKey));
+
+            const auto& bindings = inspect.Ports.at(portKey);
+            VERIFY_ARE_EQUAL(2u, bindings.size());
+
+            bool foundIpv4 = false;
+            bool foundIpv6 = false;
+            for (const auto& binding : bindings)
+            {
+                VERIFY_IS_TRUE(std::stoi(binding.HostPort) > 0);
+                if (binding.HostIp == "127.0.0.1")
+                {
+                    foundIpv4 = true;
+                }
+                else if (binding.HostIp == "::1")
+                {
+                    foundIpv6 = true;
+                }
+            }
+            VERIFY_IS_TRUE(foundIpv4);
+            VERIFY_IS_TRUE(foundIpv6);
+        }
+    }
+
 private:
     // Test container name
     const std::wstring WslcContainerName = L"wslc-test-container";
@@ -1401,6 +1468,9 @@ private:
     const TestImage& AlpineImage = AlpineTestImage();
     const TestImage& DebianImage = DebianTestImage();
     const TestImage& InvalidImage = InvalidTestImage();
+
+    // Image built at test time with exposed TCP and UDP ports for publish-all coverage.
+    const TestImage PublishAllImage{L"wslc-e2e-publish-all", L"latest", L""};
 
     // Test ports
     const uint16_t ContainerTestPort = 8080;

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1469,15 +1469,15 @@ while True:
             uint16_t ipv6Port = 0;
             for (const auto& binding : bindings)
             {
-                const auto hostPort = static_cast<uint16_t>(std::stoi(binding.HostPort));
-                VERIFY_IS_TRUE(hostPort > 0);
+                const int hostPort = std::stoi(binding.HostPort);
+                VERIFY_IS_TRUE(hostPort > 0 && hostPort <= 65535);
                 if (binding.HostIp == "127.0.0.1")
                 {
-                    ipv4Port = hostPort;
+                    ipv4Port = static_cast<uint16_t>(hostPort);
                 }
                 else if (binding.HostIp == "::1")
                 {
-                    ipv6Port = hostPort;
+                    ipv6Port = static_cast<uint16_t>(hostPort);
                 }
             }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1388,7 +1388,11 @@ class WSLCE2EContainerCreateTests
             EnsureImageIsDeleted(PublishAllImage);
         });
 
-        // Build an image that exposes both a TCP and a UDP port so publish-all has something to map.
+        // Load the Python base image so the test image can be built offline.
+        EnsureImageIsLoaded(PythonImage);
+
+        // Build an image that exposes a TCP and a UDP port and ships a server that listens on both,
+        // so publish-all can be exercised end to end.
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-publish-all";
         auto cleanupDir = SetupTestDirectory(testRoot);
 
@@ -1397,53 +1401,100 @@ class WSLCE2EContainerCreateTests
         std::filesystem::create_directories(contextDir, ec);
         THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
 
+        // Dual-stack HTTP server on 8080/tcp plus a UDP echo server on 9090/udp in one process. Both
+        // sockets bind before "SERVERS READY" is printed, so that marker signals both ports accept.
+        WriteTestFileContent(
+            contextDir / L"server.py",
+            R"PY(
+import contextlib, socket, threading
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+class DualStackHttp(ThreadingHTTPServer):
+    address_family = socket.AF_INET6
+
+    def server_bind(self):
+        with contextlib.suppress(Exception):
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        super().server_bind()
+
+http_server = DualStackHttp(('::', 8080), SimpleHTTPRequestHandler)
+
+udp = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+udp.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+udp.bind(('::', 9090))
+
+threading.Thread(target=http_server.serve_forever, daemon=True).start()
+print('SERVERS READY', flush=True)
+
+while True:
+    data, address = udp.recvfrom(1024)
+    udp.sendto(data.upper(), address)
+)PY");
+
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
             std::format(
                 "FROM {}\n"
+                "COPY server.py /server.py\n"
                 "EXPOSE 8080/tcp\n"
                 "EXPOSE 9090/udp\n",
-                string::WideToMultiByte(DebianImage.NameAndTag())));
+                string::WideToMultiByte(PythonImage.NameAndTag())));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {}", contextDir.wstring(), dockerfilePath.wstring(), PublishAllImage.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         // Port bindings only show up in inspect after start, so create then start before inspecting.
-        auto result = RunWslc(std::format(L"container create --name {} -P {} sleep 5", WslcContainerName, PublishAllImage.NameAndTag()));
+        auto result = RunWslc(
+            std::format(L"container create --name {} -P {} python3 -u /server.py", WslcContainerName, PublishAllImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start {}", WslcContainerName));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        // Each exposed port (tcp and udp) must be published dual-stack: one IPv4 loopback and one IPv6
-        // loopback binding, each on an ephemeral host port.
+        // Wait until both listeners are bound before probing the published ports.
+        WaitForContainerOutput(WslcContainerName, "SERVERS READY");
+
+        // Each exposed port must be published dual-stack: one IPv4 (127.0.0.1) and one IPv6 (::1)
+        // loopback binding, each on an ephemeral host port. Return both host ports for the protocol.
         const auto inspect = InspectContainer(WslcContainerName);
-        for (const auto& portKey : {std::string{"8080/tcp"}, std::string{"9090/udp"}})
-        {
+        auto getDualStackHostPorts = [&](const std::string& portKey) -> std::pair<uint16_t, uint16_t> {
             VERIFY_IS_TRUE(inspect.Ports.contains(portKey));
 
             const auto& bindings = inspect.Ports.at(portKey);
             VERIFY_ARE_EQUAL(2u, bindings.size());
 
-            bool foundIpv4 = false;
-            bool foundIpv6 = false;
+            uint16_t ipv4Port = 0;
+            uint16_t ipv6Port = 0;
             for (const auto& binding : bindings)
             {
-                VERIFY_IS_TRUE(std::stoi(binding.HostPort) > 0);
+                const auto hostPort = static_cast<uint16_t>(std::stoi(binding.HostPort));
+                VERIFY_IS_TRUE(hostPort > 0);
                 if (binding.HostIp == "127.0.0.1")
                 {
-                    foundIpv4 = true;
+                    ipv4Port = hostPort;
                 }
                 else if (binding.HostIp == "::1")
                 {
-                    foundIpv6 = true;
+                    ipv6Port = hostPort;
                 }
             }
-            VERIFY_IS_TRUE(foundIpv4);
-            VERIFY_IS_TRUE(foundIpv6);
-        }
+
+            VERIFY_IS_TRUE(ipv4Port > 0);
+            VERIFY_IS_TRUE(ipv6Port > 0);
+            return {ipv4Port, ipv6Port};
+        };
+
+        // TCP: the HTTP server must respond over both IPv4 and IPv6 loopback.
+        const auto [tcpIpv4, tcpIpv6] = getDualStackHostPorts("8080/tcp");
+        ExpectHttpResponse(std::format(L"http://127.0.0.1:{}", tcpIpv4).c_str(), HTTP_STATUS_OK, true);
+        ExpectHttpResponse(std::format(L"http://[::1]:{}", tcpIpv6).c_str(), HTTP_STATUS_OK, true);
+
+        // UDP: the echo server must reply over both IPv4 and IPv6 loopback.
+        const auto [udpIpv4, udpIpv6] = getDualStackHostPorts("9090/udp");
+        SendUdpAndReceive(udpIpv4, "hello", "HELLO", AF_INET);
+        SendUdpAndReceive(udpIpv6, "hello", "HELLO", AF_INET6);
     }
 
 private:
@@ -1467,6 +1518,7 @@ private:
     // Test images
     const TestImage& AlpineImage = AlpineTestImage();
     const TestImage& DebianImage = DebianTestImage();
+    const TestImage& PythonImage = PythonTestImage();
     const TestImage& InvalidImage = InvalidTestImage();
 
     // Image built at test time with exposed TCP and UDP ports for publish-all coverage.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Support IPv6 and UDP in image-declared exposed ports. The `wslc -P`/`--publish-all` path now publishes every port from an image's `ExposedPorts` config on both IPv4 and IPv6 loopback, for both TCP and UDP — previously it silently published only TCP on IPv4 loopback. UDP publishing is conditional on networking relay (which is TCP only) and emits a warning and gracefully skips.
<!-- Please review the items on the PR checklist before submitting-->

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
When a container is created with `-P`/`--publish-all`, wslc reads the image's `ExposedPorts` config and publishes each declared port to an ephemeral host port. The prior implementation had two limitations:

- **UDP was dropped.** The loop skipped any non-TCP protocol (`if (protocol != IPPROTO_TCP) continue;`), so a `EXPOSE 53/udp` port was never published.
- **IPv6 was unsupported.** Each mapping hardcoded `AF_INET` and `127.0.0.1`, so exposed ports were reachable only over IPv4 loopback.

An image's `ExposedPorts` keys carry only a port and protocol (`port/tcp` or `port/udp`) and never an address family, so the code has to choose what to bind. This change mirrors Docker's documented `-P` default, which publishes to all host addresses on both IPv4 and IPv6, while preserving wslc's convention of binding loopback by default. Each exposed port is now published **dual-stack**: one mapping on `127.0.0.1` (IPv4) and one on `::1` (IPv6), preserving the port's declared protocol (tcp/udp).

### Networking-mode handling for UDP

wslc has two port-forwarding backends. The virtioNet path (`MapVirtioNetPort`, Consomme mode) maps ports at the netstack level and natively supports UDP and IPv6. The userspace wslrelay path (NAT mode, or Consomme with the wslrelay feature flag) is a TCP-only stream relay — `WSLCVirtualMachine::MapPort()` rejects any non-TCP mapping with `ERROR_NOT_SUPPORTED`.

Because publish-all previously skipped UDP unconditionally, an image exposing a UDP port worked (the port was just dropped) regardless of mode. Now that UDP mappings are generated, they would fail the entire container create/start under the wslrelay path. To avoid that regression, the exposed-ports loop now skips UDP ports when `UseWslRelayPortForwarding()` is active and emits a one-time user warning (`MessageWslcPublishAllUdpNotSupported`). TCP (IPv4 + IPv6) publishes normally in all modes; UDP publishes fully on the virtioNet path. This guard is self-retiring — it becomes a no-op automatically once the relay path is no longer used. Adding UDP support to the wslrelay stream relay is potential follow-up work; it is a substantial cross-boundary feature (datagram framing over hvsocket, per-source session tracking) and unnecessary given virtioNet already covers UDP.

### Testing

Added end-to-end test `WSLCE2E_Container_Create_PublishAll_DualStack` (`test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp`). It builds an image with `EXPOSE 8080/tcp` and `EXPOSE 9090/udp`, runs `-P`, and asserts that each port is published with exactly two bindings — one on `127.0.0.1` and one on `::1` — each on a non-zero ephemeral host port. This covers the full `{tcp, udp} × {ipv4, ipv6}` matrix in a single test. Verified passing against a locally built and deployed x64 Debug build.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Newly added E2E test passes locally.