### PR TITLE
Add --output flag to wslc build

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2330,6 +2330,10 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>Invalid --secret value '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}{Locked="--secret "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcOutputInvalidSpec" xml:space="preserve">
+    <value>Invalid --output value '{}': {}</value>
+    <comment>{FixedPlaceholder="{}"}{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name = "MessageWslcMissingVolumeOption" xml:space = "preserve" >
     <value>Missing required option: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
@@ -2890,6 +2894,9 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_BuildPullArgDescription" xml:space="preserve">
     <value>Always attempt to pull a newer version of the image</value>
+  </data>
+  <data name="WSLCCLI_BuildOutputArgDescription" xml:space="preserve">
+    <value>Output destination (format: type=local,dest=path)</value>
   </data>
   <data name="WSLCCLI_BuildTargetArgDescription" xml:space="preserve">
     <value>Set the target build stage to build</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2332,7 +2332,7 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   </data>
   <data name="MessageWslcOutputInvalidSpec" xml:space="preserve">
     <value>Invalid --output value '{}': {}</value>
-    <comment>{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
+    <comment>{FixedPlaceholder="{}"}{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name = "MessageWslcMissingVolumeOption" xml:space = "preserve" >
     <value>Missing required option: '{}'</value>
@@ -2897,7 +2897,7 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_BuildOutputArgDescription" xml:space="preserve">
     <value>Build output destination (docker buildx --output spec; e.g. type=local,dest=path or type=tar,dest=out.tar)</value>
-    <comment>{Locked="--output"}{Locked="type=local,dest=path"}{Locked="type=tar,dest=out.tar"}Command line arguments, file names and string inserts should not be translated</comment>
+    <comment>{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_BuildTargetArgDescription" xml:space="preserve">
     <value>Set the target build stage to build</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2896,7 +2896,8 @@ On first run, creates the file with all settings commented out at their defaults
     <value>Always attempt to pull a newer version of the image</value>
   </data>
   <data name="WSLCCLI_BuildOutputArgDescription" xml:space="preserve">
-    <value>Output destination (format: type=local,dest=path)</value>
+    <value>Build output destination (docker buildx --output spec; e.g. type=local,dest=path or type=tar,dest=out.tar)</value>
+    <comment>{Locked="--output"}{Locked="type=local,dest=path"}{Locked="type=tar,dest=out.tar"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="WSLCCLI_BuildTargetArgDescription" xml:space="preserve">
     <value>Set the target build stage to build</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2332,7 +2332,7 @@ For privacy information about this product please visit https://aka.ms/privacy.<
   </data>
   <data name="MessageWslcOutputInvalidSpec" xml:space="preserve">
     <value>Invalid --output value '{}': {}</value>
-    <comment>{FixedPlaceholder="{}"}{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
+    <comment>{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name = "MessageWslcMissingVolumeOption" xml:space = "preserve" >
     <value>Missing required option: '{}'</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2334,6 +2334,10 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>Invalid --output value '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcOutputConsoleNotSupported" xml:space="preserve">
+    <value>Cannot write build output to the console for --output value '{}'.</value>
+    <comment>{FixedPlaceholder="{}"}{Locked="--output "}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name = "MessageWslcMissingVolumeOption" xml:space = "preserve" >
     <value>Missing required option: '{}'</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -69,7 +69,7 @@ inline bool EndsWith(const std::basic_string<T>& String, const std::basic_string
 // locale-independent (no Turkish-'I' surprises) and has no signed-char UB, which is what you want when
 // normalizing ASCII protocol tokens such as buildx CSV keys.
 template <class T>
-inline std::basic_string<T> AsciiToLower(const std::basic_string_view<T> &String)
+inline std::basic_string<T> AsciiToLower(const std::basic_string_view<T>& String)
 {
     std::basic_string<T> Result(String);
     for (auto& Ch : Result)
@@ -87,7 +87,7 @@ inline std::basic_string<T> AsciiToLower(const std::basic_string_view<T> &String
 // the ASCII subset of Go's strings.TrimSpace. Returns a view into the input, so the input must outlive
 // the result. The stdlib has no trim, so this centralizes the find_first/last_not_of idiom.
 template <class T>
-inline std::basic_string_view<T> TrimAscii(const std::basic_string_view<T> &String)
+inline std::basic_string_view<T> TrimAscii(const std::basic_string_view<T>& String)
 {
     constexpr T Whitespace[] = {
         static_cast<T>(' '), static_cast<T>('\t'), static_cast<T>('\r'), static_cast<T>('\n'), static_cast<T>('\v'), static_cast<T>('\f'), static_cast<T>('\0')};

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -65,6 +65,43 @@ inline bool EndsWith(const std::basic_string<T>& String, const std::basic_string
     return std::equal(Suffix.rbegin(), Suffix.rend(), String.rbegin());
 }
 
+// Lowercases ASCII 'A'-'Z' only, leaving every other code unit untouched. Unlike std::tolower this is
+// locale-independent (no Turkish-'I' surprises) and has no signed-char UB, which is what you want when
+// normalizing ASCII protocol tokens such as buildx CSV keys.
+template <class T>
+inline std::basic_string<T> AsciiToLower(std::basic_string_view<T> String)
+{
+    std::basic_string<T> Result(String);
+    for (auto& Ch : Result)
+    {
+        if (Ch >= static_cast<T>('A') && Ch <= static_cast<T>('Z'))
+        {
+            Ch = static_cast<T>(Ch - static_cast<T>('A') + static_cast<T>('a'));
+        }
+    }
+
+    return Result;
+}
+
+// Trims leading and trailing ASCII whitespace (space, tab, CR, LF, vertical tab, form feed), matching
+// the ASCII subset of Go's strings.TrimSpace. Returns a view into the input, so the input must outlive
+// the result. The stdlib has no trim, so this centralizes the find_first/last_not_of idiom.
+template <class T>
+inline std::basic_string_view<T> TrimAscii(std::basic_string_view<T> String)
+{
+    constexpr T Whitespace[] = {
+        static_cast<T>(' '), static_cast<T>('\t'), static_cast<T>('\r'), static_cast<T>('\n'), static_cast<T>('\v'), static_cast<T>('\f'), static_cast<T>('\0')};
+
+    const auto First = String.find_first_not_of(Whitespace);
+    if (First == std::basic_string_view<T>::npos)
+    {
+        return {};
+    }
+
+    const auto Last = String.find_last_not_of(Whitespace);
+    return String.substr(First, Last - First + 1);
+}
+
 template <class T, class TInput>
 inline std::basic_string<T> Join(const std::vector<TInput>& Input, T Separator)
 {

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -69,7 +69,7 @@ inline bool EndsWith(const std::basic_string<T>& String, const std::basic_string
 // locale-independent (no Turkish-'I' surprises) and has no signed-char UB, which is what you want when
 // normalizing ASCII protocol tokens such as buildx CSV keys.
 template <class T>
-inline std::basic_string<T> AsciiToLower(std::basic_string_view<T> String)
+inline std::basic_string<T> AsciiToLower(const std::basic_string_view<T> &String)
 {
     std::basic_string<T> Result(String);
     for (auto& Ch : Result)
@@ -87,7 +87,7 @@ inline std::basic_string<T> AsciiToLower(std::basic_string_view<T> String)
 // the ASCII subset of Go's strings.TrimSpace. Returns a view into the input, so the input must outlive
 // the result. The stdlib has no trim, so this centralizes the find_first/last_not_of idiom.
 template <class T>
-inline std::basic_string_view<T> TrimAscii(std::basic_string_view<T> String)
+inline std::basic_string_view<T> TrimAscii(const std::basic_string_view<T> &String)
 {
     constexpr T Whitespace[] = {
         static_cast<T>(' '), static_cast<T>('\t'), static_cast<T>('\r'), static_cast<T>('\n'), static_cast<T>('\v'), static_cast<T>('\f'), static_cast<T>('\0')};

--- a/src/windows/service/inc/WSLCShared.idl
+++ b/src/windows/service/inc/WSLCShared.idl
@@ -220,9 +220,10 @@ typedef enum _WSLCBuildImageFlags
     WSLCBuildImageFlagsVerbose = 1, // Show all build progress including internal steps.
     WSLCBuildImageFlagsNoCache = 2, // Do not use cache when building the image.
     WSLCBuildImageFlagsPull = 4,    // Always attempt to pull a newer version of the image.
+    WSLCBuildImageFlagsOutputIsDirectory = 8, // OutputHandle receives a tar stream of a directory exporter (type=local); the client extracts it into the destination directory.
 } WSLCBuildImageFlags;
 
-cpp_quote("#define WSLCBuildImageFlagsValid (WSLCBuildImageFlagsVerbose | WSLCBuildImageFlagsNoCache | WSLCBuildImageFlagsPull)")
+cpp_quote("#define WSLCBuildImageFlagsValid (WSLCBuildImageFlagsVerbose | WSLCBuildImageFlagsNoCache | WSLCBuildImageFlagsPull | WSLCBuildImageFlagsOutputIsDirectory)")
 
 cpp_quote("DEFINE_ENUM_FLAG_OPERATORS(WSLCBuildImageFlags);")
 

--- a/src/windows/service/inc/WSLCShared.idl
+++ b/src/windows/service/inc/WSLCShared.idl
@@ -220,10 +220,9 @@ typedef enum _WSLCBuildImageFlags
     WSLCBuildImageFlagsVerbose = 1, // Show all build progress including internal steps.
     WSLCBuildImageFlagsNoCache = 2, // Do not use cache when building the image.
     WSLCBuildImageFlagsPull = 4,    // Always attempt to pull a newer version of the image.
-    WSLCBuildImageFlagsOutputIsDirectory = 8, // OutputHandle receives a tar stream of a directory exporter (type=local); the client extracts it into the destination directory.
 } WSLCBuildImageFlags;
 
-cpp_quote("#define WSLCBuildImageFlagsValid (WSLCBuildImageFlagsVerbose | WSLCBuildImageFlagsNoCache | WSLCBuildImageFlagsPull | WSLCBuildImageFlagsOutputIsDirectory)")
+cpp_quote("#define WSLCBuildImageFlagsValid (WSLCBuildImageFlagsVerbose | WSLCBuildImageFlagsNoCache | WSLCBuildImageFlagsPull)")
 
 cpp_quote("DEFINE_ENUM_FLAG_OPERATORS(WSLCBuildImageFlags);")
 

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -549,8 +549,8 @@ typedef struct _WSLCBuildImageOptions
     WSLCBuildImageFlags Flags; // WSLCBuildImageFlags
     WSLCStringArray Labels;    // KEY=VALUE pairs passed as --label to docker.
     WSLCBuildSecretArray Secrets; // --secret entries; the server writes each secret's bytes to a host file exposed to the VM read-only over virtiofs and emits the corresponding id=...,src=... spec.
-    [unique, string] LPCSTR Output; // buildx exporter spec passed as --output to docker build (e.g. type=local, type=tar). The client omits dest= for exporters with a client destination; the server rewrites it to a VM temp path (streamed back over OutputHandle) or into the OutputMountPath mount (single-file exporters with a real destination).
-    WSLCHandle OutputHandle; // When Type != WSLCHandleTypeUnknown, the server streams the build exporter output to this handle after a successful build: a raw stream for dest=- (stdout), or a tar stream of the export directory for type=local (indicated by WSLCBuildImageFlagsOutputIsDirectory).
+    [unique, string] LPCSTR Output; // buildx exporter spec passed as --output to docker build (e.g. type=tar, type=oci). The client omits dest= for exporters with a client destination; the server rewrites it to a VM temp path (streamed back over OutputHandle) or into the OutputMountPath mount (single-file exporters with a real destination). Directory exporters (type=local, or oci/docker with tar=false) are not supported.
+    WSLCHandle OutputHandle; // When Type != WSLCHandleTypeUnknown, the server streams the single-file exporter output (a tar/oci/docker tarball, or dest=- stdout) to this handle after a successful build.
     [unique, string] LPCWSTR OutputMountPath; // When set, the server mounts this Windows directory read-write into the VM and points the exporter's dest at it (plus OutputMountFile). Used for single-file exporters with a real destination; mutually exclusive with OutputHandle.
     [unique, string] LPCWSTR OutputMountFile; // Leaf filename within OutputMountPath that a single-file exporter writes to.
 } WSLCBuildImageOptions;

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -549,8 +549,10 @@ typedef struct _WSLCBuildImageOptions
     WSLCBuildImageFlags Flags; // WSLCBuildImageFlags
     WSLCStringArray Labels;    // KEY=VALUE pairs passed as --label to docker.
     WSLCBuildSecretArray Secrets; // --secret entries; the server writes each secret's bytes to a host file exposed to the VM read-only over virtiofs and emits the corresponding id=...,src=... spec.
-    [unique, string] LPCSTR Output; // buildx exporter spec passed as --output to docker build (e.g. type=local, type=tar). When OutputHandle is set the client omits dest= and the server rewrites it to a VM temp path, then streams the result back over OutputHandle.
-    WSLCHandle OutputHandle; // When Type != WSLCHandleTypeUnknown, the server streams the build exporter output to this handle after a successful build (a raw file for tar/oci/docker, or a tar stream of the export directory for type=local, indicated by WSLCBuildImageFlagsOutputIsDirectory).
+    [unique, string] LPCSTR Output; // buildx exporter spec passed as --output to docker build (e.g. type=local, type=tar). The client omits dest= for exporters with a client destination; the server rewrites it to a VM temp path (streamed back over OutputHandle) or into the OutputMountPath mount (single-file exporters with a real destination).
+    WSLCHandle OutputHandle; // When Type != WSLCHandleTypeUnknown, the server streams the build exporter output to this handle after a successful build: a raw stream for dest=- (stdout), or a tar stream of the export directory for type=local (indicated by WSLCBuildImageFlagsOutputIsDirectory).
+    [unique, string] LPCWSTR OutputMountPath; // When set, the server mounts this Windows directory read-write into the VM and points the exporter's dest at it (plus OutputMountFile). Used for single-file exporters with a real destination; mutually exclusive with OutputHandle.
+    [unique, string] LPCWSTR OutputMountFile; // Leaf filename within OutputMountPath that a single-file exporter writes to.
 } WSLCBuildImageOptions;
 
 typedef struct _WSLCTagImageOptions

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -549,7 +549,8 @@ typedef struct _WSLCBuildImageOptions
     WSLCBuildImageFlags Flags; // WSLCBuildImageFlags
     WSLCStringArray Labels;    // KEY=VALUE pairs passed as --label to docker.
     WSLCBuildSecretArray Secrets; // --secret entries; the server writes each secret's bytes to a host file exposed to the VM read-only over virtiofs and emits the corresponding id=...,src=... spec.
-    [unique, string] LPCSTR Output; // Passed verbatim as --output to docker build (buildx exporter spec, e.g. type=local,dest=path).
+    [unique, string] LPCSTR Output; // buildx exporter spec passed as --output to docker build (e.g. type=local, type=tar). When OutputHandle is set the client omits dest= and the server rewrites it to a VM temp path, then streams the result back over OutputHandle.
+    WSLCHandle OutputHandle; // When Type != WSLCHandleTypeUnknown, the server streams the build exporter output to this handle after a successful build (a raw file for tar/oci/docker, or a tar stream of the export directory for type=local, indicated by WSLCBuildImageFlagsOutputIsDirectory).
 } WSLCBuildImageOptions;
 
 typedef struct _WSLCTagImageOptions

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -549,6 +549,7 @@ typedef struct _WSLCBuildImageOptions
     WSLCBuildImageFlags Flags; // WSLCBuildImageFlags
     WSLCStringArray Labels;    // KEY=VALUE pairs passed as --label to docker.
     WSLCBuildSecretArray Secrets; // --secret entries; the server writes each secret's bytes to a host file exposed to the VM read-only over virtiofs and emits the corresponding id=...,src=... spec.
+    [unique, string] LPCSTR Output; // Passed verbatim as --output to docker build (buildx exporter spec, e.g. type=local,dest=path).
 } WSLCBuildImageOptions;
 
 typedef struct _WSLCTagImageOptions

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -199,109 +199,6 @@ services::BuildSecret ParseSecretSpec(const std::wstring& spec)
     };
 }
 
-namespace {
-
-    // Splits a single CSV record (RFC 4180) as buildx does via go-csvvalue / encoding/csv: fields are
-    // comma separated, a field may be wrapped in double quotes, a doubled quote inside a quoted field is
-    // a literal quote, and a comma inside a quoted field is part of the value. Returns std::nullopt when
-    // the record is malformed (an unterminated quoted field, or extra text right after a closing quote).
-    std::optional<std::vector<std::wstring>> SplitCsvRecord(const std::wstring& input)
-    {
-        std::vector<std::wstring> fields;
-        std::wstring field;
-        const size_t length = input.size();
-        size_t i = 0;
-
-        while (true)
-        {
-            field.clear();
-            if (i < length && input[i] == L'"')
-            {
-                ++i;
-                bool closed = false;
-                while (i < length)
-                {
-                    if (input[i] == L'"')
-                    {
-                        if (i + 1 < length && input[i + 1] == L'"')
-                        {
-                            field.push_back(L'"');
-                            i += 2;
-                            continue;
-                        }
-
-                        ++i;
-                        closed = true;
-                        break;
-                    }
-
-                    field.push_back(input[i]);
-                    ++i;
-                }
-
-                if (!closed)
-                {
-                    return std::nullopt; // unterminated quoted field
-                }
-
-                // After a closing quote only a comma (end of field) or end of input is valid.
-                if (i < length && input[i] != L',')
-                {
-                    return std::nullopt;
-                }
-            }
-            else
-            {
-                while (i < length && input[i] != L',')
-                {
-                    field.push_back(input[i]);
-                    ++i;
-                }
-            }
-
-            fields.push_back(field);
-            if (i >= length)
-            {
-                break;
-            }
-
-            ++i; // consume the ',' and start the next field
-        }
-
-        return fields;
-    }
-
-    // CSV-quotes a "key=value" token when it contains a comma, quote, CR, LF, or a leading space, doubling
-    // any embedded quote. Mirrors Go's encoding/csv writer that buildx uses, so the emitted spec parses
-    // back to the same fields.
-    std::wstring CsvQuoteField(const std::wstring& field)
-    {
-        const bool needsQuote = field.find_first_of(L",\"\r\n") != std::wstring::npos ||
-                                (!field.empty() && (field.front() == L' ' || field.back() == L' '));
-        if (!needsQuote)
-        {
-            return field;
-        }
-
-        std::wstring quoted;
-        quoted.reserve(field.size() + 2);
-        quoted.push_back(L'"');
-        for (const auto ch : field)
-        {
-            if (ch == L'"')
-            {
-                quoted.push_back(L'"');
-            }
-
-            quoted.push_back(ch);
-        }
-
-        quoted.push_back(L'"');
-        return quoted;
-    }
-
-} // namespace
-
 services::BuildOutput ParseOutputSpec(const std::wstring& spec)
 {
     // Mirrors `docker buildx build --output`. A bare token is shorthand for a destination; otherwise
@@ -315,7 +212,7 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
     // buildx parses the spec as one CSV record (go-csvvalue / encoding/csv): fields are comma
     // separated, a field may be double-quoted, "" inside a quoted field is a literal quote, and a
     // comma inside quotes is part of the value. This lets a value such as an annotation contain commas.
-    const auto fields = SplitCsvRecord(spec);
+    const auto fields = SplitCsvFields(spec);
     if (!fields.has_value())
     {
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, L"malformed quoting"));
@@ -479,28 +376,20 @@ std::wstring FormatOutputSpec(const services::BuildOutput& output)
 {
     // buildx consumes the same CSV key=value form we parsed, so we round-trip the parsed struct back
     // into a canonical spec. This is what actually reaches `docker build --output <spec>`. Each token
-    // is CSV-quoted so a value containing a comma or quote survives the trip.
-    std::wstring spec;
-    const auto append = [&](const std::wstring& token) {
-        if (!spec.empty())
-        {
-            spec.push_back(L',');
-        }
-        spec += CsvQuoteField(token);
-    };
-
-    append(std::format(L"type={}", output.Type));
+    // is CSV-escaped so a value containing a comma or quote survives the trip.
+    std::vector<std::wstring> fields;
+    fields.push_back(std::format(L"type={}", output.Type));
     if (!output.Dest.empty())
     {
-        append(std::format(L"dest={}", output.Dest));
+        fields.push_back(std::format(L"dest={}", output.Dest));
     }
 
     for (const auto& [key, value] : output.Attributes)
     {
-        append(std::format(L"{}={}", key, value));
+        fields.push_back(std::format(L"{}={}", key, value));
     }
 
-    return spec;
+    return JoinCsvFields(fields);
 }
 
 std::tuple<std::string, int64_t, int64_t> ParseUlimit(const std::wstring& input, const std::wstring& argName)

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -223,7 +223,7 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
 
     // Shorthand: a single field that is exactly the input and does not start with "type=" names the
     // destination. Matching Docker, '-' streams a tarball to stdout ('type=tar,dest=-'); anything else
-    // exports the final stage's filesystem to that local path ('type=local,dest=<path>').
+    // is the local (directory) exporter ('type=local,dest=<path>'), which is not supported.
     if (fields->size() == 1 && fields->front() == spec && spec.compare(0, 5, L"type=") != 0)
     {
         if (fields->front() == L"-")
@@ -231,7 +231,11 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
             return services::BuildOutput{.Type = L"tar", .Dest = L"-"};
         }
 
-        return services::BuildOutput{.Type = L"local", .Dest = fields->front()};
+        throw ArgumentException(
+            Localization::MessageWslcOutputInvalidSpec(
+                spec,
+                L"directory exporters are not supported; write a single file with 'dest=<file>' (type=tar/oci/docker) "
+                L"or stream a tarball to stdout with 'type=tar,dest=-'"));
     }
 
     services::BuildOutput output;
@@ -303,20 +307,19 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
     }
 
     // Destination resolution, mirroring `docker buildx build --output`:
-    const bool destIsStdout = output.Dest == L"-";
     if (OutputIsDirectory(output))
     {
-        // Directory exporters (local, or oci/docker with tar=false) write a tree, so they need a path
-        // and cannot stream to stdout.
-        if (output.Dest.empty() || destIsStdout)
-        {
-            throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
+        // Directory exporters (local, or oci/docker with tar=false) write a Linux directory tree, which
+        // cannot be materialized faithfully on a Windows destination, so they are not supported. Point
+        // users at the single-file exporters instead.
+        throw ArgumentException(
+            Localization::MessageWslcOutputInvalidSpec(
                 spec,
-                L"this exporter writes a directory tree, so pass a directory path via 'dest=' (use 'type=tar,dest=-' "
-                L"to stream a tarball to stdout instead)"));
-        }
+                L"directory exporters are not supported; write a single file with 'dest=<file>' (type=tar/oci/docker) "
+                L"or stream a tarball to stdout with 'type=tar,dest=-'"));
     }
-    else if (output.Type == L"tar" || output.Type == L"oci")
+
+    if (output.Type == L"tar" || output.Type == L"oci")
     {
         // Single-tarball exporters stream to stdout when no destination is given (buildx default).
         if (output.Dest.empty())
@@ -620,8 +623,8 @@ models::FormatType GetFormatTypeFromString(const std::wstring& input, const std:
     }
     else
     {
-        throw ArgumentException(std::format(
-            L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
+        throw ArgumentException(
+            std::format(L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
     }
 }
 

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -236,15 +236,14 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         return value;
     };
 
-    // Shorthand: a single token with no '=' names the destination. '-' would stream a tarball to
-    // stdout, which we disallow (see the tar+stdout rejection below); anything else exports the final
-    // stage's filesystem to that local path.
+    // Shorthand: a single token with no '=' names the destination. Matching Docker, '-' streams a
+    // tarball to stdout ('type=tar,dest=-'); anything else exports the final stage's filesystem to
+    // that local path ('type=local,dest=<path>').
     if (fields.size() == 1 && fields[0].find(L'=') == std::wstring::npos)
     {
         if (fields[0] == L"-")
         {
-            throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
-                spec, L"streaming a tarball to stdout is not supported; use 'dest=' with a file path"));
+            return services::BuildOutput{.Type = L"tar", .Dest = L"-"};
         }
 
         return services::BuildOutput{.Type = L"local", .Dest = fields[0]};
@@ -302,11 +301,14 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"'type={}' requires 'dest='", output.Type)));
     }
 
-    // Streaming a tarball to stdout ('dest=-') is not supported; require a real file path instead.
-    if (output.Type == L"tar" && output.Dest == L"-")
+    // Mirroring Docker: the local exporter writes a directory tree and so cannot stream to stdout.
+    // tar/oci/docker stream fine and image/registry/cacheonly ignore 'dest', so only local is rejected.
+    if (output.Type == L"local" && output.Dest == L"-")
     {
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
-            spec, L"streaming a tarball to stdout is not supported; use 'dest=' with a file path"));
+            spec,
+            L"dest cannot be stdout for local exporter; the local exporter writes a directory tree, so pass a directory "
+            L"path via 'dest=' (or use 'type=tar,dest=-' to stream a tarball to stdout)"));
     }
 
     // The registry exporter pushes to a named reference, so 'name=' is mandatory.

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -199,29 +199,126 @@ services::BuildSecret ParseSecretSpec(const std::wstring& spec)
     };
 }
 
+namespace {
+
+    // Splits a single CSV record (RFC 4180) as buildx does via go-csvvalue / encoding/csv: fields are
+    // comma separated, a field may be wrapped in double quotes, a doubled quote inside a quoted field is
+    // a literal quote, and a comma inside a quoted field is part of the value. Returns std::nullopt when
+    // the record is malformed (an unterminated quoted field, or extra text right after a closing quote).
+    std::optional<std::vector<std::wstring>> SplitCsvRecord(const std::wstring& input)
+    {
+        std::vector<std::wstring> fields;
+        std::wstring field;
+        const size_t length = input.size();
+        size_t i = 0;
+
+        while (true)
+        {
+            field.clear();
+            if (i < length && input[i] == L'"')
+            {
+                ++i;
+                bool closed = false;
+                while (i < length)
+                {
+                    if (input[i] == L'"')
+                    {
+                        if (i + 1 < length && input[i + 1] == L'"')
+                        {
+                            field.push_back(L'"');
+                            i += 2;
+                            continue;
+                        }
+
+                        ++i;
+                        closed = true;
+                        break;
+                    }
+
+                    field.push_back(input[i]);
+                    ++i;
+                }
+
+                if (!closed)
+                {
+                    return std::nullopt; // unterminated quoted field
+                }
+
+                // After a closing quote only a comma (end of field) or end of input is valid.
+                if (i < length && input[i] != L',')
+                {
+                    return std::nullopt;
+                }
+            }
+            else
+            {
+                while (i < length && input[i] != L',')
+                {
+                    field.push_back(input[i]);
+                    ++i;
+                }
+            }
+
+            fields.push_back(field);
+            if (i >= length)
+            {
+                break;
+            }
+
+            ++i; // consume the ',' and start the next field
+        }
+
+        return fields;
+    }
+
+    // CSV-quotes a "key=value" token when it contains a comma, quote, CR, LF, or a leading space, doubling
+    // any embedded quote. Mirrors Go's encoding/csv writer that buildx uses, so the emitted spec parses
+    // back to the same fields.
+    std::wstring CsvQuoteField(const std::wstring& field)
+    {
+        const bool needsQuote = field.find_first_of(L",\"\r\n") != std::wstring::npos ||
+                                (!field.empty() && (field.front() == L' ' || field.back() == L' '));
+        if (!needsQuote)
+        {
+            return field;
+        }
+
+        std::wstring quoted;
+        quoted.reserve(field.size() + 2);
+        quoted.push_back(L'"');
+        for (const auto ch : field)
+        {
+            if (ch == L'"')
+            {
+                quoted.push_back(L'"');
+            }
+
+            quoted.push_back(ch);
+        }
+
+        quoted.push_back(L'"');
+        return quoted;
+    }
+
+} // namespace
+
 services::BuildOutput ParseOutputSpec(const std::wstring& spec)
 {
     // Mirrors `docker buildx build --output`. A bare token is shorthand for a destination; otherwise
-    // the spec is a comma separated list of key=value pairs where 'type'/'dest' are structural and
-    // every other key is forwarded verbatim to buildx as an exporter attribute.
+    // the spec is a single CSV record of key=value pairs where 'type'/'dest' are structural and every
+    // other key is forwarded verbatim to buildx as an exporter attribute.
     if (spec.empty())
     {
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, L"the value may not be empty"));
     }
 
-    // Split on ',' preserving empty fields. Unlike the shared Split helper (which drops them), an
-    // empty field such as in "type=local,,dest=x" is a malformed spec that must be rejected.
-    std::vector<std::wstring> fields;
-    for (size_t start = 0;;)
+    // buildx parses the spec as one CSV record (go-csvvalue / encoding/csv): fields are comma
+    // separated, a field may be double-quoted, "" inside a quoted field is a literal quote, and a
+    // comma inside quotes is part of the value. This lets a value such as an annotation contain commas.
+    const auto fields = SplitCsvRecord(spec);
+    if (!fields.has_value())
     {
-        const auto pos = spec.find(L',', start);
-        if (pos == std::wstring::npos)
-        {
-            fields.emplace_back(spec.substr(start));
-            break;
-        }
-        fields.emplace_back(spec.substr(start, pos - start));
-        start = pos + 1;
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, L"malformed quoting"));
     }
 
     // Keys are ASCII and matched case-insensitively; lowercase them without touching values.
@@ -236,50 +333,67 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         return value;
     };
 
-    // Shorthand: a single token with no '=' names the destination. Matching Docker, '-' streams a
-    // tarball to stdout ('type=tar,dest=-'); anything else exports the final stage's filesystem to
-    // that local path ('type=local,dest=<path>').
-    if (fields.size() == 1 && fields[0].find(L'=') == std::wstring::npos)
+    // Trim ASCII spaces/tabs (buildx TrimSpace's the key so " dest=x" after a comma is accepted).
+    const auto trim = [](const std::wstring& value) {
+        const auto first = value.find_first_not_of(L" \t");
+        if (first == std::wstring::npos)
+        {
+            return std::wstring{};
+        }
+        const auto last = value.find_last_not_of(L" \t");
+        return value.substr(first, last - first + 1);
+    };
+
+    // Shorthand: a single field that is exactly the input and does not start with "type=" names the
+    // destination. Matching Docker, '-' streams a tarball to stdout ('type=tar,dest=-'); anything else
+    // exports the final stage's filesystem to that local path ('type=local,dest=<path>').
+    if (fields->size() == 1 && fields->front() == spec && spec.compare(0, 5, L"type=") != 0)
     {
-        if (fields[0] == L"-")
+        if (fields->front() == L"-")
         {
             return services::BuildOutput{.Type = L"tar", .Dest = L"-"};
         }
 
-        return services::BuildOutput{.Type = L"local", .Dest = fields[0]};
+        return services::BuildOutput{.Type = L"local", .Dest = fields->front()};
     }
 
     services::BuildOutput output;
     std::wstring rawType;
     bool hasType = false;
-    bool hasDest = false;
 
-    for (const auto& field : fields)
+    for (const auto& field : *fields)
     {
-        const auto kv = SplitKeyValue(field);
-        if (!kv.HadSeparator || kv.Key.empty())
+        // buildx splits each field on the FIRST '=' and requires two parts; the value is not trimmed.
+        const auto pos = field.find(L'=');
+        if (pos == std::wstring::npos)
         {
             throw ArgumentException(
                 Localization::MessageWslcOutputInvalidSpec(spec, L"expected key=value pairs separated by ','"));
         }
 
-        const auto key = toLower(kv.Key);
+        const auto key = toLower(trim(field.substr(0, pos)));
+        auto value = field.substr(pos + 1);
+        if (key.empty())
+        {
+            throw ArgumentException(
+                Localization::MessageWslcOutputInvalidSpec(spec, L"expected key=value pairs separated by ','"));
+        }
+
         if (key == L"type")
         {
-            rawType = kv.Value;
-            output.Type = toLower(kv.Value);
+            rawType = value;
+            output.Type = toLower(value);
             hasType = true;
         }
         else if (key == L"dest")
         {
-            output.Dest = kv.Value;
-            hasDest = true;
+            output.Dest = std::move(value);
         }
         else
         {
-            // Remaining attributes (name, push, compression, annotations, ...) are matched
-            // case-insensitively by buildx, so normalize their keys to lowercase like type/dest above.
-            output.Attributes[toLower(kv.Key)] = kv.Value;
+            // Remaining attributes (name, push, compression, tar, annotations, ...) are matched
+            // case-insensitively by buildx, so their keys are already lowercased above.
+            output.Attributes[key] = std::move(value);
         }
     }
 
@@ -288,6 +402,8 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, L"type is required"));
     }
 
+    // buildx forwards the type to buildkit and only rejects it there; we route the exporter ourselves,
+    // so an unroutable type has to be rejected up front. Every real exporter is in this list.
     const bool supportedType = output.Type == L"local" || output.Type == L"tar" || output.Type == L"oci" ||
                                output.Type == L"docker" || output.Type == L"image" || output.Type == L"registry" ||
                                output.Type == L"cacheonly";
@@ -296,49 +412,92 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"unsupported output type '{}'", rawType)));
     }
 
-    // Filesystem/tarball exporters write to a caller-provided location, so 'dest=' is mandatory.
-    if ((output.Type == L"local" || output.Type == L"tar" || output.Type == L"oci") && (!hasDest || output.Dest.empty()))
+    // Destination resolution, mirroring `docker buildx build --output`:
+    const bool destIsStdout = output.Dest == L"-";
+    if (OutputIsDirectory(output))
     {
-        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"'type={}' requires 'dest='", output.Type)));
-    }
-
-    // Mirroring Docker: the local exporter writes a directory tree and so cannot stream to stdout.
-    // tar/oci/docker stream fine and image/registry/cacheonly ignore 'dest', so only local is rejected.
-    if (output.Type == L"local" && output.Dest == L"-")
-    {
-        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
-            spec,
-            L"dest cannot be stdout for local exporter; the local exporter writes a directory tree, so pass a directory "
-            L"path via 'dest=' (or use 'type=tar,dest=-' to stream a tarball to stdout)"));
-    }
-
-    // The registry exporter pushes to a named reference, so 'name=' is mandatory.
-    if (output.Type == L"registry")
-    {
-        const auto it = output.Attributes.find(L"name");
-        if (it == output.Attributes.end() || it->second.empty())
+        // Directory exporters (local, or oci/docker with tar=false) write a tree, so they need a path
+        // and cannot stream to stdout.
+        if (output.Dest.empty() || destIsStdout)
         {
-            throw ArgumentException(
-                Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"'type={}' requires 'name='", output.Type)));
+            throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
+                spec,
+                L"this exporter writes a directory tree, so pass a directory path via 'dest=' (use 'type=tar,dest=-' "
+                L"to stream a tarball to stdout instead)"));
         }
     }
+    else if (output.Type == L"tar" || output.Type == L"oci")
+    {
+        // Single-tarball exporters stream to stdout when no destination is given (buildx default).
+        if (output.Dest.empty())
+        {
+            output.Dest = L"-";
+        }
+    }
+    // docker: no dest -> load into the VM image store (leave empty); dest='-' streams a tarball to
+    //         stdout; a path writes a file. image/registry/cacheonly run in the VM and ignore 'dest'.
 
     return output;
 }
 
+bool OutputStreamsToClient(const services::BuildOutput& output)
+{
+    if (output.Type == L"local" || output.Type == L"tar" || output.Type == L"oci")
+    {
+        return true;
+    }
+
+    if (output.Type == L"docker")
+    {
+        // An omitted destination loads the image into the store in the VM; any destination (a file or
+        // stdout '-') is produced in the VM and streamed back to the client.
+        return !output.Dest.empty();
+    }
+
+    // image / registry / cacheonly run entirely in the build VM.
+    return false;
+}
+
+bool OutputIsDirectory(const services::BuildOutput& output)
+{
+    if (output.Type == L"local")
+    {
+        return true;
+    }
+
+    if (output.Type == L"oci" || output.Type == L"docker")
+    {
+        // oci/docker default to a single tarball but export an OCI layout directory when tar=false.
+        const auto it = output.Attributes.find(L"tar");
+        return it != output.Attributes.end() && it->second == L"false";
+    }
+
+    return false;
+}
+
 std::wstring FormatOutputSpec(const services::BuildOutput& output)
 {
-    // buildx consumes the same comma separated key=value form we parsed, so we round-trip the parsed
-    // struct back into a canonical spec. This is what actually reaches `docker build --output <spec>`.
-    std::wstring spec = std::format(L"type={}", output.Type);
+    // buildx consumes the same CSV key=value form we parsed, so we round-trip the parsed struct back
+    // into a canonical spec. This is what actually reaches `docker build --output <spec>`. Each token
+    // is CSV-quoted so a value containing a comma or quote survives the trip.
+    std::wstring spec;
+    const auto append = [&](const std::wstring& token) {
+        if (!spec.empty())
+        {
+            spec.push_back(L',');
+        }
+        spec += CsvQuoteField(token);
+    };
+
+    append(std::format(L"type={}", output.Type));
     if (!output.Dest.empty())
     {
-        spec += std::format(L",dest={}", output.Dest);
+        append(std::format(L"dest={}", output.Dest));
     }
 
     for (const auto& [key, value] : output.Attributes)
     {
-        spec += std::format(L",{}={}", key, value);
+        append(std::format(L"{}={}", key, value));
     }
 
     return spec;

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -231,11 +231,10 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
             return services::BuildOutput{.Type = L"tar", .Dest = L"-"};
         }
 
-        throw ArgumentException(
-            Localization::MessageWslcOutputInvalidSpec(
-                spec,
-                L"directory exporters are not supported; write a single file with 'dest=<file>' (type=tar/oci/docker) "
-                L"or stream a tarball to stdout with 'type=tar,dest=-'"));
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
+            spec,
+            L"directory exporters are not supported; write a single file with 'dest=<file>' (type=tar/oci/docker) "
+            L"or stream a tarball to stdout with 'type=tar,dest=-'"));
     }
 
     services::BuildOutput output;
@@ -312,11 +311,10 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         // Directory exporters (local, or oci/docker with tar=false) write a Linux directory tree, which
         // cannot be materialized faithfully on a Windows destination, so they are not supported. Point
         // users at the single-file exporters instead.
-        throw ArgumentException(
-            Localization::MessageWslcOutputInvalidSpec(
-                spec,
-                L"directory exporters are not supported; write a single file with 'dest=<file>' (type=tar/oci/docker) "
-                L"or stream a tarball to stdout with 'type=tar,dest=-'"));
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
+            spec,
+            L"directory exporters are not supported; write a single file with 'dest=<file>' (type=tar/oci/docker) "
+            L"or stream a tarball to stdout with 'type=tar,dest=-'"));
     }
 
     if (output.Type == L"tar" || output.Type == L"oci")
@@ -623,8 +621,8 @@ models::FormatType GetFormatTypeFromString(const std::wstring& input, const std:
     }
     else
     {
-        throw ArgumentException(
-            std::format(L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
+        throw ArgumentException(std::format(
+            L"Invalid {} value: {} is not a recognized format type. Supported format types are: json, table.", argName, input));
     }
 }
 

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -236,13 +236,15 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         return value;
     };
 
-    // Shorthand: a single token with no '=' names the destination. '-' streams a tarball to stdout;
-    // anything else exports the final stage's filesystem to that local path.
+    // Shorthand: a single token with no '=' names the destination. '-' would stream a tarball to
+    // stdout, which we disallow (see the tar+stdout rejection below); anything else exports the final
+    // stage's filesystem to that local path.
     if (fields.size() == 1 && fields[0].find(L'=') == std::wstring::npos)
     {
         if (fields[0] == L"-")
         {
-            return services::BuildOutput{.Type = L"tar", .Dest = L"-"};
+            throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
+                spec, L"streaming a tarball to stdout is not supported; use 'dest=' with a file path"));
         }
 
         return services::BuildOutput{.Type = L"local", .Dest = fields[0]};
@@ -298,6 +300,13 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
     if ((output.Type == L"local" || output.Type == L"tar" || output.Type == L"oci") && (!hasDest || output.Dest.empty()))
     {
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"'type={}' requires 'dest='", output.Type)));
+    }
+
+    // Streaming a tarball to stdout ('dest=-') is not supported; require a real file path instead.
+    if (output.Type == L"tar" && output.Dest == L"-")
+    {
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(
+            spec, L"streaming a tarball to stdout is not supported; use 'dest=' with a file path"));
     }
 
     // The registry exporter pushes to a named reference, so 'name=' is mandatory.

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -199,6 +199,139 @@ services::BuildSecret ParseSecretSpec(const std::wstring& spec)
     };
 }
 
+services::BuildOutput ParseOutputSpec(const std::wstring& spec)
+{
+    // Mirrors `docker buildx build --output`. A bare token is shorthand for a destination; otherwise
+    // the spec is a comma separated list of key=value pairs where 'type'/'dest' are structural and
+    // every other key is forwarded verbatim to buildx as an exporter attribute.
+    if (spec.empty())
+    {
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, L"the value may not be empty"));
+    }
+
+    // Split on ',' preserving empty fields. Unlike the shared Split helper (which drops them), an
+    // empty field such as in "type=local,,dest=x" is a malformed spec that must be rejected.
+    std::vector<std::wstring> fields;
+    for (size_t start = 0;;)
+    {
+        const auto pos = spec.find(L',', start);
+        if (pos == std::wstring::npos)
+        {
+            fields.emplace_back(spec.substr(start));
+            break;
+        }
+        fields.emplace_back(spec.substr(start, pos - start));
+        start = pos + 1;
+    }
+
+    // Keys are ASCII and matched case-insensitively; lowercase them without touching values.
+    const auto toLower = [](std::wstring value) {
+        for (auto& ch : value)
+        {
+            if (ch >= L'A' && ch <= L'Z')
+            {
+                ch = static_cast<wchar_t>(ch - L'A' + L'a');
+            }
+        }
+        return value;
+    };
+
+    // Shorthand: a single token with no '=' names the destination. '-' streams a tarball to stdout;
+    // anything else exports the final stage's filesystem to that local path.
+    if (fields.size() == 1 && fields[0].find(L'=') == std::wstring::npos)
+    {
+        if (fields[0] == L"-")
+        {
+            return services::BuildOutput{.Type = L"tar", .Dest = L"-"};
+        }
+
+        return services::BuildOutput{.Type = L"local", .Dest = fields[0]};
+    }
+
+    services::BuildOutput output;
+    std::wstring rawType;
+    bool hasType = false;
+    bool hasDest = false;
+
+    for (const auto& field : fields)
+    {
+        const auto kv = SplitKeyValue(field);
+        if (!kv.HadSeparator || kv.Key.empty())
+        {
+            throw ArgumentException(
+                Localization::MessageWslcOutputInvalidSpec(spec, L"expected key=value pairs separated by ','"));
+        }
+
+        const auto key = toLower(kv.Key);
+        if (key == L"type")
+        {
+            rawType = kv.Value;
+            output.Type = toLower(kv.Value);
+            hasType = true;
+        }
+        else if (key == L"dest")
+        {
+            output.Dest = kv.Value;
+            hasDest = true;
+        }
+        else
+        {
+            // Remaining attributes (name, push, compression, annotations, ...) are stored verbatim.
+            output.Attributes[kv.Key] = kv.Value;
+        }
+    }
+
+    if (!hasType || output.Type.empty())
+    {
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, L"type is required"));
+    }
+
+    const bool supportedType = output.Type == L"local" || output.Type == L"tar" || output.Type == L"oci" ||
+                               output.Type == L"docker" || output.Type == L"image" || output.Type == L"registry" ||
+                               output.Type == L"cacheonly";
+    if (!supportedType)
+    {
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"unsupported output type '{}'", rawType)));
+    }
+
+    // Filesystem/tarball exporters write to a caller-provided location, so 'dest=' is mandatory.
+    if ((output.Type == L"local" || output.Type == L"tar" || output.Type == L"oci") && (!hasDest || output.Dest.empty()))
+    {
+        throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"'type={}' requires 'dest='", output.Type)));
+    }
+
+    // The registry exporter pushes to a named reference, so 'name=' is mandatory.
+    if (output.Type == L"registry")
+    {
+        const auto it = output.Attributes.find(L"name");
+        if (it == output.Attributes.end() || it->second.empty())
+        {
+            throw ArgumentException(
+                Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"'type={}' requires 'name='", output.Type)));
+        }
+    }
+
+    return output;
+}
+
+std::wstring FormatOutputSpec(const services::BuildOutput& output)
+{
+    // buildx consumes the same comma separated key=value form we parsed, so we round-trip the parsed
+    // struct back into a canonical spec. This is what actually reaches `docker build --output <spec>`.
+    std::wstring spec = std::format(L"type={}", output.Type);
+    if (!output.Dest.empty())
+    {
+        spec += std::format(L",dest={}", output.Dest);
+    }
+
+    for (const auto& [key, value] : output.Attributes)
+    {
+        spec += std::format(L",{}={}", key, value);
+    }
+
+    return spec;
+}
+
 std::tuple<std::string, int64_t, int64_t> ParseUlimit(const std::wstring& input, const std::wstring& argName)
 {
     // Accepts <name>=<soft>[:<hard>]; if hard is omitted hard = soft. -1 means unlimited.

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -277,8 +277,9 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         }
         else
         {
-            // Remaining attributes (name, push, compression, annotations, ...) are stored verbatim.
-            output.Attributes[kv.Key] = kv.Value;
+            // Remaining attributes (name, push, compression, annotations, ...) are matched
+            // case-insensitively by buildx, so normalize their keys to lowercase like type/dest above.
+            output.Attributes[toLower(kv.Key)] = kv.Value;
         }
     }
 

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -218,28 +218,8 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, L"malformed quoting"));
     }
 
-    // Keys are ASCII and matched case-insensitively; lowercase them without touching values.
-    const auto toLower = [](std::wstring value) {
-        for (auto& ch : value)
-        {
-            if (ch >= L'A' && ch <= L'Z')
-            {
-                ch = static_cast<wchar_t>(ch - L'A' + L'a');
-            }
-        }
-        return value;
-    };
-
-    // Trim ASCII spaces/tabs (buildx TrimSpace's the key so " dest=x" after a comma is accepted).
-    const auto trim = [](const std::wstring& value) {
-        const auto first = value.find_first_not_of(L" \t");
-        if (first == std::wstring::npos)
-        {
-            return std::wstring{};
-        }
-        const auto last = value.find_last_not_of(L" \t");
-        return value.substr(first, last - first + 1);
-    };
+    // Keys are ASCII and matched case-insensitively, and buildx TrimSpace's each key so " dest=x" after
+    // a comma is accepted; values are left untouched. AsciiToLower/TrimAscii live in stringshared.h.
 
     // Shorthand: a single field that is exactly the input and does not start with "type=" names the
     // destination. Matching Docker, '-' streams a tarball to stdout ('type=tar,dest=-'); anything else
@@ -268,7 +248,7 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
                 Localization::MessageWslcOutputInvalidSpec(spec, L"expected key=value pairs separated by ','"));
         }
 
-        const auto key = toLower(trim(field.substr(0, pos)));
+        const auto key = AsciiToLower(TrimAscii(std::wstring_view(field).substr(0, pos)));
         auto value = field.substr(pos + 1);
         if (key.empty())
         {
@@ -279,7 +259,7 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
         if (key == L"type")
         {
             rawType = value;
-            output.Type = toLower(value);
+            output.Type = AsciiToLower(std::wstring_view(value));
             hasType = true;
         }
         else if (key == L"dest")
@@ -307,6 +287,19 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec)
     if (!supportedType)
     {
         throw ArgumentException(Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"unsupported output type '{}'", rawType)));
+    }
+
+    // The 'tar' attribute selects a single tarball vs. an OCI layout directory for oci/docker, and it
+    // drives file-vs-directory routing here. buildx parses it with Go's ParseBool and errors on
+    // anything else, so reject an invalid value up front rather than failing confusingly in the VM.
+    if (output.Type == L"oci" || output.Type == L"docker")
+    {
+        const auto tarIt = output.Attributes.find(L"tar");
+        if (tarIt != output.Attributes.end() && !ParseBool(tarIt->second.c_str(), true).has_value())
+        {
+            throw ArgumentException(
+                Localization::MessageWslcOutputInvalidSpec(spec, std::format(L"invalid boolean value '{}' for 'tar'", tarIt->second)));
+        }
     }
 
     // Destination resolution, mirroring `docker buildx build --output`:
@@ -364,9 +357,13 @@ bool OutputIsDirectory(const services::BuildOutput& output)
 
     if (output.Type == L"oci" || output.Type == L"docker")
     {
-        // oci/docker default to a single tarball but export an OCI layout directory when tar=false.
+        // oci/docker default to a single tarball but export an OCI layout directory when tar is false.
         const auto it = output.Attributes.find(L"tar");
-        return it != output.Attributes.end() && it->second == L"false";
+        if (it != output.Attributes.end())
+        {
+            const auto tar = ParseBool(it->second.c_str(), true);
+            return tar.has_value() && !tar.value();
+        }
     }
 
     return false;

--- a/src/windows/wslc/arguments/SpecParsing.h
+++ b/src/windows/wslc/arguments/SpecParsing.h
@@ -23,7 +23,8 @@ Abstract:
 
 namespace wsl::windows::wslc::services {
 struct BuildSecret;
-}
+struct BuildOutput;
+} // namespace wsl::windows::wslc::services
 
 namespace wsl::windows::wslc::validation {
 
@@ -42,6 +43,12 @@ KeyValueSplit SplitKeyValue(const std::wstring& value, wchar_t separator = L'=')
 
 // Parses a docker-style --secret spec ("id=...,type=...,src=...") and resolves its value bytes.
 services::BuildSecret ParseSecretSpec(const std::wstring& spec);
+
+// Parses a docker-style --output spec ("type=...,dest=...,<attr>=...") into a BuildOutput.
+services::BuildOutput ParseOutputSpec(const std::wstring& spec);
+
+// Serializes a BuildOutput back into a canonical buildx --output spec ("type=...,dest=...,<attr>=...").
+std::wstring FormatOutputSpec(const services::BuildOutput& output);
 
 // Parses a --ulimit spec ("<name>=<soft>[:<hard>]") into (name, soft, hard). -1 means unlimited.
 std::tuple<std::string, int64_t, int64_t> ParseUlimit(const std::wstring& input, const std::wstring& argName = {});

--- a/src/windows/wslc/arguments/SpecParsing.h
+++ b/src/windows/wslc/arguments/SpecParsing.h
@@ -50,6 +50,16 @@ services::BuildOutput ParseOutputSpec(const std::wstring& spec);
 // Serializes a BuildOutput back into a canonical buildx --output spec ("type=...,dest=...,<attr>=...").
 std::wstring FormatOutputSpec(const services::BuildOutput& output);
 
+// True when the exporter produces a destination (file, directory, or stdout stream) that the client
+// must materialize, versus running entirely in the build VM. Mirrors `docker buildx build --output`:
+// local/tar/oci always stream a result back; docker streams only when a 'dest=' is given (an omitted
+// dest loads the image into the VM store); image/registry/cacheonly never stream.
+bool OutputStreamsToClient(const services::BuildOutput& output);
+
+// True when the exporter writes a directory tree rather than a single file/stream. The local exporter
+// is always a directory; oci/docker export an OCI layout directory when 'tar=false' is set.
+bool OutputIsDirectory(const services::BuildOutput& output);
+
 // Parses a --ulimit spec ("<name>=<soft>[:<hard>]") into (name, soft, hard). -1 means unlimited.
 std::tuple<std::string, int64_t, int64_t> ParseUlimit(const std::wstring& input, const std::wstring& argName = {});
 

--- a/src/windows/wslc/commands/ImageBuildCommand.cpp
+++ b/src/windows/wslc/commands/ImageBuildCommand.cpp
@@ -34,6 +34,7 @@ std::vector<Argument> ImageBuildCommand::GetArguments() const
         Argument::Create(ArgType::File),
         Argument::Create(ArgType::Label, false, Limit::Unlimited),
         Argument::Create(ArgType::NoCache),
+        Argument::Create(ArgType::Output, false, std::nullopt, Localization::WSLCCLI_BuildOutputArgDescription()),
         Argument::Create(ArgType::Secret, false, Limit::Unlimited),
         Argument::Create(ArgType::Tag, false, Limit::Unlimited),
         Argument::Create(ArgType::Verbose),

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -121,6 +121,7 @@ void ImageService::Build(
     const std::vector<BuildSecret>& secrets,
     const std::wstring& dockerfilePath,
     const std::wstring& target,
+    const std::wstring& output,
     WSLCBuildImageFlags flags,
     IProgressCallback* callback,
     HANDLE cancelEvent)
@@ -190,6 +191,7 @@ void ImageService::Build(
     }
 
     auto targetStr = wsl::windows::common::string::WideToMultiByte(target);
+    auto outputStr = wsl::windows::common::string::WideToMultiByte(output);
 
     auto contextPathStr = absolutePath.wstring();
     WSLCBuildImageOptions options{
@@ -201,6 +203,7 @@ void ImageService::Build(
         .Flags = flags,
         .Labels = {labelPointers.data(), static_cast<ULONG>(labelPointers.size())},
         .Secrets = {secretEntries.data(), static_cast<ULONG>(secretEntries.size())},
+        .Output = outputStr.empty() ? nullptr : outputStr.c_str(),
     };
 
     THROW_IF_FAILED(session.Get()->BuildImage(&options, callback, cancelEvent));

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -252,11 +252,18 @@ void ImageService::Build(
             std::filesystem::create_directories(std::filesystem::absolute(spec.Dest), dirError);
             THROW_HR_IF_MSG(HRESULT_FROM_WIN32(dirError.value()), !!dirError, "Failed to create directory: %ls", spec.Dest.c_str());
 
-            // Strip any trailing separator so the CRT does not parse '\"' as an escaped quote.
+            // Strip a trailing separator so the CRT does not parse '\"' as an escaped quote.
             auto destDir = std::filesystem::absolute(spec.Dest).wstring();
             while (destDir.size() > 1 && (destDir.back() == L'\\' || destDir.back() == L'/'))
             {
                 destDir.pop_back();
+            }
+
+            // A drive root like "C:\\" collapses to "C:" above, which tar treats as the current
+            // directory on that drive rather than its root; restore a rooted path in that case.
+            if (destDir.size() == 2 && destDir[1] == L':')
+            {
+                destDir += L"\\.";
             }
 
             auto [pipeRead, pipeWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(0, false, false);

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -264,9 +264,7 @@ void ImageService::Build(
                 // destination in place.
                 auto destPath = std::filesystem::absolute(spec.Dest);
                 auto destDir = destPath.parent_path();
-                std::error_code dirError;
-                std::filesystem::create_directories(destDir, dirError);
-                THROW_HR_IF_MSG(HRESULT_FROM_WIN32(dirError.value()), !!dirError, "Failed to create directory: %ls", destDir.c_str());
+                std::filesystem::create_directories(destDir);
 
                 outputMountPath = destDir.wstring();
                 outputMountFile = destPath.filename().wstring();
@@ -279,9 +277,7 @@ void ImageService::Build(
         }
         else if (isDirExporter)
         {
-            std::error_code dirError;
-            std::filesystem::create_directories(std::filesystem::absolute(spec.Dest), dirError);
-            THROW_HR_IF_MSG(HRESULT_FROM_WIN32(dirError.value()), !!dirError, "Failed to create directory: %ls", spec.Dest.c_str());
+            std::filesystem::create_directories(std::filesystem::absolute(spec.Dest));
 
             // Strip a trailing separator so the CRT does not parse '\"' as an escaped quote.
             auto destDir = std::filesystem::absolute(spec.Dest).wstring();

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -15,7 +15,6 @@ Abstract:
 #include "RegistryService.h"
 #include "SessionService.h"
 #include "SpecParsing.h"
-#include "SubProcess.h"
 #include "WarningCallback.h"
 #include <wslutil.h>
 #include <HandleConsoleProgressBar.h>
@@ -184,24 +183,24 @@ void ImageService::Build(
     for (const auto& secret : secrets)
     {
         secretIdStrings.push_back(wsl::windows::common::string::WideToMultiByte(secret.Id));
-        secretEntries.push_back(WSLCBuildSecret{
-            .Id = secretIdStrings.back().c_str(),
-            .SourcePath = secret.SourcePath.empty() ? nullptr : secret.SourcePath.c_str(),
-            .Value = secret.Value.empty() ? nullptr : secret.Value.data(),
-            .ValueSize = static_cast<ULONG>(secret.Value.size()),
-        });
+        secretEntries.push_back(
+            WSLCBuildSecret{
+                .Id = secretIdStrings.back().c_str(),
+                .SourcePath = secret.SourcePath.empty() ? nullptr : secret.SourcePath.c_str(),
+                .Value = secret.Value.empty() ? nullptr : secret.Value.data(),
+                .ValueSize = static_cast<ULONG>(secret.Value.size()),
+            });
     }
 
     auto targetStr = wsl::windows::common::string::WideToMultiByte(target);
 
     // Route the docker-style --output exporter. A single-file exporter with a real destination (tar/oci/
     // docker with dest=) has the destination's parent directory mounted read-write into the VM, so buildx
-    // writes the output file straight to the destination in place. dest=- (stdout) and directory exporters
-    // (type=local) are instead streamed back out of the VM to OutputHandle: dest=- to stdout, and
-    // type=local as a tarball the client feeds to tar.exe to extract into the destination directory (a
-    // Linux tree cannot be written faithfully to a Windows-backed mount). Exporters with no client
-    // destination (docker load, image, registry, cacheonly) run entirely in the VM and the spec is
-    // forwarded as-is.
+    // writes the output file straight to the destination in place. dest=- (stdout) streams the exporter
+    // tarball back out of the VM to OutputHandle. Exporters with no client destination (docker load,
+    // image, registry, cacheonly) run entirely in the VM and the spec is forwarded as-is. Directory
+    // exporters (type=local, or oci/docker with tar=false) are rejected up front by ParseOutputSpec: a
+    // Linux tree cannot be written faithfully to a Windows-backed destination.
     std::string outputStr;
     HANDLE outputHandle = nullptr;
 
@@ -211,37 +210,16 @@ void ImageService::Build(
     std::wstring outputMountPath;
     std::wstring outputMountFile;
 
-    // For directory exporters (type=local, or oci/docker with tar=false) the server streams a tarball of
-    // the export directory; the client extracts it into the destination directory by feeding the stream
-    // to `tar.exe -xf -`. These stay alive until after the (synchronous) BuildImage call so the pipe
-    // keeps draining while the server writes.
-    wil::unique_hfile extractPipeWrite;
-    wil::unique_handle extractProcess;
-
-    // Failsafe for the directory (tar.exe) path: if the build throws before we drain tar.exe below,
-    // signal EOF by closing the pipe and, if the process is still running, wait briefly and terminate
-    // it so it cannot leak or block indefinitely on a full pipe. Released on the success path.
-    auto tarCleanup = wil::scope_exit([&] {
-        if (extractProcess)
-        {
-            extractPipeWrite.reset();
-            if (WaitForSingleObject(extractProcess.get(), 30000) != WAIT_OBJECT_0)
-            {
-                TerminateProcess(extractProcess.get(), 1);
-            }
-        }
-    });
-
     if (output.has_value())
     {
         const auto& spec = output.value();
         // Route the exporter the same way `docker buildx build --output` does: some exporters produce a
-        // result the client must materialize (a file, a stdout stream, or a directory tree), while
-        // others run entirely in the build VM. See OutputStreamsToClient / OutputIsDirectory.
+        // result the client must materialize (a file or a stdout stream), while others run entirely in
+        // the build VM. Directory exporters are already rejected by ParseOutputSpec. See
+        // OutputStreamsToClient.
         const bool streamsBack = validation::OutputStreamsToClient(spec);
-        const bool isDirExporter = validation::OutputIsDirectory(spec);
 
-        if (streamsBack && !isDirExporter)
+        if (streamsBack)
         {
             if (spec.Dest == L"-")
             {
@@ -275,42 +253,6 @@ void ImageService::Build(
             vmSpec.Dest.clear();
             outputStr = wsl::windows::common::string::WideToMultiByte(validation::FormatOutputSpec(vmSpec));
         }
-        else if (isDirExporter)
-        {
-            std::filesystem::create_directories(std::filesystem::absolute(spec.Dest));
-
-            // Strip a trailing separator so the CRT does not parse '\"' as an escaped quote.
-            auto destDir = std::filesystem::absolute(spec.Dest).wstring();
-            while (destDir.size() > 1 && (destDir.back() == L'\\' || destDir.back() == L'/'))
-            {
-                destDir.pop_back();
-            }
-
-            // A drive root like "C:\\" collapses to "C:" above, which tar treats as the current
-            // directory on that drive rather than its root; restore a rooted path in that case.
-            if (destDir.size() == 2 && destDir[1] == L':')
-            {
-                destDir += L"\\.";
-            }
-
-            auto [pipeRead, pipeWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(0, false, false);
-            THROW_IF_WIN32_BOOL_FALSE(SetHandleInformation(pipeRead.get(), HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT));
-
-            auto tarCmd = std::format(L"tar.exe -xf - -C \"{}\"", destDir);
-            wsl::windows::common::SubProcess tarProcess(nullptr, tarCmd.c_str());
-            tarProcess.SetStdHandles(pipeRead.get(), nullptr, nullptr);
-            extractProcess = tarProcess.Start();
-            pipeRead.reset();
-
-            extractPipeWrite = std::move(pipeWrite);
-            outputHandle = extractPipeWrite.get();
-            WI_SetFlag(flags, WSLCBuildImageFlagsOutputIsDirectory);
-
-            // The server picks the VM-side export directory, so forward the spec without the client's dest.
-            BuildOutput vmSpec = spec;
-            vmSpec.Dest.clear();
-            outputStr = wsl::windows::common::string::WideToMultiByte(validation::FormatOutputSpec(vmSpec));
-        }
         else
         {
             outputStr = wsl::windows::common::string::WideToMultiByte(validation::FormatOutputSpec(spec));
@@ -334,17 +276,6 @@ void ImageService::Build(
     };
 
     THROW_IF_FAILED(session.Get()->BuildImage(&options, callback, cancelEvent));
-
-    // Signal EOF to tar.exe (the server has finished writing) and confirm it extracted the stream
-    // cleanly. The write end must be reset before waiting so tar sees end-of-input.
-    if (extractProcess)
-    {
-        extractPipeWrite.reset();
-        auto exitCode = wsl::windows::common::SubProcess::GetExitCode(extractProcess.get());
-        THROW_HR_IF_MSG(E_FAIL, exitCode != 0, "tar.exe exited with code %u", exitCode);
-    }
-
-    tarCleanup.release();
 }
 
 std::vector<ImageInformation> ImageService::List(

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -254,17 +254,13 @@ void ImageService::Build(
                 // dest=- streams the exporter tarball to the client's stdout, matching docker.
                 outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
 
-                // Refuse to dump the binary exporter stream onto an interactive console (matching docker);
-                // stdout must be redirected to a file or pipe. Otherwise ToCOMInputHandle would fail the
-                // marshal with a cryptic ERROR_NOT_SUPPORTED for the console handle. A redirected character
-                // device such as NUL is not a console, so IsConsoleHandle (which also checks
-                // GetConsoleMode) still lets those through.
+                // Refuse to dump the binary exporter stream onto an interactive console (matching docker).
+                // Otherwise ToCOMInputHandle would fail the marshal with a cryptic ERROR_NOT_SUPPORTED for
+                // the console handle. A redirected character device such as NUL is not a console, so
+                // IsConsoleHandle (which also checks GetConsoleMode) still lets those through.
                 THROW_HR_WITH_USER_ERROR_IF(
                     E_INVALIDARG,
-                    Localization::MessageWslcOutputInvalidSpec(
-                        validation::FormatOutputSpec(spec),
-                        L"refusing to write build output to the console; redirect stdout to a file or pipe (for example "
-                        L"'> out.tar') or pass 'dest=' with a file path"),
+                    Localization::MessageWslcOutputConsoleNotSupported(validation::FormatOutputSpec(spec)),
                     IsConsoleHandle(outputHandle));
             }
             else

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -194,14 +194,22 @@ void ImageService::Build(
 
     auto targetStr = wsl::windows::common::string::WideToMultiByte(target);
 
-    // Route the docker-style --output exporter. Exporters that write to a caller-provided destination
-    // (tar/oci/docker with dest=, and local) are streamed back out of the VM: the client opens the
-    // destination here, forwards the spec with dest= stripped, and the server writes the exporter
-    // output to a VM temp path then streams it to OutputHandle. Exporters with no client destination
-    // (docker load, image, registry, cacheonly) run entirely in the VM and the spec is forwarded as-is.
+    // Route the docker-style --output exporter. A single-file exporter with a real destination (tar/oci/
+    // docker with dest=) has the destination's parent directory mounted read-write into the VM, so buildx
+    // writes the output file straight to the destination in place. dest=- (stdout) and directory exporters
+    // (type=local) are instead streamed back out of the VM to OutputHandle: dest=- to stdout, and
+    // type=local as a tarball the client feeds to tar.exe to extract into the destination directory (a
+    // Linux tree cannot be written faithfully to a Windows-backed mount). Exporters with no client
+    // destination (docker load, image, registry, cacheonly) run entirely in the VM and the spec is
+    // forwarded as-is.
     std::string outputStr;
     HANDLE outputHandle = nullptr;
-    wil::unique_hfile outputFile;
+
+    // For a single-file exporter with a real destination the server writes the exporter output into a
+    // read-write virtiofs mount of the destination's parent directory rather than streaming it back:
+    // outputMountPath is that parent directory and outputMountFile the destination file's leaf name.
+    std::wstring outputMountPath;
+    std::wstring outputMountFile;
 
     // For directory exporters (type=local, or oci/docker with tar=false) the server streams a tarball of
     // the export directory; the client extracts it into the destination directory by feeding the stream
@@ -221,20 +229,6 @@ void ImageService::Build(
             {
                 TerminateProcess(extractProcess.get(), 1);
             }
-        }
-    });
-
-    // For a single-file exporter the server streams into a client handle. We point that handle at a
-    // sibling temp file and rename it over the destination only after the build succeeds, so a failed
-    // build leaves any existing file intact (buildx uses a lazy writer that never truncates on failure).
-    // These track the pending rename; outputFileTemp is cleared once committed to disarm the cleanup.
-    std::filesystem::path outputFileDest;
-    std::filesystem::path outputFileTemp;
-    auto outputFileCleanup = wil::scope_exit([&] {
-        if (!outputFileTemp.empty())
-        {
-            outputFile.reset();
-            DeleteFileW(outputFileTemp.c_str());
         }
     });
 
@@ -265,23 +259,17 @@ void ImageService::Build(
             }
             else
             {
-                // Create the destination's parent directory (buildx creates missing parents) and stream
-                // into a sibling temp file that is renamed over the destination only on success (below).
+                // Single-file exporter with a real destination: mount the destination's parent directory
+                // read-write into the VM so buildx writes the exporter output file straight to the
+                // destination in place.
                 auto destPath = std::filesystem::absolute(spec.Dest);
+                auto destDir = destPath.parent_path();
                 std::error_code dirError;
-                std::filesystem::create_directories(destPath.parent_path(), dirError);
+                std::filesystem::create_directories(destDir, dirError);
+                THROW_HR_IF_MSG(HRESULT_FROM_WIN32(dirError.value()), !!dirError, "Failed to create directory: %ls", destDir.c_str());
 
-                GUID tempGuid{};
-                THROW_IF_FAILED(CoCreateGuid(&tempGuid));
-                const auto tempSuffix = string::GuidToString<wchar_t>(tempGuid, string::GuidToStringFlags::None);
-                outputFileDest = destPath;
-                outputFileTemp = destPath;
-                outputFileTemp += std::format(L".{}.wslctmp", tempSuffix);
-
-                outputFile.reset(CreateFileW(
-                    outputFileTemp.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
-                THROW_LAST_ERROR_IF_MSG(!outputFile, "Failed to create output file: %ls", spec.Dest.c_str());
-                outputHandle = outputFile.get();
+                outputMountPath = destDir.wstring();
+                outputMountFile = destPath.filename().wstring();
             }
 
             // The server picks the VM-side dest, so forward the spec without the client's dest.
@@ -345,6 +333,8 @@ void ImageService::Build(
         .Secrets = {secretEntries.data(), static_cast<ULONG>(secretEntries.size())},
         .Output = outputStr.empty() ? nullptr : outputStr.c_str(),
         .OutputHandle = outputHandle != nullptr ? ToCOMInputHandle(outputHandle) : WSLCHandle{.Type = WSLCHandleTypeUnknown},
+        .OutputMountPath = outputMountPath.empty() ? nullptr : outputMountPath.c_str(),
+        .OutputMountFile = outputMountFile.empty() ? nullptr : outputMountFile.c_str(),
     };
 
     THROW_IF_FAILED(session.Get()->BuildImage(&options, callback, cancelEvent));
@@ -356,18 +346,6 @@ void ImageService::Build(
         extractPipeWrite.reset();
         auto exitCode = wsl::windows::common::SubProcess::GetExitCode(extractProcess.get());
         THROW_HR_IF_MSG(E_FAIL, exitCode != 0, "tar.exe exited with code %u", exitCode);
-    }
-
-    // The build succeeded, so atomically move the streamed temp file over the destination. The temp
-    // file is a sibling of the destination, so the rename stays on one volume and replaces in place.
-    if (!outputFileTemp.empty())
-    {
-        outputFile.reset();
-        THROW_IF_WIN32_BOOL_FALSE_MSG(
-            MoveFileExW(outputFileTemp.c_str(), outputFileDest.c_str(), MOVEFILE_REPLACE_EXISTING),
-            "Failed to write build output to %ls",
-            outputFileDest.c_str());
-        outputFileTemp.clear();
     }
 
     tarCleanup.release();

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -14,6 +14,8 @@ Abstract:
 #include "ImageService.h"
 #include "RegistryService.h"
 #include "SessionService.h"
+#include "SpecParsing.h"
+#include "SubProcess.h"
 #include "WarningCallback.h"
 #include <wslutil.h>
 #include <HandleConsoleProgressBar.h>
@@ -121,7 +123,7 @@ void ImageService::Build(
     const std::vector<BuildSecret>& secrets,
     const std::wstring& dockerfilePath,
     const std::wstring& target,
-    const std::wstring& output,
+    const std::optional<BuildOutput>& output,
     WSLCBuildImageFlags flags,
     IProgressCallback* callback,
     HANDLE cancelEvent)
@@ -191,7 +193,95 @@ void ImageService::Build(
     }
 
     auto targetStr = wsl::windows::common::string::WideToMultiByte(target);
-    auto outputStr = wsl::windows::common::string::WideToMultiByte(output);
+
+    // Route the docker-style --output exporter. Exporters that write to a caller-provided destination
+    // (tar/oci/docker with dest=, and local) are streamed back out of the VM: the client opens the
+    // destination here, forwards the spec with dest= stripped, and the server writes the exporter
+    // output to a VM temp path then streams it to OutputHandle. Exporters with no client destination
+    // (docker load, image, registry, cacheonly) run entirely in the VM and the spec is forwarded as-is.
+    std::string outputStr;
+    HANDLE outputHandle = nullptr;
+    wil::unique_hfile outputFile;
+
+    // For type=local the server streams a tarball of the export directory; the client extracts it into
+    // the destination directory by feeding the stream to `tar.exe -xf -`. These stay alive until after
+    // the (synchronous) BuildImage call so the pipe keeps draining while the server writes.
+    wil::unique_hfile extractPipeWrite;
+    wil::unique_handle extractProcess;
+
+    if (output.has_value())
+    {
+        const auto& spec = output.value();
+        const bool isFileExporter = spec.Type == L"tar" || spec.Type == L"oci" || (spec.Type == L"docker" && !spec.Dest.empty());
+        const bool isDirExporter = spec.Type == L"local";
+
+        if (isFileExporter)
+        {
+            if (spec.Dest == L"-")
+            {
+                // dest=- streams the exporter tarball to the client's stdout, matching docker.
+                outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+
+                // Refuse to dump the binary exporter stream onto an interactive console (matching docker);
+                // stdout must be redirected to a file or pipe. Otherwise ToCOMInputHandle would fail the
+                // marshal with a cryptic ERROR_NOT_SUPPORTED for the FILE_TYPE_CHAR console handle.
+                THROW_HR_WITH_USER_ERROR_IF(
+                    E_INVALIDARG,
+                    Localization::MessageWslcOutputInvalidSpec(
+                        validation::FormatOutputSpec(spec),
+                        L"refusing to write build output to the console; redirect stdout to a file or pipe (for example "
+                        L"'> out.tar') or pass 'dest=' with a file path"),
+                    GetFileType(outputHandle) == FILE_TYPE_CHAR);
+            }
+            else
+            {
+                outputFile.reset(CreateFileW(
+                    spec.Dest.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+                THROW_LAST_ERROR_IF_MSG(!outputFile, "Failed to create output file: %ls", spec.Dest.c_str());
+                outputHandle = outputFile.get();
+            }
+
+            // The server picks the VM-side dest, so forward the spec without the client's dest.
+            BuildOutput vmSpec = spec;
+            vmSpec.Dest.clear();
+            outputStr = wsl::windows::common::string::WideToMultiByte(validation::FormatOutputSpec(vmSpec));
+        }
+        else if (isDirExporter)
+        {
+            std::error_code dirError;
+            std::filesystem::create_directories(std::filesystem::absolute(spec.Dest), dirError);
+            THROW_HR_IF_MSG(HRESULT_FROM_WIN32(dirError.value()), !!dirError, "Failed to create directory: %ls", spec.Dest.c_str());
+
+            // Strip any trailing separator so the CRT does not parse '\"' as an escaped quote.
+            auto destDir = std::filesystem::absolute(spec.Dest).wstring();
+            while (destDir.size() > 1 && (destDir.back() == L'\\' || destDir.back() == L'/'))
+            {
+                destDir.pop_back();
+            }
+
+            auto [pipeRead, pipeWrite] = wsl::windows::common::wslutil::OpenAnonymousPipe(0, false, false);
+            THROW_IF_WIN32_BOOL_FALSE(SetHandleInformation(pipeRead.get(), HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT));
+
+            auto tarCmd = std::format(L"tar.exe -xf - -C \"{}\"", destDir);
+            wsl::windows::common::SubProcess tarProcess(nullptr, tarCmd.c_str());
+            tarProcess.SetStdHandles(pipeRead.get(), nullptr, nullptr);
+            extractProcess = tarProcess.Start();
+            pipeRead.reset();
+
+            extractPipeWrite = std::move(pipeWrite);
+            outputHandle = extractPipeWrite.get();
+            WI_SetFlag(flags, WSLCBuildImageFlagsOutputIsDirectory);
+
+            // The server picks the VM-side export directory, so forward the spec without the client's dest.
+            BuildOutput vmSpec = spec;
+            vmSpec.Dest.clear();
+            outputStr = wsl::windows::common::string::WideToMultiByte(validation::FormatOutputSpec(vmSpec));
+        }
+        else
+        {
+            outputStr = wsl::windows::common::string::WideToMultiByte(validation::FormatOutputSpec(spec));
+        }
+    }
 
     auto contextPathStr = absolutePath.wstring();
     WSLCBuildImageOptions options{
@@ -204,9 +294,19 @@ void ImageService::Build(
         .Labels = {labelPointers.data(), static_cast<ULONG>(labelPointers.size())},
         .Secrets = {secretEntries.data(), static_cast<ULONG>(secretEntries.size())},
         .Output = outputStr.empty() ? nullptr : outputStr.c_str(),
+        .OutputHandle = outputHandle != nullptr ? ToCOMInputHandle(outputHandle) : WSLCHandle{.Type = WSLCHandleTypeUnknown},
     };
 
     THROW_IF_FAILED(session.Get()->BuildImage(&options, callback, cancelEvent));
+
+    // For type=local, signal EOF to tar.exe (the server has finished writing) and confirm it extracted
+    // the stream cleanly. The write end must be reset before waiting so tar sees end-of-input.
+    if (extractProcess)
+    {
+        extractPipeWrite.reset();
+        auto exitCode = wsl::windows::common::SubProcess::GetExitCode(extractProcess.get());
+        THROW_HR_IF_MSG(E_FAIL, exitCode != 0, "tar.exe exited with code %u", exitCode);
+    }
 }
 
 std::vector<ImageInformation> ImageService::List(

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -224,6 +224,20 @@ void ImageService::Build(
         }
     });
 
+    // For a single-file exporter the server streams into a client handle. We point that handle at a
+    // sibling temp file and rename it over the destination only after the build succeeds, so a failed
+    // build leaves any existing file intact (buildx uses a lazy writer that never truncates on failure).
+    // These track the pending rename; outputFileTemp is cleared once committed to disarm the cleanup.
+    std::filesystem::path outputFileDest;
+    std::filesystem::path outputFileTemp;
+    auto outputFileCleanup = wil::scope_exit([&] {
+        if (!outputFileTemp.empty())
+        {
+            outputFile.reset();
+            DeleteFileW(outputFileTemp.c_str());
+        }
+    });
+
     if (output.has_value())
     {
         const auto& spec = output.value();
@@ -242,19 +256,34 @@ void ImageService::Build(
 
                 // Refuse to dump the binary exporter stream onto an interactive console (matching docker);
                 // stdout must be redirected to a file or pipe. Otherwise ToCOMInputHandle would fail the
-                // marshal with a cryptic ERROR_NOT_SUPPORTED for the FILE_TYPE_CHAR console handle.
+                // marshal with a cryptic ERROR_NOT_SUPPORTED for the console handle. A redirected character
+                // device such as NUL is not a console, so IsConsoleHandle (which also checks
+                // GetConsoleMode) still lets those through.
                 THROW_HR_WITH_USER_ERROR_IF(
                     E_INVALIDARG,
                     Localization::MessageWslcOutputInvalidSpec(
                         validation::FormatOutputSpec(spec),
                         L"refusing to write build output to the console; redirect stdout to a file or pipe (for example "
                         L"'> out.tar') or pass 'dest=' with a file path"),
-                    GetFileType(outputHandle) == FILE_TYPE_CHAR);
+                    IsConsoleHandle(outputHandle));
             }
             else
             {
+                // Create the destination's parent directory (buildx creates missing parents) and stream
+                // into a sibling temp file that is renamed over the destination only on success (below).
+                auto destPath = std::filesystem::absolute(spec.Dest);
+                std::error_code dirError;
+                std::filesystem::create_directories(destPath.parent_path(), dirError);
+
+                GUID tempGuid{};
+                THROW_IF_FAILED(CoCreateGuid(&tempGuid));
+                const auto tempSuffix = string::GuidToString<wchar_t>(tempGuid, string::GuidToStringFlags::None);
+                outputFileDest = destPath;
+                outputFileTemp = destPath;
+                outputFileTemp += std::format(L".{}.wslctmp", tempSuffix);
+
                 outputFile.reset(CreateFileW(
-                    spec.Dest.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+                    outputFileTemp.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
                 THROW_LAST_ERROR_IF_MSG(!outputFile, "Failed to create output file: %ls", spec.Dest.c_str());
                 outputHandle = outputFile.get();
             }
@@ -331,6 +360,18 @@ void ImageService::Build(
         extractPipeWrite.reset();
         auto exitCode = wsl::windows::common::SubProcess::GetExitCode(extractProcess.get());
         THROW_HR_IF_MSG(E_FAIL, exitCode != 0, "tar.exe exited with code %u", exitCode);
+    }
+
+    // The build succeeded, so atomically move the streamed temp file over the destination. The temp
+    // file is a sibling of the destination, so the rename stays on one volume and replaces in place.
+    if (!outputFileTemp.empty())
+    {
+        outputFile.reset();
+        THROW_IF_WIN32_BOOL_FALSE_MSG(
+            MoveFileExW(outputFileTemp.c_str(), outputFileDest.c_str(), MOVEFILE_REPLACE_EXISTING),
+            "Failed to write build output to %ls",
+            outputFileDest.c_str());
+        outputFileTemp.clear();
     }
 
     tarCleanup.release();

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -203,19 +203,37 @@ void ImageService::Build(
     HANDLE outputHandle = nullptr;
     wil::unique_hfile outputFile;
 
-    // For type=local the server streams a tarball of the export directory; the client extracts it into
-    // the destination directory by feeding the stream to `tar.exe -xf -`. These stay alive until after
-    // the (synchronous) BuildImage call so the pipe keeps draining while the server writes.
+    // For directory exporters (type=local, or oci/docker with tar=false) the server streams a tarball of
+    // the export directory; the client extracts it into the destination directory by feeding the stream
+    // to `tar.exe -xf -`. These stay alive until after the (synchronous) BuildImage call so the pipe
+    // keeps draining while the server writes.
     wil::unique_hfile extractPipeWrite;
     wil::unique_handle extractProcess;
+
+    // Failsafe for the directory (tar.exe) path: if the build throws before we drain tar.exe below,
+    // signal EOF by closing the pipe and, if the process is still running, wait briefly and terminate
+    // it so it cannot leak or block indefinitely on a full pipe. Released on the success path.
+    auto tarCleanup = wil::scope_exit([&] {
+        if (extractProcess)
+        {
+            extractPipeWrite.reset();
+            if (WaitForSingleObject(extractProcess.get(), 30000) != WAIT_OBJECT_0)
+            {
+                TerminateProcess(extractProcess.get(), 1);
+            }
+        }
+    });
 
     if (output.has_value())
     {
         const auto& spec = output.value();
-        const bool isFileExporter = spec.Type == L"tar" || spec.Type == L"oci" || (spec.Type == L"docker" && !spec.Dest.empty());
-        const bool isDirExporter = spec.Type == L"local";
+        // Route the exporter the same way `docker buildx build --output` does: some exporters produce a
+        // result the client must materialize (a file, a stdout stream, or a directory tree), while
+        // others run entirely in the build VM. See OutputStreamsToClient / OutputIsDirectory.
+        const bool streamsBack = validation::OutputStreamsToClient(spec);
+        const bool isDirExporter = validation::OutputIsDirectory(spec);
 
-        if (isFileExporter)
+        if (streamsBack && !isDirExporter)
         {
             if (spec.Dest == L"-")
             {
@@ -306,14 +324,16 @@ void ImageService::Build(
 
     THROW_IF_FAILED(session.Get()->BuildImage(&options, callback, cancelEvent));
 
-    // For type=local, signal EOF to tar.exe (the server has finished writing) and confirm it extracted
-    // the stream cleanly. The write end must be reset before waiting so tar sees end-of-input.
+    // Signal EOF to tar.exe (the server has finished writing) and confirm it extracted the stream
+    // cleanly. The write end must be reset before waiting so tar sees end-of-input.
     if (extractProcess)
     {
         extractPipeWrite.reset();
         auto exitCode = wsl::windows::common::SubProcess::GetExitCode(extractProcess.get());
         THROW_HR_IF_MSG(E_FAIL, exitCode != 0, "tar.exe exited with code %u", exitCode);
     }
+
+    tarCleanup.release();
 }
 
 std::vector<ImageInformation> ImageService::List(

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -183,13 +183,12 @@ void ImageService::Build(
     for (const auto& secret : secrets)
     {
         secretIdStrings.push_back(wsl::windows::common::string::WideToMultiByte(secret.Id));
-        secretEntries.push_back(
-            WSLCBuildSecret{
-                .Id = secretIdStrings.back().c_str(),
-                .SourcePath = secret.SourcePath.empty() ? nullptr : secret.SourcePath.c_str(),
-                .Value = secret.Value.empty() ? nullptr : secret.Value.data(),
-                .ValueSize = static_cast<ULONG>(secret.Value.size()),
-            });
+        secretEntries.push_back(WSLCBuildSecret{
+            .Id = secretIdStrings.back().c_str(),
+            .SourcePath = secret.SourcePath.empty() ? nullptr : secret.SourcePath.c_str(),
+            .Value = secret.Value.empty() ? nullptr : secret.Value.data(),
+            .ValueSize = static_cast<ULONG>(secret.Value.size()),
+        });
     }
 
     auto targetStr = wsl::windows::common::string::WideToMultiByte(target);

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -16,6 +16,7 @@ Abstract:
 #include "SessionModel.h"
 #include "ImageModel.h"
 #include "Reporter.h"
+#include <map>
 #include <wslc_schema.h>
 
 namespace wsl::windows::wslc::services {
@@ -32,6 +33,15 @@ struct BuildSecret
     std::vector<BYTE> Value;
 };
 
+// Parsed docker-style --output spec (buildx exporter). Type/Dest are the resolved exporter type and
+// destination; any remaining key=value attributes (name, push, compression, ...) are carried verbatim.
+struct BuildOutput
+{
+    std::wstring Type;                               // resolved exporter type (e.g. L"local", L"tar", ...)
+    std::wstring Dest;                               // destination path; L"-" means stdout; empty when not applicable
+    std::map<std::wstring, std::wstring> Attributes; // remaining key=value attributes
+};
+
 class ImageService
 {
 public:
@@ -44,6 +54,7 @@ public:
         const std::vector<BuildSecret>& secrets,
         const std::wstring& dockerfilePath,
         const std::wstring& target,
+        const std::wstring& output,
         WSLCBuildImageFlags flags,
         IProgressCallback* callback,
         HANDLE cancelEvent = nullptr);

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -18,6 +18,7 @@ Abstract:
 #include "Reporter.h"
 #include <map>
 #include <optional>
+#include <vector>
 #include <wslc_schema.h>
 
 namespace wsl::windows::wslc::services {

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -17,6 +17,7 @@ Abstract:
 #include "ImageModel.h"
 #include "Reporter.h"
 #include <map>
+#include <optional>
 #include <wslc_schema.h>
 
 namespace wsl::windows::wslc::services {
@@ -54,7 +55,7 @@ public:
         const std::vector<BuildSecret>& secrets,
         const std::wstring& dockerfilePath,
         const std::wstring& target,
-        const std::wstring& output,
+        const std::optional<BuildOutput>& output,
         WSLCBuildImageFlags flags,
         IProgressCallback* callback,
         HANDLE cancelEvent = nullptr);

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -126,11 +126,12 @@ void BuildImage(CLIExecutionContext& context)
         target = context.Args.Get<ArgType::BuildTarget>();
     }
 
-    std::wstring output;
+    std::optional<services::BuildOutput> output;
     if (context.Args.Contains(ArgType::Output))
     {
-        // Validate and normalize the spec client-side, then forward the canonical form to buildx.
-        output = validation::FormatOutputSpec(validation::ParseOutputSpec(context.Args.Get<ArgType::Output>()));
+        // Validate and normalize the spec client-side; ImageService::Build decides how to route the
+        // exporter (stream a destination file/dir back over a handle, or run entirely in the VM).
+        output = validation::ParseOutputSpec(context.Args.Get<ArgType::Output>());
     }
 
     WSLCBuildImageFlags flags = WSLCBuildImageFlagsNone;

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -126,6 +126,13 @@ void BuildImage(CLIExecutionContext& context)
         target = context.Args.Get<ArgType::BuildTarget>();
     }
 
+    std::wstring output;
+    if (context.Args.Contains(ArgType::Output))
+    {
+        // Validate and normalize the spec client-side, then forward the canonical form to buildx.
+        output = validation::FormatOutputSpec(validation::ParseOutputSpec(context.Args.Get<ArgType::Output>()));
+    }
+
     WSLCBuildImageFlags flags = WSLCBuildImageFlagsNone;
     WI_SetFlagIf(flags, WSLCBuildImageFlagsVerbose, context.Args.GetFlag<ArgType::Verbose>());
     WI_SetFlagIf(flags, WSLCBuildImageFlagsNoCache, context.Args.GetFlag<ArgType::NoCache>());
@@ -133,7 +140,8 @@ void BuildImage(CLIExecutionContext& context)
 
     auto cancelEvent = context.CreateCancelEvent();
     BuildImageCallback callback(context.Reporter, cancelEvent, context.Args.GetFlag<ArgType::Verbose>());
-    services::ImageService::Build(session, contextPath, tags, buildArgs, labels, secrets, dockerfilePath, target, flags, &callback, cancelEvent);
+    services::ImageService::Build(
+        session, contextPath, tags, buildArgs, labels, secrets, dockerfilePath, target, output, flags, &callback, cancelEvent);
 }
 
 void GetImages(CLIExecutionContext& context)

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -953,6 +953,11 @@ try
         buildArgs.push_back("--target");
         buildArgs.push_back(Options->Target);
     }
+    if (Options->Output != nullptr && Options->Output[0] != '\0')
+    {
+        buildArgs.push_back("--output");
+        buildArgs.push_back(Options->Output);
+    }
     for (ULONG i = 0; i < Options->Tags.Count; i++)
     {
         RETURN_HR_IF_NULL(E_INVALIDARG, Options->Tags.Values[i]);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -998,8 +998,8 @@ try
             constexpr auto c_outputBaseDir = "/var/lib/docker/tmp/wslc-build-output";
             outputDestPath = std::format("{}/{}", c_outputBaseDir, wsl::shared::string::GuidToString<char>(id));
 
-            // buildx creates the leaf dest (a file for tar/oci/docker, a directory for local) but not
-            // the parent, so ensure the base directory exists first.
+            // buildx creates the leaf dest (a file for tar/oci/docker tarballs, a directory for local
+            // or oci/docker with tar=false) but not the parent, so ensure the base directory exists first.
             ServiceProcessLauncher mkdir("/bin/sh", {"/bin/sh", "--norc", "-c", std::format("mkdir -p '{}'", c_outputBaseDir)}, {}, WSLCProcessFlagsNone);
             auto mkdirResult = mkdir.Launch(*m_virtualMachine).WaitAndCaptureOutput(60000UL);
             THROW_HR_IF_MSG(E_FAIL, mkdirResult.Code != 0, "failed to create build output directory");
@@ -1396,9 +1396,10 @@ try
     std::erase(allOutput, '\r');
     THROW_HR_WITH_USER_ERROR_IF(E_FAIL, allOutput, exitCode != 0);
 
-    // Stream the exporter output back to the client. For file exporters (tar/oci/docker) cat the temp
-    // file; for the directory exporter (type=local) tar the export directory so the client can extract
-    // it into the destination directory. The streamer's stdout is relayed to the client OutputHandle.
+    // Stream the exporter output back to the client. For file exporters (tar/oci/docker tarballs) cat
+    // the temp file; for directory exporters (type=local, or oci/docker with tar=false) tar the export
+    // directory so the client can extract it into the destination directory. The streamer's stdout is
+    // relayed to the client OutputHandle.
     if (streamOutput)
     {
         auto userHandle = OpenUserHandle(Options->OutputHandle);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -959,6 +959,10 @@ try
     // after a successful build, a streamer process relays that path to the client handle. Without a
     // handle the spec is forwarded verbatim and the build runs entirely in the VM.
     const bool streamOutput = Options->OutputHandle.Type != WSLCHandleTypeUnknown;
+    // When an OutputHandle is provided the exporter output must be streamed back, which requires a
+    // non-empty Output spec to route from. Reject the mismatched combination at the boundary rather
+    // than later failing to stream an unassigned dest path.
+    RETURN_HR_IF(E_INVALIDARG, streamOutput && (Options->Output == nullptr || Options->Output[0] == '\0'));
     const bool outputIsDirectory = WI_IsFlagSet(Options->Flags, WSLCBuildImageFlagsOutputIsDirectory);
     std::string outputDestPath;
     auto removeOutput = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
@@ -968,7 +972,18 @@ try
             auto cleanupResult = cleanup.LaunchNoThrow(*m_virtualMachine);
             if (auto& process = std::get<2>(cleanupResult); process)
             {
-                std::ignore = process->WaitAndCaptureOutput(60000UL);
+                auto result = process->WaitAndCaptureOutput(60000UL);
+                if (result.Code != 0)
+                {
+                    WSL_LOG(
+                        "BuildOutputCleanupFailed",
+                        TraceLoggingValue(outputDestPath.c_str(), "Path"),
+                        TraceLoggingValue(result.Code, "ExitCode"));
+                }
+            }
+            else
+            {
+                WSL_LOG("BuildOutputCleanupLaunchFailed", TraceLoggingValue(outputDestPath.c_str(), "Path"));
             }
         }
     });

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -45,75 +45,6 @@ constexpr DWORD c_processKillTimeoutMs = 10 * 1000;
 
 namespace {
 
-// Minimal parse of a docker buildx --output spec to detect directory exporters (type=local, or
-// oci/docker with tar=false), which cannot be written faithfully to a Windows destination. The
-// authoritative parser lives in the client (wslclib); this is a defensive check for direct COM callers.
-bool IsDirectoryExporterSpec(std::string_view spec)
-{
-    const auto trim = [](std::string_view value) {
-        while (!value.empty() && (value.front() == ' ' || value.front() == '\t'))
-        {
-            value.remove_prefix(1);
-        }
-        while (!value.empty() && (value.back() == ' ' || value.back() == '\t'))
-        {
-            value.remove_suffix(1);
-        }
-        return value;
-    };
-    const auto toLower = [](std::string_view value) {
-        std::string result(value);
-        std::transform(
-            result.begin(), result.end(), result.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-        return result;
-    };
-
-    std::string type;
-    std::optional<bool> tar;
-    for (size_t pos = 0; pos <= spec.size();)
-    {
-        const auto comma = spec.find(',', pos);
-        const auto field = spec.substr(pos, comma == std::string_view::npos ? spec.size() - pos : comma - pos);
-
-        if (const auto eq = field.find('='); eq != std::string_view::npos)
-        {
-            // buildx trims spaces around the key and matches it case-insensitively.
-            const auto key = toLower(trim(field.substr(0, eq)));
-            const auto value = field.substr(eq + 1);
-            if (key == "type")
-            {
-                type = toLower(value);
-            }
-            else if (key == "tar")
-            {
-                // Go's ParseBool: 1/t/true and 0/f/false (case-insensitive).
-                const auto boolValue = toLower(value);
-                if (boolValue == "0" || boolValue == "f" || boolValue == "false")
-                {
-                    tar = false;
-                }
-                else if (boolValue == "1" || boolValue == "t" || boolValue == "true")
-                {
-                    tar = true;
-                }
-            }
-        }
-
-        if (comma == std::string_view::npos)
-        {
-            break;
-        }
-        pos = comma + 1;
-    }
-
-    if (type == "local")
-    {
-        return true;
-    }
-
-    return (type == "oci" || type == "docker") && tar.has_value() && !tar.value();
-}
-
 // Group policy: WSLContainerRegistryAllowlist restricts which container-image
 // registries can be pulled from or pushed to. The check is enforced here at the
 // service boundary so it covers ALL callers (wslc.exe CLI, the WslcSDK C API, and
@@ -1025,15 +956,14 @@ try
     }
     // Docker-style --output routing. Three cases, distinguished by what the client set:
     //   * OutputHandle set (dest=- stdout): the client stripped dest= and expects the exporter output
-    //     streamed back. The exporter writes to a VM temp path (disk-backed under the docker storage
-    //     root to avoid buffering large outputs in tmpfs) and, after a successful build, a streamer
-    //     cats it to the client handle.
+    //     streamed back. The exporter writes to the build process's stdout, which is relayed to the
+    //     client handle as the build runs, so the output never touches the VM's disk.
     //   * OutputMountPath set (single-file exporter with a real destination): the client stripped dest=
     //     and passed the destination file's parent directory, mounted read-write into the VM so buildx
     //     writes the file (at OutputMountFile within the mount) in place - nothing is streamed back.
     //   * Neither set: the spec is forwarded verbatim and the build runs entirely in the VM.
-    // Directory exporters (type=local, or oci/docker with tar=false) are rejected below: a Linux tree
-    // cannot be written faithfully to a Windows destination.
+    // Directory exporters (type=local, or oci/docker with tar=false) are rejected by the client while
+    // parsing --output: a Linux tree cannot be written faithfully to a Windows destination.
     const bool streamOutput = Options->OutputHandle.Type != WSLCHandleTypeUnknown;
     const bool mountOutput = Options->OutputMountPath != nullptr && Options->OutputMountPath[0] != L'\0';
     // Streaming or mounting the exporter output requires a non-empty Output spec to route from, and the
@@ -1041,50 +971,16 @@ try
     // than later failing to assign a dest path.
     RETURN_HR_IF(E_INVALIDARG, (streamOutput || mountOutput) && (Options->Output == nullptr || Options->Output[0] == '\0'));
     RETURN_HR_IF(E_INVALIDARG, streamOutput && mountOutput);
-    // Directory exporters cannot be materialized faithfully on a Windows destination and are unsupported.
-    // The client rejects them while parsing --output; reject them here too for direct COM callers.
-    RETURN_HR_IF(E_INVALIDARG, Options->Output != nullptr && IsDirectoryExporterSpec(Options->Output));
-    std::string outputDestPath;
-    auto removeOutput = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-        if (!outputDestPath.empty())
-        {
-            ServiceProcessLauncher cleanup("/bin/sh", {"/bin/sh", "--norc", "-c", std::format("rm -rf '{}'", outputDestPath)}, {}, WSLCProcessFlagsNone);
-            auto cleanupResult = cleanup.LaunchNoThrow(*m_virtualMachine);
-            if (auto& process = std::get<2>(cleanupResult); process)
-            {
-                auto result = process->WaitAndCaptureOutput(60000UL);
-                if (result.Code != 0)
-                {
-                    WSL_LOG(
-                        "BuildOutputCleanupFailed",
-                        TraceLoggingValue(outputDestPath.c_str(), "Path"),
-                        TraceLoggingValue(result.Code, "ExitCode"));
-                }
-            }
-            else
-            {
-                WSL_LOG("BuildOutputCleanupLaunchFailed", TraceLoggingValue(outputDestPath.c_str(), "Path"));
-            }
-        }
-    });
 
     if (Options->Output != nullptr && Options->Output[0] != '\0')
     {
         std::string outputSpec = Options->Output;
         if (streamOutput)
         {
-            GUID id{};
-            THROW_IF_FAILED(CoCreateGuid(&id));
-            constexpr auto c_outputBaseDir = "/var/lib/docker/tmp/wslc-build-output";
-            outputDestPath = std::format("{}/{}", c_outputBaseDir, wsl::shared::string::GuidToString<char>(id));
-
-            // buildx creates the leaf dest (a file for tar/oci/docker tarballs, a directory for local
-            // or oci/docker with tar=false) but not the parent, so ensure the base directory exists first.
-            ServiceProcessLauncher mkdir("/bin/sh", {"/bin/sh", "--norc", "-c", std::format("mkdir -p '{}'", c_outputBaseDir)}, {}, WSLCProcessFlagsNone);
-            auto mkdirResult = mkdir.Launch(*m_virtualMachine).WaitAndCaptureOutput(60000UL);
-            THROW_HR_IF_MSG(E_FAIL, mkdirResult.Code != 0, "failed to create build output directory");
-
-            outputSpec += std::format(",dest={}", outputDestPath);
+            // buildx writes the exporter tarball to stdout for dest=-, which is relayed to the client
+            // handle below. With no image to load, buildx prints no image ID, so stdout carries only
+            // the tarball.
+            outputSpec += ",dest=-";
         }
         else if (mountOutput)
         {
@@ -1224,6 +1120,13 @@ try
 
     ServiceProcessLauncher buildLauncher(buildArgs[0], buildArgs, buildEnv, WSLCProcessFlagsStdin);
     auto buildProcess = buildLauncher.Launch(*m_virtualMachine);
+
+    // Opened before the IO context so it outlives the relay registered on it below.
+    std::optional<UserHandle> userHandle;
+    if (streamOutput)
+    {
+        userHandle.emplace(OpenUserHandle(Options->OutputHandle));
+    }
 
     auto io = CreateIOContext();
 
@@ -1412,9 +1315,21 @@ try
     };
 
     // With --progress=rawjson, docker writes progress to stderr and the final image ID to stdout on success (empty on
-    // failure). Stdout is drained into allOutput (shown only on error) and its EOF signals build completion.
-    io.AddHandle(std::make_unique<io::ReadHandle>(
-        buildProcess.GetStdHandle(1), [&](const auto& content) { allOutput.append(content.begin(), content.end()); }));
+    // failure). Stdout's EOF signals build completion.
+    //
+    // For dest=- the exporter tarball is written to stdout instead, so it is relayed straight to the
+    // client handle as the build runs rather than being collected. RelayHandle is an overlapped handle,
+    // so a slow client only marks the relay pending and stderr keeps draining in the same IO loop.
+    if (streamOutput)
+    {
+        io.AddHandle(std::make_unique<io::RelayHandle<io::ReadHandle>>(
+            common::io::HandleWrapper{buildProcess.GetStdHandle(1)}, userHandle->Get()));
+    }
+    else
+    {
+        io.AddHandle(std::make_unique<io::ReadHandle>(
+            buildProcess.GetStdHandle(1), [&](const auto& content) { allOutput.append(content.begin(), content.end()); }));
+    }
 
     io.AddHandle(std::make_unique<io::LineBasedReadHandle>(buildProcess.GetStdHandle(2), captureOutput, false));
 
@@ -1488,42 +1403,6 @@ try
     // translation.
     std::erase(allOutput, '\r');
     THROW_HR_WITH_USER_ERROR_IF(E_FAIL, allOutput, exitCode != 0);
-
-    // Stream the exporter output back to the client by cat-ing the temp file (tar/oci/docker single-file
-    // tarballs, or dest=- stdout). The streamer's stdout is relayed to the client OutputHandle.
-    if (streamOutput)
-    {
-        auto userHandle = OpenUserHandle(Options->OutputHandle);
-
-        std::vector<std::string> streamArgs = {"/bin/cat", outputDestPath};
-
-        ServiceProcessLauncher streamLauncher(streamArgs[0], streamArgs, {}, WSLCProcessFlagsNone);
-        auto streamProcess = streamLauncher.Launch(*m_virtualMachine);
-
-        auto streamIo = CreateIOContext(CancelEvent);
-        std::string streamError;
-        streamIo.AddHandle(std::make_unique<io::RelayHandle<io::ReadHandle>>(
-            common::io::HandleWrapper{streamProcess.GetStdHandle(1)}, userHandle.Get()));
-        streamIo.AddHandle(std::make_unique<io::ReadHandle>(streamProcess.GetStdHandle(2), [&](const gsl::span<char>& content) {
-            streamError.append(content.data(), content.size());
-        }));
-
-        try
-        {
-            streamIo.Run({});
-        }
-        catch (...)
-        {
-            // Tear the streamer down so a cancelled or failed relay cannot leave it running (and
-            // holding the temp path open) while removeOutput deletes it on scope exit.
-            StopProcess(streamProcess, 10 * 1000, 10 * 1000);
-            throw;
-        }
-
-        std::erase(streamError, '\r');
-        int streamCode = streamProcess.Wait();
-        THROW_HR_IF_MSG(E_FAIL, streamCode != 0, "failed to stream build output: %hs", streamError.c_str());
-    }
 
     return S_OK;
 }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1315,11 +1315,11 @@ try
     };
 
     // With --progress=rawjson, docker writes progress to stderr and the final image ID to stdout on success (empty on
-    // failure). Stdout's EOF signals build completion.
+    // failure).
     //
-    // For dest=- the exporter tarball is written to stdout instead, so it is relayed straight to the
-    // client handle as the build runs rather than being collected. RelayHandle is an overlapped handle,
-    // so a slow client only marks the relay pending and stderr keeps draining in the same IO loop.
+    // For dest=- the exporter tarball is written to stdout, so it is relayed to the client handle as the
+    // build runs. RelayHandle is an overlapped handle, so a slow client only marks the relay pending and
+    // stderr keeps draining in the same IO loop.
     if (streamOutput)
     {
         io.AddHandle(std::make_unique<io::RelayHandle<io::ReadHandle>>(

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1386,25 +1386,6 @@ try
     // it into the destination directory. The streamer's stdout is relayed to the client OutputHandle.
     if (streamOutput)
     {
-        // TEMP DIAGNOSTIC: inspect the VM-side exporter output before streaming it back.
-        {
-            ServiceProcessLauncher diag(
-                "/bin/sh",
-                {"/bin/sh",
-                 "--norc",
-                 "-c",
-                 std::format(
-                     "echo DEST={0}; stat -c 'STAT size=%s name=%n' '{0}' 2>&1; echo '--- ls base ---'; ls -la '{1}' 2>&1; "
-                     "echo '--- find tmp ---'; find /var/lib/docker/tmp 2>&1; echo '--- mounts ---'; grep -E 'docker' "
-                     "/proc/self/mountinfo 2>&1",
-                     outputDestPath,
-                     "/var/lib/docker/tmp/wslc-build-output")},
-                {},
-                WSLCProcessFlagsNone);
-            auto diagResult = diag.Launch(*m_virtualMachine).WaitAndCaptureOutput(60000UL);
-            reportProgress(std::format("\n===WSLC BUILD OUTPUT DIAGNOSTIC===\n{}\n===END DIAGNOSTIC===\n", diag.FormatResult(diagResult)), c_logId);
-        }
-
         auto userHandle = OpenUserHandle(Options->OutputHandle);
 
         std::vector<std::string> streamArgs;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1424,7 +1424,18 @@ try
         streamIo.AddHandle(std::make_unique<io::ReadHandle>(streamProcess.GetStdHandle(2), [&](const gsl::span<char>& content) {
             streamError.append(content.data(), content.size());
         }));
-        streamIo.Run({});
+
+        try
+        {
+            streamIo.Run({});
+        }
+        catch (...)
+        {
+            // Tear the streamer down so a cancelled or failed relay cannot leave it running (and
+            // holding the temp path open) while removeOutput deletes it on scope exit.
+            StopProcess(streamProcess, 10 * 1000, 10 * 1000);
+            throw;
+        }
 
         std::erase(streamError, '\r');
         int streamCode = streamProcess.Wait();

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -45,6 +45,75 @@ constexpr DWORD c_processKillTimeoutMs = 10 * 1000;
 
 namespace {
 
+// Minimal parse of a docker buildx --output spec to detect directory exporters (type=local, or
+// oci/docker with tar=false), which cannot be written faithfully to a Windows destination. The
+// authoritative parser lives in the client (wslclib); this is a defensive check for direct COM callers.
+bool IsDirectoryExporterSpec(std::string_view spec)
+{
+    const auto trim = [](std::string_view value) {
+        while (!value.empty() && (value.front() == ' ' || value.front() == '\t'))
+        {
+            value.remove_prefix(1);
+        }
+        while (!value.empty() && (value.back() == ' ' || value.back() == '\t'))
+        {
+            value.remove_suffix(1);
+        }
+        return value;
+    };
+    const auto toLower = [](std::string_view value) {
+        std::string result(value);
+        std::transform(
+            result.begin(), result.end(), result.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return result;
+    };
+
+    std::string type;
+    std::optional<bool> tar;
+    for (size_t pos = 0; pos <= spec.size();)
+    {
+        const auto comma = spec.find(',', pos);
+        const auto field = spec.substr(pos, comma == std::string_view::npos ? spec.size() - pos : comma - pos);
+
+        if (const auto eq = field.find('='); eq != std::string_view::npos)
+        {
+            // buildx trims spaces around the key and matches it case-insensitively.
+            const auto key = toLower(trim(field.substr(0, eq)));
+            const auto value = field.substr(eq + 1);
+            if (key == "type")
+            {
+                type = toLower(value);
+            }
+            else if (key == "tar")
+            {
+                // Go's ParseBool: 1/t/true and 0/f/false (case-insensitive).
+                const auto boolValue = toLower(value);
+                if (boolValue == "0" || boolValue == "f" || boolValue == "false")
+                {
+                    tar = false;
+                }
+                else if (boolValue == "1" || boolValue == "t" || boolValue == "true")
+                {
+                    tar = true;
+                }
+            }
+        }
+
+        if (comma == std::string_view::npos)
+        {
+            break;
+        }
+        pos = comma + 1;
+    }
+
+    if (type == "local")
+    {
+        return true;
+    }
+
+    return (type == "oci" || type == "docker") && tar.has_value() && !tar.value();
+}
+
 // Group policy: WSLContainerRegistryAllowlist restricts which container-image
 // registries can be pulled from or pushed to. The check is enforced here at the
 // service boundary so it covers ALL callers (wslc.exe CLI, the WslcSDK C API, and
@@ -630,11 +699,13 @@ ServiceRunningProcess WSLCSession::StartProcess(
 
     auto process = launcher.Launch(*m_virtualMachine);
 
-    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
-        process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(
+        std::make_unique<windows::common::io::LineBasedReadHandle>(
+            process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
-    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
-        process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(
+        std::make_unique<windows::common::io::LineBasedReadHandle>(
+            process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
     m_ioRelay.AddHandle(std::make_unique<windows::common::io::EventHandle>(process.GetExitEvent(), std::move(ExitCallback)));
 
@@ -955,14 +1026,16 @@ try
         buildArgs.push_back(Options->Target);
     }
     // Docker-style --output routing. Three cases, distinguished by what the client set:
-    //   * OutputHandle set (dest=- stdout, or a type=local directory): the client stripped dest= and
-    //     expects the exporter output streamed back. The exporter writes to a VM temp path (disk-backed
-    //     under the docker storage root to avoid buffering large outputs in tmpfs) and, after a
-    //     successful build, a streamer relays it to the client handle (cat for a file, tar for a tree).
+    //   * OutputHandle set (dest=- stdout): the client stripped dest= and expects the exporter output
+    //     streamed back. The exporter writes to a VM temp path (disk-backed under the docker storage
+    //     root to avoid buffering large outputs in tmpfs) and, after a successful build, a streamer
+    //     cats it to the client handle.
     //   * OutputMountPath set (single-file exporter with a real destination): the client stripped dest=
     //     and passed the destination file's parent directory, mounted read-write into the VM so buildx
     //     writes the file (at OutputMountFile within the mount) in place - nothing is streamed back.
     //   * Neither set: the spec is forwarded verbatim and the build runs entirely in the VM.
+    // Directory exporters (type=local, or oci/docker with tar=false) are rejected below: a Linux tree
+    // cannot be written faithfully to a Windows destination.
     const bool streamOutput = Options->OutputHandle.Type != WSLCHandleTypeUnknown;
     const bool mountOutput = Options->OutputMountPath != nullptr && Options->OutputMountPath[0] != L'\0';
     // Streaming or mounting the exporter output requires a non-empty Output spec to route from, and the
@@ -970,7 +1043,9 @@ try
     // than later failing to assign a dest path.
     RETURN_HR_IF(E_INVALIDARG, (streamOutput || mountOutput) && (Options->Output == nullptr || Options->Output[0] == '\0'));
     RETURN_HR_IF(E_INVALIDARG, streamOutput && mountOutput);
-    const bool outputIsDirectory = WI_IsFlagSet(Options->Flags, WSLCBuildImageFlagsOutputIsDirectory);
+    // Directory exporters cannot be materialized faithfully on a Windows destination and are unsupported.
+    // The client rejects them while parsing --output; reject them here too for direct COM callers.
+    RETURN_HR_IF(E_INVALIDARG, Options->Output != nullptr && IsDirectoryExporterSpec(Options->Output));
     std::string outputDestPath;
     auto removeOutput = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
         if (!outputDestPath.empty())
@@ -1340,8 +1415,9 @@ try
 
     // With --progress=rawjson, docker writes progress to stderr and the final image ID to stdout on success (empty on
     // failure). Stdout is drained into allOutput (shown only on error) and its EOF signals build completion.
-    io.AddHandle(std::make_unique<io::ReadHandle>(
-        buildProcess.GetStdHandle(1), [&](const auto& content) { allOutput.append(content.begin(), content.end()); }));
+    io.AddHandle(std::make_unique<io::ReadHandle>(buildProcess.GetStdHandle(1), [&](const auto& content) {
+        allOutput.append(content.begin(), content.end());
+    }));
 
     io.AddHandle(std::make_unique<io::LineBasedReadHandle>(buildProcess.GetStdHandle(2), captureOutput, false));
 
@@ -1416,31 +1492,21 @@ try
     std::erase(allOutput, '\r');
     THROW_HR_WITH_USER_ERROR_IF(E_FAIL, allOutput, exitCode != 0);
 
-    // Stream the exporter output back to the client. For file exporters (tar/oci/docker tarballs) cat
-    // the temp file; for directory exporters (type=local, or oci/docker with tar=false) tar the export
-    // directory so the client can extract it into the destination directory. The streamer's stdout is
-    // relayed to the client OutputHandle.
+    // Stream the exporter output back to the client by cat-ing the temp file (tar/oci/docker single-file
+    // tarballs, or dest=- stdout). The streamer's stdout is relayed to the client OutputHandle.
     if (streamOutput)
     {
         auto userHandle = OpenUserHandle(Options->OutputHandle);
 
-        std::vector<std::string> streamArgs;
-        if (outputIsDirectory)
-        {
-            streamArgs = {"/usr/bin/tar", "-C", outputDestPath, "-cf", "-", "."};
-        }
-        else
-        {
-            streamArgs = {"/bin/cat", outputDestPath};
-        }
+        std::vector<std::string> streamArgs = {"/bin/cat", outputDestPath};
 
         ServiceProcessLauncher streamLauncher(streamArgs[0], streamArgs, {}, WSLCProcessFlagsNone);
         auto streamProcess = streamLauncher.Launch(*m_virtualMachine);
 
         auto streamIo = CreateIOContext(CancelEvent);
         std::string streamError;
-        streamIo.AddHandle(std::make_unique<io::RelayHandle<io::ReadHandle>>(
-            common::io::HandleWrapper{streamProcess.GetStdHandle(1)}, userHandle.Get()));
+        streamIo.AddHandle(
+            std::make_unique<io::RelayHandle<io::ReadHandle>>(common::io::HandleWrapper{streamProcess.GetStdHandle(1)}, userHandle.Get()));
         streamIo.AddHandle(std::make_unique<io::ReadHandle>(streamProcess.GetStdHandle(2), [&](const gsl::span<char>& content) {
             streamError.append(content.data(), content.size());
         }));
@@ -1740,8 +1806,9 @@ void WSLCSession::SaveImageImpl(std::pair<uint32_t, wil::unique_socket>& SocketC
     }
     else
     {
-        io.AddHandle(std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
-            common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
+        io.AddHandle(
+            std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
+                common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
     }
 
     io.Run({});

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -699,13 +699,11 @@ ServiceRunningProcess WSLCSession::StartProcess(
 
     auto process = launcher.Launch(*m_virtualMachine);
 
-    m_ioRelay.AddHandle(
-        std::make_unique<windows::common::io::LineBasedReadHandle>(
-            process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
+        process.GetStdHandle(1), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
-    m_ioRelay.AddHandle(
-        std::make_unique<windows::common::io::LineBasedReadHandle>(
-            process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
+    m_ioRelay.AddHandle(std::make_unique<windows::common::io::LineBasedReadHandle>(
+        process.GetStdHandle(2), [this, LogSource](const auto& data) { OnProcessLog(data, LogSource); }, false));
 
     m_ioRelay.AddHandle(std::make_unique<windows::common::io::EventHandle>(process.GetExitEvent(), std::move(ExitCallback)));
 
@@ -1415,9 +1413,8 @@ try
 
     // With --progress=rawjson, docker writes progress to stderr and the final image ID to stdout on success (empty on
     // failure). Stdout is drained into allOutput (shown only on error) and its EOF signals build completion.
-    io.AddHandle(std::make_unique<io::ReadHandle>(buildProcess.GetStdHandle(1), [&](const auto& content) {
-        allOutput.append(content.begin(), content.end());
-    }));
+    io.AddHandle(std::make_unique<io::ReadHandle>(
+        buildProcess.GetStdHandle(1), [&](const auto& content) { allOutput.append(content.begin(), content.end()); }));
 
     io.AddHandle(std::make_unique<io::LineBasedReadHandle>(buildProcess.GetStdHandle(2), captureOutput, false));
 
@@ -1505,8 +1502,8 @@ try
 
         auto streamIo = CreateIOContext(CancelEvent);
         std::string streamError;
-        streamIo.AddHandle(
-            std::make_unique<io::RelayHandle<io::ReadHandle>>(common::io::HandleWrapper{streamProcess.GetStdHandle(1)}, userHandle.Get()));
+        streamIo.AddHandle(std::make_unique<io::RelayHandle<io::ReadHandle>>(
+            common::io::HandleWrapper{streamProcess.GetStdHandle(1)}, userHandle.Get()));
         streamIo.AddHandle(std::make_unique<io::ReadHandle>(streamProcess.GetStdHandle(2), [&](const gsl::span<char>& content) {
             streamError.append(content.data(), content.size());
         }));
@@ -1806,9 +1803,8 @@ void WSLCSession::SaveImageImpl(std::pair<uint32_t, wil::unique_socket>& SocketC
     }
     else
     {
-        io.AddHandle(
-            std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
-                common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
+        io.AddHandle(std::make_unique<io::RelayHandle<io::HTTPChunkBasedReadHandle>>(
+            common::io::HandleWrapper{std::move(SocketCodePair.second)}, userHandle.Get()));
     }
 
     io.Run({});

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -931,8 +931,9 @@ try
 
     // Reserve up front so mountInVm's push_back can never reallocate-and-throw after a successful
     // MountWindowsFolder, which would leak a mount the scope_exit hasn't recorded yet. At most the build
-    // context (1) and one parent directory per file secret are mounted.
-    mountedPaths.reserve(static_cast<size_t>(1) + Options->Secrets.Count);
+    // context (1), the single-file exporter output destination (1), and one parent directory per file
+    // secret are mounted.
+    mountedPaths.reserve(static_cast<size_t>(2) + Options->Secrets.Count);
 
     auto mountPath = mountInVm(Options->ContextPath, TRUE);
 
@@ -953,16 +954,22 @@ try
         buildArgs.push_back("--target");
         buildArgs.push_back(Options->Target);
     }
-    // Docker-style --output routing. When the client provides an OutputHandle it has stripped dest=
-    // from the spec and expects the exporter output streamed back: the exporter writes to a VM temp
-    // path (disk-backed under the docker storage root to avoid buffering large outputs in tmpfs) and,
-    // after a successful build, a streamer process relays that path to the client handle. Without a
-    // handle the spec is forwarded verbatim and the build runs entirely in the VM.
+    // Docker-style --output routing. Three cases, distinguished by what the client set:
+    //   * OutputHandle set (dest=- stdout, or a type=local directory): the client stripped dest= and
+    //     expects the exporter output streamed back. The exporter writes to a VM temp path (disk-backed
+    //     under the docker storage root to avoid buffering large outputs in tmpfs) and, after a
+    //     successful build, a streamer relays it to the client handle (cat for a file, tar for a tree).
+    //   * OutputMountPath set (single-file exporter with a real destination): the client stripped dest=
+    //     and passed the destination file's parent directory, mounted read-write into the VM so buildx
+    //     writes the file (at OutputMountFile within the mount) in place - nothing is streamed back.
+    //   * Neither set: the spec is forwarded verbatim and the build runs entirely in the VM.
     const bool streamOutput = Options->OutputHandle.Type != WSLCHandleTypeUnknown;
-    // When an OutputHandle is provided the exporter output must be streamed back, which requires a
-    // non-empty Output spec to route from. Reject the mismatched combination at the boundary rather
-    // than later failing to stream an unassigned dest path.
-    RETURN_HR_IF(E_INVALIDARG, streamOutput && (Options->Output == nullptr || Options->Output[0] == '\0'));
+    const bool mountOutput = Options->OutputMountPath != nullptr && Options->OutputMountPath[0] != L'\0';
+    // Streaming or mounting the exporter output requires a non-empty Output spec to route from, and the
+    // two destinations are mutually exclusive. Reject the mismatched combinations at the boundary rather
+    // than later failing to assign a dest path.
+    RETURN_HR_IF(E_INVALIDARG, (streamOutput || mountOutput) && (Options->Output == nullptr || Options->Output[0] == '\0'));
+    RETURN_HR_IF(E_INVALIDARG, streamOutput && mountOutput);
     const bool outputIsDirectory = WI_IsFlagSet(Options->Flags, WSLCBuildImageFlagsOutputIsDirectory);
     std::string outputDestPath;
     auto removeOutput = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
@@ -1005,6 +1012,19 @@ try
             THROW_HR_IF_MSG(E_FAIL, mkdirResult.Code != 0, "failed to create build output directory");
 
             outputSpec += std::format(",dest={}", outputDestPath);
+        }
+        else if (mountOutput)
+        {
+            // Mount the client's destination directory read-write and point the exporter at the temp file
+            // to write within it, so buildx writes the single-file output straight to the Windows target.
+            auto guestMountPath = mountInVm(Options->OutputMountPath, FALSE);
+            std::string dest = guestMountPath;
+            if (Options->OutputMountFile != nullptr && Options->OutputMountFile[0] != L'\0')
+            {
+                dest += '/';
+                dest += wsl::shared::string::WideToMultiByte(Options->OutputMountFile);
+            }
+            outputSpec += std::format(",dest={}", dest);
         }
         buildArgs.push_back("--output");
         buildArgs.push_back(outputSpec);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -953,10 +953,46 @@ try
         buildArgs.push_back("--target");
         buildArgs.push_back(Options->Target);
     }
+    // Docker-style --output routing. When the client provides an OutputHandle it has stripped dest=
+    // from the spec and expects the exporter output streamed back: the exporter writes to a VM temp
+    // path (disk-backed under the docker storage root to avoid buffering large outputs in tmpfs) and,
+    // after a successful build, a streamer process relays that path to the client handle. Without a
+    // handle the spec is forwarded verbatim and the build runs entirely in the VM.
+    const bool streamOutput = Options->OutputHandle.Type != WSLCHandleTypeUnknown;
+    const bool outputIsDirectory = WI_IsFlagSet(Options->Flags, WSLCBuildImageFlagsOutputIsDirectory);
+    std::string outputDestPath;
+    auto removeOutput = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+        if (!outputDestPath.empty())
+        {
+            ServiceProcessLauncher cleanup("/bin/sh", {"/bin/sh", "--norc", "-c", std::format("rm -rf '{}'", outputDestPath)}, {}, WSLCProcessFlagsNone);
+            auto cleanupResult = cleanup.LaunchNoThrow(*m_virtualMachine);
+            if (auto& process = std::get<2>(cleanupResult); process)
+            {
+                std::ignore = process->WaitAndCaptureOutput(60000UL);
+            }
+        }
+    });
+
     if (Options->Output != nullptr && Options->Output[0] != '\0')
     {
+        std::string outputSpec = Options->Output;
+        if (streamOutput)
+        {
+            GUID id{};
+            THROW_IF_FAILED(CoCreateGuid(&id));
+            constexpr auto c_outputBaseDir = "/var/lib/docker/tmp/wslc-build-output";
+            outputDestPath = std::format("{}/{}", c_outputBaseDir, wsl::shared::string::GuidToString<char>(id));
+
+            // buildx creates the leaf dest (a file for tar/oci/docker, a directory for local) but not
+            // the parent, so ensure the base directory exists first.
+            ServiceProcessLauncher mkdir("/bin/sh", {"/bin/sh", "--norc", "-c", std::format("mkdir -p '{}'", c_outputBaseDir)}, {}, WSLCProcessFlagsNone);
+            auto mkdirResult = mkdir.Launch(*m_virtualMachine).WaitAndCaptureOutput(60000UL);
+            THROW_HR_IF_MSG(E_FAIL, mkdirResult.Code != 0, "failed to create build output directory");
+
+            outputSpec += std::format(",dest={}", outputDestPath);
+        }
         buildArgs.push_back("--output");
-        buildArgs.push_back(Options->Output);
+        buildArgs.push_back(outputSpec);
     }
     for (ULONG i = 0; i < Options->Tags.Count; i++)
     {
@@ -1344,6 +1380,59 @@ try
     // translation.
     std::erase(allOutput, '\r');
     THROW_HR_WITH_USER_ERROR_IF(E_FAIL, allOutput, exitCode != 0);
+
+    // Stream the exporter output back to the client. For file exporters (tar/oci/docker) cat the temp
+    // file; for the directory exporter (type=local) tar the export directory so the client can extract
+    // it into the destination directory. The streamer's stdout is relayed to the client OutputHandle.
+    if (streamOutput)
+    {
+        // TEMP DIAGNOSTIC: inspect the VM-side exporter output before streaming it back.
+        {
+            ServiceProcessLauncher diag(
+                "/bin/sh",
+                {"/bin/sh",
+                 "--norc",
+                 "-c",
+                 std::format(
+                     "echo DEST={0}; stat -c 'STAT size=%s name=%n' '{0}' 2>&1; echo '--- ls base ---'; ls -la '{1}' 2>&1; "
+                     "echo '--- find tmp ---'; find /var/lib/docker/tmp 2>&1; echo '--- mounts ---'; grep -E 'docker' "
+                     "/proc/self/mountinfo 2>&1",
+                     outputDestPath,
+                     "/var/lib/docker/tmp/wslc-build-output")},
+                {},
+                WSLCProcessFlagsNone);
+            auto diagResult = diag.Launch(*m_virtualMachine).WaitAndCaptureOutput(60000UL);
+            reportProgress(std::format("\n===WSLC BUILD OUTPUT DIAGNOSTIC===\n{}\n===END DIAGNOSTIC===\n", diag.FormatResult(diagResult)), c_logId);
+        }
+
+        auto userHandle = OpenUserHandle(Options->OutputHandle);
+
+        std::vector<std::string> streamArgs;
+        if (outputIsDirectory)
+        {
+            streamArgs = {"/usr/bin/tar", "-C", outputDestPath, "-cf", "-", "."};
+        }
+        else
+        {
+            streamArgs = {"/bin/cat", outputDestPath};
+        }
+
+        ServiceProcessLauncher streamLauncher(streamArgs[0], streamArgs, {}, WSLCProcessFlagsNone);
+        auto streamProcess = streamLauncher.Launch(*m_virtualMachine);
+
+        auto streamIo = CreateIOContext(CancelEvent);
+        std::string streamError;
+        streamIo.AddHandle(std::make_unique<io::RelayHandle<io::ReadHandle>>(
+            common::io::HandleWrapper{streamProcess.GetStdHandle(1)}, userHandle.Get()));
+        streamIo.AddHandle(std::make_unique<io::ReadHandle>(streamProcess.GetStdHandle(2), [&](const gsl::span<char>& content) {
+            streamError.append(content.data(), content.size());
+        }));
+        streamIo.Run({});
+
+        std::erase(streamError, '\r');
+        int streamCode = streamProcess.Wait();
+        THROW_HR_IF_MSG(E_FAIL, streamCode != 0, "failed to stream build output: %hs", streamError.c_str());
+    }
 
     return S_OK;
 }

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -2342,7 +2342,7 @@ class WSLCTests
         WSLCBuildImageOptions options{
             .ContextPath = contextDir.c_str(),
             .DockerfileHandle = ToCOMInputHandle(dummyDockerfile.get()),
-            .Flags = static_cast<WSLCBuildImageFlags>(0x8)};
+            .Flags = static_cast<WSLCBuildImageFlags>(0x10)};
 
         VERIFY_ARE_EQUAL(E_INVALIDARG, m_defaultSession->BuildImage(&options, nullptr, nullptr));
     }

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -28,7 +28,7 @@ Abstract:
 
     Grammar / behavior (docker buildx parity):
       * A single token with no '=' is shorthand for the destination:
-          - L"-"            -> rejected (streaming a tarball to stdout is not supported)
+          - L"-"            -> {type=tar, dest=-} (stream a tarball to stdout, matching docker)
           - any other path  -> {type=local, dest=<path>}
       * Otherwise the spec is a comma separated list of key=value pairs. Keys are matched
         case-insensitively. 'type' and 'dest' populate the struct fields; every other key is
@@ -37,7 +37,8 @@ Abstract:
           - 'type' is required once any key=value pair is present.
           - 'type' must be one of: local, tar, oci, docker, image, registry, cacheonly.
           - local / tar / oci require 'dest='.
-          - tar may not target stdout ('dest=-').
+          - local may not target stdout ('dest=-'); tar / oci / docker may (they stream to stdout),
+            and image / registry / cacheonly ignore 'dest' entirely (matching docker).
           - registry requires 'name='.
           - docker / image / cacheonly do not require a destination.
       * On rejection the parser throws ArgumentException whose message is the standard
@@ -114,8 +115,8 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Shorthand_DashIsTarToStdout)
     {
-        // '-' is docker's shorthand for streaming a tarball to stdout, which we disallow.
-        VerifyInvalid(L"-", L"streaming a tarball to stdout is not supported");
+        // '-' is docker's shorthand for streaming a tarball to stdout ('type=tar,dest=-').
+        VerifyValid(L"-", L"tar", L"-");
     }
 
     // --- Valid: explicit local / tar / oci / docker exporters ---
@@ -132,8 +133,14 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Tar_ToStdout)
     {
-        // Streaming a tarball to stdout is not supported; a real file path is required.
-        VerifyInvalid(L"type=tar,dest=-", L"streaming a tarball to stdout is not supported");
+        // tar streams a single tarball, so it may target stdout ('dest=-'), matching docker.
+        VerifyValid(L"type=tar,dest=-", L"tar", L"-");
+    }
+
+    TEST_METHOD(Output_Local_ToStdout_Rejected)
+    {
+        // The local exporter writes a directory tree, so it cannot stream to stdout.
+        VerifyInvalid(L"type=local,dest=-", L"dest cannot be stdout for local exporter");
     }
 
     TEST_METHOD(Output_Oci_ToFile)

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -310,6 +310,73 @@ class WSLCCLIOutputParserUnitTests
     {
         VerifyInvalid(L"type=registry", L"'type=registry' requires 'name='");
     }
+
+    // --- Round-trip: FormatOutputSpec re-serializes a BuildOutput into a canonical buildx spec ---
+
+    // Parses spec, formats the result, and asserts the canonical serialized form.
+    static void VerifyFormat(const std::wstring& spec, const std::wstring& expectedCanonical)
+    {
+        const auto canonical = validation::FormatOutputSpec(validation::ParseOutputSpec(spec));
+        VERIFY_ARE_EQUAL(expectedCanonical, canonical);
+
+        // The canonical form must itself parse back to an equivalent BuildOutput (idempotent round-trip).
+        const auto reparsed = validation::ParseOutputSpec(canonical);
+        const auto original = validation::ParseOutputSpec(spec);
+        VERIFY_ARE_EQUAL(original.Type, reparsed.Type);
+        VERIFY_ARE_EQUAL(original.Dest, reparsed.Dest);
+        VERIFY_ARE_EQUAL(original.Attributes.size(), reparsed.Attributes.size());
+        for (const auto& [key, value] : original.Attributes)
+        {
+            const auto it = reparsed.Attributes.find(key);
+            VERIFY_IS_TRUE(it != reparsed.Attributes.end());
+            if (it != reparsed.Attributes.end())
+            {
+                VERIFY_ARE_EQUAL(value, it->second);
+            }
+        }
+    }
+
+    TEST_METHOD(Format_Shorthand_LocalNormalizedToCanonical)
+    {
+        // Shorthand paths are normalized to their explicit type=local,dest= form for buildx.
+        VerifyFormat(L"./out", L"type=local,dest=./out");
+    }
+
+    TEST_METHOD(Format_Shorthand_DashNormalizedToTarStdout)
+    {
+        VerifyFormat(L"-", L"type=tar,dest=-");
+    }
+
+    TEST_METHOD(Format_TypeOnly_NoDestOrAttributes)
+    {
+        // docker/cacheonly need neither dest nor attributes, so the canonical form is just the type.
+        VerifyFormat(L"type=docker", L"type=docker");
+        VerifyFormat(L"type=cacheonly", L"type=cacheonly");
+    }
+
+    TEST_METHOD(Format_TypeAndDest)
+    {
+        VerifyFormat(L"type=tar,dest=out.tar", L"type=tar,dest=out.tar");
+    }
+
+    TEST_METHOD(Format_CaseInsensitiveKeysNormalizedToLower)
+    {
+        // 'type'/'dest' keys are lowercased; the type value is lowercased too.
+        VerifyFormat(L"TYPE=LOCAL,DEST=./out", L"type=local,dest=./out");
+    }
+
+    TEST_METHOD(Format_AttributesAppendedAfterDest)
+    {
+        // Attributes follow type/dest; std::map orders them, so 'name' precedes 'push'.
+        VerifyFormat(L"type=image,push=true,name=x", L"type=image,name=x,push=true");
+    }
+
+    TEST_METHOD(Format_RegistryWithAttributes)
+    {
+        VerifyFormat(
+            L"type=registry,name=myrepo/app:latest,push-by-digest=true",
+            L"type=registry,name=myrepo/app:latest,push-by-digest=true");
+    }
 };
 
 } // namespace WSLCCLIOutputParserUnitTests

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -28,7 +28,7 @@ Abstract:
 
     Grammar / behavior (docker buildx parity):
       * A single token with no '=' is shorthand for the destination:
-          - L"-"            -> {type=tar,  dest=-}     (stream a tarball to stdout)
+          - L"-"            -> rejected (streaming a tarball to stdout is not supported)
           - any other path  -> {type=local, dest=<path>}
       * Otherwise the spec is a comma separated list of key=value pairs. Keys are matched
         case-insensitively. 'type' and 'dest' populate the struct fields; every other key is
@@ -37,6 +37,7 @@ Abstract:
           - 'type' is required once any key=value pair is present.
           - 'type' must be one of: local, tar, oci, docker, image, registry, cacheonly.
           - local / tar / oci require 'dest='.
+          - tar may not target stdout ('dest=-').
           - registry requires 'name='.
           - docker / image / cacheonly do not require a destination.
       * On rejection the parser throws ArgumentException whose message is the standard
@@ -113,8 +114,8 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Shorthand_DashIsTarToStdout)
     {
-        // '-' is docker's shorthand for streaming a tarball to stdout.
-        VerifyValid(L"-", L"tar", L"-");
+        // '-' is docker's shorthand for streaming a tarball to stdout, which we disallow.
+        VerifyInvalid(L"-", L"streaming a tarball to stdout is not supported");
     }
 
     // --- Valid: explicit local / tar / oci / docker exporters ---
@@ -131,7 +132,8 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Tar_ToStdout)
     {
-        VerifyValid(L"type=tar,dest=-", L"tar", L"-");
+        // Streaming a tarball to stdout is not supported; a real file path is required.
+        VerifyInvalid(L"type=tar,dest=-", L"streaming a tarball to stdout is not supported");
     }
 
     TEST_METHOD(Output_Oci_ToFile)
@@ -340,11 +342,6 @@ class WSLCCLIOutputParserUnitTests
     {
         // Shorthand paths are normalized to their explicit type=local,dest= form for buildx.
         VerifyFormat(L"./out", L"type=local,dest=./out");
-    }
-
-    TEST_METHOD(Format_Shorthand_DashNormalizedToTarStdout)
-    {
-        VerifyFormat(L"-", L"type=tar,dest=-");
     }
 
     TEST_METHOD(Format_TypeOnly_NoDestOrAttributes)

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -1,0 +1,315 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    WSLCCLIOutputParserUnitTests.cpp
+
+Abstract:
+
+    This file contains unit tests for WSLC CLI --output spec validation and parsing (validation::ParseOutputSpec).
+
+    These tests define the contract for the docker-style `wslc image build --output` flag, mirroring
+    `docker buildx build --output`. The parser under test is expected to expose:
+
+        namespace wsl::windows::wslc::services {
+        struct BuildOutput
+        {
+            std::wstring Type;                             // resolved exporter type (e.g. L"local", L"tar", ...)
+            std::wstring Dest;                             // destination path; L"-" means stdout; empty when not applicable
+            std::map<std::wstring, std::wstring> Attributes; // remaining key=value attributes (name, push, compression, ...)
+        };
+        }
+
+        namespace wsl::windows::wslc::validation {
+        services::BuildOutput ParseOutputSpec(const std::wstring& spec);
+        }
+
+    Grammar / behavior (docker buildx parity):
+      * A single token with no '=' is shorthand for the destination:
+          - L"-"            -> {type=tar,  dest=-}     (stream a tarball to stdout)
+          - any other path  -> {type=local, dest=<path>}
+      * Otherwise the spec is a comma separated list of key=value pairs. Keys are matched
+        case-insensitively. 'type' and 'dest' populate the struct fields; every other key is
+        stored verbatim in Attributes (values may themselves contain '=').
+      * Validation:
+          - 'type' is required once any key=value pair is present.
+          - 'type' must be one of: local, tar, oci, docker, image, registry, cacheonly.
+          - local / tar / oci require 'dest='.
+          - registry requires 'name='.
+          - docker / image / cacheonly do not require a destination.
+      * On rejection the parser throws ArgumentException whose message is the standard
+        "Invalid --output value '<spec>': <reason>" wrapper (Localization::MessageWslcOutputInvalidSpec).
+
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCCLITestHelpers.h"
+#include "ArgumentValidation.h"
+#include "ImageService.h"
+#include "Exceptions.h"
+#include <map>
+#include <string>
+
+using namespace wsl::windows::wslc;
+
+namespace WSLCCLIOutputParserUnitTests {
+
+using AttrMap = std::map<std::wstring, std::wstring>;
+
+class WSLCCLIOutputParserUnitTests
+{
+    WSLC_TEST_CLASS(WSLCCLIOutputParserUnitTests)
+
+    // Parses a spec expected to be valid and asserts the resolved type, destination and attributes.
+    static void VerifyValid(const std::wstring& spec, const std::wstring& expectedType, const std::wstring& expectedDest, const AttrMap& expectedAttrs = {})
+    {
+        auto output = validation::ParseOutputSpec(spec);
+        VERIFY_ARE_EQUAL(expectedType, output.Type);
+        VERIFY_ARE_EQUAL(expectedDest, output.Dest);
+        VERIFY_ARE_EQUAL(expectedAttrs.size(), output.Attributes.size());
+        for (const auto& [key, value] : expectedAttrs)
+        {
+            const auto it = output.Attributes.find(key);
+            VERIFY_IS_TRUE(it != output.Attributes.end());
+            if (it != output.Attributes.end())
+            {
+                VERIFY_ARE_EQUAL(value, it->second);
+            }
+        }
+    }
+
+    // Parses a spec expected to be rejected and asserts it throws an ArgumentException whose message is
+    // the standard "Invalid --output value '<spec>': <reason>" wrapper and contains the expected reason.
+    static void VerifyInvalid(const std::wstring& spec, const std::wstring& expectedReasonSubstr)
+    {
+        try
+        {
+            (void)validation::ParseOutputSpec(spec);
+            VERIFY_FAIL(L"Expected ArgumentException for invalid output spec");
+        }
+        catch (const ArgumentException& ex)
+        {
+            const std::wstring& message = ex.Message();
+            VERIFY_IS_TRUE(message.find(L"Invalid --output value") != std::wstring::npos);
+            VERIFY_IS_TRUE(message.find(expectedReasonSubstr) != std::wstring::npos);
+        }
+    }
+
+    // --- Valid: shorthand (single token, no key=value pairs) ---
+
+    TEST_METHOD(Output_Shorthand_LocalDirectory)
+    {
+        // A bare path is shorthand for exporting the final stage's filesystem to that directory.
+        VerifyValid(L"./out", L"local", L"./out");
+    }
+
+    TEST_METHOD(Output_Shorthand_WindowsPath)
+    {
+        VerifyValid(L"C:\\build\\artifacts", L"local", L"C:\\build\\artifacts");
+    }
+
+    TEST_METHOD(Output_Shorthand_DashIsTarToStdout)
+    {
+        // '-' is docker's shorthand for streaming a tarball to stdout.
+        VerifyValid(L"-", L"tar", L"-");
+    }
+
+    // --- Valid: explicit local / tar / oci / docker exporters ---
+
+    TEST_METHOD(Output_Local_ExplicitDest)
+    {
+        VerifyValid(L"type=local,dest=./out", L"local", L"./out");
+    }
+
+    TEST_METHOD(Output_Tar_ToFile)
+    {
+        VerifyValid(L"type=tar,dest=out.tar", L"tar", L"out.tar");
+    }
+
+    TEST_METHOD(Output_Tar_ToStdout)
+    {
+        VerifyValid(L"type=tar,dest=-", L"tar", L"-");
+    }
+
+    TEST_METHOD(Output_Oci_ToFile)
+    {
+        VerifyValid(L"type=oci,dest=image.tar", L"oci", L"image.tar");
+    }
+
+    TEST_METHOD(Output_Docker_ToFile)
+    {
+        VerifyValid(L"type=docker,dest=image.tar", L"docker", L"image.tar");
+    }
+
+    TEST_METHOD(Output_Docker_NoDestLoadsIntoStore)
+    {
+        // The docker exporter loads the image into the local store when no destination is given.
+        VerifyValid(L"type=docker", L"docker", L"");
+    }
+
+    TEST_METHOD(Output_CacheOnly)
+    {
+        // cacheonly runs the build without exporting an artifact.
+        VerifyValid(L"type=cacheonly", L"cacheonly", L"");
+    }
+
+    // --- Valid: image / registry exporters with attributes ---
+
+    TEST_METHOD(Output_Image_NameAndPush)
+    {
+        VerifyValid(
+            L"type=image,name=myrepo/app:1.0,push=true", L"image", L"", AttrMap{{L"name", L"myrepo/app:1.0"}, {L"push", L"true"}});
+    }
+
+    TEST_METHOD(Output_Registry_Name)
+    {
+        VerifyValid(L"type=registry,name=myrepo/app:latest", L"registry", L"", AttrMap{{L"name", L"myrepo/app:latest"}});
+    }
+
+    TEST_METHOD(Output_Registry_PushAttributes)
+    {
+        // Registry/push related attributes are passed through verbatim.
+        VerifyValid(
+            L"type=registry,name=myrepo/app:latest,push-by-digest=true,insecure=true,dangling-name-prefix=cache",
+            L"registry",
+            L"",
+            AttrMap{
+                {L"name", L"myrepo/app:latest"},
+                {L"push-by-digest", L"true"},
+                {L"insecure", L"true"},
+                {L"dangling-name-prefix", L"cache"}});
+    }
+
+    TEST_METHOD(Output_Image_StoreAttributes)
+    {
+        // Image-store related attributes are passed through verbatim.
+        VerifyValid(
+            L"type=image,name=x,store=true,unpack=true,name-canonical=true",
+            L"image",
+            L"",
+            AttrMap{{L"name", L"x"}, {L"store", L"true"}, {L"unpack", L"true"}, {L"name-canonical", L"true"}});
+    }
+
+    // --- Valid: attribute passthrough ---
+
+    TEST_METHOD(Output_Attributes_CompressionOptions)
+    {
+        VerifyValid(
+            L"type=image,name=x,compression=zstd,compression-level=19,oci-mediatypes=true",
+            L"image",
+            L"",
+            AttrMap{{L"name", L"x"}, {L"compression", L"zstd"}, {L"compression-level", L"19"}, {L"oci-mediatypes", L"true"}});
+    }
+
+    TEST_METHOD(Output_Attributes_ForceCompression)
+    {
+        VerifyValid(
+            L"type=oci,dest=o.tar,compression=gzip,compression-level=5,force-compression=true",
+            L"oci",
+            L"o.tar",
+            AttrMap{{L"compression", L"gzip"}, {L"compression-level", L"5"}, {L"force-compression", L"true"}});
+    }
+
+    TEST_METHOD(Output_Attributes_ScopedAnnotation)
+    {
+        // Scoped annotations (annotation-manifest./annotation-index.) are preserved as-is.
+        VerifyValid(
+            L"type=oci,dest=o.tar,annotation-manifest.org.opencontainers.image.title=app",
+            L"oci",
+            L"o.tar",
+            AttrMap{{L"annotation-manifest.org.opencontainers.image.title", L"app"}});
+    }
+
+    TEST_METHOD(Output_Local_PlatformSplit)
+    {
+        // platform-split controls per-platform subdirectories for the local/tar exporters.
+        VerifyValid(L"type=local,dest=./out,platform-split=false", L"local", L"./out", AttrMap{{L"platform-split", L"false"}});
+    }
+
+    TEST_METHOD(Output_Attributes_AnnotationValueMayContainEquals)
+    {
+        // Only the first '=' separates key from value, so annotation values may themselves contain '='.
+        VerifyValid(
+            L"type=oci,dest=o.tar,annotation.org.opencontainers.image.source=https://example.com/repo?ref=main",
+            L"oci",
+            L"o.tar",
+            AttrMap{{L"annotation.org.opencontainers.image.source", L"https://example.com/repo?ref=main"}});
+    }
+
+    TEST_METHOD(Output_Attributes_EmptyValuePreserved)
+    {
+        // A key with an explicit but empty value is preserved (the separator was present).
+        VerifyValid(L"type=image,name=x,push=", L"image", L"", AttrMap{{L"name", L"x"}, {L"push", L""}});
+    }
+
+    TEST_METHOD(Output_Keys_AreCaseInsensitive)
+    {
+        VerifyValid(L"TYPE=local,DEST=./out", L"local", L"./out");
+    }
+
+    // --- Invalid: spec structure ---
+
+    TEST_METHOD(Output_Invalid_Empty)
+    {
+        VerifyInvalid(L"", L"may not be empty");
+    }
+
+    TEST_METHOD(Output_Invalid_FieldWithoutEquals)
+    {
+        VerifyInvalid(L"type=local,garbage", L"expected key=value pairs separated by ','");
+    }
+
+    TEST_METHOD(Output_Invalid_LeadingFieldWithoutEquals)
+    {
+        VerifyInvalid(L"garbage,type=local", L"expected key=value pairs separated by ','");
+    }
+
+    TEST_METHOD(Output_Invalid_EmptyField)
+    {
+        VerifyInvalid(L"type=local,,dest=x", L"expected key=value pairs separated by ','");
+    }
+
+    // --- Invalid: type constraints ---
+
+    TEST_METHOD(Output_Invalid_EmptyTypeValue)
+    {
+        VerifyInvalid(L"type=,dest=x", L"type is required");
+    }
+
+    TEST_METHOD(Output_Invalid_MissingType)
+    {
+        VerifyInvalid(L"dest=./out", L"type is required");
+    }
+
+    TEST_METHOD(Output_Invalid_UnsupportedType)
+    {
+        VerifyInvalid(L"type=bogus", L"unsupported output type 'bogus'");
+    }
+
+    // --- Invalid: destination / name requirements ---
+
+    TEST_METHOD(Output_Invalid_LocalRequiresDest)
+    {
+        VerifyInvalid(L"type=local", L"'type=local' requires 'dest='");
+    }
+
+    TEST_METHOD(Output_Invalid_TarRequiresDest)
+    {
+        VerifyInvalid(L"type=tar", L"'type=tar' requires 'dest='");
+    }
+
+    TEST_METHOD(Output_Invalid_OciRequiresDest)
+    {
+        VerifyInvalid(L"type=oci", L"'type=oci' requires 'dest='");
+    }
+
+    TEST_METHOD(Output_Invalid_RegistryRequiresName)
+    {
+        VerifyInvalid(L"type=registry", L"'type=registry' requires 'name='");
+    }
+};
+
+} // namespace WSLCCLIOutputParserUnitTests

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -183,6 +183,69 @@ class WSLCCLIOutputParserUnitTests
         VerifyValid(L"type=docker,dest=./layout,tar=false", L"docker", L"./layout", AttrMap{{L"tar", L"false"}});
     }
 
+    // --- Valid: 'tar' accepts every spelling Go's strconv.ParseBool does (buildx parity) ---
+
+    TEST_METHOD(Output_Oci_TarFalse_CapitalizedIsDirectory)
+    {
+        // buildx parses 'tar' with Go's ParseBool, so "False" is a directory exporter just like "false".
+        // The attribute value is preserved verbatim (only routing is case-insensitive).
+        VerifyValid(L"type=oci,dest=./layout,tar=False", L"oci", L"./layout", AttrMap{{L"tar", L"False"}});
+    }
+
+    TEST_METHOD(Output_Oci_TarZeroIsDirectory)
+    {
+        // "0" is false for Go's ParseBool, so it selects the OCI layout directory exporter.
+        VerifyValid(L"type=oci,dest=./layout,tar=0", L"oci", L"./layout", AttrMap{{L"tar", L"0"}});
+    }
+
+    TEST_METHOD(Output_Oci_TarShortFalseIsDirectory)
+    {
+        // "f" is the short false form accepted by Go's ParseBool.
+        VerifyValid(L"type=oci,dest=./layout,tar=f", L"oci", L"./layout", AttrMap{{L"tar", L"f"}});
+    }
+
+    TEST_METHOD(Output_Oci_TarCapitalizedFalse_RequiresDest)
+    {
+        // A directory exporter cannot stream to stdout regardless of the boolean spelling, so tar=False
+        // with no dest is rejected the same as tar=false.
+        VerifyInvalid(L"type=oci,tar=False", L"writes a directory tree");
+    }
+
+    TEST_METHOD(Output_Docker_TarZeroIsDirectory)
+    {
+        // docker with tar=0 likewise exports an OCI layout directory.
+        VerifyValid(L"type=docker,dest=./layout,tar=0", L"docker", L"./layout", AttrMap{{L"tar", L"0"}});
+    }
+
+    TEST_METHOD(Output_Oci_TarTrue_IsSingleTarballToStdout)
+    {
+        // "True" is true for Go's ParseBool, so oci stays a single tarball and defaults to stdout.
+        VerifyValid(L"type=oci,tar=True", L"oci", L"-", AttrMap{{L"tar", L"True"}});
+    }
+
+    TEST_METHOD(Output_Oci_TarOne_IsSingleTarballToFile)
+    {
+        // "1" is true, so this is a single-tarball export to a file (not a directory).
+        VerifyValid(L"type=oci,dest=image.tar,tar=1", L"oci", L"image.tar", AttrMap{{L"tar", L"1"}});
+    }
+
+    TEST_METHOD(Output_Docker_TarTrue_LoadsIntoStore)
+    {
+        // docker with tar=true is a single tarball; with no dest it loads into the VM store (dest empty).
+        VerifyValid(L"type=docker,tar=t", L"docker", L"", AttrMap{{L"tar", L"t"}});
+    }
+
+    TEST_METHOD(Output_Oci_TarInvalidBool_Rejected)
+    {
+        // A non-boolean 'tar' value is rejected up front, matching buildx (which errors in ParseBool).
+        VerifyInvalid(L"type=oci,dest=./layout,tar=yes", L"invalid boolean value 'yes' for 'tar'");
+    }
+
+    TEST_METHOD(Output_Docker_TarInvalidBool_Rejected)
+    {
+        VerifyInvalid(L"type=docker,dest=./layout,tar=maybe", L"invalid boolean value 'maybe' for 'tar'");
+    }
+
     TEST_METHOD(Output_Docker_ToFile)
     {
         VerifyValid(L"type=docker,dest=image.tar", L"docker", L"image.tar");

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -27,20 +27,25 @@ Abstract:
         }
 
     Grammar / behavior (docker buildx parity):
-      * A single token with no '=' is shorthand for the destination:
+      * The spec is parsed as a single CSV record (RFC 4180, as buildx does via go-csvvalue): fields
+        are comma separated, a field may be double-quoted, "" inside a quoted field is a literal quote,
+        and a comma inside a quoted field is part of the value.
+      * A single field that equals the whole input and does not start with "type=" is shorthand for the
+        destination:
           - L"-"            -> {type=tar, dest=-} (stream a tarball to stdout, matching docker)
           - any other path  -> {type=local, dest=<path>}
-      * Otherwise the spec is a comma separated list of key=value pairs. Keys are matched
-        case-insensitively. 'type' and 'dest' populate the struct fields; every other key is
-        stored verbatim in Attributes (values may themselves contain '=').
-      * Validation:
-          - 'type' is required once any key=value pair is present.
-          - 'type' must be one of: local, tar, oci, docker, image, registry, cacheonly.
-          - local / tar / oci require 'dest='.
-          - local may not target stdout ('dest=-'); tar / oci / docker may (they stream to stdout),
-            and image / registry / cacheonly ignore 'dest' entirely (matching docker).
-          - registry requires 'name='.
-          - docker / image / cacheonly do not require a destination.
+      * Otherwise each field is split on its FIRST '=' into key/value (two parts required). The key is
+        trimmed and lowercased; the value is kept verbatim (may itself contain '='). 'type' and 'dest'
+        populate the struct fields; every other key is stored in Attributes.
+      * Validation / destination resolution:
+          - 'type' is required and must be one of: local, tar, oci, docker, image, registry, cacheonly.
+          - Directory exporters (local, or oci/docker with tar=false) require a directory 'dest=' and
+            may not stream to stdout ('dest=-').
+          - tar / oci with no 'dest=' default to streaming a tarball to stdout ('dest=-'), matching buildx.
+          - docker with no 'dest=' loads the image into the store; 'dest=-' streams a tarball to stdout;
+            a path writes a file.
+          - image / registry / cacheonly run in the build VM and ignore 'dest'; 'name=' is optional
+            (buildx only enforces it at export time, not at parse time).
       * On rejection the parser throws ArgumentException whose message is the standard
         "Invalid --output value '<spec>': <reason>" wrapper (Localization::MessageWslcOutputInvalidSpec).
 
@@ -137,10 +142,16 @@ class WSLCCLIOutputParserUnitTests
         VerifyValid(L"type=tar,dest=-", L"tar", L"-");
     }
 
+    TEST_METHOD(Output_Tar_NoDest_DefaultsToStdout)
+    {
+        // tar with no destination streams a tarball to stdout ('dest=-'), matching buildx.
+        VerifyValid(L"type=tar", L"tar", L"-");
+    }
+
     TEST_METHOD(Output_Local_ToStdout_Rejected)
     {
         // The local exporter writes a directory tree, so it cannot stream to stdout.
-        VerifyInvalid(L"type=local,dest=-", L"dest cannot be stdout for local exporter");
+        VerifyInvalid(L"type=local,dest=-", L"writes a directory tree");
     }
 
     TEST_METHOD(Output_Oci_ToFile)
@@ -148,9 +159,40 @@ class WSLCCLIOutputParserUnitTests
         VerifyValid(L"type=oci,dest=image.tar", L"oci", L"image.tar");
     }
 
+    TEST_METHOD(Output_Oci_NoDest_DefaultsToStdout)
+    {
+        // oci with no destination streams a tarball to stdout ('dest=-'), matching buildx.
+        VerifyValid(L"type=oci", L"oci", L"-");
+    }
+
+    TEST_METHOD(Output_Oci_TarFalse_Directory)
+    {
+        // oci with tar=false exports an OCI layout directory, so a directory 'dest=' is required.
+        VerifyValid(L"type=oci,dest=./layout,tar=false", L"oci", L"./layout", AttrMap{{L"tar", L"false"}});
+    }
+
+    TEST_METHOD(Output_Oci_TarFalse_RequiresDest)
+    {
+        // A directory exporter cannot stream to stdout, so tar=false with no dest is rejected.
+        VerifyInvalid(L"type=oci,tar=false", L"writes a directory tree");
+    }
+
+    TEST_METHOD(Output_Docker_TarFalse_Directory)
+    {
+        // docker with tar=false likewise exports an OCI layout directory.
+        VerifyValid(L"type=docker,dest=./layout,tar=false", L"docker", L"./layout", AttrMap{{L"tar", L"false"}});
+    }
+
     TEST_METHOD(Output_Docker_ToFile)
     {
         VerifyValid(L"type=docker,dest=image.tar", L"docker", L"image.tar");
+    }
+
+    TEST_METHOD(Output_Docker_ToStdout)
+    {
+        // docker with dest=- streams the image tarball to stdout (matching docker), which the client
+        // routes to the redirected stdout handle.
+        VerifyValid(L"type=docker,dest=-", L"docker", L"-");
     }
 
     TEST_METHOD(Output_Docker_NoDestLoadsIntoStore)
@@ -176,6 +218,12 @@ class WSLCCLIOutputParserUnitTests
     TEST_METHOD(Output_Registry_Name)
     {
         VerifyValid(L"type=registry,name=myrepo/app:latest", L"registry", L"", AttrMap{{L"name", L"myrepo/app:latest"}});
+    }
+
+    TEST_METHOD(Output_Registry_NoName_Valid)
+    {
+        // buildx only enforces 'name=' at export time, not at parse time, so parsing must accept it.
+        VerifyValid(L"type=registry", L"registry", L"");
     }
 
     TEST_METHOD(Output_Registry_PushAttributes)
@@ -290,7 +338,16 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Invalid_MissingType)
     {
-        VerifyInvalid(L"dest=./out", L"type is required");
+        // With two or more fields no shorthand applies, so a spec without 'type=' is rejected.
+        VerifyInvalid(L"dest=./out,compression=gzip", L"type is required");
+    }
+
+    TEST_METHOD(Output_Shorthand_SingleFieldWithEqualsIsLocalPath)
+    {
+        // buildx parity quirk: a single field equal to the whole input that does not start with
+        // "type=" is shorthand for a local path, even if it happens to contain '=' (so '--output
+        // dest=./out' exports to a directory literally named "dest=./out", it is NOT 'dest=./out').
+        VerifyValid(L"dest=./out", L"local", L"dest=./out");
     }
 
     TEST_METHOD(Output_Invalid_UnsupportedType)
@@ -298,26 +355,39 @@ class WSLCCLIOutputParserUnitTests
         VerifyInvalid(L"type=bogus", L"unsupported output type 'bogus'");
     }
 
-    // --- Invalid: destination / name requirements ---
+    // --- Invalid: destination requirements ---
 
     TEST_METHOD(Output_Invalid_LocalRequiresDest)
     {
-        VerifyInvalid(L"type=local", L"'type=local' requires 'dest='");
+        // The local exporter writes a directory tree, so an omitted dest is rejected.
+        VerifyInvalid(L"type=local", L"writes a directory tree");
     }
 
-    TEST_METHOD(Output_Invalid_TarRequiresDest)
+    // --- CSV grammar (buildx go-csvvalue parity) ---
+
+    TEST_METHOD(Output_Csv_QuotedValueWithComma)
     {
-        VerifyInvalid(L"type=tar", L"'type=tar' requires 'dest='");
+        // A comma inside a double-quoted field is part of the value, not a field separator.
+        VerifyValid(
+            L"type=image,name=x,\"annotation.foo=a,b,c\"", L"image", L"", AttrMap{{L"name", L"x"}, {L"annotation.foo", L"a,b,c"}});
     }
 
-    TEST_METHOD(Output_Invalid_OciRequiresDest)
+    TEST_METHOD(Output_Csv_QuotedValueWithEscapedQuote)
     {
-        VerifyInvalid(L"type=oci", L"'type=oci' requires 'dest='");
+        // A doubled quote inside a quoted field is a single literal quote.
+        VerifyValid(
+            L"type=image,name=x,\"annotation.foo=a\"\"b\"", L"image", L"", AttrMap{{L"name", L"x"}, {L"annotation.foo", L"a\"b"}});
     }
 
-    TEST_METHOD(Output_Invalid_RegistryRequiresName)
+    TEST_METHOD(Output_Csv_LeadingSpaceAfterCommaTrimmedFromKey)
     {
-        VerifyInvalid(L"type=registry", L"'type=registry' requires 'name='");
+        // buildx TrimSpace's the key, so a space after a comma is accepted (the value is untrimmed).
+        VerifyValid(L"type=local, dest=./out", L"local", L"./out");
+    }
+
+    TEST_METHOD(Output_Csv_UnterminatedQuoteRejected)
+    {
+        VerifyInvalid(L"type=image,\"name=x", L"malformed quoting");
     }
 
     // --- Round-trip: FormatOutputSpec re-serializes a BuildOutput into a canonical buildx spec ---
@@ -380,6 +450,19 @@ class WSLCCLIOutputParserUnitTests
         VerifyFormat(
             L"type=registry,name=myrepo/app:latest,push-by-digest=true",
             L"type=registry,name=myrepo/app:latest,push-by-digest=true");
+    }
+
+    TEST_METHOD(Format_QuotesValueContainingComma)
+    {
+        // An attribute value containing a comma is CSV-quoted so it round-trips through the parser.
+        // std::map orders attributes, so 'annotation.foo' precedes 'name'.
+        VerifyFormat(L"type=image,name=x,\"annotation.foo=a,b,c\"", L"type=image,\"annotation.foo=a,b,c\",name=x");
+    }
+
+    TEST_METHOD(Format_TarNoDestDefaultsToStdout)
+    {
+        // tar with no dest resolves to dest=- and serializes back to that canonical form.
+        VerifyFormat(L"type=tar", L"type=tar,dest=-");
     }
 };
 

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -60,6 +60,8 @@ Abstract:
 #include <string>
 
 using namespace wsl::windows::wslc;
+using namespace WEX::Logging;
+using namespace WEX::Common;
 
 namespace WSLCCLIOutputParserUnitTests {
 
@@ -91,6 +93,7 @@ class WSLCCLIOutputParserUnitTests
     // the standard "Invalid --output value '<spec>': <reason>" wrapper and contains the expected reason.
     static void VerifyInvalid(const std::wstring& spec, const std::wstring& expectedReasonSubstr)
     {
+        Log::Comment(String().Format(L"Rejecting: %ls", spec.c_str()));
         try
         {
             (void)validation::ParseOutputSpec(spec);
@@ -106,31 +109,46 @@ class WSLCCLIOutputParserUnitTests
 
     // --- Valid: shorthand (single token, no key=value pairs) ---
 
-    TEST_METHOD(Output_Shorthand_LocalDirectory)
-    {
-        // A bare path is shorthand for the local (directory) exporter, which is not supported.
-        VerifyInvalid(L"./out", L"directory exporters are not supported");
-    }
-
-    TEST_METHOD(Output_Shorthand_WindowsPath)
-    {
-        // A bare Windows path is likewise the local (directory) exporter, which is not supported.
-        VerifyInvalid(L"C:\\build\\artifacts", L"directory exporters are not supported");
-    }
-
     TEST_METHOD(Output_Shorthand_DashIsTarToStdout)
     {
         // '-' is docker's shorthand for streaming a tarball to stdout ('type=tar,dest=-').
         VerifyValid(L"-", L"tar", L"-");
     }
 
-    // --- Valid: explicit local / tar / oci / docker exporters ---
+    // --- Invalid: directory exporters are not supported ---
 
-    TEST_METHOD(Output_Local_ExplicitDest)
+    TEST_METHOD(Output_LocalExporter_Rejected)
     {
-        // The local exporter writes a directory tree and is not supported.
-        VerifyInvalid(L"type=local,dest=./out", L"directory exporters are not supported");
+        // The local exporter - a bare-path shorthand or an explicit type=local - writes a Linux
+        // directory tree, which is not supported, so every form is rejected regardless of destination.
+        // 'dest=./out' is buildx's single-field shorthand quirk: a lone field containing '=' that does
+        // not start with 'type=' still names a local path.
+        for (const auto* spec :
+             {L"./out", L"C:\\build\\artifacts", L"dest=./out", L"type=local", L"type=local,dest=./out", L"type=local,dest=-"})
+        {
+            VerifyInvalid(spec, L"directory exporters are not supported");
+        }
     }
+
+    TEST_METHOD(Output_OciDockerTarFalse_Rejected)
+    {
+        // oci/docker export an OCI layout directory when 'tar' is false; buildx parses 'tar' with Go's
+        // ParseBool, so every false spelling (false/False/0/f) is a directory exporter and is rejected
+        // the same way, with or without a destination.
+        for (const auto* spec :
+             {L"type=oci,dest=./layout,tar=false",
+              L"type=oci,tar=false",
+              L"type=oci,dest=./layout,tar=False",
+              L"type=oci,dest=./layout,tar=0",
+              L"type=oci,dest=./layout,tar=f",
+              L"type=docker,dest=./layout,tar=false",
+              L"type=docker,dest=./layout,tar=0"})
+        {
+            VerifyInvalid(spec, L"directory exporters are not supported");
+        }
+    }
+
+    // --- Valid: explicit tar / oci / docker exporters ---
 
     TEST_METHOD(Output_Tar_ToFile)
     {
@@ -149,12 +167,6 @@ class WSLCCLIOutputParserUnitTests
         VerifyValid(L"type=tar", L"tar", L"-");
     }
 
-    TEST_METHOD(Output_Local_ToStdout_Rejected)
-    {
-        // The local exporter writes a directory tree and is not supported.
-        VerifyInvalid(L"type=local,dest=-", L"directory exporters are not supported");
-    }
-
     TEST_METHOD(Output_Oci_ToFile)
     {
         VerifyValid(L"type=oci,dest=image.tar", L"oci", L"image.tar");
@@ -166,57 +178,7 @@ class WSLCCLIOutputParserUnitTests
         VerifyValid(L"type=oci", L"oci", L"-");
     }
 
-    TEST_METHOD(Output_Oci_TarFalse_Directory)
-    {
-        // oci with tar=false exports an OCI layout directory, which is not supported.
-        VerifyInvalid(L"type=oci,dest=./layout,tar=false", L"directory exporters are not supported");
-    }
-
-    TEST_METHOD(Output_Oci_TarFalse_RequiresDest)
-    {
-        // A directory exporter is not supported regardless of dest.
-        VerifyInvalid(L"type=oci,tar=false", L"directory exporters are not supported");
-    }
-
-    TEST_METHOD(Output_Docker_TarFalse_Directory)
-    {
-        // docker with tar=false likewise exports an OCI layout directory, which is not supported.
-        VerifyInvalid(L"type=docker,dest=./layout,tar=false", L"directory exporters are not supported");
-    }
-
-    // --- Valid: 'tar' accepts every spelling Go's strconv.ParseBool does (buildx parity) ---
-
-    TEST_METHOD(Output_Oci_TarFalse_CapitalizedIsDirectory)
-    {
-        // buildx parses 'tar' with Go's ParseBool, so "False" is a directory exporter just like "false",
-        // and is rejected the same way.
-        VerifyInvalid(L"type=oci,dest=./layout,tar=False", L"directory exporters are not supported");
-    }
-
-    TEST_METHOD(Output_Oci_TarZeroIsDirectory)
-    {
-        // "0" is false for Go's ParseBool, so it selects the OCI layout directory exporter, which is not
-        // supported.
-        VerifyInvalid(L"type=oci,dest=./layout,tar=0", L"directory exporters are not supported");
-    }
-
-    TEST_METHOD(Output_Oci_TarShortFalseIsDirectory)
-    {
-        // "f" is the short false form accepted by Go's ParseBool, so it too is a directory exporter.
-        VerifyInvalid(L"type=oci,dest=./layout,tar=f", L"directory exporters are not supported");
-    }
-
-    TEST_METHOD(Output_Oci_TarCapitalizedFalse_RequiresDest)
-    {
-        // A directory exporter is not supported regardless of the boolean spelling.
-        VerifyInvalid(L"type=oci,tar=False", L"directory exporters are not supported");
-    }
-
-    TEST_METHOD(Output_Docker_TarZeroIsDirectory)
-    {
-        // docker with tar=0 likewise exports an OCI layout directory, which is not supported.
-        VerifyInvalid(L"type=docker,dest=./layout,tar=0", L"directory exporters are not supported");
-    }
+    // --- Valid: 'tar' true spellings keep oci/docker a single tarball (buildx parity) ---
 
     TEST_METHOD(Output_Oci_TarTrue_IsSingleTarballToStdout)
     {
@@ -406,25 +368,9 @@ class WSLCCLIOutputParserUnitTests
         VerifyInvalid(L"dest=./out,compression=gzip", L"type is required");
     }
 
-    TEST_METHOD(Output_Shorthand_SingleFieldWithEqualsIsLocalPath)
-    {
-        // buildx parity quirk: a single field equal to the whole input that does not start with
-        // "type=" is shorthand for a local path, even if it happens to contain '=' (so '--output
-        // dest=./out' names a local directory "dest=./out"). The local exporter is not supported.
-        VerifyInvalid(L"dest=./out", L"directory exporters are not supported");
-    }
-
     TEST_METHOD(Output_Invalid_UnsupportedType)
     {
         VerifyInvalid(L"type=bogus", L"unsupported output type 'bogus'");
-    }
-
-    // --- Invalid: destination requirements ---
-
-    TEST_METHOD(Output_Invalid_LocalRequiresDest)
-    {
-        // The local exporter writes a directory tree and is not supported.
-        VerifyInvalid(L"type=local", L"directory exporters are not supported");
     }
 
     // --- CSV grammar (buildx go-csvvalue parity) ---

--- a/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIOutputParserUnitTests.cpp
@@ -33,14 +33,13 @@ Abstract:
       * A single field that equals the whole input and does not start with "type=" is shorthand for the
         destination:
           - L"-"            -> {type=tar, dest=-} (stream a tarball to stdout, matching docker)
-          - any other path  -> {type=local, dest=<path>}
+          - any other path  -> {type=local, dest=<path>} (rejected: directory exporters are unsupported)
       * Otherwise each field is split on its FIRST '=' into key/value (two parts required). The key is
         trimmed and lowercased; the value is kept verbatim (may itself contain '='). 'type' and 'dest'
         populate the struct fields; every other key is stored in Attributes.
       * Validation / destination resolution:
           - 'type' is required and must be one of: local, tar, oci, docker, image, registry, cacheonly.
-          - Directory exporters (local, or oci/docker with tar=false) require a directory 'dest=' and
-            may not stream to stdout ('dest=-').
+          - Directory exporters (local, or oci/docker with tar=false) are not supported and are rejected.
           - tar / oci with no 'dest=' default to streaming a tarball to stdout ('dest=-'), matching buildx.
           - docker with no 'dest=' loads the image into the store; 'dest=-' streams a tarball to stdout;
             a path writes a file.
@@ -109,13 +108,14 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Shorthand_LocalDirectory)
     {
-        // A bare path is shorthand for exporting the final stage's filesystem to that directory.
-        VerifyValid(L"./out", L"local", L"./out");
+        // A bare path is shorthand for the local (directory) exporter, which is not supported.
+        VerifyInvalid(L"./out", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Shorthand_WindowsPath)
     {
-        VerifyValid(L"C:\\build\\artifacts", L"local", L"C:\\build\\artifacts");
+        // A bare Windows path is likewise the local (directory) exporter, which is not supported.
+        VerifyInvalid(L"C:\\build\\artifacts", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Shorthand_DashIsTarToStdout)
@@ -128,7 +128,8 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Local_ExplicitDest)
     {
-        VerifyValid(L"type=local,dest=./out", L"local", L"./out");
+        // The local exporter writes a directory tree and is not supported.
+        VerifyInvalid(L"type=local,dest=./out", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Tar_ToFile)
@@ -150,8 +151,8 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Local_ToStdout_Rejected)
     {
-        // The local exporter writes a directory tree, so it cannot stream to stdout.
-        VerifyInvalid(L"type=local,dest=-", L"writes a directory tree");
+        // The local exporter writes a directory tree and is not supported.
+        VerifyInvalid(L"type=local,dest=-", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Oci_ToFile)
@@ -167,54 +168,54 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Oci_TarFalse_Directory)
     {
-        // oci with tar=false exports an OCI layout directory, so a directory 'dest=' is required.
-        VerifyValid(L"type=oci,dest=./layout,tar=false", L"oci", L"./layout", AttrMap{{L"tar", L"false"}});
+        // oci with tar=false exports an OCI layout directory, which is not supported.
+        VerifyInvalid(L"type=oci,dest=./layout,tar=false", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Oci_TarFalse_RequiresDest)
     {
-        // A directory exporter cannot stream to stdout, so tar=false with no dest is rejected.
-        VerifyInvalid(L"type=oci,tar=false", L"writes a directory tree");
+        // A directory exporter is not supported regardless of dest.
+        VerifyInvalid(L"type=oci,tar=false", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Docker_TarFalse_Directory)
     {
-        // docker with tar=false likewise exports an OCI layout directory.
-        VerifyValid(L"type=docker,dest=./layout,tar=false", L"docker", L"./layout", AttrMap{{L"tar", L"false"}});
+        // docker with tar=false likewise exports an OCI layout directory, which is not supported.
+        VerifyInvalid(L"type=docker,dest=./layout,tar=false", L"directory exporters are not supported");
     }
 
     // --- Valid: 'tar' accepts every spelling Go's strconv.ParseBool does (buildx parity) ---
 
     TEST_METHOD(Output_Oci_TarFalse_CapitalizedIsDirectory)
     {
-        // buildx parses 'tar' with Go's ParseBool, so "False" is a directory exporter just like "false".
-        // The attribute value is preserved verbatim (only routing is case-insensitive).
-        VerifyValid(L"type=oci,dest=./layout,tar=False", L"oci", L"./layout", AttrMap{{L"tar", L"False"}});
+        // buildx parses 'tar' with Go's ParseBool, so "False" is a directory exporter just like "false",
+        // and is rejected the same way.
+        VerifyInvalid(L"type=oci,dest=./layout,tar=False", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Oci_TarZeroIsDirectory)
     {
-        // "0" is false for Go's ParseBool, so it selects the OCI layout directory exporter.
-        VerifyValid(L"type=oci,dest=./layout,tar=0", L"oci", L"./layout", AttrMap{{L"tar", L"0"}});
+        // "0" is false for Go's ParseBool, so it selects the OCI layout directory exporter, which is not
+        // supported.
+        VerifyInvalid(L"type=oci,dest=./layout,tar=0", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Oci_TarShortFalseIsDirectory)
     {
-        // "f" is the short false form accepted by Go's ParseBool.
-        VerifyValid(L"type=oci,dest=./layout,tar=f", L"oci", L"./layout", AttrMap{{L"tar", L"f"}});
+        // "f" is the short false form accepted by Go's ParseBool, so it too is a directory exporter.
+        VerifyInvalid(L"type=oci,dest=./layout,tar=f", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Oci_TarCapitalizedFalse_RequiresDest)
     {
-        // A directory exporter cannot stream to stdout regardless of the boolean spelling, so tar=False
-        // with no dest is rejected the same as tar=false.
-        VerifyInvalid(L"type=oci,tar=False", L"writes a directory tree");
+        // A directory exporter is not supported regardless of the boolean spelling.
+        VerifyInvalid(L"type=oci,tar=False", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Docker_TarZeroIsDirectory)
     {
-        // docker with tar=0 likewise exports an OCI layout directory.
-        VerifyValid(L"type=docker,dest=./layout,tar=0", L"docker", L"./layout", AttrMap{{L"tar", L"0"}});
+        // docker with tar=0 likewise exports an OCI layout directory, which is not supported.
+        VerifyInvalid(L"type=docker,dest=./layout,tar=0", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Oci_TarTrue_IsSingleTarballToStdout)
@@ -343,10 +344,10 @@ class WSLCCLIOutputParserUnitTests
             AttrMap{{L"annotation-manifest.org.opencontainers.image.title", L"app"}});
     }
 
-    TEST_METHOD(Output_Local_PlatformSplit)
+    TEST_METHOD(Output_Tar_PlatformSplit)
     {
-        // platform-split controls per-platform subdirectories for the local/tar exporters.
-        VerifyValid(L"type=local,dest=./out,platform-split=false", L"local", L"./out", AttrMap{{L"platform-split", L"false"}});
+        // platform-split is forwarded verbatim as an exporter attribute for the tar exporter.
+        VerifyValid(L"type=tar,dest=out.tar,platform-split=false", L"tar", L"out.tar", AttrMap{{L"platform-split", L"false"}});
     }
 
     TEST_METHOD(Output_Attributes_AnnotationValueMayContainEquals)
@@ -367,7 +368,7 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Keys_AreCaseInsensitive)
     {
-        VerifyValid(L"TYPE=local,DEST=./out", L"local", L"./out");
+        VerifyValid(L"TYPE=tar,DEST=out.tar", L"tar", L"out.tar");
     }
 
     // --- Invalid: spec structure ---
@@ -409,8 +410,8 @@ class WSLCCLIOutputParserUnitTests
     {
         // buildx parity quirk: a single field equal to the whole input that does not start with
         // "type=" is shorthand for a local path, even if it happens to contain '=' (so '--output
-        // dest=./out' exports to a directory literally named "dest=./out", it is NOT 'dest=./out').
-        VerifyValid(L"dest=./out", L"local", L"dest=./out");
+        // dest=./out' names a local directory "dest=./out"). The local exporter is not supported.
+        VerifyInvalid(L"dest=./out", L"directory exporters are not supported");
     }
 
     TEST_METHOD(Output_Invalid_UnsupportedType)
@@ -422,8 +423,8 @@ class WSLCCLIOutputParserUnitTests
 
     TEST_METHOD(Output_Invalid_LocalRequiresDest)
     {
-        // The local exporter writes a directory tree, so an omitted dest is rejected.
-        VerifyInvalid(L"type=local", L"writes a directory tree");
+        // The local exporter writes a directory tree and is not supported.
+        VerifyInvalid(L"type=local", L"directory exporters are not supported");
     }
 
     // --- CSV grammar (buildx go-csvvalue parity) ---
@@ -445,7 +446,7 @@ class WSLCCLIOutputParserUnitTests
     TEST_METHOD(Output_Csv_LeadingSpaceAfterCommaTrimmedFromKey)
     {
         // buildx TrimSpace's the key, so a space after a comma is accepted (the value is untrimmed).
-        VerifyValid(L"type=local, dest=./out", L"local", L"./out");
+        VerifyValid(L"type=tar, dest=out.tar", L"tar", L"out.tar");
     }
 
     TEST_METHOD(Output_Csv_UnterminatedQuoteRejected)
@@ -478,12 +479,6 @@ class WSLCCLIOutputParserUnitTests
         }
     }
 
-    TEST_METHOD(Format_Shorthand_LocalNormalizedToCanonical)
-    {
-        // Shorthand paths are normalized to their explicit type=local,dest= form for buildx.
-        VerifyFormat(L"./out", L"type=local,dest=./out");
-    }
-
     TEST_METHOD(Format_TypeOnly_NoDestOrAttributes)
     {
         // docker/cacheonly need neither dest nor attributes, so the canonical form is just the type.
@@ -499,7 +494,7 @@ class WSLCCLIOutputParserUnitTests
     TEST_METHOD(Format_CaseInsensitiveKeysNormalizedToLower)
     {
         // 'type'/'dest' keys are lowercased; the type value is lowercased too.
-        VerifyFormat(L"TYPE=LOCAL,DEST=./out", L"type=local,dest=./out");
+        VerifyFormat(L"TYPE=TAR,DEST=out.tar", L"type=tar,dest=out.tar");
     }
 
     TEST_METHOD(Format_AttributesAppendedAfterDest)

--- a/test/windows/wslc/WSLCCLISecretParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLISecretParserUnitTests.cpp
@@ -36,9 +36,11 @@ public:
         m_path = std::filesystem::temp_directory_path() /
                  (L"wslc_ut_secret_" + std::to_wstring(GetCurrentProcessId()) + L"_" + std::to_wstring(++s_counter) + L".bin");
         std::ofstream file(m_path, std::ios::binary | std::ios::trunc);
+        THROW_HR_IF_MSG(E_FAIL, !file.is_open(), "Failed to create temp file: %ls", m_path.c_str());
         if (!bytes.empty())
         {
             file.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+            THROW_HR_IF_MSG(E_FAIL, !file.good(), "Failed to write temp file: %ls", m_path.c_str());
         }
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -858,6 +858,89 @@ class WSLCE2EImageBuildTests
         VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --secret value 'id=x,type=bogus': unsupported secret type 'bogus'") != std::wstring::npos);
     }
 
+    // Tier 1: an invalid --output spec is rejected client-side before any build runs. This exercises the
+    // full parser through the real binary and asserts the localized "Invalid --output value" wrapper.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_UnsupportedType_Fails)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-type-bad";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
+
+        auto buildResult =
+            RunWslc(std::format(L"build \"{}\" -f \"{}\" --output type=bogus", contextDir.wstring(), dockerfilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
+        VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --output value 'type=bogus': unsupported output type 'bogus'") != std::wstring::npos);
+    }
+
+    // Tier 2: the docker exporter loads the built image into the engine's image store, so the result is
+    // host-observable via inspect. The -t flag supplies the tag; the default docker builder does not
+    // honor the exporter 'name=' attribute for tagging (that requires the docker-container driver), so
+    // these tests deliberately tag with -t rather than name=.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeDockerWithTagFlag_LoadsIntoStore_Success)
+    {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageOutputDockerTag);
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-docker-tag";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-tag-ok\"]\n");
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=docker",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputDockerTag.NameAndTag()));
+        buildResult.Verify({.Stdout = L"", .ExitCode = 0});
+
+        auto inspectData = InspectImage(BuiltImageOutputDockerTag.NameAndTag());
+        VERIFY_IS_TRUE(inspectData.RepoTags.has_value());
+        VERIFY_ARE_EQUAL(1u, inspectData.RepoTags.value().size());
+        VERIFY_ARE_EQUAL(BuiltImageOutputDockerTag.NameAndTag(), wsl::shared::string::MultiByteToWide(inspectData.RepoTags.value()[0]));
+    }
+
+    // Tier 2: the docker exporter produces a complete, correct image (not just a tag). Build with a
+    // distinctive CMD and verify it round-trips through inspect, proving --output built a real image.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeDocker_ProducesImageWithConfig_Success)
+    {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageOutputDockerConfig);
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-docker-config";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-config-ok\"]\n");
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=docker",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputDockerConfig.NameAndTag()));
+        buildResult.Verify({.Stdout = L"", .ExitCode = 0});
+
+        auto inspectData = InspectImage(BuiltImageOutputDockerConfig.NameAndTag());
+        VERIFY_IS_TRUE(inspectData.Config.has_value());
+        VERIFY_IS_TRUE(inspectData.Config.value().Cmd.has_value());
+        const std::vector<std::string> expectedCmd{"echo", "output-docker-config-ok"};
+        VERIFY_ARE_EQUAL(expectedCmd, inspectData.Config.value().Cmd.value());
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_DockerfileInContextDir_Success)
     {
         auto imageCleanup = DeleteImageOnExit(BuiltImageDockerfile);
@@ -987,6 +1070,9 @@ private:
 
     // Maximum secret size allowed by BuildKit (500kb)
     static constexpr size_t c_maxSecretSize = 500 * 1024;
+
+    const TestImage BuiltImageOutputDockerTag{L"wslc-e2e-build-output-docker-tag", L"latest", L""};
+    const TestImage BuiltImageOutputDockerConfig{L"wslc-e2e-build-output-docker-config", L"latest", L""};
 
     void BuildFromContextFile(const std::wstring& fileName, const TestImage& image)
     {

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -941,6 +941,259 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_EQUAL(expectedCmd, inspectData.Config.value().Cmd.value());
     }
 
+    // Tier 2: the tar exporter streams a filesystem tarball out of the VM to a client-side file. Verify
+    // the file is a valid, non-empty tar that contains the marker written by the build. Asserting the
+    // file is non-empty guards the regression where the streamed tarball once came back with 0 bytes.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeTarToFile_ProducesValidTarball_Success)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-tar-file";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-tar-marker > /wslc-build-marker.txt\n");
+
+        auto tarPath = testRoot / L"out.tar";
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --output type=tar,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), tarPath.wstring()));
+        buildResult.Verify({.ExitCode = 0});
+
+        VERIFY_IS_TRUE(std::filesystem::exists(tarPath));
+        VERIFY_IS_TRUE(std::filesystem::file_size(tarPath) > 0, L"the streamed tarball must not be empty");
+        VERIFY_IS_TRUE(ListTarEntries(tarPath).find(L"wslc-build-marker.txt") != std::wstring::npos);
+    }
+
+    // Tier 2: dest=- streams the tarball to the client's stdout (matching docker). This is the exact path
+    // that once regressed to an empty tarball, so it redirects stdout to a file and asserts the result is
+    // a non-empty tar containing the build marker.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeTarToStdout_ProducesValidTarball_Success)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-tar-stdout";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-tar-marker > /wslc-build-marker.txt\n");
+
+        auto tarPath = testRoot / L"stdout.tar";
+        auto buildResult = RunWslcAndRedirectToFile(
+            std::format(L"build \"{}\" -f \"{}\" --output type=tar,dest=-", contextDir.wstring(), dockerfilePath.wstring()), tarPath);
+        buildResult.Verify({.ExitCode = 0});
+
+        VERIFY_IS_TRUE(std::filesystem::exists(tarPath));
+        VERIFY_IS_TRUE(std::filesystem::file_size(tarPath) > 0, L"the streamed tarball must not be empty");
+        VERIFY_IS_TRUE(ListTarEntries(tarPath).find(L"wslc-build-marker.txt") != std::wstring::npos);
+    }
+
+    // Tier 2: the local exporter streams a directory tree out of the VM; the client extracts it into the
+    // destination directory. Verify the marker file lands on disk under the dest directory.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeLocalToDirectory_ExtractsTree_Success)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-local-dir";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-local-marker > /wslc-build-marker.txt\n");
+
+        auto destDir = testRoot / L"export";
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --output type=local,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), destDir.wstring()));
+        buildResult.Verify({.ExitCode = 0});
+
+        VERIFY_IS_TRUE(
+            std::filesystem::exists(destDir / L"wslc-build-marker.txt"),
+            L"the local exporter must extract the build tree to disk");
+    }
+
+    // Tier 1: the local exporter writes a directory tree, so dest=- (stdout) is rejected client-side
+    // before any build runs, mirroring docker.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeLocalToStdout_Rejected_Fails)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-local-stdout";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
+
+        auto buildResult =
+            RunWslc(std::format(L"build \"{}\" -f \"{}\" --output type=local,dest=-", contextDir.wstring(), dockerfilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
+        VERIFY_IS_TRUE(
+            buildResult.Stderr->find(L"Invalid --output value 'type=local,dest=-': dest cannot be stdout for local exporter") !=
+            std::wstring::npos);
+    }
+
+    // Tier 2: the image exporter loads the built image into the engine's image store (like the docker
+    // exporter with no dest), so the result is host-observable via inspect. Tag with -t.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeImage_LoadsIntoStore_Success)
+    {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageOutputImage);
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-image";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-image-ok\"]\n");
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=image",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputImage.NameAndTag()));
+        buildResult.Verify({.Stdout = L"", .ExitCode = 0});
+
+        auto inspectData = InspectImage(BuiltImageOutputImage.NameAndTag());
+        VERIFY_IS_TRUE(inspectData.RepoTags.has_value());
+        VERIFY_ARE_EQUAL(1u, inspectData.RepoTags.value().size());
+        VERIFY_ARE_EQUAL(BuiltImageOutputImage.NameAndTag(), wsl::shared::string::MultiByteToWide(inspectData.RepoTags.value()[0]));
+    }
+
+    // Tier 2: the cacheonly exporter runs the build only to populate the build cache, producing no image
+    // artifact. Verify the build succeeds and, because nothing is exported, the tag is not in the store.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeCacheOnly_ProducesNoImage_Success)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-cacheonly";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"cacheonly-ok\"]\n");
+
+        // Guard against a leaked image if cacheonly ever regresses to loading into the store.
+        auto imageCleanup = DeleteImageOnExit(BuiltImageOutputCacheOnly);
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=cacheonly",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputCacheOnly.NameAndTag()));
+        buildResult.Verify({.ExitCode = 0});
+
+        // cacheonly exports nothing, so the tag must not resolve in the image store.
+        auto inspectResult = RunWslc(std::format(L"image inspect {}", BuiltImageOutputCacheOnly.NameAndTag()));
+        VERIFY_ARE_NOT_EQUAL(0u, inspectResult.ExitCode.value_or(0u), L"cacheonly must not load an image into the store");
+    }
+
+    // Tier 1: the registry exporter pushes to a named reference, so 'name=' is mandatory and its absence
+    // is rejected client-side before any build runs.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeRegistryMissingName_Fails)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-registry-noname";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
+
+        auto buildResult =
+            RunWslc(std::format(L"build \"{}\" -f \"{}\" --output type=registry", contextDir.wstring(), dockerfilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
+        VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --output value 'type=registry': 'type=registry' requires 'name='") != std::wstring::npos);
+    }
+
+    // Tier 1: the tar exporter writes a tarball to a caller-provided location, so 'dest=' is mandatory
+    // and its absence is rejected client-side before any build runs.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeTarMissingDest_Fails)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-tar-nodest";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
+
+        auto buildResult =
+            RunWslc(std::format(L"build \"{}\" -f \"{}\" --output type=tar", contextDir.wstring(), dockerfilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
+        VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --output value 'type=tar': 'type=tar' requires 'dest='") != std::wstring::npos);
+    }
+
+    // Tier 2: a failing build step must surface as a non-zero exit with the image exporter, and the tag
+    // must not be left in the store. This is the failing counterpart to TypeImage_LoadsIntoStore.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeImage_BuildFailure_Fails)
+    {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageOutputImageFail);
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-image-fail";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN exit 7\n");
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=image",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputImageFail.NameAndTag()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.StderrContainsSubstring(L"failed to solve"));
+
+        auto inspectResult = RunWslc(std::format(L"image inspect {}", BuiltImageOutputImageFail.NameAndTag()));
+        VERIFY_ARE_NOT_EQUAL(0u, inspectResult.ExitCode.value_or(0u), L"a failed build must not leave an image in the store");
+    }
+
+    // Tier 2: a failing build step must surface as a non-zero exit with the cacheonly exporter. This is
+    // the failing counterpart to TypeCacheOnly_ProducesNoImage.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeCacheOnly_BuildFailure_Fails)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-cacheonly-fail";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN exit 7\n");
+
+        auto buildResult =
+            RunWslc(std::format(L"build \"{}\" -f \"{}\" --output type=cacheonly", contextDir.wstring(), dockerfilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.StderrContainsSubstring(L"failed to solve"));
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_DockerfileInContextDir_Success)
     {
         auto imageCleanup = DeleteImageOnExit(BuiltImageDockerfile);
@@ -1073,6 +1326,20 @@ private:
 
     const TestImage BuiltImageOutputDockerTag{L"wslc-e2e-build-output-docker-tag", L"latest", L""};
     const TestImage BuiltImageOutputDockerConfig{L"wslc-e2e-build-output-docker-config", L"latest", L""};
+    const TestImage BuiltImageOutputImage{L"wslc-e2e-build-output-image", L"latest", L""};
+    const TestImage BuiltImageOutputImageFail{L"wslc-e2e-build-output-image-fail", L"latest", L""};
+    const TestImage BuiltImageOutputCacheOnly{L"wslc-e2e-build-output-cacheonly", L"latest", L""};
+
+    // Runs `tar.exe -tf <path>` and returns the member listing so tests can assert an exporter produced a
+    // valid, non-empty archive that contains an expected entry.
+    static std::wstring ListTarEntries(const std::filesystem::path& tarPath)
+    {
+        auto cmd = std::format(L"tar.exe -tf \"{}\"", tarPath.wstring());
+        wsl::windows::common::SubProcess process(nullptr, cmd.c_str());
+        auto output = process.RunAndCaptureOutput();
+        VERIFY_ARE_EQUAL(0u, output.ExitCode, L"tar.exe failed to list the produced archive");
+        return output.Stdout;
+    }
 
     void BuildFromContextFile(const std::wstring& fileName, const TestImage& image)
     {

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -135,13 +135,12 @@ class WSLCE2EImageBuildTests
             "COPY hello.txt /hello.txt\n"
             "CMD [\"cat\", \"/hello.txt\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} -t {} --build-arg TEST_LABEL=wslc_e2e_test",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageTag1.NameAndTag(),
-                BuiltImageTag2.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} -t {} --build-arg TEST_LABEL=wslc_e2e_test",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageTag1.NameAndTag(),
+            BuiltImageTag2.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         // Verify both tags are present by inspecting each one
@@ -181,9 +180,8 @@ class WSLCE2EImageBuildTests
         // Build with --pull --verbose. When --pull causes docker to resolve the base image
         // from the registry, the FROM step includes a @sha256: digest (e.g.
         // "FROM docker.io/library/debian:latest@sha256:..."). Build progress goes to stderr.
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --pull --verbose", contextDir.wstring(), dockerfilePath.wstring(), BuiltImagePull.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --pull --verbose", contextDir.wstring(), dockerfilePath.wstring(), BuiltImagePull.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
@@ -211,12 +209,8 @@ class WSLCE2EImageBuildTests
             "COPY --from=build-stage /stage.txt /stage.txt\n"
             "CMD [\"cat\", \"/stage.txt\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --target build-stage",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageTarget.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --target build-stage", contextDir.wstring(), dockerfilePath.wstring(), BuiltImageTarget.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageTarget.NameAndTag());
@@ -246,12 +240,11 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"label-ok\"]\n");
 
         // Use both the short alias (-l) and long form (--label) to confirm both parse paths.
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} -l first=one --label second=two",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageLabel.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} -l first=one --label second=two",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageLabel.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageLabel.NameAndTag());
@@ -283,12 +276,11 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(
             dockerfilePath, "FROM debian:latest\nLABEL conflict=from-dockerfile\nCMD [\"echo\", \"label-override-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --label conflict=from-cli",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageLabelOverride.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --label conflict=from-cli",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageLabelOverride.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageLabelOverride.NameAndTag());
@@ -323,12 +315,11 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"expected-secret-content-12345\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_VALUE",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecret.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_VALUE",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecret.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecret.NameAndTag());
@@ -358,12 +349,11 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/WSLC_E2E_BARE_SECRET)\" = \"bare-id-secret-content-67890\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=WSLC_E2E_BARE_SECRET",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretBareId.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=WSLC_E2E_BARE_SECRET",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretBareId.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretBareId.NameAndTag());
@@ -388,8 +378,8 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
 
-        auto buildResult = RunWslc(
-            std::format(L"build \"{}\" -f \"{}\" --secret id=WSLC_E2E_SECRET_BARE_ID_UNSET", contextDir.wstring(), dockerfilePath.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --secret id=WSLC_E2E_SECRET_BARE_ID_UNSET", contextDir.wstring(), dockerfilePath.wstring()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_FALSE(buildResult.Stderr->empty());
@@ -415,12 +405,11 @@ class WSLCE2EImageBuildTests
             "RUN --mount=type=secret,id=mysecret [ -z \"$(cat /run/secrets/mysecret)\" ]\n"
             "CMD [\"echo\", \"secret-empty-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_UNSET_VAR",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretMissingEnv.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_UNSET_VAR",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretMissingEnv.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretMissingEnv.NameAndTag());
@@ -453,13 +442,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"file-secret-content-67890\" ]\n"
             "CMD [\"echo\", \"secret-src-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretSrc.NameAndTag(),
-                secretFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretSrc.NameAndTag(),
+            secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretSrc.NameAndTag());
@@ -499,13 +487,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"symlinked-secret-content-44444\" ]\n"
             "CMD [\"echo\", \"secret-symlink-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretSrcSymlink.NameAndTag(),
-                linkFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretSrcSymlink.NameAndTag(),
+            linkFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretSrcSymlink.NameAndTag());
@@ -527,9 +514,8 @@ class WSLCE2EImageBuildTests
 
         // Build should fail if the src file does not exist
         auto missingFile = testRoot / L"does-not-exist.txt";
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" --secret id=x,src=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), missingFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --secret id=x,src=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), missingFile.wstring()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_FALSE(buildResult.Stderr->empty());
@@ -562,13 +548,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"env-wins-content-55555\" ]\n"
             "CMD [\"echo\", \"secret-env-wins-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_ENV_WINS_VALUE,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretEnvWins.NameAndTag(),
-                secretFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_ENV_WINS_VALUE,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretEnvWins.NameAndTag(),
+            secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretEnvWins.NameAndTag());
@@ -596,12 +581,11 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-content-11111\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,env=WSLC_E2E_TYPE_ENV_VALUE",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretTypeEnv.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,env=WSLC_E2E_TYPE_ENV_VALUE",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretTypeEnv.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretTypeEnv.NameAndTag());
@@ -630,12 +614,11 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-src-content-22222\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,src=WSLC_E2E_TYPE_ENV_SRC_VALUE",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretTypeEnvSrc.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,src=WSLC_E2E_TYPE_ENV_SRC_VALUE",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretTypeEnvSrc.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretTypeEnvSrc.NameAndTag());
@@ -662,13 +645,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"type-file-content-33333\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretTypeFile.NameAndTag(),
-                secretFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretTypeFile.NameAndTag(),
+            secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretTypeFile.NameAndTag());
@@ -700,13 +682,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(tr -d '\\000' < /run/secrets/mysecret | tr -d '\\377')\" = \"beforeafter\" ]\n"
             "CMD [\"echo\", \"secret-binary-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretBinary.NameAndTag(),
-                secretFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretBinary.NameAndTag(),
+            secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretBinary.NameAndTag());
@@ -739,13 +720,12 @@ class WSLCE2EImageBuildTests
                 "CMD [\"echo\", \"secret-size-ok\"]\n",
                 size));
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                image.NameAndTag(),
-                secretFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            image.NameAndTag(),
+            secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(image.NameAndTag());
@@ -773,13 +753,12 @@ class WSLCE2EImageBuildTests
             "[ -f /run/secrets/mysecret ] && [ \"$(wc -c < /run/secrets/mysecret)\" = \"0\" ]\n"
             "CMD [\"echo\", \"secret-empty-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretEmptyFile.NameAndTag(),
-                secretFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretEmptyFile.NameAndTag(),
+            secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretEmptyFile.NameAndTag());
@@ -818,12 +797,8 @@ class WSLCE2EImageBuildTests
             "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret > /dev/null\n"
             "CMD [\"echo\", \"secret-oversize\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" --secret id=mysecret,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                secretFile.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --secret id=mysecret,src=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), secretFile.wstring()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_FALSE(buildResult.Stderr->empty());
@@ -865,15 +840,14 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/s3)\" = \"multi-secret-three-33333\" ]\n"
             "CMD [\"echo\", \"secret-multi-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --secret id=s1,src=\"{}\" --secret id=s2,src=\"{}\" --secret id=s3,src=\"{}\"",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageSecretMultiple.NameAndTag(),
-                secret1.wstring(),
-                secret2.wstring(),
-                secret3.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --secret id=s1,src=\"{}\" --secret id=s2,src=\"{}\" --secret id=s3,src=\"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageSecretMultiple.NameAndTag(),
+            secret1.wstring(),
+            secret2.wstring(),
+            secret3.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretMultiple.NameAndTag());
@@ -934,12 +908,11 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-tag-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --output type=docker",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageOutputDockerTag.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=docker",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputDockerTag.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageOutputDockerTag.NameAndTag());
@@ -961,12 +934,11 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-config-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --output type=docker",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageOutputDockerConfig.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=docker",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputDockerConfig.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageOutputDockerConfig.NameAndTag());
@@ -990,9 +962,8 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-tar-marker > /wslc-build-marker.txt\n");
 
         auto tarPath = testRoot / L"out.tar";
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" --output type=tar,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), tarPath.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --output type=tar,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), tarPath.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         VERIFY_IS_TRUE(std::filesystem::exists(tarPath));
@@ -1036,9 +1007,8 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-local-marker > /wslc-build-marker.txt\n");
 
         auto destDir = testRoot / L"export";
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" --output type=local,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), destDir.wstring()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --output type=local,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), destDir.wstring()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_TRUE(buildResult.Stderr->find(L"directory exporters are not supported") != std::wstring::npos);
@@ -1077,12 +1047,11 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-image-ok\"]\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --output type=image",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageOutputImage.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=image",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputImage.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageOutputImage.NameAndTag());
@@ -1106,12 +1075,11 @@ class WSLCE2EImageBuildTests
         // Guard against a leaked image if cacheonly ever regresses to loading into the store.
         auto imageCleanup = DeleteImageOnExit(BuiltImageOutputCacheOnly);
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --output type=cacheonly",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageOutputCacheOnly.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=cacheonly",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputCacheOnly.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         // cacheonly exports nothing, so the tag must not resolve in the image store.
@@ -1154,12 +1122,11 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN exit 7\n");
 
-        auto buildResult = RunWslc(
-            std::format(
-                L"build \"{}\" -f \"{}\" -t {} --output type=image",
-                contextDir.wstring(),
-                dockerfilePath.wstring(),
-                BuiltImageOutputImageFail.NameAndTag()));
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --output type=image",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageOutputImageFail.NameAndTag()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.StderrContainsSubstring(L"failed to solve"));
 

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -70,6 +70,22 @@ class WSLCE2EImageBuildTests
         return dir;
     }
 
+    // All --output tests build from this single shared (empty) context directory, for the same reason
+    // as SharedSecretBuildContext above: the session never releases virtiofs shares (see
+    // WSLCVirtualMachine::UnmountWindowsFolder), so giving each --output test its own context directory
+    // would permanently consume one share slot per test and eventually exhaust the session's budget.
+    // Reusing one path keeps all --output builds to a single shared slot. Each test's Dockerfile is
+    // streamed via -f and its output artifacts (tarballs, extracted trees) live under its own testRoot,
+    // so none of that is mounted.
+    static std::filesystem::path SharedOutputBuildContext()
+    {
+        auto dir = std::filesystem::current_path() / L"wslc-e2e-build-output-context";
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::is_directory(dir));
+        return dir;
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_EmptyContextDirectory_Success)
     {
         auto imageCleanup = DeleteImageOnExit(BuiltImage);
@@ -865,10 +881,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-type-bad";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
@@ -890,10 +903,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-docker-tag";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-tag-ok\"]\n");
@@ -919,10 +929,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-docker-config";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-config-ok\"]\n");
@@ -949,10 +956,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-tar-file";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-tar-marker > /wslc-build-marker.txt\n");
@@ -975,10 +979,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-tar-stdout";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-tar-marker > /wslc-build-marker.txt\n");
@@ -1000,10 +1001,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-local-dir";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-local-marker > /wslc-build-marker.txt\n");
@@ -1025,10 +1023,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-local-stdout";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
@@ -1050,10 +1045,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-image";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-image-ok\"]\n");
@@ -1078,10 +1070,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-cacheonly";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"cacheonly-ok\"]\n");
@@ -1108,10 +1097,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-registry-noname";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
@@ -1130,10 +1116,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-tar-nodest";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
@@ -1153,10 +1136,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-image-fail";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN exit 7\n");
@@ -1180,10 +1160,7 @@ class WSLCE2EImageBuildTests
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-cacheonly-fail";
         auto cleanup = SetupTestDirectory(testRoot);
 
-        auto contextDir = testRoot / L"context";
-        std::error_code ec;
-        std::filesystem::create_directories(contextDir, ec);
-        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+        auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN exit 7\n");

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -874,7 +874,7 @@ class WSLCE2EImageBuildTests
         VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --secret value 'id=x,type=bogus': unsupported secret type 'bogus'") != std::wstring::npos);
     }
 
-    // Tier 1: an invalid --output spec is rejected client-side before any build runs. This exercises the
+    // An invalid --output spec is rejected client-side before any build runs. This exercises the
     // full parser through the real binary and asserts the localized "Invalid --output value" wrapper.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_UnsupportedType_Fails)
     {
@@ -893,7 +893,7 @@ class WSLCE2EImageBuildTests
         VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --output value 'type=bogus': unsupported output type 'bogus'") != std::wstring::npos);
     }
 
-    // Tier 2: the docker exporter loads the built image into the engine's image store, so the result is
+    // The docker exporter loads the built image into the engine's image store, so the result is
     // host-observable via inspect. The -t flag supplies the tag; the default docker builder does not
     // honor the exporter 'name=' attribute for tagging (that requires the docker-container driver), so
     // these tests deliberately tag with -t rather than name=.
@@ -921,7 +921,7 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_EQUAL(BuiltImageOutputDockerTag.NameAndTag(), wsl::shared::string::MultiByteToWide(inspectData.RepoTags.value()[0]));
     }
 
-    // Tier 2: the docker exporter produces a complete, correct image (not just a tag). Build with a
+    // The docker exporter produces a complete, correct image (not just a tag). Build with a
     // distinctive CMD and verify it round-trips through inspect, proving --output built a real image.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeDocker_ProducesImageWithConfig_Success)
     {
@@ -948,7 +948,7 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_EQUAL(expectedCmd, inspectData.Config.value().Cmd.value());
     }
 
-    // Tier 2: the tar exporter streams a filesystem tarball out of the VM to a client-side file. Verify
+    // The tar exporter streams a filesystem tarball out of the VM to a client-side file. Verify
     // the file is a valid, non-empty tar that contains the marker written by the build. Asserting the
     // file is non-empty guards the regression where the streamed tarball once came back with 0 bytes.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeTarToFile_ProducesValidTarball_Success)
@@ -971,7 +971,7 @@ class WSLCE2EImageBuildTests
         VERIFY_IS_TRUE(ListTarEntries(tarPath).find(L"wslc-build-marker.txt") != std::wstring::npos);
     }
 
-    // Tier 2: dest=- streams the tarball to the client's stdout (matching docker). This is the exact path
+    // dest=- streams the tarball to the client's stdout (matching docker). This is the exact path
     // that once regressed to an empty tarball, so it redirects stdout to a file and asserts the result is
     // a non-empty tar containing the build marker.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeTarToStdout_ProducesValidTarball_Success)
@@ -994,7 +994,7 @@ class WSLCE2EImageBuildTests
         VERIFY_IS_TRUE(ListTarEntries(tarPath).find(L"wslc-build-marker.txt") != std::wstring::npos);
     }
 
-    // Tier 2: the local exporter streams a directory tree out of the VM; the client extracts it into the
+    // The local exporter streams a directory tree out of the VM; the client extracts it into the
     // destination directory. Verify the marker file lands on disk under the dest directory.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeLocalToDirectory_ExtractsTree_Success)
     {
@@ -1016,7 +1016,7 @@ class WSLCE2EImageBuildTests
             L"the local exporter must extract the build tree to disk");
     }
 
-    // Tier 1: the local exporter writes a directory tree, so dest=- (stdout) is rejected client-side
+    // The local exporter writes a directory tree, so dest=- (stdout) is rejected client-side
     // before any build runs, mirroring docker.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeLocalToStdout_Rejected_Fails)
     {
@@ -1033,11 +1033,10 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_TRUE(
-            buildResult.Stderr->find(L"Invalid --output value 'type=local,dest=-': dest cannot be stdout for local exporter") !=
-            std::wstring::npos);
+            buildResult.Stderr->find(L"Invalid --output value 'type=local,dest=-': this exporter writes a directory tree") != std::wstring::npos);
     }
 
-    // Tier 2: the image exporter loads the built image into the engine's image store (like the docker
+    // The image exporter loads the built image into the engine's image store (like the docker
     // exporter with no dest), so the result is host-observable via inspect. Tag with -t.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeImage_LoadsIntoStore_Success)
     {
@@ -1063,7 +1062,7 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_EQUAL(BuiltImageOutputImage.NameAndTag(), wsl::shared::string::MultiByteToWide(inspectData.RepoTags.value()[0]));
     }
 
-    // Tier 2: the cacheonly exporter runs the build only to populate the build cache, producing no image
+    // The cacheonly exporter runs the build only to populate the build cache, producing no image
     // artifact. Verify the build succeeds and, because nothing is exported, the tag is not in the store.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeCacheOnly_ProducesNoImage_Success)
     {
@@ -1090,28 +1089,9 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_NOT_EQUAL(0u, inspectResult.ExitCode.value_or(0u), L"cacheonly must not load an image into the store");
     }
 
-    // Tier 1: the registry exporter pushes to a named reference, so 'name=' is mandatory and its absence
-    // is rejected client-side before any build runs.
-    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeRegistryMissingName_Fails)
-    {
-        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-registry-noname";
-        auto cleanup = SetupTestDirectory(testRoot);
-
-        auto contextDir = SharedOutputBuildContext();
-
-        auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
-
-        auto buildResult =
-            RunWslc(std::format(L"build \"{}\" -f \"{}\" --output type=registry", contextDir.wstring(), dockerfilePath.wstring()));
-        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
-        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
-        VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --output value 'type=registry': 'type=registry' requires 'name='") != std::wstring::npos);
-    }
-
-    // Tier 1: the tar exporter writes a tarball to a caller-provided location, so 'dest=' is mandatory
-    // and its absence is rejected client-side before any build runs.
-    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeTarMissingDest_Fails)
+    // tar with no 'dest=' defaults to streaming a tarball to stdout ('dest=-'), matching buildx.
+    // Redirect stdout to a file and assert the result is a non-empty tar containing the build marker.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeTarNoDest_StreamsToStdout_Success)
     {
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-tar-nodest";
         auto cleanup = SetupTestDirectory(testRoot);
@@ -1119,16 +1099,19 @@ class WSLCE2EImageBuildTests
         auto contextDir = SharedOutputBuildContext();
 
         auto dockerfilePath = testRoot / L"Dockerfile";
-        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-tar-nodest-marker > /wslc-build-marker.txt\n");
 
-        auto buildResult =
-            RunWslc(std::format(L"build \"{}\" -f \"{}\" --output type=tar", contextDir.wstring(), dockerfilePath.wstring()));
-        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
-        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
-        VERIFY_IS_TRUE(buildResult.Stderr->find(L"Invalid --output value 'type=tar': 'type=tar' requires 'dest='") != std::wstring::npos);
+        auto tarPath = testRoot / L"stdout.tar";
+        auto buildResult = RunWslcAndRedirectToFile(
+            std::format(L"build \"{}\" -f \"{}\" --output type=tar", contextDir.wstring(), dockerfilePath.wstring()), tarPath);
+        buildResult.Verify({.ExitCode = 0});
+
+        VERIFY_IS_TRUE(std::filesystem::exists(tarPath));
+        VERIFY_IS_TRUE(std::filesystem::file_size(tarPath) > 0, L"the streamed tarball must not be empty");
+        VERIFY_IS_TRUE(ListTarEntries(tarPath).find(L"wslc-build-marker.txt") != std::wstring::npos);
     }
 
-    // Tier 2: a failing build step must surface as a non-zero exit with the image exporter, and the tag
+    // A failing build step must surface as a non-zero exit with the image exporter, and the tag
     // must not be left in the store. This is the failing counterpart to TypeImage_LoadsIntoStore.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeImage_BuildFailure_Fails)
     {
@@ -1153,7 +1136,7 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_NOT_EQUAL(0u, inspectResult.ExitCode.value_or(0u), L"a failed build must not leave an image in the store");
     }
 
-    // Tier 2: a failing build step must surface as a non-zero exit with the cacheonly exporter. This is
+    // A failing build step must surface as a non-zero exit with the cacheonly exporter. This is
     // the failing counterpart to TypeCacheOnly_ProducesNoImage.
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeCacheOnly_BuildFailure_Fails)
     {

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -135,12 +135,13 @@ class WSLCE2EImageBuildTests
             "COPY hello.txt /hello.txt\n"
             "CMD [\"cat\", \"/hello.txt\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} -t {} --build-arg TEST_LABEL=wslc_e2e_test",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageTag1.NameAndTag(),
-            BuiltImageTag2.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} -t {} --build-arg TEST_LABEL=wslc_e2e_test",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageTag1.NameAndTag(),
+                BuiltImageTag2.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         // Verify both tags are present by inspecting each one
@@ -180,8 +181,9 @@ class WSLCE2EImageBuildTests
         // Build with --pull --verbose. When --pull causes docker to resolve the base image
         // from the registry, the FROM step includes a @sha256: digest (e.g.
         // "FROM docker.io/library/debian:latest@sha256:..."). Build progress goes to stderr.
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --pull --verbose", contextDir.wstring(), dockerfilePath.wstring(), BuiltImagePull.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --pull --verbose", contextDir.wstring(), dockerfilePath.wstring(), BuiltImagePull.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
@@ -209,8 +211,12 @@ class WSLCE2EImageBuildTests
             "COPY --from=build-stage /stage.txt /stage.txt\n"
             "CMD [\"cat\", \"/stage.txt\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --target build-stage", contextDir.wstring(), dockerfilePath.wstring(), BuiltImageTarget.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --target build-stage",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageTarget.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageTarget.NameAndTag());
@@ -240,11 +246,12 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"label-ok\"]\n");
 
         // Use both the short alias (-l) and long form (--label) to confirm both parse paths.
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} -l first=one --label second=two",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageLabel.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} -l first=one --label second=two",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageLabel.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageLabel.NameAndTag());
@@ -276,11 +283,12 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(
             dockerfilePath, "FROM debian:latest\nLABEL conflict=from-dockerfile\nCMD [\"echo\", \"label-override-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --label conflict=from-cli",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageLabelOverride.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --label conflict=from-cli",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageLabelOverride.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageLabelOverride.NameAndTag());
@@ -315,11 +323,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"expected-secret-content-12345\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_VALUE",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecret.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_VALUE",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecret.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecret.NameAndTag());
@@ -349,11 +358,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/WSLC_E2E_BARE_SECRET)\" = \"bare-id-secret-content-67890\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=WSLC_E2E_BARE_SECRET",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretBareId.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=WSLC_E2E_BARE_SECRET",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretBareId.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretBareId.NameAndTag());
@@ -378,8 +388,8 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" --secret id=WSLC_E2E_SECRET_BARE_ID_UNSET", contextDir.wstring(), dockerfilePath.wstring()));
+        auto buildResult = RunWslc(
+            std::format(L"build \"{}\" -f \"{}\" --secret id=WSLC_E2E_SECRET_BARE_ID_UNSET", contextDir.wstring(), dockerfilePath.wstring()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_FALSE(buildResult.Stderr->empty());
@@ -405,11 +415,12 @@ class WSLCE2EImageBuildTests
             "RUN --mount=type=secret,id=mysecret [ -z \"$(cat /run/secrets/mysecret)\" ]\n"
             "CMD [\"echo\", \"secret-empty-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_UNSET_VAR",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretMissingEnv.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_UNSET_VAR",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretMissingEnv.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretMissingEnv.NameAndTag());
@@ -442,12 +453,13 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"file-secret-content-67890\" ]\n"
             "CMD [\"echo\", \"secret-src-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretSrc.NameAndTag(),
-            secretFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretSrc.NameAndTag(),
+                secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretSrc.NameAndTag());
@@ -487,12 +499,13 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"symlinked-secret-content-44444\" ]\n"
             "CMD [\"echo\", \"secret-symlink-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretSrcSymlink.NameAndTag(),
-            linkFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretSrcSymlink.NameAndTag(),
+                linkFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretSrcSymlink.NameAndTag());
@@ -514,8 +527,9 @@ class WSLCE2EImageBuildTests
 
         // Build should fail if the src file does not exist
         auto missingFile = testRoot / L"does-not-exist.txt";
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" --secret id=x,src=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), missingFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" --secret id=x,src=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), missingFile.wstring()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_FALSE(buildResult.Stderr->empty());
@@ -548,12 +562,13 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"env-wins-content-55555\" ]\n"
             "CMD [\"echo\", \"secret-env-wins-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_ENV_WINS_VALUE,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretEnvWins.NameAndTag(),
-            secretFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_ENV_WINS_VALUE,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretEnvWins.NameAndTag(),
+                secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretEnvWins.NameAndTag());
@@ -581,11 +596,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-content-11111\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,env=WSLC_E2E_TYPE_ENV_VALUE",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretTypeEnv.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,env=WSLC_E2E_TYPE_ENV_VALUE",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretTypeEnv.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretTypeEnv.NameAndTag());
@@ -614,11 +630,12 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-src-content-22222\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,src=WSLC_E2E_TYPE_ENV_SRC_VALUE",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretTypeEnvSrc.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,src=WSLC_E2E_TYPE_ENV_SRC_VALUE",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretTypeEnvSrc.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretTypeEnvSrc.NameAndTag());
@@ -645,12 +662,13 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/mysecret)\" = \"type-file-content-33333\" ]\n"
             "CMD [\"echo\", \"secret-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretTypeFile.NameAndTag(),
-            secretFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretTypeFile.NameAndTag(),
+                secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretTypeFile.NameAndTag());
@@ -682,12 +700,13 @@ class WSLCE2EImageBuildTests
             "[ \"$(tr -d '\\000' < /run/secrets/mysecret | tr -d '\\377')\" = \"beforeafter\" ]\n"
             "CMD [\"echo\", \"secret-binary-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretBinary.NameAndTag(),
-            secretFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretBinary.NameAndTag(),
+                secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretBinary.NameAndTag());
@@ -720,12 +739,13 @@ class WSLCE2EImageBuildTests
                 "CMD [\"echo\", \"secret-size-ok\"]\n",
                 size));
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            image.NameAndTag(),
-            secretFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                image.NameAndTag(),
+                secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(image.NameAndTag());
@@ -753,12 +773,13 @@ class WSLCE2EImageBuildTests
             "[ -f /run/secrets/mysecret ] && [ \"$(wc -c < /run/secrets/mysecret)\" = \"0\" ]\n"
             "CMD [\"echo\", \"secret-empty-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretEmptyFile.NameAndTag(),
-            secretFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretEmptyFile.NameAndTag(),
+                secretFile.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretEmptyFile.NameAndTag());
@@ -797,8 +818,12 @@ class WSLCE2EImageBuildTests
             "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret > /dev/null\n"
             "CMD [\"echo\", \"secret-oversize\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" --secret id=mysecret,src=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), secretFile.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" --secret id=mysecret,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                secretFile.wstring()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_FALSE(buildResult.Stderr->empty());
@@ -840,14 +865,15 @@ class WSLCE2EImageBuildTests
             "[ \"$(cat /run/secrets/s3)\" = \"multi-secret-three-33333\" ]\n"
             "CMD [\"echo\", \"secret-multi-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --secret id=s1,src=\"{}\" --secret id=s2,src=\"{}\" --secret id=s3,src=\"{}\"",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageSecretMultiple.NameAndTag(),
-            secret1.wstring(),
-            secret2.wstring(),
-            secret3.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --secret id=s1,src=\"{}\" --secret id=s2,src=\"{}\" --secret id=s3,src=\"{}\"",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageSecretMultiple.NameAndTag(),
+                secret1.wstring(),
+                secret2.wstring(),
+                secret3.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageSecretMultiple.NameAndTag());
@@ -908,11 +934,12 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-tag-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --output type=docker",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageOutputDockerTag.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --output type=docker",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageOutputDockerTag.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageOutputDockerTag.NameAndTag());
@@ -934,11 +961,12 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-docker-config-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --output type=docker",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageOutputDockerConfig.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --output type=docker",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageOutputDockerConfig.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageOutputDockerConfig.NameAndTag());
@@ -962,8 +990,9 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-tar-marker > /wslc-build-marker.txt\n");
 
         auto tarPath = testRoot / L"out.tar";
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" --output type=tar,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), tarPath.wstring()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" --output type=tar,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), tarPath.wstring()));
         buildResult.Verify({.ExitCode = 0});
 
         VERIFY_IS_TRUE(std::filesystem::exists(tarPath));
@@ -994,9 +1023,9 @@ class WSLCE2EImageBuildTests
         VERIFY_IS_TRUE(ListTarEntries(tarPath).find(L"wslc-build-marker.txt") != std::wstring::npos);
     }
 
-    // The local exporter streams a directory tree out of the VM; the client extracts it into the
-    // destination directory. Verify the marker file lands on disk under the dest directory.
-    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeLocalToDirectory_ExtractsTree_Success)
+    // The local exporter writes a Linux directory tree, which cannot be materialized faithfully on a
+    // Windows destination, so it is rejected client-side before any build runs.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeLocalToDirectory_Rejected_Fails)
     {
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-local-dir";
         auto cleanup = SetupTestDirectory(testRoot);
@@ -1007,17 +1036,16 @@ class WSLCE2EImageBuildTests
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-local-marker > /wslc-build-marker.txt\n");
 
         auto destDir = testRoot / L"export";
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" --output type=local,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), destDir.wstring()));
-        buildResult.Verify({.ExitCode = 0});
-
-        VERIFY_IS_TRUE(
-            std::filesystem::exists(destDir / L"wslc-build-marker.txt"),
-            L"the local exporter must extract the build tree to disk");
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" --output type=local,dest=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), destDir.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
+        VERIFY_IS_TRUE(buildResult.Stderr->find(L"directory exporters are not supported") != std::wstring::npos);
     }
 
-    // The local exporter writes a directory tree, so dest=- (stdout) is rejected client-side
-    // before any build runs, mirroring docker.
+    // The local exporter is a directory exporter, which is not supported, so it is rejected client-side
+    // before any build runs (dest=- included).
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_Output_TypeLocalToStdout_Rejected_Fails)
     {
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-output-local-stdout";
@@ -1033,7 +1061,7 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.Stderr.has_value());
         VERIFY_IS_TRUE(
-            buildResult.Stderr->find(L"Invalid --output value 'type=local,dest=-': this exporter writes a directory tree") != std::wstring::npos);
+            buildResult.Stderr->find(L"Invalid --output value 'type=local,dest=-': directory exporters are not supported") != std::wstring::npos);
     }
 
     // The image exporter loads the built image into the engine's image store (like the docker
@@ -1049,11 +1077,12 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nCMD [\"echo\", \"output-image-ok\"]\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --output type=image",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageOutputImage.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --output type=image",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageOutputImage.NameAndTag()));
         buildResult.Verify({.Stdout = L"", .ExitCode = 0});
 
         auto inspectData = InspectImage(BuiltImageOutputImage.NameAndTag());
@@ -1077,11 +1106,12 @@ class WSLCE2EImageBuildTests
         // Guard against a leaked image if cacheonly ever regresses to loading into the store.
         auto imageCleanup = DeleteImageOnExit(BuiltImageOutputCacheOnly);
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --output type=cacheonly",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageOutputCacheOnly.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --output type=cacheonly",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageOutputCacheOnly.NameAndTag()));
         buildResult.Verify({.ExitCode = 0});
 
         // cacheonly exports nothing, so the tag must not resolve in the image store.
@@ -1124,11 +1154,12 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN exit 7\n");
 
-        auto buildResult = RunWslc(std::format(
-            L"build \"{}\" -f \"{}\" -t {} --output type=image",
-            contextDir.wstring(),
-            dockerfilePath.wstring(),
-            BuiltImageOutputImageFail.NameAndTag()));
+        auto buildResult = RunWslc(
+            std::format(
+                L"build \"{}\" -f \"{}\" -t {} --output type=image",
+                contextDir.wstring(),
+                dockerfilePath.wstring(),
+                BuiltImageOutputImageFail.NameAndTag()));
         VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
         VERIFY_IS_TRUE(buildResult.StderrContainsSubstring(L"failed to solve"));
 


### PR DESCRIPTION
This pull request introduces support for the `--output` option to the image build command, allowing users to specify a build output destination using the Docker Buildx exporter spec (e.g., `type=local,dest=path` or `type=tar,dest=out.tar`). The changes include parsing and validation logic for the new option, updates to the service interface and flags, and user-facing descriptions and error messages.

**Support for `--output` option and Buildx exporter spec:**

* Added parsing, validation, and formatting functions for the Buildx `--output` spec in `SpecParsing.cpp` and `SpecParsing.h`, including handling for CSV quoting, supported exporter types, and destination resolution. Also added helpers to determine if the output streams to the client or is a directory exporter. [[1]](diffhunk://#diff-0b75e608446791966cc2f262c6de7dbb8210668a15877301d4107502a1907599R194-R497) [[2]](diffhunk://#diff-689916116384a710c025948a0c211815525d8328bd70e2d8cb8d36db598cc519L26-R27) [[3]](diffhunk://#diff-689916116384a710c025948a0c211815525d8328bd70e2d8cb8d36db598cc519R47-R62)
* Updated the `ImageBuildCommand` to accept the new `--output` argument with an appropriate user-facing description. [[1]](diffhunk://#diff-d83b8938c1848772336f481cc4f552d3d29ac1c4b31a4240359797d561910bb3R37) [[2]](diffhunk://#diff-c64d306b3b9e1059cb6e28f3b1a3552de31a1a94490601541c4e43547f4ee8efR2898-R2901)

**Service and API updates:**

* Extended `WSLCBuildImageOptions` and related IDL definitions to include `Output` and `OutputHandle` fields, and added a new flag `WSLCBuildImageFlagsOutputIsDirectory` to indicate directory exporters. [[1]](diffhunk://#diff-f354d8f5022677f418046fbe5c50ab602814c13ed9d0041e3d238954a153b757R552-R553) [[2]](diffhunk://#diff-31454ae55bf107b64eb0765c40ca90aef82b4ba8b50d94edbf1cb2f7b0ed0f9aR223-R226)
* Modified the `ImageService::Build` method signature to accept the new `output` parameter and included necessary header imports. [[1]](diffhunk://#diff-02bd98b2ee17399f9362d63153b45508809c4508078bcb2207b466d3171babe1R17-R18) [[2]](diffhunk://#diff-02bd98b2ee17399f9362d63153b45508809c4508078bcb2207b466d3171babe1R126)

**User experience improvements:**

* Added localized error messages and help text for invalid or missing `--output` values in `Resources.resw`. [[1]](diffhunk://#diff-c64d306b3b9e1059cb6e28f3b1a3552de31a1a94490601541c4e43547f4ee8efR2333-R2336) [[2]](diffhunk://#diff-c64d306b3b9e1059cb6e28f3b1a3552de31a1a94490601541c4e43547f4ee8efR2898-R2901)



<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed