### PR TITLE
Update .NET runtime packages to 10.0.10

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="10.0.0" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.9" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.9" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.10" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.10" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.7214" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.CsWinRT" version="2.2.0" />


### PR DESCRIPTION
Updates the x64 and ARM64 .NET 10 runtime packages from 10.0.9 to 10.0.10. This addresses the ten open Dependabot alerts for GHSA-cvvh-rhrc-wg4q, GHSA-w7cw-xp7h-6j5j, GHSA-qvw7-jm5c-6hqw, GHSA-74jp-vm22-8q8x, and GHSA-wp74-jgxh-gv4q.