### PR TITLE
WSLC: Refactor ParseImage and ParseRepository (PR Feedback followup)

### DIFF
--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -1245,7 +1245,7 @@ std::vector<DWORD> wsl::windows::common::wslutil::ListRunningProcesses()
     return pids;
 }
 
-std::pair<std::string, std::string> wsl::windows::common::wslutil::NormalizeRepo(const std::string& Input)
+wsl::windows::common::wslutil::RepositoryReference wsl::windows::common::wslutil::RepositoryReference::Parse(const std::string& input)
 {
     // See: https://github.com/distribution/reference/blob/ff14fafe2236e51c2894ac07d4bdfc778e96d682/normalize.go#L126
 
@@ -1254,14 +1254,14 @@ std::pair<std::string, std::string> wsl::windows::common::wslutil::NormalizeRepo
     constexpr auto legacyDomain = "index.docker.io";
     constexpr auto localhost = "localhost";
 
-    auto slash = Input.find('/');
+    auto slash = input.find('/');
     if (slash == std::string::npos)
     {
-        return {defaultDomain, officialPrefix + Input};
+        return RepositoryReference{input, defaultDomain, officialPrefix + input};
     }
 
-    auto domain = Input.substr(0, slash);
-    auto path = Input.substr(slash + 1);
+    auto domain = input.substr(0, slash);
+    auto path = input.substr(slash + 1);
 
     if (domain == legacyDomain)
     {
@@ -1272,7 +1272,7 @@ std::pair<std::string, std::string> wsl::windows::common::wslutil::NormalizeRepo
              }))
     {
         domain = defaultDomain;
-        path = Input;
+        path = input;
     }
 
     if (domain == defaultDomain && path.find('/') == std::string::npos)
@@ -1280,7 +1280,12 @@ std::pair<std::string, std::string> wsl::windows::common::wslutil::NormalizeRepo
         path = "library/" + path;
     }
 
-    return {domain, path};
+    return RepositoryReference{input, std::move(domain), std::move(path)};
+}
+
+std::string wsl::windows::common::wslutil::RepositoryReference::GetCanonical() const
+{
+    return std::format("{}/{}", Server, Path);
 }
 
 std::pair<wil::unique_hfile, wil::unique_hfile> wsl::windows::common::wslutil::OpenAnonymousPipe(DWORD Size, bool ReadPipeOverlapped, bool WritePipeOverlapped)
@@ -1397,49 +1402,8 @@ std::tuple<uint32_t, uint32_t, uint32_t> wsl::windows::common::wslutil::ParseWsl
     }
 }
 
-std::pair<std::string, std::optional<std::string>> wsl::windows::common::wslutil::ParseImage(const std::string& Input, EnumReferenceFormat* Format)
+wsl::windows::common::wslutil::ImageReference wsl::windows::common::wslutil::ImageReference::Parse(const std::string& input)
 {
-    static const auto regex = BuildImageReferenceRegex();
-    std::smatch match;
-    if (!std::regex_match(Input, match, regex))
-    {
-        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, wsl::shared::Localization::MessageWslcInvalidImage(Input.c_str()));
-    }
-
-    const auto& repo = match[1];
-    const auto& tag = match[2];
-    const auto& digest = match[3];
-
-    THROW_HR_IF_MSG(E_UNEXPECTED, !repo.matched, "Unexpected regex match. Input: %hs", Input.c_str());
-
-    EnumReferenceFormat referenceFormat = EnumReferenceFormatNone;
-    std::optional<std::string> tagOrDigest;
-    if (digest.matched) // <repo>:[tag]@<digest> (If both digest and tag are specified, digest takes precedence).
-    {
-        tagOrDigest = digest.str();
-        referenceFormat = EnumReferenceFormatDigest;
-    }
-    else if (tag.matched) // <repo>:<tag>
-    {
-        tagOrDigest = tag.str();
-        referenceFormat = EnumReferenceFormatTag;
-    }
-
-    if (Format)
-    {
-        *Format = referenceFormat;
-    }
-
-    return {repo.str(), std::move(tagOrDigest)};
-}
-
-std::string wsl::windows::common::wslutil::GetCanonicalImageReference(const std::string& input)
-{
-    // Mirror the Docker CLI's client-side reference normalization so the final line matches `docker pull` exactly.
-    // See github.com/distribution/reference (normalize.go, reference.go) and github.com/docker/cli
-    // (cli/command/image/pull.go). Unlike ParseImage -- which collapses to a single tag-or-digest field with digest
-    // precedence -- Docker's canonical string keeps both a tag and a digest when both are present, so compose the
-    // reference directly from the parsed name, tag and digest groups.
     static const auto regex = BuildImageReferenceRegex();
     std::smatch match;
     if (!std::regex_match(input, match, regex))
@@ -1447,13 +1411,49 @@ std::string wsl::windows::common::wslutil::GetCanonicalImageReference(const std:
         THROW_HR_WITH_USER_ERROR(E_INVALIDARG, wsl::shared::Localization::MessageWslcInvalidImage(input.c_str()));
     }
 
-    auto [domain, path] = NormalizeRepo(match[1].str());
+    const auto& repo = match[1];
+    const auto& tag = match[2];
+    const auto& digest = match[3];
+
+    THROW_HR_IF_MSG(E_UNEXPECTED, !repo.matched, "Unexpected regex match. Input: %hs", input.c_str());
+
+    std::optional<std::string> tagValue;
+    if (tag.matched)
+    {
+        tagValue = tag.str();
+    }
+
+    std::optional<std::string> digestValue;
+    if (digest.matched)
+    {
+        digestValue = digest.str();
+    }
+
+    // Classify the reference the way the Docker CLI does, where a digest takes precedence over a tag.
+    EnumReferenceFormat format = EnumReferenceFormatNone;
+    if (digestValue.has_value())
+    {
+        format = EnumReferenceFormatDigest;
+    }
+    else if (tagValue.has_value())
+    {
+        format = EnumReferenceFormatTag;
+    }
+
+    return ImageReference{RepositoryReference::Parse(repo.str()), std::move(tagValue), std::move(digestValue), format};
+}
+
+std::string wsl::windows::common::wslutil::ImageReference::GetCanonical() const
+{
+    // Mirror the Docker CLI's client-side reference normalization so the result matches `docker pull` exactly.
+    // See github.com/distribution/reference (normalize.go, reference.go) and github.com/docker/cli
+    // (cli/command/image/pull.go). Docker's canonical string keeps both a tag and a digest when both are present.
 
     // A tag joins with ':' and a digest with '@'. A name-only reference (no tag and no digest) defaults to ":latest";
     // a digest-only reference is not name-only, so it keeps no tag (matching Docker's TagNameOnly).
-    const std::string tag = match[2].matched ? std::format(":{}", match[2].str()) : (match[3].matched ? "" : ":latest");
-    const std::string digest = match[3].matched ? std::format("@{}", match[3].str()) : "";
-    return std::format("{}/{}{}{}", domain, path, tag, digest);
+    const std::string tag = Tag ? std::format(":{}", *Tag) : (Digest ? "" : ":latest");
+    const std::string digest = Digest ? std::format("@{}", *Digest) : "";
+    return std::format("{}{}{}", Repository.GetCanonical(), tag, digest);
 }
 
 void wsl::windows::common::wslutil::PrintSystemError(_In_ HRESULT result, _Inout_ FILE* const stream)

--- a/src/windows/common/wslutil.h
+++ b/src/windows/common/wslutil.h
@@ -222,10 +222,6 @@ ErrorStrings ErrorToString(const Error& error);
 
 std::filesystem::path GetBasePath();
 
-// Returns the fully-qualified canonical image reference for the given input, matching the string
-// printed by `docker pull` (e.g. "ubuntu" -> "docker.io/library/ubuntu:latest").
-std::string GetCanonicalImageReference(const std::string& input);
-
 std::optional<COMErrorInfo> GetCOMErrorInfo();
 
 DWORD GetDefaultVersion(void);
@@ -268,7 +264,22 @@ bool IsVirtualMachinePlatformInstalled();
 
 std::vector<DWORD> ListRunningProcesses();
 
-std::pair<std::string, std::string> NormalizeRepo(const std::string& Input);
+// An immutable container repository reference. Holds the original repository token together with its normalized
+// registry server and path, following Docker's client-side normalization (e.g. "ubuntu" -> {"docker.io",
+// "library/ubuntu"}). Construct one with Parse(). Normalization is lossy, so the original Name is retained for
+// callers that must echo the repository exactly as it was written.
+struct RepositoryReference
+{
+    const std::string Name;
+    const std::string Server;
+    const std::string Path;
+
+    // Split and normalize a repository string into its registry server and path.
+    static RepositoryReference Parse(const std::string& repository);
+
+    // The fully-qualified "server/path" form (e.g. "docker.io/library/ubuntu").
+    std::string GetCanonical() const;
+};
 
 std::pair<wil::unique_hfile, wil::unique_hfile> OpenAnonymousPipe(DWORD Size, bool ReadPipeOverlapped, bool WritePipeOverlapped);
 
@@ -280,7 +291,29 @@ void ParseIpv6Address(const char* Address, in_addr6& Result);
 
 std::tuple<uint32_t, uint32_t, uint32_t> ParseWslPackageVersion(_In_ const std::wstring& Version);
 
-std::pair<std::string, std::optional<std::string>> ParseImage(const std::string& Input, EnumReferenceFormat* Format = nullptr);
+// A parsed, immutable image reference such as "ubuntu:22.04@sha256:...". Construct one with Parse().
+struct ImageReference
+{
+    const RepositoryReference Repository;
+    const std::optional<std::string> Tag;
+    const std::optional<std::string> Digest;
+    const EnumReferenceFormat Format;
+
+    // Parse an image reference string into its components. Throws E_INVALIDARG (with a user-facing error) when the
+    // reference is malformed.
+    static ImageReference Parse(const std::string& input);
+
+    // Collapse the reference to a single tag-or-digest field, where a digest takes precedence over a tag. This matches
+    // how callers that resolve, pull or push a single reference treat the two.
+    std::optional<std::string> TagOrDigest() const
+    {
+        return Digest.has_value() ? Digest : Tag;
+    }
+
+    // The fully-qualified canonical reference, matching the string printed by `docker pull`
+    // (e.g. "ubuntu" -> "docker.io/library/ubuntu:latest").
+    std::string GetCanonical() const;
+};
 
 void PrintSystemError(_In_ HRESULT result, _Inout_ FILE* stream = stdout);
 

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -68,9 +68,7 @@ wil::unique_hfile ResolveBuildFile(const std::filesystem::path& contextPath)
 
 std::string GetServerFromImage(const std::string& image)
 {
-    auto [repo, tag] = wsl::windows::common::wslutil::ParseImage(image);
-    auto [server, path] = wsl::windows::common::wslutil::NormalizeRepo(repo);
-    return server;
+    return wsl::windows::common::wslutil::ImageReference::Parse(image).Repository.Server;
 }
 
 struct InputSource
@@ -217,9 +215,9 @@ std::vector<ImageInformation> ImageService::List(
         std::string imageRef = image.Image;
         if (imageRef != "<none>:<none>")
         {
-            auto parsed = wsl::windows::common::wslutil::ParseImage(imageRef);
-            info.Repository = parsed.first;
-            info.Tag = parsed.second;
+            auto parsed = wsl::windows::common::wslutil::ImageReference::Parse(imageRef);
+            info.Repository = parsed.Repository.Name;
+            info.Tag = parsed.TagOrDigest();
         }
 
         info.Id = image.Hash;
@@ -277,17 +275,16 @@ void ImageService::Pull(Reporter& reporter, wsl::windows::wslc::models::Session&
 
 void ImageService::Tag(wsl::windows::wslc::models::Session& session, const std::string& sourceImage, const std::string& targetImage)
 {
-    EnumReferenceFormat format;
-    auto [repo, tag] = ParseImage(targetImage, &format);
-    if (format == EnumReferenceFormatDigest)
+    auto reference = ImageReference::Parse(targetImage);
+    if (reference.Format == EnumReferenceFormatDigest)
     {
         THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcTagImageInvalidFormat(targetImage.c_str()));
     }
 
     WSLCTagImageOptions options{};
     options.Image = sourceImage.c_str();
-    options.Repo = repo.c_str();
-    options.Tag = tag ? tag->c_str() : "";
+    options.Repo = reference.Repository.Name.c_str();
+    options.Tag = reference.Tag ? reference.Tag->c_str() : "";
 
     THROW_IF_FAILED(session.Get()->TagImage(&options));
 }

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -228,21 +228,25 @@ void PullImage(CLIExecutionContext& context)
 
     // Match `docker pull`: for a name-only reference (no tag or digest) the tag defaults to "latest". Unless quiet,
     // the client reports this on stdout before contacting the registry.
-    EnumReferenceFormat format = EnumReferenceFormatNone;
-    ParseImage(image, &format);
-    if (!quiet && format == EnumReferenceFormatNone)
+    const auto reference = ImageReference::Parse(image);
+    if (!quiet && reference.Format == EnumReferenceFormatNone)
     {
         context.Reporter.Output(L"{}\n", Localization::WSLCCLI_PullUsingDefaultTag(L"latest"));
     }
 
     // Match `docker pull`: in quiet mode, suppress progress output by passing no progress callback. Warnings are
     // unaffected because the warning callback is built internally by ImageService::Pull from the Reporter.
-    ImageProgressCallback callback(context.Reporter, Reporter::Level::Output);
-    IProgressCallback* progress = quiet ? nullptr : &callback;
+    std::optional<ImageProgressCallback> callback;
+    if (!quiet)
+    {
+        callback.emplace(context.Reporter, Reporter::Level::Output);
+    }
+
+    IProgressCallback* progress = callback ? &*callback : nullptr;
     services::ImageService::Pull(context.Reporter, session, image, progress);
 
     // Match `docker pull`: always print the resolved canonical image reference as the final line.
-    context.Reporter.Output(L"{}\n", MultiByteToWide(GetCanonicalImageReference(image)));
+    context.Reporter.Output(L"{}\n", MultiByteToWide(reference.GetCanonical()));
 }
 
 void PushImage(CLIExecutionContext& context)

--- a/src/windows/wslcsession/DockerHTTPClient.cpp
+++ b/src/windows/wslcsession/DockerHTTPClient.cpp
@@ -125,8 +125,7 @@ std::unique_ptr<DockerHTTPClient::HTTPRequestContext> DockerHTTPClient::PullImag
     auto url = URL::Create("/images/create");
 
     // Normalize the repo server & path
-    auto [server, path] = wslutil::NormalizeRepo(Repo);
-    url.SetParameter("fromImage", std::format("{}/{}", server, path));
+    url.SetParameter("fromImage", wslutil::RepositoryReference::Parse(Repo).GetCanonical());
 
     if (tagOrDigest.has_value())
     {

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -48,13 +48,12 @@ namespace {
 // Group policy: WSLContainerRegistryAllowlist restricts which container-image
 // registries can be pulled from or pushed to. The check is enforced here at the
 // service boundary so it covers ALL callers (wslc.exe CLI, the WslcSDK C API, and
-// any other COM client). The repo argument must be the parsed repo from
-// wslutil::ParseImage so callers don't pay the regex cost twice.
-void EnforceRegistryAllowlist(const std::string& Repo)
+// any other COM client). Callers pass the parsed repository so no reference is
+// parsed twice.
+void EnforceRegistryAllowlist(const wslutil::RepositoryReference& Repository)
 {
     const auto policiesKey = wsl::windows::policies::OpenPoliciesKey();
-    auto [server, path] = wsl::windows::common::wslutil::NormalizeRepo(Repo);
-    const auto serverWide = wsl::shared::string::MultiByteToWide(server);
+    const auto serverWide = wsl::shared::string::MultiByteToWide(Repository.Server);
 
     if (wsl::windows::policies::IsRegistryAllowed(policiesKey.get(), serverWide))
     {
@@ -842,7 +841,9 @@ try
 
     RETURN_HR_IF_NULL(E_POINTER, Image);
 
-    auto [repo, tagOrDigest] = wslutil::ParseImage(Image);
+    const auto reference = wslutil::ImageReference::Parse(Image);
+    const auto& repo = reference.Repository;
+    auto tagOrDigest = reference.TagOrDigest();
     EnforceRegistryAllowlist(repo);
 
     auto lock = m_lock.lock_shared();
@@ -860,7 +861,7 @@ try
         registryAuth = std::string(RegistryAuthenticationInformation);
     }
 
-    auto requestContext = m_dockerClient->PullImage(repo, tagOrDigest, registryAuth);
+    auto requestContext = m_dockerClient->PullImage(repo.Name, tagOrDigest, registryAuth);
     StreamImageOperation(*requestContext, Image, "Pull", ProgressCallback);
 
     OnImageCreated(Image);
@@ -1259,9 +1260,10 @@ try
     {
         RETURN_HR_IF(E_INVALIDARG, strlen(ImageName) > WSLC_MAX_IMAGE_NAME_LENGTH);
 
-        auto [parsedRepo, tagOrDigest] = wslutil::ParseImage(ImageName);
+        auto reference = wslutil::ImageReference::Parse(ImageName);
+        auto tagOrDigest = reference.TagOrDigest();
         THROW_HR_IF_MSG(E_INVALIDARG, !tagOrDigest.has_value(), "Expected tag for image import: %hs", ImageName);
-        repo = parsedRepo;
+        repo = reference.Repository.Name;
         tag = tagOrDigest.value();
     }
 
@@ -1607,7 +1609,7 @@ try
 
                 // Extract repo name from tag (format: "repo:tag")
                 // and lookup corresponding digest from the map
-                auto repoName = wslutil::ParseImage(tag).first;
+                auto repoName = wslutil::ImageReference::Parse(tag).Repository.Name;
                 auto it = repoToDigest.find(repoName);
                 if (it != repoToDigest.end())
                 {
@@ -1761,13 +1763,15 @@ try
     RETURN_HR_IF_NULL(E_POINTER, Image);
     RETURN_HR_IF_NULL(E_POINTER, RegistryAuthenticationInformation);
 
-    auto [repo, tagOrDigest] = wslutil::ParseImage(Image);
+    const auto reference = wslutil::ImageReference::Parse(Image);
+    const auto& repo = reference.Repository;
+    auto tagOrDigest = reference.TagOrDigest();
     EnforceRegistryAllowlist(repo);
 
     auto lock = m_lock.lock_shared();
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_dockerClient.has_value());
 
-    auto requestContext = m_dockerClient->PushImage(repo, tagOrDigest, RegistryAuthenticationInformation);
+    auto requestContext = m_dockerClient->PushImage(repo.Name, tagOrDigest, RegistryAuthenticationInformation);
     StreamImageOperation(*requestContext, Image, "Push", ProgressCallback);
 
     return S_OK;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -199,7 +199,9 @@ class WSLCTests
 
     std::string PushImageToRegistry(const std::string& imageName, const std::string& registryAddress, const std::string& registryAuth)
     {
-        auto [repo, tag] = ParseImage(imageName);
+        auto reference = ImageReference::Parse(imageName);
+        const auto& repo = reference.Repository.Name;
+        auto tag = reference.TagOrDigest();
         auto registryImage = std::format("{}/{}:{}", registryAddress, repo, tag.value_or("latest"));
         auto registryRepo = std::format("{}/{}", registryAddress, repo);
         auto registryTag = tag.value_or("latest");
@@ -11795,12 +11797,37 @@ class WSLCTests
 
     TEST_METHOD(ImageParsing)
     {
-        using wsl::windows::common::wslutil::ParseImage;
+        auto ValidateImageParsing = [](const std::string& input,
+                                       const std::string& expectedRepo,
+                                       const std::optional<std::string>& expectedTag,
+                                       const std::optional<std::string>& expectedDigest = std::nullopt) {
+            auto reference = ImageReference::Parse(input);
 
-        auto ValidateImageParsing = [](const std::string& input, const std::string& expectedRepo, const std::optional<std::string>& expectedTag) {
-            auto [repo, tag] = ParseImage(input);
-            VERIFY_ARE_EQUAL(repo, expectedRepo);
-            VERIFY_ARE_EQUAL(tag.value_or("<empty>"), expectedTag.value_or("<empty>"));
+            // The repository is parsed into a RepositoryReference; Name preserves the original token while Server and
+            // Path hold its normalized form.
+            const auto expectedRepository = RepositoryReference::Parse(expectedRepo);
+            VERIFY_ARE_EQUAL(reference.Repository.Name, expectedRepository.Name);
+            VERIFY_ARE_EQUAL(reference.Repository.Server, expectedRepository.Server);
+            VERIFY_ARE_EQUAL(reference.Repository.Path, expectedRepository.Path);
+            VERIFY_ARE_EQUAL(reference.Tag.value_or("<empty>"), expectedTag.value_or("<empty>"));
+            VERIFY_ARE_EQUAL(reference.Digest.value_or("<empty>"), expectedDigest.value_or("<empty>"));
+
+            // TagOrDigest() collapses to a single field where a digest takes precedence over a tag.
+            const std::optional<std::string> expectedTagOrDigest = expectedDigest.has_value() ? expectedDigest : expectedTag;
+            VERIFY_ARE_EQUAL(reference.TagOrDigest().value_or("<empty>"), expectedTagOrDigest.value_or("<empty>"));
+
+            // Format mirrors that same classification.
+            EnumReferenceFormat expectedFormat = EnumReferenceFormatNone;
+            if (expectedDigest.has_value())
+            {
+                expectedFormat = EnumReferenceFormatDigest;
+            }
+            else if (expectedTag.has_value())
+            {
+                expectedFormat = EnumReferenceFormatTag;
+            }
+
+            VERIFY_ARE_EQUAL(reference.Format, expectedFormat);
         };
 
         ValidateImageParsing("ubuntu:22.04", "ubuntu", "22.04");
@@ -11815,47 +11842,54 @@ class WSLCTests
         ValidateImageParsing("localhost:5000/myimage:latest", "localhost:5000/myimage", "latest");
         ValidateImageParsing("ghcr.io/owner/repo:sha-abc123", "ghcr.io/owner/repo", "sha-abc123");
 
+        // A digest-only reference populates the digest field and leaves the tag empty.
         ValidateImageParsing(
             "ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
             "ubuntu",
+            {},
             "sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
 
-        // Validate that the digest takes precedence over the tag.
+        // A reference with both a tag and a digest captures each in its own field.
         ValidateImageParsing(
             "ubuntu:latest@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
             "ubuntu",
+            "latest",
             "sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
 
         ValidateImageParsing(
             "myregistry.io:5000/myimage@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
             "myregistry.io:5000/myimage",
+            {},
             "sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
 
         ValidateImageParsing(
             "ubuntu:22.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
             "ubuntu",
+            "22.04",
             "sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30");
 
         ValidateImageParsing("pytorch/pytorch", "pytorch/pytorch", {});
 
         // Invalid inputs
-        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ParseImage(""); }), E_INVALIDARG);
-        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ParseImage(":debian:latest"); }), E_INVALIDARG);
-        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ParseImage("debian:latest@"); }), E_INVALIDARG);
-        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ParseImage(""); }), E_INVALIDARG);
-        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ParseImage(":"); }), E_INVALIDARG);
-        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ParseImage("a:"); }), E_INVALIDARG);
-        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ParseImage(":b"); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ImageReference::Parse(""); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ImageReference::Parse(":debian:latest"); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ImageReference::Parse("debian:latest@"); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ImageReference::Parse(""); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ImageReference::Parse(":"); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ImageReference::Parse("a:"); }), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(wil::ResultFromException([]() { ImageReference::Parse(":b"); }), E_INVALIDARG);
     }
 
     TEST_METHOD(RepoParsing)
     {
-        using wsl::windows::common::wslutil::NormalizeRepo;
-
         auto ValidateRepoParsing = [](const std::string& input, const std::string& expectedServer, const std::string& expectedPath) {
-            auto [server, path] = NormalizeRepo(input);
-            VERIFY_ARE_EQUAL(server, expectedServer);
-            VERIFY_ARE_EQUAL(path, expectedPath);
+            auto repository = RepositoryReference::Parse(input);
+            VERIFY_ARE_EQUAL(repository.Name, input);
+            VERIFY_ARE_EQUAL(repository.Server, expectedServer);
+            VERIFY_ARE_EQUAL(repository.Path, expectedPath);
+
+            // GetCanonical() rejoins the normalized server and path.
+            VERIFY_ARE_EQUAL(repository.GetCanonical(), std::format("{}/{}", expectedServer, expectedPath));
         };
 
         ValidateRepoParsing("ubuntu", "docker.io", "library/ubuntu");
@@ -11875,10 +11909,8 @@ class WSLCTests
 
     TEST_METHOD(CanonicalImageReference)
     {
-        using wsl::windows::common::wslutil::GetCanonicalImageReference;
-
         auto Validate = [](const std::string& input, const std::string& expected) {
-            VERIFY_ARE_EQUAL(GetCanonicalImageReference(input), expected);
+            VERIFY_ARE_EQUAL(ImageReference::Parse(input).GetCanonical(), expected);
         };
 
         // Name-only references default to ":latest" and the docker.io/library prefix (matches `docker pull` output).


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This is a follow-up from some PR commentary that had a fairly large blast radius to do it cleanly so it is a separate PR.

Replaces the free functions `ParseImage`, `GetCanonicalImageReference`, and
`NormalizeRepo` in `wslutil` with two composable, immutable value types:
`RepositoryReference` and `ImageReference`. A reference is now parsed **once**
into a single source of truth, and all derived forms (normalized server/path,
canonical strings, tag-or-digest collapsing) are available on demand via
accessors — instead of being recomputed by callers or threaded through helper
functions as loose `std::pair`/`std::string` values.

Cleanup is entirely **client-side**:
no IDL, COM, or service-ABI changes.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
### New types

**`RepositoryReference`** — an immutable container-repository reference.
- `const std::string Name` — the verbatim repository token as written.
- `const std::string Server` / `const std::string Path` — the normalized
  registry server and path (Docker client-side normalization,
  e.g. `ubuntu` → `{docker.io, library/ubuntu}`).
- `static Parse(repository)` — splits and normalizes (folds in the old
  `NormalizeRepo`).
- `GetCanonical()` — the fully-qualified `server/path` form.

**`ImageReference`** — an immutable image reference such as
`ubuntu:22.04@sha256:...`.
- `const RepositoryReference Repository` — composed, not a raw string.
- `const std::optional<std::string> Tag` / `Digest` — kept as distinct fields.
- `const EnumReferenceFormat Format` — None / Tag / Digest classification.
- `static Parse(input)` — throws `E_INVALIDARG` (with a user-facing message)
  on a malformed reference.
- `TagOrDigest()` — collapses to a single field, digest taking precedence.
- `GetCanonical()` — the canonical string matching `docker pull` output
  (keeps both a tag and a digest when both are present).

### Implementation details

- **Composition / single source of truth.** `ImageReference` embeds a
  `RepositoryReference`; every part is `const`, so a reference is fixed once
  created. Consumers that need repository parts use accessors
  (`.Repository.Server`, `.Repository.Name`, `.Repository.GetCanonical()`)
  rather than re-parsing.
- **Why `Name` is retained.** Normalization is lossy — `ubuntu`,
  `docker.io/ubuntu`, and `index.docker.io/library/ubuntu` all normalize to the
  same server/path. Consumers that must echo the repository exactly as written
  (`wslc image list` display, `wslc tag`'s C-API `Repo`) read `Name`.
- **Removed a redundant parse.** `EnforceRegistryAllowlist` now takes a
  `const RepositoryReference&` instead of a raw string, eliminating a second
  normalization/regex pass on the pull/push paths.
- **Quiet-pull tidy-up.** `wslc image pull --quiet` now only constructs the
  progress callback when it is actually needed
  (`std::optional<ImageProgressCallback>`).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Debug build clean (no errors).
- Unit tests pass: `WSLCTests::ImageParsing`, `RepoParsing`,
  `CanonicalImageReference` (converted/expanded to cover the new types,
  including `Name`/`Server`/`Path`, `TagOrDigest()`, `Format`, and
  `GetCanonical()`).
- E2E image tests pass: **87 passed, 0 failed, 3 skipped** (the skips are
  intentional — stdin/terminal/build cases). Includes
  `WSLCE2E_Image_Pull_QuietOption` and `WSLCE2E_Image_Pull_NameOnlyDefaultsTag`,
  which exercise the quiet-callback and default-tag paths.