### PR TITLE
Fix recurring TSA onboarding failure in release builds

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+    "codebaseName": "microsoft_WSL",
+    "serviceTreeID": "d8846bef-e9b5-4542-bcfc-98ebabac8a7b",
+    "instanceUrl": "https://microsoft.visualstudio.com/",
+    "projectName": "OS",
+    "areaPath": "OS\\Core\\Base\\VMAC - Virtual Machines and Containers\\LOW-Linux on Windows\\WSL",
+    "notificationAliases": [
+        "wslteam@microsoft.com"
+    ],
+    "validateToolOutput": "None",
+    "allTools": true
+}

--- a/.pipelines/wsl-build-release-onebranch.yml
+++ b/.pipelines/wsl-build-release-onebranch.yml
@@ -53,7 +53,12 @@ extends:
         credscan:
           enabled: true
       tsa:
-        enabled: false
+        # The 1ES Official governed template force-runs TSA onboarding regardless of this flag.
+        # Without a config file it auto-derives the codebase name "microsoft_Microsoft.WSL_microsoft/WSL",
+        # which contains the illegal characters '.' and '/', so onboarding fails with PreconditionFailed
+        # and breaks every release build. Point TSA at an explicit, sanitized codebase config instead.
+        enabled: true
+        configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
       evidence:
         enabled: false
     git:


### PR DESCRIPTION
## Problem
Every release build (which extends the 1ES Official governed template `v2/Microsoft.Official.yml@templates`) fails the SDL compliance leg with:

```
TsaOnboardCodebaseFailedException: ... codebase: microsoft_Microsoft.WSL_microsoft/WSL
TSA Response: Codebase Name microsoft_Microsoft.WSL_microsoft/WSL invalid. Cannot contain any of " % & ` ] [ ~ ^ / \ | } { .
Error: Guardian exited with an error exit code: 1
```

The Official template **force-runs** the TSA onboard/upload step even though `globalSdl.tsa.enabled` was `false` (that flag only suppresses bug-filing, not onboarding). With no `tsaoptions.json`, TSA auto-derives the codebase name `microsoft_Microsoft.WSL_microsoft/WSL`, which contains the illegal characters `.` (from `Microsoft.WSL`) and `/` (from the `microsoft/WSL` repo slug). Onboarding therefore fails deterministically and breaks/degrades every release build.

## Fix
- Add `.config/tsaoptions.json` with an explicit, sanitized `codebaseName` (`microsoft_WSL`) and TSA routing (OS project, WSL area path).
- Point the release pipeline's `globalSdl.tsa` at it via `configFile` and set `enabled: true` so the config is consumed.

Nightly and PR pipelines extend `v2/Microsoft.NonOfficial.yml` which does not force TSA onboarding, so they are left unchanged.