### PR TITLE
Use canonical path when copying files from containers

### DIFF
--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -398,7 +398,13 @@ void ContainerCp(CLIExecutionContext& context)
         auto [containerId, srcPath] = parseContainerPath(source);
         THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::WSLCCLI_CpInvalidSourceError(), containerId.empty() || srcPath.empty());
 
-        auto absTarget = std::filesystem::absolute(target);
+        // Resolve any symlinks in the target path since tar.exe refuses to extract through a symlink.
+        std::error_code canonicalError;
+        auto absTarget = std::filesystem::weakly_canonical(std::filesystem::absolute(target), canonicalError);
+        if (canonicalError)
+        {
+            absTarget = std::filesystem::absolute(target); // Fall back to absolute if canonicalization fails.
+        }
 
         // Determine if target is a directory or a file destination.
         // Treat as directory if: ends with separator, or already exists as a directory.

--- a/test/windows/wslc/e2e/WSLCE2EContainerCpTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCpTests.cpp
@@ -445,6 +445,7 @@ class WSLCE2EContainerCpTests
         auto cleanup = wil::scope_exit([&] {
             std::error_code ec;
             std::filesystem::remove(linkDir, ec);
+            std::filesystem::remove(L"symfile.txt", ec);
         });
 
         // Creating a symlink requires Administrator privileges, which the E2E tests already run with.

--- a/test/windows/wslc/e2e/WSLCE2EContainerCpTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCpTests.cpp
@@ -432,6 +432,33 @@ class WSLCE2EContainerCpTests
         VERIFY_IS_TRUE(std::filesystem::exists(extractedFile));
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Container_Cp_ContainerToLocal_ThroughSymlink)
+    {
+        auto runResult =
+            RunWslc(std::format(L"container run -d --name {} {} sleep infinity", WslcContainerName, DebianImage.NameAndTag()));
+        runResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto execResult = RunWslc(std::format(L"container exec {} touch /tmp/symfile.txt", WslcContainerName));
+        execResult.Verify({.ExitCode = 0});
+
+        auto linkDir = std::filesystem::current_path() / L"wslc-cp-symlink-link";
+        auto cleanup = wil::scope_exit([&] {
+            std::error_code ec;
+            std::filesystem::remove(linkDir, ec);
+        });
+
+        // Creating a symlink requires Administrator privileges, which the E2E tests already run with.
+        THROW_LAST_ERROR_IF(!CreateSymbolicLinkW(linkDir.c_str(), std::filesystem::current_path().c_str(), SYMBOLIC_LINK_FLAG_DIRECTORY));
+
+        // Copy from the container into the symlink.
+        const auto cpResult = RunWslc(std::format(L"container cp {}:/tmp/symfile.txt {}", WslcContainerName, linkDir.wstring()));
+        cpResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+
+        // The file must land in the real directory (and therefore be visible through the symlink).
+        VERIFY_IS_TRUE(std::filesystem::exists(std::filesystem::current_path() / L"symfile.txt"));
+        VERIFY_IS_TRUE(std::filesystem::exists(linkDir / L"symfile.txt"));
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Container_Cp_ContainerToLocal_FileDestination)
     {
         // When the local target doesn't end with a separator and isn't an existing directory,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves an issue with `wslc cp` when the target directory is a symlink:

```
StartGroup: WSLCE2ETests::WSLCE2EContainerCpTests::WSLCE2E_Container_Cp_ContainerToLocal_TrailingBackslash
Verify: AreEqual(*expected.Stderr, *Stderr)
Verify: AreEqual(*expected.ExitCode, *ExitCode)
Verify: AreEqual(*expected.ExitCode, *ExitCode)
Verify: AreEqual(*expected.Stdout, *Stdout)
Error: Verify: AreEqual(*expected.Stderr, *Stderr) - Values (, bstest.txt: Cannot extract through symlink \\\\?\\C:\\Users\\piboulay\\repos: No error
tar.exe: Error exit delayed from previous errors.
Unspecified error
Error code: E_FAIL
```

This change solves the issue by using a canonical path instead

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
