### PR TITLE
Mitigate and instrument the utility-VM boot-connect timeout

### DIFF
--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -340,7 +340,7 @@ struct Config
     int InstanceIdleTimeout = (15 * 1000);
     std::filesystem::path DebugConsoleLogFile;
     std::wstring VmSwitch;
-    int KernelBootTimeout = (30 * 1000);
+    int KernelBootTimeout = (90 * 1000);
     int DistributionStartTimeout = (60 * 1000);
     int MountDeviceTimeout = (5 * 1000);
     bool EnableHostFileSystemAccess = true;

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -427,7 +427,11 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
     }
 
     // Accept the connection from the Linux guest for notifications.
-    m_notifyChannel = AcceptConnection(m_vmConfig.KernelBootTimeout);
+    // Instrumented so slow/hung boots are attributed to this phase vs WaitForMiniInitConnect.
+    {
+        SlowOperationWatcher slowOperation{"WaitForNotifyChannelConnect"};
+        m_notifyChannel = AcceptConnection(m_vmConfig.KernelBootTimeout);
+    }
 
     // Receive and parse the guest kernel version
     {


### PR DESCRIPTION
## Why (the symptom)

On heavily loaded machines, utility-VM creation intermittently fails with `.../CreateVm/0x800705b4` (ERROR_TIMEOUT), which blocks install. Seen in automated test runs. Tracked as **62543002**.

## Root cause

During VM `Initialize`, the service waits for the guest to connect back over hvsocket within `KernelBootTimeout` (default **30s**). This is a give-up **watchdog**, not a boot budget — a healthy boot connects in ~1-3s. Under host CPU contention a healthy-but-slow boot exceeds 30s and trips it. Two gaps:

1. 30s leaves too little headroom on a contended host.
2. The notify-channel accept was **uninstrumented**, so telemetry could not say which boot phase was slow.

## The fix (two small changes)

1. Raise default `KernelBootTimeout` **30s -> 90s**. Still bounds a genuinely stuck VM; just gives a slow-but-alive boot room to finish. Overridable via `wsl2.kernelBootTimeout`.
2. Wrap the notify-channel accept in its own `SlowOperationWatcher{"WaitForNotifyChannelConnect"}` (mirrors the adjacent mini_init one). **Diagnostic only — no control-flow change.**

Note: this is **not** fixed by #40519. That protects processes *inside* the guest *after* it connects; this failure is the *host* starving the VM's vCPUs *before* it connects — different phase, different contention. The real cure (a host-side CPU reservation for the booting VM) is a follow-up, gated on the telemetry above confirming CPU is the starved resource.

## Testing

- `SlowOperationWatcher` unit tests: 6/6 pass (emits real `elapsedMs`; hang backstop emits once).
- `wslservice` build-verified with both changes.
- Deterministic repro on the same accept path: setting `kernelBootTimeout=1` yields the exact `.../CreateVm/0x800705b4`.

---

@shuaiyuanxx — could you review? You own the SlowOperationWatcher / boot path. (Bug 62543002 assigned to you.)