### PR TITLE
virtiofs: Use aggregate share feature in WSLC

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.WSL.bsdtar" version="0.0.2-2" />
   <package id="Microsoft.WSL.Dependencies.amd64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
   <package id="Microsoft.WSL.Dependencies.arm64fre" version="10.0.27820.1000-250318-1700.rs-base2-hyp" targetFramework="native" />
-  <package id="Microsoft.WSL.DeviceHost" version="1.2.53-0" />
+  <package id="Microsoft.WSL.DeviceHost" version="1.2.54-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.35.2-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.20.0" targetFramework="native" />
   <package id="Microsoft.WSL.TestData" version="0.5.0" />

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -669,8 +669,9 @@ void HandleMessageImpl(
     Transaction.Send(Response);
 }
 
-void HandleMessageImpl(
-    wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const WSLC_MOUNT& Message, const gsl::span<gsl::byte>& Buffer)
+template <typename TMessage>
+void HandleMountMessage(
+    wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const TMessage& Message, const gsl::span<gsl::byte>& Buffer)
 {
     WSLC_MOUNT_RESULT response{};
     response.Header.MessageType = WSLC_MOUNT_RESULT::Type;
@@ -695,7 +696,6 @@ void HandleMessageImpl(
         }
 
         const char* source = readField(Message.SourceIndex);
-        const char* childName = readField(Message.ChildNameIndex);
 
         const char* target{};
         if (WI_IsFlagSet(Message.Flags, WSLC_MOUNT::KernelModules))
@@ -719,14 +719,15 @@ void HandleMessageImpl(
         THROW_ERRNO_IF(EINVAL, WI_IsFlagSet(Message.Flags, WSLC_MOUNT::Chroot) && !WI_IsFlagSet(Message.Flags, WSLC_MOUNT::OverlayFs));
 
         auto type = readField(Message.TypeIndex);
-        if (*childName == '\0')
+        if constexpr (std::is_same_v<TMessage, WSLC_MOUNT_VIRTIOFS>)
         {
-            THROW_LAST_ERROR_IF(UtilMount(source, target, type, options.MountFlags, options.StringOptions.c_str(), c_defaultRetryTimeout) < 0);
+            const char* childName = readField(Message.ChildNameIndex);
+            THROW_ERRNO_IF(EINVAL, !wsl::shared::string::IsEqual(type, VIRTIO_FS_TYPE));
+            THROW_LAST_ERROR_IF(MountVirtioFsChild(source, childName, target, mountOptions) < 0);
         }
         else
         {
-            THROW_ERRNO_IF(EINVAL, !wsl::shared::string::IsEqual(type, VIRTIO_FS_TYPE));
-            THROW_LAST_ERROR_IF(MountVirtioFsChild(source, childName, target, mountOptions) < 0);
+            THROW_LAST_ERROR_IF(UtilMount(source, target, type, options.MountFlags, options.StringOptions.c_str(), c_defaultRetryTimeout) < 0);
         }
 
         // Workaround for a Linux bug where virtiofs permissions aren't properly propagated when an overlay is mounted on top of a virtiofs share before the permissions have been fetched.
@@ -827,6 +828,21 @@ void HandleMessageImpl(
     }
 
     Transaction.Send<WSLC_MOUNT_RESULT>(response);
+}
+
+void HandleMessageImpl(
+    wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const WSLC_MOUNT& Message, const gsl::span<gsl::byte>& Buffer)
+{
+    HandleMountMessage(Channel, Transaction, Message, Buffer);
+}
+
+void HandleMessageImpl(
+    wsl::shared::SocketChannel& Channel,
+    wsl::shared::Transaction& Transaction,
+    const WSLC_MOUNT_VIRTIOFS& Message,
+    const gsl::span<gsl::byte>& Buffer)
+{
+    HandleMountMessage(Channel, Transaction, Message, Buffer);
 }
 
 void HandleMessageImpl(
@@ -1032,7 +1048,7 @@ void ProcessMessage(wsl::shared::SocketChannel& Channel, wsl::shared::Transactio
 {
     try
     {
-        HandleMessage<WSLC_GET_DISK, WSLC_MOUNT, WSLC_EXEC, WSLC_FORK, WSLC_CONNECT, WSLC_SIGNAL, WSLC_TTY_RELAY, WSLC_PORT_RELAY, WSLC_UNMOUNT, WSLC_DETACH, WSLC_ACCEPT, WSLC_WATCH_PROCESSES, WSLC_UNIX_CONNECT, WSLC_GET_GUEST_CAPABILITIES, WSLC_LISTDIR>(
+        HandleMessage<WSLC_GET_DISK, WSLC_MOUNT, WSLC_MOUNT_VIRTIOFS, WSLC_EXEC, WSLC_FORK, WSLC_CONNECT, WSLC_SIGNAL, WSLC_TTY_RELAY, WSLC_PORT_RELAY, WSLC_UNMOUNT, WSLC_DETACH, WSLC_ACCEPT, WSLC_WATCH_PROCESSES, WSLC_UNIX_CONNECT, WSLC_GET_GUEST_CAPABILITIES, WSLC_LISTDIR>(
             Channel, Transaction, Type, Buffer);
     }
     catch (...)

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -837,10 +837,7 @@ void HandleMessageImpl(
 }
 
 void HandleMessageImpl(
-    wsl::shared::SocketChannel& Channel,
-    wsl::shared::Transaction& Transaction,
-    const WSLC_MOUNT_VIRTIOFS& Message,
-    const gsl::span<gsl::byte>& Buffer)
+    wsl::shared::SocketChannel& Channel, wsl::shared::Transaction& Transaction, const WSLC_MOUNT_VIRTIOFS& Message, const gsl::span<gsl::byte>& Buffer)
 {
     HandleMountMessage(Channel, Transaction, Message, Buffer);
 }

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -688,7 +688,7 @@ void HandleMessageImpl(
         };
 
         const char* mountOptions = readField(Message.OptionsIndex);
-        mountutil::ParsedOptions options;
+        mountutil::ParsedOptions options{};
         if (Message.OptionsIndex > 0)
         {
             options = mountutil::MountParseFlags(mountOptions);

--- a/src/linux/init/WSLCInit.cpp
+++ b/src/linux/init/WSLCInit.cpp
@@ -13,6 +13,7 @@ Abstract:
 --*/
 
 #include "util.h"
+#include "drvfs.h"
 #include "SocketChannel.h"
 #include "message.h"
 #include "localhost.h"
@@ -686,13 +687,15 @@ void HandleMessageImpl(
             return "";
         };
 
+        const char* mountOptions = readField(Message.OptionsIndex);
         mountutil::ParsedOptions options;
         if (Message.OptionsIndex > 0)
         {
-            options = mountutil::MountParseFlags(wsl::shared::string::FromSpan(Buffer, Message.OptionsIndex));
+            options = mountutil::MountParseFlags(mountOptions);
         }
 
         const char* source = readField(Message.SourceIndex);
+        const char* childName = readField(Message.ChildNameIndex);
 
         const char* target{};
         if (WI_IsFlagSet(Message.Flags, WSLC_MOUNT::KernelModules))
@@ -716,7 +719,15 @@ void HandleMessageImpl(
         THROW_ERRNO_IF(EINVAL, WI_IsFlagSet(Message.Flags, WSLC_MOUNT::Chroot) && !WI_IsFlagSet(Message.Flags, WSLC_MOUNT::OverlayFs));
 
         auto type = readField(Message.TypeIndex);
-        THROW_LAST_ERROR_IF(UtilMount(source, target, type, options.MountFlags, options.StringOptions.c_str(), c_defaultRetryTimeout) < 0);
+        if (*childName == '\0')
+        {
+            THROW_LAST_ERROR_IF(UtilMount(source, target, type, options.MountFlags, options.StringOptions.c_str(), c_defaultRetryTimeout) < 0);
+        }
+        else
+        {
+            THROW_ERRNO_IF(EINVAL, !wsl::shared::string::IsEqual(type, VIRTIO_FS_TYPE));
+            THROW_LAST_ERROR_IF(MountVirtioFsChild(source, childName, target, mountOptions) < 0);
+        }
 
         // Workaround for a Linux bug where virtiofs permissions aren't properly propagated when an overlay is mounted on top of a virtiofs share before the permissions have been fetched.
         // TODO: Remove once fixed upstream.

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -896,10 +896,6 @@ try
         return {};
     }
 
-    //
-    // Validate the tag is a GUID.
-    //
-
     std::string mappingName{Tag};
     if (Root != nullptr)
     {

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -88,13 +88,7 @@ bool IsMountPoint(const std::string& Path)
 }
 } // namespace
 
-int MountVirtioFsChild(
-    const char* Tag,
-    const char* ChildName,
-    const char* Target,
-    const char* Options,
-    int* ExitCode = nullptr,
-    std::string_view SubPath = "/")
+int MountVirtioFsChild(const char* Tag, const char* ChildName, const char* Target, const char* Options, int* ExitCode, std::string_view SubPath)
 {
     if ((strcmp(Tag, LX_INIT_DRVFS_VIRTIO_TAG) != 0 && strcmp(Tag, LX_INIT_DRVFS_ADMIN_VIRTIO_TAG) != 0) ||
         !wsl::shared::string::ToGuid(ChildName) || SubPath.empty() || SubPath.front() != '/')

--- a/src/linux/init/drvfs.h
+++ b/src/linux/init/drvfs.h
@@ -30,6 +30,14 @@ struct VirtioFsMountRoot
 
 std::optional<VirtioFsMountRoot> ParseAggregateVirtioFsMountRoot(std::string_view Tag, std::string_view Root);
 
+int MountVirtioFsChild(
+    const char* Tag,
+    const char* ChildName,
+    const char* Target,
+    const char* Options,
+    int* ExitCode = nullptr,
+    std::string_view SubPath = "/");
+
 int MountDrvfs(const char* Source, const char* Target, const char* Options, std::optional<bool> Admin, const wsl::linux::WslDistributionConfig& Config, int* ExitCode = nullptr);
 
 int MountDrvfsEntry(int Argc, char* Argv[]);

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -877,16 +877,16 @@ try
     while (MountEnum.Next())
     {
         //
-        // Skip internal virtiofs device mounts. The aggregate virtiofs root and
-        // its per-share child binds live under VIRTIOFS_MOUNT_DIR and carry the
-        // same Windows source as the user-facing /mnt/<drive> bind mounts. If
-        // they were considered, reverse (Windows->Linux) translation could
-        // return an internal plumbing path (for example
+        // When translating Windows paths to Linux, skip internal virtiofs
+        // device mounts. The aggregate virtiofs root and its per-share child
+        // binds live under VIRTIOFS_MOUNT_DIR and carry the same Windows source
+        // as the user-facing /mnt/<drive> bind mounts. If they were considered,
+        // translation could return an internal plumbing path (for example
         // /run/wsl/virtiofs-mounts/drvfsa/<guid>) instead of the real mount
         // point such as /mnt/c.
         //
 
-        if (UtilIsPathPrefix(MountEnum.Current().MountPoint, VIRTIOFS_MOUNT_DIR, false) > 0)
+        if (WinPath && UtilIsPathPrefix(MountEnum.Current().MountPoint, VIRTIOFS_MOUNT_DIR, false) > 0)
         {
             continue;
         }

--- a/src/shared/inc/defs.h
+++ b/src/shared/inc/defs.h
@@ -52,11 +52,6 @@ inline constexpr std::uint32_t VersionMinor = WSL_PACKAGE_VERSION_MINOR;
 inline constexpr std::uint32_t VersionRevision = WSL_PACKAGE_VERSION_REVISION;
 inline constexpr std::tuple<uint32_t, uint32_t, uint32_t> PackageVersion{VersionMajor, VersionMinor, VersionRevision};
 
-// Maximum number of virtiofs shares that can be mounted (with different paths) over the lifetime of a VM.
-// This limit is there to avoid a hang when too many virtiofs shares are mounted.
-// TODO: Remove once we can use the same PCI devices for all shares.
-inline constexpr size_t c_maxVirtioFsShares = 15;
-
 #ifdef WSL_OFFICIAL_BUILD
 
 inline constexpr bool OfficialBuild = true;

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1642,6 +1642,7 @@ struct WSLC_MOUNT
     unsigned int TypeIndex{};
     unsigned int OptionsIndex{};
     unsigned int Flags{};
+    unsigned int ChildNameIndex{};
 
     enum MountType : uint8_t
     {
@@ -1654,7 +1655,7 @@ struct WSLC_MOUNT
 
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), STRING_FIELD(SourceIndex), STRING_FIELD(DestinationIndex), STRING_FIELD(TypeIndex), STRING_FIELD(OptionsIndex));
+    PRETTY_PRINT(FIELD(Header), STRING_FIELD(SourceIndex), STRING_FIELD(DestinationIndex), STRING_FIELD(TypeIndex), STRING_FIELD(OptionsIndex), STRING_FIELD(ChildNameIndex));
 };
 
 struct WSLC_EXEC

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -413,6 +413,7 @@ typedef enum _LX_MESSAGE_TYPE
     LxMessageWSLCGetGuestCapabilitiesResult,
     LxMessageWSLCListDir,
     LxMessageWSLCListDirResult,
+    LxMessageWSLCMountVirtioFs,
 } LX_MESSAGE_TYPE,
     *PLX_MESSAGE_TYPE;
 
@@ -527,6 +528,7 @@ inline auto ToString(LX_MESSAGE_TYPE messageType)
         X(LxMessageWSLCGetGuestCapabilitiesResult)
         X(LxMessageWSLCListDir)
         X(LxMessageWSLCListDirResult)
+        X(LxMessageWSLCMountVirtioFs)
 
     default:
         return "<unexpected LX_MESSAGE_TYPE>";
@@ -1642,7 +1644,6 @@ struct WSLC_MOUNT
     unsigned int TypeIndex{};
     unsigned int OptionsIndex{};
     unsigned int Flags{};
-    unsigned int ChildNameIndex{};
 
     enum MountType : uint8_t
     {
@@ -1653,6 +1654,25 @@ struct WSLC_MOUNT
         KernelModules = 8
     };
 
+    char Buffer[];
+
+    PRETTY_PRINT(FIELD(Header), STRING_FIELD(SourceIndex), STRING_FIELD(DestinationIndex), STRING_FIELD(TypeIndex), STRING_FIELD(OptionsIndex));
+};
+
+struct WSLC_MOUNT_VIRTIOFS
+{
+    static inline auto Type = LxMessageWSLCMountVirtioFs;
+    using TResponse = WSLC_MOUNT_RESULT;
+
+    DECLARE_MESSAGE_CTOR(WSLC_MOUNT_VIRTIOFS);
+
+    MESSAGE_HEADER Header{};
+    unsigned int SourceIndex{};
+    unsigned int DestinationIndex{};
+    unsigned int TypeIndex{};
+    unsigned int OptionsIndex{};
+    unsigned int Flags{};
+    unsigned int ChildNameIndex{};
     char Buffer[];
 
     PRETTY_PRINT(FIELD(Header), STRING_FIELD(SourceIndex), STRING_FIELD(DestinationIndex), STRING_FIELD(TypeIndex), STRING_FIELD(OptionsIndex), STRING_FIELD(ChildNameIndex));

--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -180,6 +180,14 @@ void DeviceHostProxy::AddVirtiofsChild(const GUID& InstanceId, const std::wstrin
     THROW_IF_FAILED(GetVirtiofsDevice(InstanceId)->AddChild(name.get(), rootPath.get(), mountOptions.get()));
 }
 
+void DeviceHostProxy::RemoveVirtiofsChild(const GUID& InstanceId, const std::wstring& Name)
+{
+    std::lock_guard lifecycleLock(m_deviceLifecycleLock);
+
+    const auto name = wil::make_bstr(Name.c_str());
+    THROW_IF_FAILED(GetVirtiofsDevice(InstanceId)->RemoveChild(name.get()));
+}
+
 GUID DeviceHostProxy::AddVirtioPmemDevice(_In_ HANDLE UserToken, const std::wstring& Path, bool Writable)
 {
     std::lock_guard lifecycleLock(m_deviceLifecycleLock);

--- a/src/windows/common/DeviceHostProxy.h
+++ b/src/windows/common/DeviceHostProxy.h
@@ -23,6 +23,8 @@ public:
 
     void AddVirtiofsChild(const GUID& InstanceId, const std::wstring& Name, const std::wstring& RootPath, const std::wstring& MountOptions);
 
+    void RemoveVirtiofsChild(const GUID& InstanceId, const std::wstring& Name);
+
     GUID AddVirtioPmemDevice(_In_ HANDLE UserToken, const std::wstring& Path, bool Writable);
 
     void RemoveDevice(const GUID& InstanceId);

--- a/src/windows/common/GuestDeviceManager.cpp
+++ b/src/windows/common/GuestDeviceManager.cpp
@@ -34,6 +34,13 @@ void GuestDeviceManager::AddVirtiofsChild(_In_ const GUID& InstanceId, _In_ PCWS
 }
 
 _Requires_lock_not_held_(m_lock)
+void GuestDeviceManager::RemoveVirtiofsChild(_In_ const GUID& InstanceId, _In_ PCWSTR Name)
+{
+    auto guestDeviceLock = m_lock.lock_exclusive();
+    m_deviceHostSupport->RemoveVirtiofsChild(InstanceId, Name);
+}
+
+_Requires_lock_not_held_(m_lock)
 GUID GuestDeviceManager::AddVirtioPmemDevice(_In_ PCWSTR Path, bool ReadOnly, _In_ HANDLE UserToken)
 {
     auto guestDeviceLock = m_lock.lock_exclusive();

--- a/src/windows/common/GuestDeviceManager.h
+++ b/src/windows/common/GuestDeviceManager.h
@@ -28,6 +28,9 @@ public:
     void AddVirtiofsChild(_In_ const GUID& InstanceId, _In_ PCWSTR Name, _In_opt_ PCWSTR MountOptions, _In_ PCWSTR RootPath);
 
     _Requires_lock_not_held_(m_lock)
+    void RemoveVirtiofsChild(_In_ const GUID& InstanceId, _In_ PCWSTR Name);
+
+    _Requires_lock_not_held_(m_lock)
     GUID AddVirtioPmemDevice(_In_ PCWSTR Path, bool ReadOnly, _In_ HANDLE UserToken);
 
     _Requires_lock_not_held_(m_lock)

--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -620,7 +620,15 @@ try
     {
         std::wstring options = ReadOnly ? L"ro" : L"";
 
-        it->second = m_guestDeviceManager->AddVirtiofsDevice(shareName.c_str(), options.c_str(), WindowsPath, m_userToken.get());
+        if (!m_virtioFsDevice.has_value())
+        {
+            VirtioFsShareOptions aggregateOptions{.Kind = VirtiofsShareKind_Aggregate};
+            m_virtioFsDevice =
+                m_guestDeviceManager->AddVirtiofsDevice(TEXT(LX_INIT_DRVFS_VIRTIO_TAG), L"", L"", m_userToken.get(), aggregateOptions);
+        }
+
+        m_guestDeviceManager->AddVirtiofsChild(m_virtioFsDevice.value(), shareName.c_str(), options.c_str(), WindowsPath);
+        it->second = m_virtioFsDevice;
     }
 
     cleanup.release();
@@ -645,7 +653,8 @@ try
     }
     else
     {
-        m_guestDeviceManager->RemoveGuestDevice(it->second.value());
+        auto shareName = wsl::shared::string::GuidToString<wchar_t>(it->first, wsl::shared::string::None);
+        m_guestDeviceManager->RemoveVirtiofsChild(it->second.value(), shareName.c_str());
     }
 
     m_shares.erase(it);

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -97,8 +97,9 @@ private:
     std::map<ULONG, DiskInfo> m_attachedDisks;
     std::bitset<MAX_VHD_COUNT> m_lunBitmap;
 
-    // Shares: key is ShareId, value is nullopt for Plan9 or DeviceInstanceId for VirtioFS
+    // Shares: key is ShareId, value is nullopt for Plan9 or the aggregate DeviceInstanceId for VirtioFS.
     std::map<GUID, std::optional<GUID>, wsl::windows::common::helpers::GuidLess> m_shares;
+    std::optional<GUID> m_virtioFsDevice;
 
     std::filesystem::path m_vmSavedStateFile;
     std::filesystem::path m_crashDumpFolder;

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -886,8 +886,7 @@ void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LP
     THROW_HR_IF(E_FAIL, response.Result != 0);
 }
 
-void WSLCVirtualMachine::MountVirtioFsChild(
-    shared::SocketChannel& Channel, LPCSTR Source, LPCSTR ChildName, LPCSTR Target, LPCSTR Options, ULONG Flags)
+void WSLCVirtualMachine::MountVirtioFsChild(shared::SocketChannel& Channel, LPCSTR Source, LPCSTR ChildName, LPCSTR Target, LPCSTR Options, ULONG Flags)
 {
     wsl::shared::MessageWriter<WSLC_MOUNT_VIRTIOFS> message;
     message.WriteString(message->SourceIndex, Source);

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -850,7 +850,7 @@ void WSLCVirtualMachine::Mount(LPCSTR Source, LPCSTR Target, LPCSTR Type, LPCSTR
     Mount(m_initChannel, Source, Target, Type, Options, Flags);
 }
 
-void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LPCSTR Target, LPCSTR Type, LPCSTR Options, ULONG Flags)
+void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LPCSTR Target, LPCSTR Type, LPCSTR Options, ULONG Flags, LPCSTR ChildName)
 {
     static_assert(WSLCMountFlagsNone == WSLC_MOUNT::None);
     static_assert(WSLCMountFlagsReadOnly == WSLC_MOUNT::ReadOnly);
@@ -871,6 +871,7 @@ void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LP
     optionalAdd(Type, message->TypeIndex);
     optionalAdd(Options, message->OptionsIndex);
     message->Flags = Flags;
+    optionalAdd(ChildName, message->ChildNameIndex);
 
     const auto& response = Channel.Transaction<WSLC_MOUNT>(message.Span());
 
@@ -881,6 +882,7 @@ void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LP
         TraceLoggingValue(Type == nullptr ? "<null>" : Type, "Type"),
         TraceLoggingValue(Options == nullptr ? "<null>" : Options, "Options"),
         TraceLoggingValue(Flags, "Flags"),
+        TraceLoggingValue(ChildName == nullptr ? "<null>" : ChildName, "ChildName"),
         TraceLoggingValue(response.Result, "Result"));
 
     THROW_HR_IF(E_FAIL, response.Result != 0);
@@ -1077,9 +1079,7 @@ try
     THROW_HR_IF_MSG(E_INVALIDARG, LinuxPath[0] != '/', "Mountpoint is not absolute: '%hs'", LinuxPath);
 
     const bool readOnly = WI_IsFlagSet(Flags, WSLCMountFlagsReadOnly);
-    auto normalizedPath = std::filesystem::weakly_canonical(path).wstring();
     GUID shareGuid{};
-    bool reusingShare = false;
 
     {
         std::lock_guard lock(m_lock);
@@ -1088,34 +1088,8 @@ try
         auto it = m_mountedWindowsFolders.find(LinuxPath);
         THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS), it != m_mountedWindowsFolders.end());
 
-        // In VirtioFs mode, try to reuse an existing share for the same Windows path and access mode.
-        if (FeatureEnabled(WslcFeatureFlagsVirtioFs))
-        {
-            auto shareIt = m_virtioFsShares.find({normalizedPath, readOnly});
-            if (shareIt != m_virtioFsShares.end())
-            {
-                shareGuid = shareIt->second;
-                reusingShare = true;
-            }
-            else
-            {
-                THROW_HR_WITH_USER_ERROR_IF(
-                    E_OUTOFMEMORY,
-                    shared::Localization::MessageWslcTooManyVirtioFsShares(shared::c_maxVirtioFsShares),
-                    m_virtioFsShares.size() >= shared::c_maxVirtioFsShares);
-            }
-        }
-
-        if (!reusingShare)
-        {
-            // Delegate to IWSLCVirtualMachine for the privileged share creation
-            THROW_IF_FAILED(m_vm->AddShare(WindowsPath, readOnly, &shareGuid));
-
-            if (FeatureEnabled(WslcFeatureFlagsVirtioFs))
-            {
-                m_virtioFsShares[{normalizedPath, readOnly}] = shareGuid;
-            }
-        }
+        // Delegate to IWSLCVirtualMachine for the privileged share creation.
+        THROW_IF_FAILED(m_vm->AddShare(WindowsPath, readOnly, &shareGuid));
 
         m_mountedWindowsFolders.emplace(LinuxPath, shareGuid);
     }
@@ -1126,11 +1100,7 @@ try
         if (WI_VERIFY(mountIt != m_mountedWindowsFolders.end()))
         {
             m_mountedWindowsFolders.erase(mountIt);
-            if (!FeatureEnabled(WslcFeatureFlagsVirtioFs))
-            {
-                m_virtioFsShares.erase({normalizedPath, readOnly});
-                LOG_IF_FAILED(m_vm->RemoveShare(shareGuid));
-            }
+            LOG_IF_FAILED(m_vm->RemoveShare(shareGuid));
         }
     });
 
@@ -1154,7 +1124,7 @@ try
     else
     {
         std::string options = readOnly ? "ro" : "rw";
-        Mount(m_initChannel, shareName.c_str(), LinuxPath, "virtiofs", options.c_str(), Flags);
+        Mount(m_initChannel, LX_INIT_DRVFS_VIRTIO_TAG, LinuxPath, "virtiofs", options.c_str(), Flags, shareName.c_str());
     }
 
     deleteOnFailure.release();
@@ -1178,13 +1148,8 @@ try
 
     auto shareId = it->second;
 
-    // Keep the share mounted in virtiofs mode to avoid accumulating devices, which can cause a hang when reached.
-    // TODO: Actually remove the device once this is supported by the device host.
-    if (!FeatureEnabled(WslcFeatureFlagsVirtioFs))
-    {
-        // Delegate to IWSLCVirtualMachine for the privileged share removal
-        THROW_IF_FAILED(m_vm->RemoveShare(shareId));
-    }
+    // Delegate to IWSLCVirtualMachine for the privileged share removal.
+    THROW_IF_FAILED(m_vm->RemoveShare(shareId));
 
     m_mountedWindowsFolders.erase(it);
 

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -850,7 +850,7 @@ void WSLCVirtualMachine::Mount(LPCSTR Source, LPCSTR Target, LPCSTR Type, LPCSTR
     Mount(m_initChannel, Source, Target, Type, Options, Flags);
 }
 
-void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LPCSTR Target, LPCSTR Type, LPCSTR Options, ULONG Flags, LPCSTR ChildName)
+void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LPCSTR Target, LPCSTR Type, LPCSTR Options, ULONG Flags)
 {
     static_assert(WSLCMountFlagsNone == WSLC_MOUNT::None);
     static_assert(WSLCMountFlagsReadOnly == WSLC_MOUNT::ReadOnly);
@@ -871,7 +871,6 @@ void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LP
     optionalAdd(Type, message->TypeIndex);
     optionalAdd(Options, message->OptionsIndex);
     message->Flags = Flags;
-    optionalAdd(ChildName, message->ChildNameIndex);
 
     const auto& response = Channel.Transaction<WSLC_MOUNT>(message.Span());
 
@@ -882,7 +881,31 @@ void WSLCVirtualMachine::Mount(shared::SocketChannel& Channel, LPCSTR Source, LP
         TraceLoggingValue(Type == nullptr ? "<null>" : Type, "Type"),
         TraceLoggingValue(Options == nullptr ? "<null>" : Options, "Options"),
         TraceLoggingValue(Flags, "Flags"),
-        TraceLoggingValue(ChildName == nullptr ? "<null>" : ChildName, "ChildName"),
+        TraceLoggingValue(response.Result, "Result"));
+
+    THROW_HR_IF(E_FAIL, response.Result != 0);
+}
+
+void WSLCVirtualMachine::MountVirtioFsChild(
+    shared::SocketChannel& Channel, LPCSTR Source, LPCSTR ChildName, LPCSTR Target, LPCSTR Options, ULONG Flags)
+{
+    wsl::shared::MessageWriter<WSLC_MOUNT_VIRTIOFS> message;
+    message.WriteString(message->SourceIndex, Source);
+    message.WriteString(message->ChildNameIndex, ChildName);
+    message.WriteString(message->DestinationIndex, Target);
+    message.WriteString(message->TypeIndex, "virtiofs");
+    message.WriteString(message->OptionsIndex, Options);
+    message->Flags = Flags;
+
+    const auto& response = Channel.Transaction<WSLC_MOUNT_VIRTIOFS>(message.Span());
+
+    WSL_LOG(
+        "WSLCMountVirtioFsChild",
+        TraceLoggingValue(Source, "Source"),
+        TraceLoggingValue(ChildName, "ChildName"),
+        TraceLoggingValue(Target, "Target"),
+        TraceLoggingValue(Options, "Options"),
+        TraceLoggingValue(Flags, "Flags"),
         TraceLoggingValue(response.Result, "Result"));
 
     THROW_HR_IF(E_FAIL, response.Result != 0);
@@ -1124,7 +1147,7 @@ try
     else
     {
         std::string options = readOnly ? "ro" : "rw";
-        Mount(m_initChannel, LX_INIT_DRVFS_VIRTIO_TAG, LinuxPath, "virtiofs", options.c_str(), Flags, shareName.c_str());
+        MountVirtioFsChild(m_initChannel, LX_INIT_DRVFS_VIRTIO_TAG, shareName.c_str(), LinuxPath, options.c_str(), Flags);
     }
 
     deleteOnFailure.release();

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -201,7 +201,7 @@ private:
     // Called after the root filesystem is mounted.
     void ReadGuestCapabilities();
 
-    static void Mount(wsl::shared::SocketChannel& Channel, LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags);
+    static void Mount(wsl::shared::SocketChannel& Channel, LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags, _In_opt_ LPCSTR ChildName = nullptr);
     void MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_ LPCSTR DriversMountpoint);
 
     Microsoft::WRL::ComPtr<WSLCProcess> CreateLinuxProcessImpl(
@@ -277,10 +277,6 @@ private:
 
     std::map<ULONG, AttachedDisk> m_attachedDisks;
     std::map<std::string, GUID> m_mountedWindowsFolders;
-
-    // VirtioFs share cache: maps (normalized WindowsPath, readOnly) to share GUID.
-    // Shares are kept alive after unmount for reuse on subsequent mounts of the same folder.
-    std::map<std::pair<std::wstring, bool>, GUID> m_virtioFsShares;
 
     std::recursive_mutex m_lock;
     std::mutex m_portRelaylock;

--- a/src/windows/wslcsession/WSLCVirtualMachine.h
+++ b/src/windows/wslcsession/WSLCVirtualMachine.h
@@ -201,7 +201,9 @@ private:
     // Called after the root filesystem is mounted.
     void ReadGuestCapabilities();
 
-    static void Mount(wsl::shared::SocketChannel& Channel, LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags, _In_opt_ LPCSTR ChildName = nullptr);
+    static void Mount(wsl::shared::SocketChannel& Channel, LPCSTR Source, _In_ LPCSTR Target, _In_ LPCSTR Type, _In_ LPCSTR Options, _In_ ULONG Flags);
+    static void MountVirtioFsChild(
+        wsl::shared::SocketChannel& Channel, _In_ LPCSTR Source, _In_ LPCSTR ChildName, _In_ LPCSTR Target, _In_ LPCSTR Options, _In_ ULONG Flags);
     void MountGpuLibraries(_In_ LPCSTR LibrariesMountPoint, _In_ LPCSTR DriversMountpoint);
 
     Microsoft::WRL::ComPtr<WSLCProcess> CreateLinuxProcessImpl(

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -3763,19 +3763,20 @@ class WSLCTests
             VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", true));
             ExpectMount(session.get(), "/win-path", expectedMountOptions(true));
 
-            // Capture the mount source and type, unmount, then remount without read-only.
+            // Remount a bind of the share as read-write to ensure the device host still enforces read-only access.
             ExpectCommandResult(
                 session.get(),
                 {"/bin/sh",
                  "-c",
-                 "src=$(findmnt -n -o SOURCE /win-path) && "
-                 "fstype=$(findmnt -n -o FSTYPE /win-path) && "
-                 "umount /win-path && "
-                 "mount -t $fstype $src /win-path"},
+                 "mkdir -p /win-path-rw && "
+                 "mount --bind /win-path /win-path-rw && "
+                 "mount -o remount,bind,rw /win-path-rw && "
+                 "findmnt -n -o VFS-OPTIONS /win-path-rw | grep -qE '(^|,)rw(,|$)'"},
                 0);
 
-            // Verify the folder is still not writeable.
-            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "echo -n content > /win-path/file.txt"}, 1);
+            // Verify the folder is still not writeable through the read-write bind.
+            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "echo -n content > /win-path-rw/file.txt"}, 1);
+            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "umount /win-path-rw && rmdir /win-path-rw"}, 0);
 
             VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
             ExpectMount(session.get(), "/win-path", {});
@@ -3809,107 +3810,154 @@ class WSLCTests
         ValidateWindowsMounts(true);
     }
 
-    // Validates that VirtioFs shares are reused across mount/unmount cycles for the same Windows folder.
-    WSLC_TEST_METHOD(WindowsMountsVirtioFsShareReuse)
+    // Validates that each mount owns an independent child on the shared aggregate device.
+    WSLC_TEST_METHOD(WindowsMountsVirtioFsIndependentShares)
     {
-        auto settings = GetDefaultSessionSettings(L"virtiofs-share-reuse-test");
+        auto settings = GetDefaultSessionSettings(L"virtiofs-independent-shares-test");
         WI_SetFlag(settings.FeatureFlags, WslcFeatureFlagsVirtioFs);
 
         auto createNewSession = !WI_IsFlagSet(m_defaultSessionSettings.FeatureFlags, WslcFeatureFlagsVirtioFs);
         auto session = createNewSession ? CreateSession(settings) : m_defaultSession;
 
-        auto testFolder = std::filesystem::current_path() / "test-folder-share-reuse";
+        auto testFolder = std::filesystem::current_path() / "test-folder-independent-shares";
         std::filesystem::create_directories(testFolder);
+        std::ofstream(testFolder / "marker.txt") << "content";
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testFolder); });
 
-        auto getMountSource = [&](const char* mountPoint) -> std::string {
-            auto cmd = std::format("findmnt -n -o SOURCE {}", mountPoint);
+        auto getMountField = [&](const char* mountPoint, const char* field) -> std::string {
+            auto cmd = std::format("findmnt -n -o {} {}", field, mountPoint);
             auto result = ExpectCommandResult(session.get(), {"/bin/sh", "-c", cmd}, 0);
             return result.Output[1];
         };
 
-        // Mount, capture the source (share GUID), unmount, remount, verify same GUID is reused.
+        // Concurrent mounts of the same host path use distinct children on the same aggregate device.
         {
-            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", false));
-            auto firstSource = getMountSource("/win-path");
-            VERIFY_IS_FALSE(firstSource.empty());
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path-1", false));
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path-2", false));
 
-            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
-            ExpectMount(session.get(), "/win-path", {});
+            auto firstDevice = getMountField("/win-path-1", "MAJ:MIN");
+            auto secondDevice = getMountField("/win-path-2", "MAJ:MIN");
+            auto firstRoot = getMountField("/win-path-1", "FSROOT");
+            auto secondRoot = getMountField("/win-path-2", "FSROOT");
+            VERIFY_ARE_EQUAL(firstDevice, secondDevice);
+            VERIFY_ARE_NOT_EQUAL(firstRoot, secondRoot);
+            VERIFY_IS_TRUE(firstRoot.starts_with('/'));
+            VERIFY_IS_TRUE(firstRoot.ends_with('\n'));
+            VERIFY_IS_TRUE(secondRoot.starts_with('/'));
+            VERIFY_IS_TRUE(secondRoot.ends_with('\n'));
+            firstRoot.pop_back();
+            secondRoot.pop_back();
 
-            // Remount the same folder - should reuse the same share GUID.
-            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", false));
-            auto secondSource = getMountSource("/win-path");
+            const auto firstChild = std::format("/run/wsl/virtiofs-mounts/{}{}", LX_INIT_DRVFS_VIRTIO_TAG, firstRoot);
+            const auto secondChild = std::format("/run/wsl/virtiofs-mounts/{}{}", LX_INIT_DRVFS_VIRTIO_TAG, secondRoot);
 
-            VERIFY_ARE_EQUAL(firstSource, secondSource);
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path-1"));
+            ExpectCommandResult(session.get(), {"/bin/cat", "/win-path-2/marker.txt"}, 0);
+            ExpectCommandResult(session.get(), {"/usr/bin/test", "!", "-e", firstChild}, 0);
+            ExpectCommandResult(session.get(), {"/usr/bin/test", "-e", secondChild}, 0);
 
-            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path-2"));
+            ExpectCommandResult(session.get(), {"/usr/bin/test", "!", "-e", secondChild}, 0);
         }
 
-        // Verify that changing the read-only flag produces a different share GUID.
+        // Verify that read-write and read-only shares use different children on the same aggregate device.
         {
-            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", false));
-            auto rwSource = getMountSource("/win-path");
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path-rw", false));
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path-ro", true));
 
-            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+            auto rwDevice = getMountField("/win-path-rw", "MAJ:MIN");
+            auto roDevice = getMountField("/win-path-ro", "MAJ:MIN");
+            auto rwRoot = getMountField("/win-path-rw", "FSROOT");
+            auto roRoot = getMountField("/win-path-ro", "FSROOT");
 
-            VERIFY_SUCCEEDED(session->MountWindowsFolder(testFolder.c_str(), "/win-path", true));
-            auto roSource = getMountSource("/win-path");
+            VERIFY_ARE_EQUAL(rwDevice, roDevice);
+            VERIFY_ARE_NOT_EQUAL(rwRoot, roRoot);
 
-            VERIFY_ARE_NOT_EQUAL(rwSource, roSource);
-
-            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path"));
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path-rw"));
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/win-path-ro"));
         }
     }
 
-    // Validate that the correct error is returned when too many virtiofs shares are mounted.
-    WSLC_TEST_METHOD(VirtiofsVolumesLimit)
+    WSLC_TEST_METHOD(WindowsMountsVirtioFsRemoveChild)
     {
-        constexpr size_t c_maxVirtioFsShares = wsl::shared::c_maxVirtioFsShares;
-
-        auto settings = GetDefaultSessionSettings(L"virtiofs-share-limit-test");
+        auto settings = GetDefaultSessionSettings(L"virtiofs-remove-child-test");
         WI_SetFlag(settings.FeatureFlags, WslcFeatureFlagsVirtioFs);
-
-        // Use a dedicated session so the share count starts at zero (no GPU libraries are mounted).
         auto session = CreateSession(settings);
 
-        auto testRoot = std::filesystem::current_path() / "test-folder-share-limit";
-        std::filesystem::create_directories(testRoot);
+        const auto testRoot = std::filesystem::current_path() / "test-folder-remove-child";
+        const auto firstFolder = testRoot / "first";
+        const auto secondFolder = testRoot / "second";
+        std::filesystem::create_directories(firstFolder);
+        std::filesystem::create_directories(secondFolder);
+        std::ofstream(firstFolder / "marker.txt") << "first";
+        std::ofstream(secondFolder / "marker.txt") << "second";
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testRoot); });
 
-        auto folderForIndex = [&](size_t index) {
-            auto folder = testRoot / std::to_string(index);
-            std::filesystem::create_directories(folder);
-            return folder;
+        auto getMountRoot = [&](const char* mountPoint) {
+            const auto command = std::format("findmnt -n -o FSROOT {}", mountPoint);
+            auto root = ExpectCommandResult(session.get(), {"/bin/sh", "-c", command}, 0).Output.at(1);
+            VERIFY_IS_TRUE(root.starts_with('/'));
+            VERIFY_IS_TRUE(root.ends_with('\n'));
+            root.pop_back();
+            return root;
         };
 
-        // Mount distinct Windows folders (each creates a new share) until the limit is reached.
-        size_t mounted = 0;
-        HRESULT lastResult = S_OK;
-        for (size_t i = 0; i <= c_maxVirtioFsShares; ++i)
+        VERIFY_SUCCEEDED(session->MountWindowsFolder(firstFolder.c_str(), "/remove-child-first", false));
+        VERIFY_SUCCEEDED(session->MountWindowsFolder(secondFolder.c_str(), "/remove-child-second", false));
+
+        const auto firstRoot = getMountRoot("/remove-child-first");
+        const auto secondRoot = getMountRoot("/remove-child-second");
+        VERIFY_ARE_NOT_EQUAL(firstRoot, secondRoot);
+
+        const auto aggregateRoot = std::format("/run/wsl/virtiofs-mounts/{}", LX_INIT_DRVFS_VIRTIO_TAG);
+        const auto firstChild = aggregateRoot + firstRoot;
+        const auto secondChild = aggregateRoot + secondRoot;
+        ExpectCommandResult(session.get(), {"/usr/bin/test", "-e", firstChild}, 0);
+        ExpectCommandResult(session.get(), {"/usr/bin/test", "-e", secondChild}, 0);
+
+        VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/remove-child-first"));
+        ExpectCommandResult(session.get(), {"/usr/bin/test", "!", "-e", firstChild}, 0);
+        ExpectCommandResult(session.get(), {"/bin/cat", "/remove-child-second/marker.txt"}, 0);
+        ExpectCommandResult(session.get(), {"/usr/bin/test", "-e", secondChild}, 0);
+
+        VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/remove-child-second"));
+        ExpectCommandResult(session.get(), {"/usr/bin/test", "!", "-e", secondChild}, 0);
+    }
+
+    // Validate that enough VirtioFs shares can be mounted to exceed the old per-device aperture limit.
+    WSLC_TEST_METHOD(VirtiofsMountManyVolumes)
+    {
+        constexpr size_t c_shareCount = 32;
+
+        auto settings = GetDefaultSessionSettings(L"virtiofs-many-shares-test");
+        WI_SetFlag(settings.FeatureFlags, WslcFeatureFlagsVirtioFs);
+
+        auto session = CreateSession(settings);
+
+        auto testRoot = std::filesystem::current_path() / "test-folder-many-shares";
+        std::filesystem::create_directories(testRoot);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testRoot); });
+        std::vector<std::string> mountPoints;
+
+        for (size_t index = 0; index < c_shareCount; ++index)
         {
-            auto folder = folderForIndex(i);
-            auto mountPoint = std::format("/vfs-limit-{}", i);
+            const auto folder = testRoot / std::to_string(index);
+            std::filesystem::create_directories(folder);
+            std::ofstream(folder / "marker.txt") << index;
 
-            lastResult = session->MountWindowsFolder(folder.c_str(), mountPoint.c_str(), false);
-            if (FAILED(lastResult))
-            {
-                break;
-            }
+            const auto mountPoint = std::format("/vfs-many-{}", index);
+            VERIFY_SUCCEEDED(session->MountWindowsFolder(folder.c_str(), mountPoint.c_str(), false));
+            mountPoints.emplace_back(mountPoint);
 
-            mounted++;
+            const auto command = std::format("cat {}/marker.txt", mountPoint);
+            const auto result = ExpectCommandResult(session.get(), {"/bin/sh", "-c", command}, 0);
+            VERIFY_ARE_EQUAL(std::to_string(index), result.Output.at(1));
         }
 
-        VERIFY_ARE_EQUAL(mounted, c_maxVirtioFsShares);
-        VERIFY_ARE_EQUAL(lastResult, E_OUTOFMEMORY);
-        ValidateCOMErrorMessage(
-            L"Too many volumes have been mounted (limit: 15). Restart the session to mount more volumes. This will be fixed in a "
-            L"future release.");
-
-        // Reusing an already-created share must still succeed.
-        auto reusedFolder = folderForIndex(0);
-        VERIFY_SUCCEEDED(session->MountWindowsFolder(reusedFolder.c_str(), "/vfs-limit-reuse", false));
-        VERIFY_SUCCEEDED(session->UnmountWindowsFolder("/vfs-limit-reuse"));
+        for (const auto& mountPoint : mountPoints)
+        {
+            VERIFY_SUCCEEDED(session->UnmountWindowsFolder(mountPoint.c_str()));
+        }
     }
 
     // This test case validates that no file descriptors are leaked to user processes.


### PR DESCRIPTION
This is a follow-up to PR: #41129 which removes the need to limit the amount of virtiofs shares in WSLC. It does so by mounting all virtiofs shares under a single, unified root share which limits the memory footprint of virtio devices. See the original PR for more details. 