### PR TITLE
Add --ip-range option to network create

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2367,6 +2367,10 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>The '--gateway' option requires '--subnet' to also be specified.</value>
     <comment>{Locked="--gateway'"}{Locked="--subnet'"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcIpRangeRequiresSubnet" xml:space="preserve">
+    <value>The '--ip-range' option requires '--subnet' to also be specified.</value>
+    <comment>{Locked="--ip-range'"}{Locked="--subnet'"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name = "MessageWslcNetworkInUse" xml:space = "preserve" >
     <value>Network '{}' has active endpoints.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
@@ -3246,6 +3250,10 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_NetworkGatewayArgDescription" xml:space="preserve">
     <value>IPv4 or IPv6 gateway for the subnet</value>
     <comment>{Locked="IPv4"}{Locked="IPv6"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="WSLCCLI_NetworkIpRangeArgDescription" xml:space="preserve">
+    <value>Allocate container IP addresses from a sub-range in CIDR format</value>
+    <comment>{Locked="CIDR"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_NetworkRemoveDesc" xml:space="preserve">
     <value>Remove one or more networks.</value>

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -118,8 +118,9 @@ struct IPAMConfig
 {
     std::string Subnet;
     std::string Gateway;
+    std::string IPRange;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAMConfig, Subnet, Gateway);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAMConfig, Subnet, Gateway, IPRange);
 };
 
 struct IPAM

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -207,8 +207,9 @@ struct IPAMConfig
 {
     std::string Subnet;
     std::string Gateway;
+    std::string IPRange;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAMConfig, Subnet, Gateway);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAMConfig, Subnet, Gateway, IPRange);
 };
 
 struct IPAM

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -561,6 +561,7 @@ typedef struct _WSLCNetworkOptions
     BOOL Internal;
     [unique] LPCSTR Subnet;
     [unique] LPCSTR Gateway;
+    [unique] LPCSTR IpRange;
 } WSLCNetworkOptions;
 
 typedef char WSLCNetworkName[WSLC_MAX_NETWORK_NAME_LENGTH + 1];

--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -78,6 +78,7 @@ _(ImportFile,     "file",                NO_ALIAS,          Kind::Positional,  L
 _(Input,          "input",               L"i",              Kind::Value,       Localization::WSLCCLI_InputArgDescription()) \
 _(Interactive,    "interactive",         L"i",              Kind::Flag,        Localization::WSLCCLI_InteractiveArgDescription()) \
 _(Internal,       "internal",            NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NetworkInternalArgDescription()) \
+_(IpRange,        "ip-range",            NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_NetworkIpRangeArgDescription()) \
 _(Label,          "label",               L"l",              Kind::Value,       Localization::WSLCCLI_LabelArgDescription()) \
 _(Last,           "last",                L"n",              Kind::Value,       Localization::WSLCCLI_LastArgDescription()) \
 _(Latest,         "latest",              L"l",              Kind::Flag,        Localization::WSLCCLI_LatestArgDescription()) \

--- a/src/windows/wslc/commands/NetworkCreateCommand.cpp
+++ b/src/windows/wslc/commands/NetworkCreateCommand.cpp
@@ -33,6 +33,7 @@ std::vector<Argument> NetworkCreateCommand::GetArguments() const
         Argument::Create(ArgType::Label, false, NO_LIMIT, Localization::WSLCCLI_NetworkLabelArgDescription()),
         Argument::Create(ArgType::Gateway),
         Argument::Create(ArgType::Internal),
+        Argument::Create(ArgType::IpRange),
         Argument::Create(ArgType::Subnet),
     };
 }

--- a/src/windows/wslc/services/NetworkModel.h
+++ b/src/windows/wslc/services/NetworkModel.h
@@ -28,6 +28,7 @@ struct CreateNetworkOptions
     bool Internal{false};
     std::optional<std::string> Subnet;
     std::optional<std::string> Gateway;
+    std::optional<std::string> IpRange;
 };
 
 struct PruneNetworksResult

--- a/src/windows/wslc/services/NetworkService.cpp
+++ b/src/windows/wslc/services/NetworkService.cpp
@@ -62,6 +62,11 @@ void NetworkService::Create(Reporter& reporter, models::Session& session, const 
         options.Gateway = createOptions.Gateway->c_str();
     }
 
+    if (createOptions.IpRange.has_value())
+    {
+        options.IpRange = createOptions.IpRange->c_str();
+    }
+
     THROW_IF_FAILED(session.Get()->CreateNetwork(&options, &warningCallback));
 }
 

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -107,6 +107,11 @@ void CreateNetwork(CLIExecutionContext& context)
         options.Gateway = WideToMultiByte(context.Args.Get<ArgType::Gateway>());
     }
 
+    if (context.Args.Contains(ArgType::IpRange))
+    {
+        options.IpRange = WideToMultiByte(context.Args.Get<ArgType::IpRange>());
+    }
+
     NetworkService::Create(context.Reporter, context.Data.Get<Data::Session>(), options);
     context.Reporter.Output(L"{}\n", MultiByteToWide(options.Name));
 }

--- a/src/windows/wslcsession/WSLCNetworkMetadata.h
+++ b/src/windows/wslcsession/WSLCNetworkMetadata.h
@@ -30,6 +30,7 @@ struct NetworkIPAMConfig
 {
     std::string Subnet;
     std::string Gateway;
+    std::string IPRange;
 };
 
 struct NetworkIPAM

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -631,11 +631,13 @@ ServiceRunningProcess WSLCSession::StartProcess(
 
     auto process = launcher.Launch(*m_virtualMachine);
 
-    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
-        process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(
+        std::make_unique<windows::common::io::LineBasedReadHandle>(
+            process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
-    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
-        process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(
+        std::make_unique<windows::common::io::LineBasedReadHandle>(
+            process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
     m_ioRelay.AddHandle(std::make_unique<windows::common::io::EventHandle>(process.GetExitEvent(), std::move(ExitCallback)));
 
@@ -1147,8 +1149,9 @@ try
 
     // With --progress=rawjson, docker writes progress to stderr and the final image ID to stdout on success (empty on
     // failure). Stdout is drained into allOutput (shown only on error) and its EOF signals build completion.
-    io.AddHandle(std::make_unique<io::ReadHandle>(
-        buildProcess.GetStdHandle(1), [&](const auto& content) { allOutput.append(content.begin(), content.end()); }));
+    io.AddHandle(std::make_unique<io::ReadHandle>(buildProcess.GetStdHandle(1), [&](const auto& content) {
+        allOutput.append(content.begin(), content.end());
+    }));
 
     io.AddHandle(std::make_unique<io::LineBasedReadHandle>(buildProcess.GetStdHandle(2), captureOutput, false));
 
@@ -1500,8 +1503,9 @@ void WSLCSession::SaveImageImpl(std::pair<uint32_t, wil::unique_socket>& SocketC
     }
     else
     {
-        io.AddHandle(std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
-            common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
+        io.AddHandle(
+            std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
+                common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
     }
 
     io.Run({});
@@ -2509,6 +2513,9 @@ try
     THROW_HR_WITH_USER_ERROR_IF(
         E_INVALIDARG, Localization::MessageWslcGatewayRequiresSubnet(), Options->Gateway != nullptr && Options->Subnet == nullptr);
 
+    THROW_HR_WITH_USER_ERROR_IF(
+        E_INVALIDARG, Localization::MessageWslcIpRangeRequiresSubnet(), Options->IpRange != nullptr && Options->Subnet == nullptr);
+
     if (Options->Subnet != nullptr)
     {
         docker_schema::IPAMConfig ipamConfig;
@@ -2517,6 +2524,11 @@ try
         if (Options->Gateway != nullptr)
         {
             ipamConfig.Gateway = Options->Gateway;
+        }
+
+        if (Options->IpRange != nullptr)
+        {
+            ipamConfig.IPRange = Options->IpRange;
         }
 
         auto& ipam = request.IPAM.emplace();
@@ -2576,7 +2588,7 @@ try
         auto& cfgs = entry.IPAM.Config.emplace();
         for (const auto& c : *full.IPAM.Config)
         {
-            cfgs.push_back({c.Subnet, c.Gateway});
+            cfgs.push_back({c.Subnet, c.Gateway, c.IPRange});
         }
     }
 
@@ -2708,6 +2720,7 @@ try
             wslc_schema::IPAMConfig inspectCfg;
             inspectCfg.Subnet = cfg.Subnet;
             inspectCfg.Gateway = cfg.Gateway;
+            inspectCfg.IPRange = cfg.IPRange;
             configs.push_back(std::move(inspectCfg));
         }
     }
@@ -3533,7 +3546,7 @@ void WSLCSession::RecoverExistingNetworks()
                 auto& cfgs = entry.IPAM.Config.emplace();
                 for (const auto& c : *network.IPAM.Config)
                 {
-                    cfgs.push_back({c.Subnet, c.Gateway});
+                    cfgs.push_back({c.Subnet, c.Gateway, c.IPRange});
                 }
             }
 

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -631,13 +631,11 @@ ServiceRunningProcess WSLCSession::StartProcess(
 
     auto process = launcher.Launch(*m_virtualMachine);
 
-    m_ioRelay.AddHandle(
-        std::make_unique<windows::common::io::LineBasedReadHandle>(
-            process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
+        process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
-    m_ioRelay.AddHandle(
-        std::make_unique<windows::common::io::LineBasedReadHandle>(
-            process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
+        process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
     m_ioRelay.AddHandle(std::make_unique<windows::common::io::EventHandle>(process.GetExitEvent(), std::move(ExitCallback)));
 
@@ -1149,9 +1147,8 @@ try
 
     // With --progress=rawjson, docker writes progress to stderr and the final image ID to stdout on success (empty on
     // failure). Stdout is drained into allOutput (shown only on error) and its EOF signals build completion.
-    io.AddHandle(std::make_unique<io::ReadHandle>(buildProcess.GetStdHandle(1), [&](const auto& content) {
-        allOutput.append(content.begin(), content.end());
-    }));
+    io.AddHandle(std::make_unique<io::ReadHandle>(
+        buildProcess.GetStdHandle(1), [&](const auto& content) { allOutput.append(content.begin(), content.end()); }));
 
     io.AddHandle(std::make_unique<io::LineBasedReadHandle>(buildProcess.GetStdHandle(2), captureOutput, false));
 
@@ -1503,9 +1500,8 @@ void WSLCSession::SaveImageImpl(std::pair<uint32_t, wil::unique_socket>& SocketC
     }
     else
     {
-        io.AddHandle(
-            std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
-                common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
+        io.AddHandle(std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
+            common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
     }
 
     io.Run({});

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5560,7 +5560,7 @@ class WSLCTests
             options.Driver = "bridge";
             options.Subnet = nullptr;
             options.Gateway = "172.44.0.1";
-            verifyInvalid(L"--subnet");
+            verifyInvalid(L"--gateway");
         }
 
         // IpRange specified without Subnet
@@ -5569,7 +5569,7 @@ class WSLCTests
             options.Subnet = nullptr;
             options.Gateway = nullptr;
             options.IpRange = "172.44.10.0/24";
-            verifyInvalid(L"--subnet");
+            verifyInvalid(L"--ip-range");
         }
     }
 
@@ -9629,18 +9629,15 @@ class WSLCTests
             std::string readStdout;
             std::string readStderr;
 
-            io.AddHandle(
-                std::make_unique<DockerIORelayHandle>(
-                    std::move(readPipe), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
+            io.AddHandle(std::make_unique<DockerIORelayHandle>(
+                std::move(readPipe), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
             io.AddHandle(std::make_unique<WriteHandle>(std::move(writePipe), Input));
 
-            io.AddHandle(std::make_unique<ReadHandle>(std::move(stdoutRead), [&](const auto& buffer) {
-                readStdout.append(buffer.data(), buffer.size());
-            }));
+            io.AddHandle(std::make_unique<ReadHandle>(
+                std::move(stdoutRead), [&](const auto& buffer) { readStdout.append(buffer.data(), buffer.size()); }));
 
-            io.AddHandle(std::make_unique<ReadHandle>(std::move(stderrRead), [&](const auto& buffer) {
-                readStderr.append(buffer.data(), buffer.size());
-            }));
+            io.AddHandle(std::make_unique<ReadHandle>(
+                std::move(stderrRead), [&](const auto& buffer) { readStderr.append(buffer.data(), buffer.size()); }));
 
             io.Run({});
 
@@ -9719,9 +9716,8 @@ class WSLCTests
                 std::string output;
                 MultiHandleWait io;
 
-                io.AddHandle(
-                    std::make_unique<DockerIORelayHandle>(
-                        std::move(inputRead), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
+                io.AddHandle(std::make_unique<DockerIORelayHandle>(
+                    std::move(inputRead), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
 
                 io.AddHandle(std::make_unique<ReadHandle>(std::move(stdoutRead), [&](const auto& buffer) {
                     output.append(buffer.data(), buffer.size());
@@ -9761,9 +9757,8 @@ class WSLCTests
 
         // Collect the relayed output.
         std::string output;
-        io.AddHandle(std::make_unique<ReadHandle>(std::move(dstRead), [&](const gsl::span<char>& buffer) {
-            output.append(buffer.data(), buffer.size());
-        }));
+        io.AddHandle(std::make_unique<ReadHandle>(
+            std::move(dstRead), [&](const gsl::span<char>& buffer) { output.append(buffer.data(), buffer.size()); }));
 
         io.Run({});
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3241,8 +3241,8 @@ class WSLCTests
 
             HRESULT OnCrashDump(LPCWSTR DumpPath, LPCSTR ProcessName, ULONG Pid, ULONG Signal, ULONGLONG Timestamp) override
             {
-                m_promise.set_value(
-                    Invocation{DumpPath ? std::wstring{DumpPath} : std::wstring{}, ProcessName ? std::string{ProcessName} : std::string{}, Pid, Signal, Timestamp});
+                m_promise.set_value(Invocation{
+                    DumpPath ? std::wstring{DumpPath} : std::wstring{}, ProcessName ? std::string{ProcessName} : std::string{}, Pid, Signal, Timestamp});
 
                 // Block until the test has finished probing, so anything the test verifies is observed mid-callback.
                 m_release.wait();
@@ -7836,10 +7836,10 @@ class WSLCTests
 
             wil::com_ptr<IWSLCContainer> container;
             VERIFY_ARE_EQUAL(E_NOTIMPL, m_defaultSession->CreateContainer(&options, nullptr, &container));
-            ValidateCOMErrorMessage(
-                std::format(
-                    L"Endpoint settings are not yet supported (network '{}').", std::wstring(networkName.begin(), networkName.end()))
-                    .c_str());
+            ValidateCOMErrorMessage(std::format(
+                                        L"Endpoint settings are not yet supported (network '{}').",
+                                        std::wstring(networkName.begin(), networkName.end()))
+                                        .c_str());
         }
     }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3241,8 +3241,8 @@ class WSLCTests
 
             HRESULT OnCrashDump(LPCWSTR DumpPath, LPCSTR ProcessName, ULONG Pid, ULONG Signal, ULONGLONG Timestamp) override
             {
-                m_promise.set_value(Invocation{
-                    DumpPath ? std::wstring{DumpPath} : std::wstring{}, ProcessName ? std::string{ProcessName} : std::string{}, Pid, Signal, Timestamp});
+                m_promise.set_value(
+                    Invocation{DumpPath ? std::wstring{DumpPath} : std::wstring{}, ProcessName ? std::string{ProcessName} : std::string{}, Pid, Signal, Timestamp});
 
                 // Block until the test has finished probing, so anything the test verifies is observed mid-callback.
                 m_release.wait();
@@ -5562,6 +5562,15 @@ class WSLCTests
             options.Gateway = "172.44.0.1";
             verifyInvalid(L"--subnet");
         }
+
+        // IpRange specified without Subnet
+        {
+            options.Driver = "bridge";
+            options.Subnet = nullptr;
+            options.Gateway = nullptr;
+            options.IpRange = "172.44.10.0/24";
+            verifyInvalid(L"--subnet");
+        }
     }
 
     WSLC_TEST_METHOD(NetworkCreateDefaultDriverTest)
@@ -5685,6 +5694,86 @@ class WSLCTests
         VERIFY_ARE_EQUAL(1u, inspect.IPAM.Config->size());
         VERIFY_ARE_EQUAL(subnet, inspect.IPAM.Config->at(0).Subnet);
         VERIFY_ARE_EQUAL(gateway, inspect.IPAM.Config->at(0).Gateway);
+    }
+
+    WSLC_TEST_METHOD(NetworkCreateWithIpRangeTest)
+    {
+        const std::string networkName = "ip-range-test-net";
+        const std::string subnet = "172.32.0.0/16";
+        const std::string ipRange = "172.32.10.0/24";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        WSLCNetworkOptions options{};
+        options.Name = networkName.c_str();
+        options.Driver = "bridge";
+        options.Subnet = subnet.c_str();
+        options.IpRange = ipRange.c_str();
+
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options, nullptr));
+
+        wil::unique_cotaskmem_ansistring output;
+        VERIFY_SUCCEEDED(m_defaultSession->InspectNetwork(networkName.c_str(), &output));
+        VERIFY_IS_NOT_NULL(output.get());
+
+        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
+        VERIFY_IS_TRUE(inspect.IPAM.Config.has_value());
+        VERIFY_ARE_EQUAL(1u, inspect.IPAM.Config->size());
+        VERIFY_ARE_EQUAL(subnet, inspect.IPAM.Config->at(0).Subnet);
+        VERIFY_ARE_EQUAL(ipRange, inspect.IPAM.Config->at(0).IPRange);
+    }
+
+    WSLC_TEST_METHOD(NetworkCreateInvalidIpRangeTest)
+    {
+        const std::string networkName = "bad-ip-range-net";
+        const std::string subnet = "172.33.0.0/16";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        WSLCNetworkOptions options{};
+        options.Name = networkName.c_str();
+        options.Driver = "bridge";
+        options.Subnet = subnet.c_str();
+        options.IpRange = "10.0.0.0/24";
+
+        VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->CreateNetwork(&options, nullptr));
+
+        wil::unique_cotaskmem_ansistring output;
+        VERIFY_ARE_EQUAL(WSLC_E_NETWORK_NOT_FOUND, m_defaultSession->InspectNetwork(networkName.c_str(), &output));
+    }
+
+    WSLC_TEST_METHOD(NetworkSessionRecoveryWithIpRangeTest)
+    {
+        const std::string networkName = "recovery-ip-range-net";
+        const std::string subnet = "172.34.0.0/16";
+        const std::string ipRange = "172.34.20.0/24";
+
+        LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
+
+        WSLCNetworkOptions options{};
+        options.Name = networkName.c_str();
+        options.Driver = "bridge";
+        options.Subnet = subnet.c_str();
+        options.IpRange = ipRange.c_str();
+        VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options, nullptr));
+
+        auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+        // Reset the session (simulates session restart).
+        ResetTestSession();
+
+        wil::unique_cotaskmem_ansistring output;
+        VERIFY_SUCCEEDED(m_defaultSession->InspectNetwork(networkName.c_str(), &output));
+        VERIFY_IS_NOT_NULL(output.get());
+
+        auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
+        VERIFY_IS_TRUE(inspect.IPAM.Config.has_value());
+        VERIFY_ARE_EQUAL(1u, inspect.IPAM.Config->size());
+        VERIFY_ARE_EQUAL(subnet, inspect.IPAM.Config->at(0).Subnet);
+        VERIFY_ARE_EQUAL(ipRange, inspect.IPAM.Config->at(0).IPRange);
     }
 
     WSLC_TEST_METHOD(NetworkCreateWithArbitraryDriverOptsTest)
@@ -7747,10 +7836,10 @@ class WSLCTests
 
             wil::com_ptr<IWSLCContainer> container;
             VERIFY_ARE_EQUAL(E_NOTIMPL, m_defaultSession->CreateContainer(&options, nullptr, &container));
-            ValidateCOMErrorMessage(std::format(
-                                        L"Endpoint settings are not yet supported (network '{}').",
-                                        std::wstring(networkName.begin(), networkName.end()))
-                                        .c_str());
+            ValidateCOMErrorMessage(
+                std::format(
+                    L"Endpoint settings are not yet supported (network '{}').", std::wstring(networkName.begin(), networkName.end()))
+                    .c_str());
         }
     }
 
@@ -9540,15 +9629,18 @@ class WSLCTests
             std::string readStdout;
             std::string readStderr;
 
-            io.AddHandle(std::make_unique<DockerIORelayHandle>(
-                std::move(readPipe), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
+            io.AddHandle(
+                std::make_unique<DockerIORelayHandle>(
+                    std::move(readPipe), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
             io.AddHandle(std::make_unique<WriteHandle>(std::move(writePipe), Input));
 
-            io.AddHandle(std::make_unique<ReadHandle>(
-                std::move(stdoutRead), [&](const auto& buffer) { readStdout.append(buffer.data(), buffer.size()); }));
+            io.AddHandle(std::make_unique<ReadHandle>(std::move(stdoutRead), [&](const auto& buffer) {
+                readStdout.append(buffer.data(), buffer.size());
+            }));
 
-            io.AddHandle(std::make_unique<ReadHandle>(
-                std::move(stderrRead), [&](const auto& buffer) { readStderr.append(buffer.data(), buffer.size()); }));
+            io.AddHandle(std::make_unique<ReadHandle>(std::move(stderrRead), [&](const auto& buffer) {
+                readStderr.append(buffer.data(), buffer.size());
+            }));
 
             io.Run({});
 
@@ -9627,8 +9719,9 @@ class WSLCTests
                 std::string output;
                 MultiHandleWait io;
 
-                io.AddHandle(std::make_unique<DockerIORelayHandle>(
-                    std::move(inputRead), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
+                io.AddHandle(
+                    std::make_unique<DockerIORelayHandle>(
+                        std::move(inputRead), std::move(stdoutWrite), std::move(stderrWrite), DockerIORelayHandle::Format::Raw));
 
                 io.AddHandle(std::make_unique<ReadHandle>(std::move(stdoutRead), [&](const auto& buffer) {
                     output.append(buffer.data(), buffer.size());
@@ -9668,8 +9761,9 @@ class WSLCTests
 
         // Collect the relayed output.
         std::string output;
-        io.AddHandle(std::make_unique<ReadHandle>(
-            std::move(dstRead), [&](const gsl::span<char>& buffer) { output.append(buffer.data(), buffer.size()); }));
+        io.AddHandle(std::make_unique<ReadHandle>(std::move(dstRead), [&](const gsl::span<char>& buffer) {
+            output.append(buffer.data(), buffer.size());
+        }));
 
         io.Run({});
 

--- a/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
@@ -97,8 +97,8 @@ class WSLCE2ENetworkCreateTests
     {
         auto result = RunWslc(std::format(L"network create --driver invalid_driver {}", TestNetworkName));
         result.Verify({.Stdout = L"", .ExitCode = 1});
-        VERIFY_IS_TRUE(result.StderrContainsSubstring(
-            std::format(L"Unsupported network driver: 'invalid_driver'\r\nError code: E_INVALIDARG")));
+        VERIFY_IS_TRUE(
+            result.StderrContainsSubstring(std::format(L"Unsupported network driver: 'invalid_driver'\r\nError code: E_INVALIDARG")));
 
         VerifyNetworkIsNotListed(TestNetworkName);
     }
@@ -163,6 +163,34 @@ class WSLCE2ENetworkCreateTests
         result.Verify(
             {.Stdout = L"",
              .Stderr = L"The '--gateway' option requires '--subnet' to also be specified.\r\nError code: E_INVALIDARG\r\n",
+             .ExitCode = 1});
+
+        VerifyNetworkIsNotListed(TestNetworkName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Create_SubnetAndIpRange_Success)
+    {
+        const std::wstring subnet = L"172.51.0.0/16";
+        const std::wstring ipRange = L"172.51.10.0/24";
+        auto result = RunWslc(std::format(L"network create --subnet {} --ip-range {} {}", subnet, ipRange, TestNetworkName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_ARE_EQUAL(TestNetworkName, result.GetStdoutOneLine());
+
+        VerifyNetworkIsListed(TestNetworkName);
+        auto inspect = InspectNetwork(TestNetworkName);
+        VERIFY_ARE_EQUAL("bridge", inspect.Driver);
+        VERIFY_IS_TRUE(inspect.IPAM.Config.has_value());
+        VERIFY_ARE_EQUAL(1u, inspect.IPAM.Config->size());
+        VERIFY_ARE_EQUAL(wsl::shared::string::WideToMultiByte(subnet), (*inspect.IPAM.Config)[0].Subnet);
+        VERIFY_ARE_EQUAL(wsl::shared::string::WideToMultiByte(ipRange), (*inspect.IPAM.Config)[0].IPRange);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Create_IpRangeWithoutSubnet_Fail)
+    {
+        auto result = RunWslc(std::format(L"network create --ip-range 172.52.10.0/24 {}", TestNetworkName));
+        result.Verify(
+            {.Stdout = L"",
+             .Stderr = L"The '--ip-range' option requires '--subnet' to also be specified.\r\nError code: E_INVALIDARG\r\n",
              .ExitCode = 1});
 
         VerifyNetworkIsNotListed(TestNetworkName);

--- a/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
@@ -97,8 +97,8 @@ class WSLCE2ENetworkCreateTests
     {
         auto result = RunWslc(std::format(L"network create --driver invalid_driver {}", TestNetworkName));
         result.Verify({.Stdout = L"", .ExitCode = 1});
-        VERIFY_IS_TRUE(
-            result.StderrContainsSubstring(std::format(L"Unsupported network driver: 'invalid_driver'\r\nError code: E_INVALIDARG")));
+        VERIFY_IS_TRUE(result.StderrContainsSubstring(
+            std::format(L"Unsupported network driver: 'invalid_driver'\r\nError code: E_INVALIDARG")));
 
         VerifyNetworkIsNotListed(TestNetworkName);
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds --ip-range support to wslc network create, mirroring Docker CLI behavior. The flag restricts container IP allocation to a sub-range of the subnet (e.g. --subnet 172.51.0.0/16 --ip-range 172.51.10.0/24). Using --ip-range without --subnet is rejected with a clear error message.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Added IpRange argument to ArgumentDefinitions.h and wired it through NetworkCreateCommand → NetworkTasks → NetworkService → IDL (WSLCNetworkOptions) → WSLCSession
- Extended IPAMConfig in docker_schema.h, wslc_schema.h, and WSLCNetworkMetadata.h with an IPRange field
- Added validation in WSLCSession::CreateNetwork: --ip-range requires --subnet, producing MessageWslcIpRangeRequiresSubnet (E_INVALIDARG) if omitted
- Propagates IpRange through all three IPAM copy sites in WSLCSession.cpp (CreateNetwork, InspectNetwork, RecoverExistingNetworks)
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Unit tests (WSLCTests.cpp): validation rejects --gateway without --subnet and --ip-range without --subnet with correct error messages
- E2E tests (WSLCE2ENetworkCreateTests.cpp): WSLCE2E_Network_Create_SubnetAndIpRange_Success: creates a network with --subnet 172.51.0.0/16 --ip-range 172.51.10.0/24 and verifies IPRange is returned correctly by inspect
- WSLCE2E_Network_Create_IpRangeWithoutSubnet_Fail: verifies the correct error is returned when --subnet is omitted