### PR TITLE
wslc: switch image build from docker build to docker buildx build

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -914,7 +914,7 @@ try
     auto unmountFolder =
         wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { m_virtualMachine->UnmountWindowsFolder(mountPath.c_str()); });
 
-    std::vector<std::string> buildArgs{"/usr/bin/docker", "buildx", "build", "--progress=rawjson"};
+    std::vector<std::string> buildArgs{"/usr/bin/docker", "buildx", "build", "--builder", "default", "--progress=rawjson"};
     if (WI_IsFlagSet(Options->Flags, WSLCBuildImageFlagsNoCache))
     {
         buildArgs.push_back("--no-cache");

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -914,7 +914,7 @@ try
     auto unmountFolder =
         wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { m_virtualMachine->UnmountWindowsFolder(mountPath.c_str()); });
 
-    std::vector<std::string> buildArgs{"/usr/bin/docker", "build", "--progress=rawjson"};
+    std::vector<std::string> buildArgs{"/usr/bin/docker", "buildx", "build", "--progress=rawjson"};
     if (WI_IsFlagSet(Options->Flags, WSLCBuildImageFlagsNoCache))
     {
         buildArgs.push_back("--no-cache");

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1639,38 +1639,6 @@ class WSLCTests
         VERIFY_IS_TRUE(result.Output[1].find("Hello from a WSL container!") != std::string::npos);
     }
 
-    WSLC_TEST_METHOD(BuildImageIgnoresSelectedBuildxBuilder)
-    {
-        constexpr auto imageTag = "wslc-test-build-selected-builder:latest";
-        constexpr auto builderName = "wslc-test-unreachable-remote";
-        auto contextDir = std::filesystem::current_path() / "build-context-selected-builder";
-        std::filesystem::create_directories(contextDir);
-
-        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-            RunCommand(m_defaultSession.get(), {"/usr/bin/docker", "buildx", "use", "default"});
-            RunCommand(m_defaultSession.get(), {"/usr/bin/docker", "buildx", "rm", builderName});
-            LOG_IF_FAILED(DeleteImageNoThrow(imageTag, WSLCDeleteImageFlagsForce).first);
-
-            std::error_code ec;
-            std::filesystem::remove_all(contextDir, ec);
-        });
-
-        RunCommand(m_defaultSession.get(), {"/usr/bin/docker", "buildx", "rm", builderName});
-        ExpectCommandResult(
-            m_defaultSession.get(),
-            {"/usr/bin/docker", "buildx", "create", "--name", builderName, "--driver", "remote", "tcp://127.0.0.1:1", "--use"},
-            0);
-
-        {
-            std::ofstream dockerfile(contextDir / "Dockerfile");
-            dockerfile << "FROM debian:latest\n";
-            dockerfile << "CMD [\"echo\", \"selected-builder-ok\"]\n";
-        }
-
-        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, imageTag));
-        ExpectImagePresent(*m_defaultSession, imageTag);
-    }
-
     // This test validates both that we can build an image with an empty CMD, and that we can run such an image.
     WSLC_TEST_METHOD(BuildImageEntrypoint)
     {

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1639,6 +1639,38 @@ class WSLCTests
         VERIFY_IS_TRUE(result.Output[1].find("Hello from a WSL container!") != std::string::npos);
     }
 
+    WSLC_TEST_METHOD(BuildImageIgnoresSelectedBuildxBuilder)
+    {
+        constexpr auto imageTag = "wslc-test-build-selected-builder:latest";
+        constexpr auto builderName = "wslc-test-unreachable-remote";
+        auto contextDir = std::filesystem::current_path() / "build-context-selected-builder";
+        std::filesystem::create_directories(contextDir);
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            RunCommand(m_defaultSession.get(), {"/usr/bin/docker", "buildx", "use", "default"});
+            RunCommand(m_defaultSession.get(), {"/usr/bin/docker", "buildx", "rm", builderName});
+            LOG_IF_FAILED(DeleteImageNoThrow(imageTag, WSLCDeleteImageFlagsForce).first);
+
+            std::error_code ec;
+            std::filesystem::remove_all(contextDir, ec);
+        });
+
+        RunCommand(m_defaultSession.get(), {"/usr/bin/docker", "buildx", "rm", builderName});
+        ExpectCommandResult(
+            m_defaultSession.get(),
+            {"/usr/bin/docker", "buildx", "create", "--name", builderName, "--driver", "remote", "tcp://127.0.0.1:1", "--use"},
+            0);
+
+        {
+            std::ofstream dockerfile(contextDir / "Dockerfile");
+            dockerfile << "FROM debian:latest\n";
+            dockerfile << "CMD [\"echo\", \"selected-builder-ok\"]\n";
+        }
+
+        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, imageTag));
+        ExpectImagePresent(*m_defaultSession, imageTag);
+    }
+
     // This test validates both that we can build an image with an empty CMD, and that we can run such an image.
     WSLC_TEST_METHOD(BuildImageEntrypoint)
     {


### PR DESCRIPTION


<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Change the command wslc runs inside the container VM for wslc image build from docker build to docker buildx build. Zero behavior change, same flags, same context mount, same rawjson output parsed by the existing BuildKitSolveStatus parser.
This is a preparatory PR. It unblocks a follow-up that will enforce the WSLContainerRegistryAllowlist group policy on image builds. Classic docker build cannot honor a BuildKit source policy; docker buildx build can. Splitting the invocation swap from the policy logic keeps both PRs small and gives a clean bisect point.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Why we're doing this
The WSLContainerRegistryAllowlist group policy (added in #40466) lists which registries wslc may talk to. PullImage and PushImage enforce it per-call, but BuildImage couldn't, a Dockerfile's FROMs resolve inside dockerd via ARGs, COPY --from=, --build-context, etc., which we can't reliably parse client-side. So #40466 took the strict-secure default: whenever the allowlist is configured, every wslc image build is refused outright. That leaves enterprise customers with the policy enabled unable to build images at all, even from an allowed registry.
The follow-up PR fixes that by pushing enforcement into BuildKit itself, via its per-invocation source-policy JSON (evaluated after ARG substitution, before any registry request). The catch: classic docker build in moby v25.0.7 silently drops the SourcePolicy field, no CLI flag or env var fills it in. docker buildx build with the default docker driver speaks BuildKit gRPC directly, so SourcePolicy (via EXPERIMENTAL_BUILDKIT_SOURCE_POLICY) travels intact.
This PR makes wslc image build go through buildx so the follow-up can enforce the policy. That's it.

Zero-behavior-change verification
Argv shape: buildx accepts every flag BuildImage passes (--progress=rawjson, -f -, -t, --build-arg, --label, --target, --no-cache, --pull) plus the mounted context path - unchanged.
Rawjson stream: all 14 fields the C++ parser destructures (vertexes, statuses, logs, digest, name, started, completed, error, id, vertex, current, total, data, stream) parse identically.
VM availability: buildx already ships at /usr/libexec/docker/cli-plugins/docker-buildx (BuildKit v0.12.5) - no new dependency.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
