### PR TITLE
Backport security fixes to release/2.7

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
   <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.8" />
   <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.8" />
-  <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6676" />
+  <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.7214" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.251108.1" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.NET.Ref" version="10.0.26100.81" />

--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="10.0.0" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.6" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.6" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.8" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.8" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.6676" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.251108.1" targetFramework="native" />

--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="10.0.0" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.8" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.8" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.9" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.9" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.7214" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.251108.1" targetFramework="native" />


### PR DESCRIPTION
Backports the following security fixes from master to release/2.7:

- 09a8afee Bump Microsoft.NETCore.App.Runtime to 10.0.8, fixes CVE-2026-32175 (#40581)
- 2a7269e8 Update MSRDC to 1.2.7214, fixes CVE-2026-32157 (use-after-free RCE) (#40882)
- 73a6afb0 Update .NET runtime to 10.0.9, fixes CVE-2026-45491 (#40883)

All cherry-picked cleanly with no conflicts.