### PR TITLE
Serialize move/resize/set-sparse against in-progress conversions

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -914,9 +914,9 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     // Fail if the distribution is running.
     RETURN_HR_IF(WSL_E_DISTRO_NOT_STOPPED, m_runningInstances.contains(*DistroGuid));
 
-    // Fail if a conversion/export/compaction is in progress for this distribution. Those operations
-    // release m_instanceLock while running but keep the distribution in m_lockedDistributions, so
-    // mutating the VHD here would race with them.
+    // Fail if a conversion or export is in progress for this distribution. Those operations release
+    // m_instanceLock while running but keep the distribution in m_lockedDistributions, so mutating
+    // the VHD here would race with them.
     _EnsureNotLocked(DistroGuid);
 
     // Lookup the distribution configuration
@@ -1779,8 +1779,8 @@ try
     // Don't attempt if running
     RETURN_HR_IF(WSL_E_DISTRO_NOT_STOPPED, m_runningInstances.contains(*DistroGuid));
 
-    // Don't attempt while a conversion/export/compaction holds this distribution; those operations
-    // release m_instanceLock while running but keep the entry in m_lockedDistributions.
+    // Don't attempt while a conversion or export holds this distribution; those operations release
+    // m_instanceLock while running but keep the entry in m_lockedDistributions.
     _EnsureNotLocked(DistroGuid);
 
     const wil::unique_hfile vhd{::CreateFileW(configuration.VhdFilePath.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr)};
@@ -1812,9 +1812,9 @@ try
     const auto configuration = s_GetDistributionConfiguration(registration);
     RETURN_HR_IF(WSL_E_WSL2_NEEDED, WI_IsFlagClear(configuration.Flags, LXSS_DISTRO_FLAGS_VM_MODE));
 
-    // Fail if a conversion/export/compaction is in progress; those operations release m_instanceLock
-    // while running but keep this distribution in m_lockedDistributions, so resizing its VHD now
-    // would race with them.
+    // Fail if a conversion or export is in progress; those operations release m_instanceLock while
+    // running but keep this distribution in m_lockedDistributions, so resizing its VHD now would
+    // race with them.
     _EnsureNotLocked(DistroGuid);
 
     const auto& vhdPath = configuration.VhdFilePath;

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -914,6 +914,11 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     // Fail if the distribution is running.
     RETURN_HR_IF(WSL_E_DISTRO_NOT_STOPPED, m_runningInstances.contains(*DistroGuid));
 
+    // Fail if a conversion/export/compaction is in progress for this distribution. Those operations
+    // release m_instanceLock while running but keep the distribution in m_lockedDistributions, so
+    // mutating the VHD here would race with them.
+    _EnsureNotLocked(DistroGuid);
+
     // Lookup the distribution configuration
     const auto lxssKey = s_OpenLxssUserKey();
     _ValidateDistributionNameAndPathNotInUse(lxssKey.get(), Location, nullptr);
@@ -1774,6 +1779,10 @@ try
     // Don't attempt if running
     RETURN_HR_IF(WSL_E_DISTRO_NOT_STOPPED, m_runningInstances.contains(*DistroGuid));
 
+    // Don't attempt while a conversion/export/compaction holds this distribution; those operations
+    // release m_instanceLock while running but keep the entry in m_lockedDistributions.
+    _EnsureNotLocked(DistroGuid);
+
     const wil::unique_hfile vhd{::CreateFileW(configuration.VhdFilePath.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr)};
     if (!vhd)
     {
@@ -1802,6 +1811,11 @@ try
     const auto registration = DistributionRegistration::Open(lxssKey.get(), *DistroGuid);
     const auto configuration = s_GetDistributionConfiguration(registration);
     RETURN_HR_IF(WSL_E_WSL2_NEEDED, WI_IsFlagClear(configuration.Flags, LXSS_DISTRO_FLAGS_VM_MODE));
+
+    // Fail if a conversion/export/compaction is in progress; those operations release m_instanceLock
+    // while running but keep this distribution in m_lockedDistributions, so resizing its VHD now
+    // would race with them.
+    _EnsureNotLocked(DistroGuid);
 
     const auto& vhdPath = configuration.VhdFilePath;
     if (m_utilityVm && m_utilityVm->IsVhdAttached(vhdPath.c_str()))

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -3269,6 +3269,59 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         }
     }
 
+    // Verifies that VHD-mutating manage operations (--resize, --set-sparse, --move) are rejected while a
+    // long-running conversion/export holds the distribution lock, rather than racing with it on the VHD.
+    WSL2_TEST_METHOD(ManageRejectedWhileLocked)
+    {
+        constexpr auto name = L"manage-locked-test-distro";
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--import {} . \"{}\" --version 2", name, g_testDistroPath)), 0L);
+        auto cleanupName =
+            wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [name]() { LxsstuLaunchWsl(std::format(L"--unregister {}", name)); });
+        WslShutdown();
+
+        // Start an export to a pipe we deliberately don't drain. Once the pipe buffer fills, the export
+        // blocks mid-stream, deterministically holding the distribution in the "Exporting" locked state.
+        auto [readPipe, writePipe] = CreateSubprocessPipe(false, true);
+
+        std::thread exportThread([&]() { LxsstuLaunchWsl(std::format(L"--export {} -", name), nullptr, writePipe.get()); });
+
+        auto joinExport = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            // Drain the pipe so the blocked export can complete, then join the thread.
+            readPipe.reset();
+            if (exportThread.joinable())
+            {
+                exportThread.join();
+            }
+        });
+
+        // Wait until the service reports the distribution as Exporting (i.e. the lock is held).
+        bool locked = false;
+        for (int i = 0; i < 100 && !locked; ++i)
+        {
+            auto [out, _] = LxsstuLaunchWslAndCaptureOutput(L"--list --verbose");
+            locked = (out.find(name) != std::wstring::npos) && (out.find(L"Exporting") != std::wstring::npos);
+            if (!locked)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+        }
+
+        VERIFY_IS_TRUE(locked);
+
+        // Each VHD-mutating manage operation must be rejected with E_ILLEGAL_STATE_CHANGE while the lock is held.
+        auto verifyRejected = [&](const std::wstring& command) {
+            auto [out, _] = LxsstuLaunchWslAndCaptureOutput(command, -1);
+            VERIFY_IS_TRUE(out.find(L"E_ILLEGAL_STATE_CHANGE") != std::wstring::npos);
+        };
+
+        verifyRejected(std::format(L"--manage {} --resize 2GB", name));
+        verifyRejected(std::format(L"--manage {} --set-sparse false", name));
+
+        const auto moveTarget = std::filesystem::absolute(L"manage-locked-move-target").wstring();
+        verifyRejected(std::format(L"--manage {} --move \"{}\"", name, moveTarget));
+    }
+
     WSL2_TEST_METHOD(FileOffsets)
     {
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, []() { DeleteFile(L"output.txt"); });

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -3280,14 +3280,15 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
             wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [name]() { LxsstuLaunchWsl(std::format(L"--unregister {}", name)); });
         WslShutdown();
 
-        // Start an export to a pipe we deliberately don't drain. Once the pipe buffer fills, the export
-        // blocks mid-stream, deterministically holding the distribution in the "Exporting" locked state.
-        auto [readPipe, writePipe] = CreateSubprocessPipe(false, true);
+        // Start an export to a pipe we deliberately don't drain. Use a tiny buffer so the export blocks
+        // as soon as it writes any data, regardless of the test distro's size, deterministically holding
+        // the distribution in the "Exporting" locked state.
+        auto [readPipe, writePipe] = CreateSubprocessPipe(false, true, 1);
 
         std::thread exportThread([&]() { LxsstuLaunchWsl(std::format(L"--export {} -", name), nullptr, writePipe.get()); });
 
         auto joinExport = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-            // Drain the pipe so the blocked export can complete, then join the thread.
+            // Close the read end so the blocked export fails with a broken pipe and returns, then join.
             readPipe.reset();
             if (exportThread.joinable())
             {


### PR DESCRIPTION
## Summary of the Pull Request

Fixes a latent concurrency bug: `--manage --move`, `--manage --resize`, and `--manage --set-sparse` were not serialized against an in-progress `--set-version` conversion or `--export`.

## Detailed Description

`MoveDistribution`, `SetSparse`, and `ResizeDistribution` mutate a distribution's VHD but never consulted `m_lockedDistributions`. A conversion (`--set-version`) or export calls `_ConversionBegin`, which releases `m_instanceLock` while the long operation runs yet keeps the distribution registered in `m_lockedDistributions`. Because the three manage operations above only checked `m_runningInstances`/`IsVhdAttached` (neither of which reflects an in-progress conversion), they could start mid-conversion and race on the same VHD — e.g. a corrupt export, or the VHD being moved/resized out from under a running conversion.

### Fix

Add `_EnsureNotLocked(DistroGuid)` (under `m_instanceLock`) to `MoveDistribution`, `SetSparse`, and `ResizeDistribution` so they fail with `E_ILLEGAL_STATE_CHANGE` while a conversion/export/compaction is in progress — matching how the conversion paths already guard each other via `_ConversionBegin` -> `_EnsureNotLocked`.

### Test

Adds `ManageRejectedWhileLocked` (WSL2): imports a distro, starts an `--export` to a pipe that is deliberately not drained so the export blocks mid-stream and deterministically holds the `Exporting` lock, polls `wsl -l -v` until the state is `Exporting`, then asserts `--resize`, `--set-sparse`, and `--move` are all rejected with `E_ILLEGAL_STATE_CHANGE`.

## PR Checklist

- [x] Tests: added `ManageRejectedWhileLocked`
- [ ] Documentation updated: n/a (internal behavior)