### PR TITLE
Track implicit autobind ports from listen() in Consomme networking

### DIFF
--- a/src/linux/inc/seccomp_defs.h
+++ b/src/linux/inc/seccomp_defs.h
@@ -11,3 +11,4 @@
 // You will not get this value with the standard defines.
 #define I386_NR_socketcall (102)
 #define ARMV7_NR_bind (282)
+#define ARMV7_NR_listen (284)

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -458,9 +458,10 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
     // listen() can trigger an implicit autobind (assigning an ephemeral port) on a socket that
     // was never explicitly bind()'d. There's no sockaddr to inspect here (listen() only takes a
     // socket fd and a backlog), and we can't tell in advance whether the socket is already bound,
-    // so always duplicate the fd and defer resolution to ResolvePortZeroBind(), the same as a
-    // bind(port=0) call. If the socket already had an explicit bind(), this just re-resolves and
-    // re-tracks the same port, which is harmless (TrackPort() refreshes the existing entry).
+    // so duplicate the fd and check getsockname() immediately: if it's already bound (the common
+    // bind()+listen() case), resolve the port synchronously here. Otherwise defer resolution to
+    // ResolvePortZeroBind(), the same as a bind(port=0) call, since the port isn't assigned until
+    // the listen() syscall (which performs the implicit autobind) actually completes in-kernel.
     auto ParseListen = [&](int Socket) -> std::optional<BindCall> {
         auto networkNamespace = std::filesystem::read_symlink(std::format("/proc/{}/ns/net", Pid)).string();
         if (networkNamespace != m_networkNamespace)

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -13,6 +13,7 @@
 #include "NetlinkTransactionError.h"
 #include "GnsPortTracker.h"
 #include "lxinitshared.h"
+#include "seccomp_defs.h"
 
 constexpr size_t c_bind_timeout_seconds = 60;
 constexpr auto c_sock_diag_refresh_delay = std::chrono::milliseconds(500);
@@ -453,19 +454,104 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
 
         return {{{PortAllocation(port, address.sa_family, protocol, storedAddress)}, {}, CallId}};
     };
+
+    // listen() can trigger an implicit autobind (assigning an ephemeral port) on a socket that
+    // was never explicitly bind()'d. There's no sockaddr to inspect here (listen() only takes a
+    // socket fd and a backlog), and we can't tell in advance whether the socket is already bound,
+    // so always duplicate the fd and defer resolution to ResolvePortZeroBind(), the same as a
+    // bind(port=0) call. If the socket already had an explicit bind(), this just re-resolves and
+    // re-tracks the same port, which is harmless (TrackPort() refreshes the existing entry).
+    auto ParseListen = [&](int Socket) -> std::optional<BindCall> {
+        auto networkNamespace = std::filesystem::read_symlink(std::format("/proc/{}/ns/net", Pid)).string();
+        if (networkNamespace != m_networkNamespace)
+        {
+            GNS_LOG_INFO("Skipping listen() call for pid {} in network namespace {}", Pid, networkNamespace.c_str());
+            return {{{}, {}, CallId}}; // Different network namespace. Let it go through.
+        }
+
+        try
+        {
+            const int protocol = GetSocketProtocol(Pid, Socket);
+            auto dupFd = DuplicateSocketFd(Pid, Socket);
+            if (!dupFd)
+            {
+                return {{{}, {}, CallId}};
+            }
+            if (!m_seccompDispatcher->ValidateCookie(CallId))
+            {
+                return {{{}, {}, CallId}};
+            }
+
+            // If the socket was already explicitly bind()'d - the common case of a normal
+            // bind() followed by listen() - its port is already known right now, before the
+            // listen() syscall even runs, so resolve it immediately instead of deferring
+            // through the post-completion polling path. That path is reserved for the case
+            // where listen() itself is what triggers the kernel's implicit autobind (i.e. no
+            // prior bind() call), which can only be observed after listen() has completed.
+            sockaddr_storage storage{};
+            socklen_t addressLength = sizeof(storage);
+            if (getsockname(dupFd.get(), reinterpret_cast<sockaddr*>(&storage), &addressLength) == 0)
+            {
+                in_port_t port = 0;
+                in6_addr address = {};
+                if (storage.ss_family == AF_INET)
+                {
+                    const auto* sin = reinterpret_cast<const sockaddr_in*>(&storage);
+                    port = ntohs(sin->sin_port);
+                    address.s6_addr32[0] = sin->sin_addr.s_addr;
+                }
+                else if (storage.ss_family == AF_INET6)
+                {
+                    const auto* sin6 = reinterpret_cast<const sockaddr_in6*>(&storage);
+                    port = ntohs(sin6->sin6_port);
+                    memcpy(address.s6_addr32, sin6->sin6_addr.s6_addr32, sizeof(address.s6_addr32));
+                }
+
+                if (port != 0)
+                {
+                    return {{{PortAllocation(port, static_cast<int>(storage.ss_family), protocol, address)}, {}, CallId}};
+                }
+            }
+
+            return {{{}, DeferredPortLookup{Pid, std::move(dupFd), protocol}, CallId}};
+        }
+        catch (const std::exception&)
+        {
+            return {{{}, {}, CallId}}; // Not an IP socket (or can't determine its protocol), just let it through
+        }
+    };
+
 #ifdef __x86_64__
     if (Arch & __AUDIT_ARCH_64BIT)
     {
+        if (SysCallNumber == __NR_listen)
+        {
+            return ParseListen(Arguments[0]);
+        }
+
         return ParseSocket(Arguments[0], Arguments[1], Arguments[2]);
     }
     // Note: 32bit on x86_64 uses the __NR_socketcall with the first argument
-    // set to SYS_BIND to make bind system call and the second argument is
-    // a pointer to a block of memory containing the original arguments.
+    // set to SYS_BIND/SYS_LISTEN to make bind()/listen() system calls and the
+    // second argument is a pointer to a block of memory containing the original arguments.
     else
     {
+        if (Arguments[0] == SYS_LISTEN)
+        {
+            // Grab the first parameter (the socket fd).
+            auto processMemory = m_seccompDispatcher->ReadProcessMemory(CallId, Pid, Arguments[1], sizeof(uint32_t));
+            if (!processMemory.has_value())
+            {
+                throw RuntimeErrorWithSourceLocation("Failed to read process memory");
+            }
+
+            const uint32_t* CopiedArguments = reinterpret_cast<uint32_t*>(processMemory->data());
+            return ParseListen(CopiedArguments[0]);
+        }
+
         if (Arguments[0] != SYS_BIND)
         {
-            return {{{}, {}, CallId}}; // Not a bind call, just let the call go through
+            return {{{}, {}, CallId}}; // Not a bind or listen call, just let the call go through
         }
         // Grab the first 3 parameters
         auto processMemory = m_seccompDispatcher->ReadProcessMemory(CallId, Pid, Arguments[1], sizeof(uint32_t) * 3);
@@ -478,6 +564,14 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
         return ParseSocket(CopiedArguments[0], CopiedArguments[1], CopiedArguments[2]);
     }
 #else
+    // Both native 64-bit listen() (trapped via __NR_listen, e.g. on aarch64) and 32-bit ARM
+    // compat listen() (trapped via the hardcoded ARMV7_NR_listen syscall number) land here, so
+    // both syscall numbers must be checked.
+    if (SysCallNumber == __NR_listen || SysCallNumber == ARMV7_NR_listen)
+    {
+        return ParseListen(Arguments[0]);
+    }
+
     return ParseSocket(Arguments[0], Arguments[1], Arguments[2]);
 #endif
 }
@@ -558,6 +652,10 @@ catch (const std::exception& e)
 
 std::optional<GnsPortTracker::PortAllocation> GnsPortTracker::ResolvePortZeroBind(DeferredPortLookup lookup)
 {
+    // This resolves the port for both an explicit bind(port=0) and an implicit
+    // autobind triggered by listen(), since neither can be known until after the
+    // syscall has actually completed in-kernel.
+    //
     // The socket fd was already duplicated (via pidfd_getfd) while the target process
     // was stopped by seccomp, so it remains valid even if the process has closed or
     // reused the original fd number.

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -463,15 +463,15 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
     // ResolvePortZeroBind(), the same as a bind(port=0) call, since the port isn't assigned until
     // the listen() syscall (which performs the implicit autobind) actually completes in-kernel.
     auto ParseListen = [&](int Socket) -> std::optional<BindCall> {
-        auto networkNamespace = std::filesystem::read_symlink(std::format("/proc/{}/ns/net", Pid)).string();
-        if (networkNamespace != m_networkNamespace)
-        {
-            GNS_LOG_INFO("Skipping listen() call for pid {} in network namespace {}", Pid, networkNamespace.c_str());
-            return {{{}, {}, CallId}}; // Different network namespace. Let it go through.
-        }
-
         try
         {
+            auto networkNamespace = std::filesystem::read_symlink(std::format("/proc/{}/ns/net", Pid)).string();
+            if (networkNamespace != m_networkNamespace)
+            {
+                GNS_LOG_INFO("Skipping listen() call for pid {} in network namespace {}", Pid, networkNamespace.c_str());
+                return {{{}, {}, CallId}}; // Different network namespace. Let it go through.
+            }
+
             const int protocol = GetSocketProtocol(Pid, Socket);
             auto dupFd = DuplicateSocketFd(Pid, Socket);
             if (!dupFd)

--- a/src/linux/init/localhost.cpp
+++ b/src/linux/init/localhost.cpp
@@ -485,12 +485,21 @@ int RunPortTracker(int Argc, char** Argv)
     seccompDispatcher->RegisterHandler(
         __NR_bind, [&portTracker](seccomp_notif* notification) { return portTracker.ProcessSecCompNotification(notification); });
 
+    // listen() can perform an implicit autobind (assigning an ephemeral port) when called on a
+    // socket that was never explicitly bind()'d. That autobind is otherwise invisible to the
+    // port tracker, so listen() needs to be intercepted the same way bind() is.
+    seccompDispatcher->RegisterHandler(
+        __NR_listen, [&portTracker](seccomp_notif* notification) { return portTracker.ProcessSecCompNotification(notification); });
+
 #ifdef __x86_64__
     seccompDispatcher->RegisterHandler(I386_NR_socketcall, [&portTracker](seccomp_notif* notification) {
         return portTracker.ProcessSecCompNotification(notification);
     });
 #else
     seccompDispatcher->RegisterHandler(ARMV7_NR_bind, [&portTracker](seccomp_notif* notification) {
+        return portTracker.ProcessSecCompNotification(notification);
+    });
+    seccompDispatcher->RegisterHandler(ARMV7_NR_listen, [&portTracker](seccomp_notif* notification) {
         return portTracker.ProcessSecCompNotification(notification);
     });
 #endif

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3336,7 +3336,7 @@ wil::unique_fd RegisterSeccompHook()
 
 Routine Description:
 
-    Register a seccomp notification for bind(), listen() & ioctl(*, TUNSETIFF, *) calls.
+    Register a seccomp notification for bind(), listen() & ioctl(*, SIOCSIFFLAGS, *) calls.
 
     listen() is intercepted in addition to bind() because it can perform an implicit
     autobind (assigning an ephemeral port) on a socket that was never explicitly bind()'d;

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3336,7 +3336,8 @@ wil::unique_fd RegisterSeccompHook()
 
 Routine Description:
 
-    Register a seccomp notification for bind(), listen() & ioctl(*, SIOCSIFFLAGS, *) calls.
+    Register a seccomp notification for bind() & listen() calls (both the native and 32-bit
+    compat ABIs), plus ioctl(*, SIOCSIFFLAGS, *) calls on the native 64-bit ABI only.
 
     listen() is intercepted in addition to bind() because it can perform an implicit
     autobind (assigning an ephemeral port) on a socket that was never explicitly bind()'d;

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3336,7 +3336,11 @@ wil::unique_fd RegisterSeccompHook()
 
 Routine Description:
 
-    Register a seccomp notification for bind() & ioctl(*, TUNSETIFF, *) calls.
+    Register a seccomp notification for bind(), listen() & ioctl(*, TUNSETIFF, *) calls.
+
+    listen() is intercepted in addition to bind() because it can perform an implicit
+    autobind (assigning an ephemeral port) on a socket that was never explicitly bind()'d;
+    that autobind would otherwise be invisible to the port tracker.
 
 Arguments:
 
@@ -3360,11 +3364,13 @@ Return Value:
         // If syscall_arch & __AUDIT_ARCH_64BIT then continue else goto :32bit
         BPF_STMT(BPF_LD + BPF_W + BPF_ABS, syscall_arch),
         // For now, notify on all non-native arch
-        BPF_JUMP(BPF_JMP + BPF_JSET + BPF_K, __AUDIT_ARCH_64BIT, 0, 7),
+        BPF_JUMP(BPF_JMP + BPF_JSET + BPF_K, __AUDIT_ARCH_64BIT, 0, 8),
         // If syscall_nr == __NR_bind then goto user_notify: else continue
         BPF_STMT(BPF_LD + BPF_W + BPF_ABS, syscall_nr),
-        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, __NR_bind, 3, 0),
-        // if (syscall_nr == __NR_bind) then continue else goto allow:
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, __NR_bind, 4, 0),
+        // if (syscall_nr == __NR_listen) then goto user_notify: else continue
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, __NR_listen, 3, 0),
+        // if (syscall_nr == __NR_ioctl) then continue else goto allow:
         BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, __NR_ioctl, 0, 3),
         // if (syscall arg1 == SIOCSIFFLAGS) goto user_notify else goto allow:
         BPF_STMT(BPF_LD + BPF_W + BPF_ABS, syscall_arg(1)),
@@ -3377,15 +3383,17 @@ Return Value:
         BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
 
     // Note: 32bit on x86_64 uses the __NR_socketcall with the first argument
-    // set to SYS_BIND to make bind system call.
+    // set to SYS_BIND/SYS_LISTEN to make bind()/listen() system calls.
 #ifdef __x86_64__
         // 32bit:
         // If syscall_nr == __NR_socketcall then continue else goto allow:
         BPF_STMT(BPF_LD + BPF_W + BPF_ABS, syscall_nr),
-        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, I386_NR_socketcall, 0, 3),
-        // if syscall arg0 == SYS_BIND then goto user_notify: else goto allow:
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, I386_NR_socketcall, 0, 4),
+        // if syscall arg0 == SYS_BIND then goto user_notify: else continue
         BPF_STMT(BPF_LD + BPF_W + BPF_ABS, syscall_arg(0)),
-        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_BIND, 0, 1),
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_BIND, 1, 0),
+        // if syscall arg0 == SYS_LISTEN then continue else goto allow:
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_LISTEN, 0, 1),
         // user_notify:
         //     return SECCOMP_RET_USER_NOTIF;
         BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_USER_NOTIF),
@@ -3394,9 +3402,11 @@ Return Value:
         BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
 #else
         // 32bit:
-        // If syscall_nr == __NR_bind then goto user_notify: else goto allow:
+        // If syscall_nr == __NR_bind then goto user_notify: else continue
         BPF_STMT(BPF_LD + BPF_W + BPF_ABS, syscall_nr),
-        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, ARMV7_NR_bind, 0, 1),
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, ARMV7_NR_bind, 1, 0),
+        // if (syscall_nr == __NR_listen) then goto user_notify: else goto allow:
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, ARMV7_NR_listen, 0, 1),
         // user_notify:
         //     return SECCOMP_RET_USER_NOTIF;
         BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_USER_NOTIF),

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2130,14 +2130,15 @@ class NetworkTests
 
         // Perl one-liner: socket() + listen() with no bind(), print the kernel-assigned
         // port via getsockname(), then accept() (blocking) to keep the socket alive.
-        const std::wstring wslCmd = L"perl -MSocket -e '"
-                                     L"$|=1;"
-                                     L"socket(S,AF_INET,SOCK_STREAM,0) or die;"
-                                     L"listen(S,5) or die;"
-                                     L"my $port=(sockaddr_in(getsockname(S)))[0];"
-                                     L"print \"PORT=$port\\n\";"
-                                     L"accept(C,S);"
-                                     L"'";
+        const std::wstring wslCmd =
+            L"perl -MSocket -e '"
+            L"$|=1;"
+            L"socket(S,AF_INET,SOCK_STREAM,0) or die;"
+            L"listen(S,5) or die;"
+            L"my $port=(sockaddr_in(getsockname(S)))[0];"
+            L"print \"PORT=$port\\n\";"
+            L"accept(C,S);"
+            L"'";
         auto cmd = LxssGenerateWslCommandLine(wslCmd.data());
 
         auto process = LxsstuStartProcess(cmd.data(), nullptr, stdOutWrite.get(), nullptr);

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2120,6 +2120,124 @@ class NetworkTests
         return {std::move(process), assignedPort};
     }
 
+    // Create a TCP listening socket in the guest via listen() WITHOUT ever calling bind() first
+    // (implicit autobind to an ephemeral port on the wildcard address, e.g. INADDR_ANY:0).
+    // This exercises the seccomp listen() trap added for the implicit-autobind port tracking fix,
+    // as opposed to BindGuestPortZero() which exercises the pre-existing explicit bind(0) path.
+    static std::tuple<unique_kill_process, uint16_t> BindGuestPortViaListenOnly()
+    {
+        auto [stdOutRead, stdOutWrite] = CreateSubprocessPipe(false, true);
+
+        // Perl one-liner: socket() + listen() with no bind(), print the kernel-assigned
+        // port via getsockname(), then accept() (blocking) to keep the socket alive.
+        const std::wstring wslCmd = L"perl -MSocket -e '"
+                                     L"$|=1;"
+                                     L"socket(S,AF_INET,SOCK_STREAM,0) or die;"
+                                     L"listen(S,5) or die;"
+                                     L"my $port=(sockaddr_in(getsockname(S)))[0];"
+                                     L"print \"PORT=$port\\n\";"
+                                     L"accept(C,S);"
+                                     L"'";
+        auto cmd = LxssGenerateWslCommandLine(wslCmd.data());
+
+        auto process = LxsstuStartProcess(cmd.data(), nullptr, stdOutWrite.get(), nullptr);
+        stdOutWrite.reset();
+
+        std::string output(256, '\0');
+        DWORD writeOffset = 0;
+        uint16_t assignedPort = 0;
+        bool found = false;
+
+        while (!found)
+        {
+            if (writeOffset == output.size())
+            {
+                output.resize(output.size() * 2);
+            }
+
+            DWORD bytesRead = 0;
+            if (!ReadFile(stdOutRead.get(), output.data() + writeOffset, static_cast<DWORD>(output.size() - writeOffset), &bytesRead, nullptr) ||
+                bytesRead == 0)
+            {
+                break;
+            }
+
+            writeOffset += bytesRead;
+            LogInfo("output %hs", output.c_str());
+            std::string_view outputView(output.data(), writeOffset);
+            auto pos = outputView.find("PORT=");
+            if (pos != std::string_view::npos)
+            {
+                auto portStr = outputView.substr(pos + 5);
+                auto end = portStr.find_first_not_of("0123456789");
+                if (end != std::string_view::npos)
+                {
+                    portStr = portStr.substr(0, end);
+                }
+
+                if (!portStr.empty())
+                {
+                    assignedPort = static_cast<uint16_t>(std::stoi(std::string(portStr)));
+                    found = true;
+                }
+            }
+        }
+
+        VERIFY_IS_TRUE(found);
+        VERIFY_IS_TRUE(assignedPort > 0);
+        LogInfo("listen()-only autobind resolved to port %u", assignedPort);
+
+        return {std::move(process), assignedPort};
+    }
+
+    // Verifies that a listen() call with no preceding bind() (implicit autobind) is tracked
+    // by the host port tracker, mirroring VerifyPortZeroBindIsTracked's coverage of the
+    // pre-existing explicit bind(0) path.
+    static void VerifyListenWithoutBindIsTracked(bool verifyRelease = true)
+    {
+        WslKeepAlive keepAlive;
+
+        auto [guestProcess, assignedPort] = BindGuestPortViaListenOnly();
+
+        // Port resolution is asynchronous (deferred to a background thread) for the case where
+        // the socket wasn't already bound. Retry until the host port tracker registers the port,
+        // blocking the host bind.
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&assignedPort]() {
+                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                THROW_LAST_ERROR_IF(!sock);
+
+                SOCKADDR_IN addr{};
+                addr.sin_family = AF_INET;
+                addr.sin_port = htons(assignedPort);
+                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) != SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::seconds(30)));
+
+        if (!verifyRelease)
+        {
+            return;
+        }
+
+        // Kill the guest process so the port tracker releases the port.
+        guestProcess.reset();
+
+        // Retry until the host can bind the port again, confirming it was released.
+        VERIFY_NO_THROW(wsl::shared::retry::RetryWithTimeout<void>(
+            [&assignedPort]() {
+                wil::unique_socket sock(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+                THROW_LAST_ERROR_IF(!sock);
+
+                SOCKADDR_IN addr{};
+                addr.sin_family = AF_INET;
+                addr.sin_port = htons(assignedPort);
+                THROW_HR_IF(E_FAIL, bind(sock.get(), reinterpret_cast<SOCKADDR*>(&addr), sizeof(addr)) == SOCKET_ERROR);
+            },
+            std::chrono::seconds(1),
+            std::chrono::minutes(2)));
+    }
+
     static void VerifyPortZeroBindIsTracked(bool verifyRelease = true)
     {
         // Make sure the VM doesn't time out while we wait for async port resolution
@@ -4171,6 +4289,17 @@ class MirroredTests
         NetworkTests::VerifyPortZeroBindIsTracked(false);
     }
 
+    WSL2_TEST_METHOD(ListenWithoutBindIsTracked)
+    {
+        MIRRORED_NETWORKING_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
+        WaitForMirroredStateInLinux();
+
+        // See PortZeroBindIsTracked above for why release verification is skipped in mirrored mode.
+        NetworkTests::VerifyListenWithoutBindIsTracked(false);
+    }
+
     WSL2_TEST_METHOD(AcceptedConnectionPortTracking)
     {
         MIRRORED_NETWORKING_TEST_ONLY();
@@ -5126,6 +5255,15 @@ class ConsommeTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
 
         NetworkTests::VerifyPortZeroBindIsTracked();
+    }
+
+    WSL2_TEST_METHOD(ListenWithoutBindIsTracked)
+    {
+        CONSOMME_TEST_ONLY();
+
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Consomme}));
+
+        NetworkTests::VerifyListenWithoutBindIsTracked();
     }
 
     WSL2_TEST_METHOD(PortZeroRebindSucceeds)

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2170,16 +2170,18 @@ class NetworkTests
             if (pos != std::string_view::npos)
             {
                 auto portStr = outputView.substr(pos + 5);
-                auto end = portStr.find_first_not_of("0123456789");
-                if (end != std::string_view::npos)
-                {
-                    portStr = portStr.substr(0, end);
-                }
 
-                if (!portStr.empty())
+                // Only parse once the line is fully read (terminated by '\n'); otherwise a
+                // partial read could truncate the port digits (e.g. "123" read as "12").
+                auto newlinePos = portStr.find('\n');
+                if (newlinePos != std::string_view::npos)
                 {
-                    assignedPort = static_cast<uint16_t>(std::stoi(std::string(portStr)));
-                    found = true;
+                    portStr = portStr.substr(0, newlinePos);
+                    if (!portStr.empty())
+                    {
+                        assignedPort = static_cast<uint16_t>(std::stoi(std::string(portStr)));
+                        found = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

WSL2's Consomme networking mode only forwards TCP/UDP ports that were explicitly `bind()`'d in the guest. If an application calls `listen()` without first calling `bind()` (relying on the kernel's implicit autobind to an ephemeral port on the wildcard address), the port tracker never observes the bind, so the port is never registered for host forwarding and the socket is unreachable via `127.0.0.1:<port>` from Windows.

Fixes #41117

## Root cause

The seccomp filter installed by `RegisterSeccompHook()` in `src/linux/init/main.cpp` only ever trapped `bind()`. `listen()` was never trapped, so a `socket()` + `listen()` sequence with no prior `bind()` call was invisible to `GnsPortTracker`.

## What this changes

- Extends the seccomp BPF filter to also trap `listen()` across all supported architectures (native 64-bit `__NR_listen`, x86 compat via `socketcall(SYS_LISTEN, ...)`, and 32-bit ARM EABI via a new `ARMV7_NR_listen` constant).
- `GnsPortTracker::GetCallInfo` dispatches `listen()` calls through a new `ParseListen` path, reusing the existing `DeferredPortLookup`/`ResolvePortZeroBind` mechanism already used for explicit `bind(port=0)`.
- To avoid adding latency to the overwhelmingly common `bind()` + `listen()` sequence (where the port is already known before `listen()` runs), `ParseListen` first checks `getsockname()` synchronously and only falls back to the deferred/polling resolution path for genuine implicit-autobind-via-`listen()` calls (no prior `bind()`).

## Testing

- Added `ListenWithoutBindIsTracked` to both `NetworkTests::ConsommeTests` and `NetworkTests::MirroredTests`, mirroring the existing `PortZeroBindIsTracked` coverage but exercising `listen()` with no preceding `bind()`.
- Verified with a real before/after run against a full local build+deploy:
  - Pre-fix: `ConsommeTests::ListenWithoutBindIsTracked` **fails** (host can bind the port — Consomme never tracked it).
  - Post-fix: passes.
  - `MirroredTests::ListenWithoutBindIsTracked` passes both before and after — mirrored mode already has an independent port+protocol refresh mechanism (`OnRefreshAllocatedPorts`, added in #40287) that covers this case, so this change doesn't affect mirrored mode's behavior.
- Also validated the raw BPF filter bytes directly against the running kernel via a standalone seccomp-unotify harness, confirming the old filter never traps `listen()` and the new filter does (`__NR_listen`, syscall nr 50 on x86_64).
