### PR TITLE
Handle offlink default gateways in GNS

### DIFF
--- a/src/linux/netlinkutil/RoutingTable.cpp
+++ b/src/linux/netlinkutil/RoutingTable.cpp
@@ -139,7 +139,9 @@ void RoutingTable::SendMessage(const Route& route, int operation, int flags, con
     message.route.rtm_type = route.IsMulticast() ? RTN_MULTICAST : RTN_UNICAST;
     message.route.rtm_scope = route.IsOnlink() ? RT_SCOPE_LINK : RT_SCOPE_UNIVERSE;
     message.route.rtm_flags = RTM_F_NOTIFY;
-    if (route.via.has_value() && route.via.value().IsLinkLocal())
+    // Default gateways received from the host are directly reachable through the specified interface,
+    // even when a VPN exposes the interface as a host route and the gateway is outside that prefix.
+    if (route.via.has_value() && (route.defaultRoute || route.via.value().IsLinkLocal()))
     {
         message.route.rtm_flags |= RTNH_F_ONLINK;
     }

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -345,6 +345,11 @@ class NetworkTests
         VERIFY_ARE_EQUAL(v6State.DefaultRoute->Device, L"eth0");
     }
 
+    WSL2_TEST_METHOD(AddDefaultRouteWithOfflinkGateway)
+    {
+        TestCase({{L"eth0", {{L"100.96.5.160", 32}}, L"100.96.5.161"}});
+    }
+
     WSL2_TEST_METHOD(AddRemoveDefaultOnlinkRoutes)
     {
         wsl::shared::hns::Route defaultRouteV4;


### PR DESCRIPTION
## Summary

WSLC session startup can fail with `E_UNEXPECTED` when a VPN exposes its interface as a `/32` and provides a non-link-local gateway outside that prefix. Mark host-supplied default gateways as on-link so the Linux kernel accepts the route through the specified interface.

Fixes #41082

## Root cause

The issue trace shows the guest receiving `100.96.5.160/32` followed by `default via 100.96.5.161`. The kernel rejects the default route with `ENETUNREACH` because the gateway is outside the interface prefix. The earlier fix in #41003 only covered link-local gateways, while Cloudflare WARP and Tailscale use non-link-local gateways.

## Testing

- Full x64 Debug build
- `NetworkTests::AddDefaultRouteWithOfflinkGateway`
- `NetworkTests::RemoveAndAddDefaultRoute`