### PR TITLE
Use 4 request queues for aggregate virtiofs devices

### DIFF
--- a/src/windows/common/DeviceHostProxy.cpp
+++ b/src/windows/common/DeviceHostProxy.cpp
@@ -146,13 +146,17 @@ GUID DeviceHostProxy::AddVirtiofsDevice(
         const auto label = wil::make_bstr(Label.c_str());
         const auto rootPath = wil::make_bstr(RootPath.c_str());
         const auto mountOptions = wil::make_bstr(MountOptions.c_str());
+
+        // Only a few aggregate devices exist per VM, so they can afford multiple queues. Per-share
+        // devices stay at one queue to avoid exhausting the memory aperture.
+        const UINT32 queueCount = (Kind == VirtiofsShareKind_Aggregate) ? 4 : 1;
+
         WslVirtiofsConfig config{
             .label = label.get(),
             .rootPath = rootPath.get(),
             .kind = Kind,
             .shmemSizeMb = ShmemSizeMb,
-            // To workaround memory aperture limitations, limit virtiofs devices to one queue.
-            .queueCount = 1,
+            .queueCount = queueCount,
             .mountOptions = mountOptions.get()};
         THROW_IF_FAILED(GetWslVm(UserToken)->CreateVirtiofsDevice(&instanceIdForCall, GetCallback().get(), &config, virtiofsDevice.put()));
     }


### PR DESCRIPTION
## Summary

Now that DrvFs shares are carried by a single **aggregate** virtiofs device (#41129 / #41151), only a small, fixed number of virtiofs devices exist per VM. That leaves enough memory-aperture headroom to give each aggregate **4 request queues** instead of 1, significantly improving concurrent DrvFs throughput.

Non-aggregate (per-share file-backed) and section-backed devices **stay at a single queue**: many of them can exist, and raising their queue count would reintroduce the aperture exhaustion that the one-queue default was added to avoid.

## Benchmarks

fio on `/mnt/c` (16 parallel jobs, psync engine), 4 queues vs 1 queue:

| Workload | IOPS 4q | IOPS 1q | Δ IOPS | Mean latency |
|---|--:|--:|--:|--:|
| randread 4k | 40,282 | 25,800 | **+56%** | −36% |
| randwrite 4k | 33,103 | 4,584 | **+622%** | −85% |
| smallfile randrw (read) | 19,597 | 13,237 | **+48%** | −33% |
| smallfile randrw (write) | 19,563 | 13,232 | **+48%** | −33% |
| seqread 1M | 1,453 | 1,258 | +15% | −13% |
| seqwrite 1M | 982 | 1,095 | −10% | +11% |

Multiqueue is a decisive win on concurrent random/metadata workloads. The only regression is single-stream sequential write (−10%), which is bandwidth-bound rather than concurrency-bound and within run-to-run noise.

## Testing

- Built and deployed on x64; verified the aggregate device (`drvfsa`) exposes 4 request queues (`virtio1-requests.0–3`) while per-share devices remain at 1.
- A/B benchmarked 4q vs 1q builds as above.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
