### PR TITLE
Update GitHub Actions workflow for issue comments

### DIFF
--- a/.github/workflows/new_issue_comment.yml
+++ b/.github/workflows/new_issue_comment.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ !github.event.issue.pull_request && github.event.issue.user.id == github.event.comment.user.id }}
     steps: 
         - name: Checkout repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
         
         - uses: ./.github/actions/triage
           with: 


### PR DESCRIPTION
Updated checkout action version to v6 to support node 24 in github actions. Node 20 has been disabled june 2026.
