### PR TITLE
Address memory reclaim follow-ups from #41096

### DIFF
--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3638,7 +3638,7 @@ Return Value:
     // are ignored.
     //
 
-    static const std::regex cpuLine{R"(^cpu\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+(\d+))?(?:\s+(\d+))?(?:\s+(\d+))?)"};
+    static const std::regex cpuLine{R"(^cpu[ \t]+(\d+)[ \t]+(\d+)[ \t]+(\d+)[ \t]+(\d+)[ \t]+(\d+)(?:[ \t]+(\d+))?(?:[ \t]+(\d+))?(?:[ \t]+(\d+))?)"};
     std::cmatch match;
     if (!std::regex_search(buffer, match, cpuLine))
     {

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3633,46 +3633,30 @@ Return Value:
     buffer[result] = '\0';
 
     //
-    // Format: "cpu  user nice system idle iowait irq softirq steal ...". Fields after steal are ignored.
+    // Format: "cpu  user nice system idle iowait irq softirq steal ...". The user, nice, system, idle,
+    // and iowait fields are required; irq, softirq, and steal are optional and any fields after steal
+    // are ignored.
     //
 
-    if (strncmp(buffer, "cpu ", 4) != 0)
+    static const std::regex cpuLine{R"(^cpu\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+(\d+))?(?:\s+(\d+))?(?:\s+(\d+))?)"};
+    std::cmatch match;
+    if (!std::regex_search(buffer, match, cpuLine))
     {
-        LOG_ERROR("/proc/stat first line missing cpu label");
+        LOG_ERROR("failed to parse /proc/stat cpu line");
         return false;
     }
 
     unsigned long long fields[8] = {};
-    const char* cursor = buffer + 3;
-    int parsed = 0;
-    for (; parsed < static_cast<int>(COUNT_OF(fields)); parsed += 1)
+    for (size_t index = 0; index < COUNT_OF(fields); index += 1)
     {
-        char* end = nullptr;
-        const unsigned long long value = strtoull(cursor, &end, 10);
-        if (end == cursor)
+        if (match[index + 1].matched)
         {
-            break;
+            fields[index] = strtoull(match[index + 1].str().c_str(), nullptr, 10);
         }
-
-        fields[parsed] = value;
-        cursor = end;
-    }
-
-    if (parsed < 5)
-    {
-        LOG_ERROR("failed to parse /proc/stat cpu line (parsed {})", parsed);
-        return false;
     }
 
     Idle = fields[3] + fields[4];
-    Busy = 0;
-    for (int index = 0; index < parsed; index += 1)
-    {
-        if (index != 3 && index != 4)
-        {
-            Busy += fields[index];
-        }
-    }
+    Busy = fields[0] + fields[1] + fields[2] + fields[5] + fields[6] + fields[7];
 
     return true;
 }
@@ -3957,7 +3941,12 @@ try
                 }
                 else if (!droppedThisIdlePeriod)
                 {
-                    if (WriteToFile("/proc/sys/vm/drop_caches", "1\n") == 0)
+                    //
+                    // drop_caches=3 frees the page cache along with reclaimable slab (dentries and
+                    // inodes), matching the SReclaimable slab counted by GetReclaimableCacheBytes.
+                    //
+
+                    if (WriteToFile("/proc/sys/vm/drop_caches", "3\n") == 0)
                     {
                         droppedThisIdlePeriod = true;
                         reclaimed = true;

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -3651,7 +3651,7 @@ Return Value:
     {
         if (match[index + 1].matched)
         {
-            fields[index] = strtoull(match[index + 1].str().c_str(), nullptr, 10);
+            fields[index] = strtoull(match[index + 1].first, nullptr, 10);
         }
     }
 


### PR DESCRIPTION
## What this changes

Addresses the two review follow-ups from #41096 in `src/linux/init/util.cpp`:

1. **Parse `/proc/stat` with `std::regex`** (per @OneBlue's suggestion). `ReadCpuBusyIdle()` now matches the aggregate `cpu` line with a regex instead of a manual `strtoull` cursor loop. The five leading fields (user, nice, system, idle, iowait) are required and irq/softirq/steal are optional, preserving the previous "at least 5 fields" semantics. `Idle = idle + iowait` and `Busy = user + nice + system + irq + softirq + steal` are unchanged. The raw `open() + O_CLOEXEC + TEMP_FAILURE_RETRY` bounded read is retained so the fd is not leaked to forked children and reads still retry on `EINTR`.

2. **`drop_caches=3` in DropCache mode** (per @OneBlue's suggestion). Switching from `1` to `3` also drops reclaimable slab (dentries/inodes), matching the `SReclaimable` slab already counted by `GetReclaimableCacheBytes()`.

## Validation

- `clang-format` clean.
- Multi-model code review (Opus, GPT, Gemini) — no outstanding issues; the original `O_CLOEXEC`/`EINTR` guarantees were retained per review feedback.
