### PR TITLE
Fix infinite CPU spin in ProcessInteropMessages on synchronous EOF

### DIFF
--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -424,10 +424,9 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
         DWORD BytesRead;
         LX_INIT_WINDOW_SIZE_CHANGED WindowSizeMessage;
         bool Success = ReadFile(MessageHandle, &WindowSizeMessage, sizeof(WindowSizeMessage), &BytesRead, &Overlapped);
-        if (!Success)
+        if (Success)
         {
-            const auto LastError = GetLastError();
-            if ((LastError == ERROR_BROKEN_PIPE) || (LastError == ERROR_HANDLE_EOF))
+            if (BytesRead == 0)
             {
                 if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
                 {
@@ -437,45 +436,62 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
                 break;
             }
 
-            THROW_LAST_ERROR_IF(LastError != ERROR_IO_PENDING);
+            WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
 
-            auto CancelIo = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
-                CancelIoEx(MessageHandle, &Overlapped);
-                GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, TRUE);
-            });
+            const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
+            THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
+            continue;
+        }
 
-            const DWORD WaitStatus = WaitForMultipleObjects(RTL_NUMBER_OF(WaitHandles), WaitHandles, FALSE, INFINITE);
-            if (WaitStatus == WAIT_OBJECT_0)
+        const auto LastError = GetLastError();
+        if ((LastError == ERROR_BROKEN_PIPE) || (LastError == ERROR_HANDLE_EOF))
+        {
+            if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
             {
-                Success = GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, FALSE);
-                CancelIo.release();
-                if ((!Success) || (BytesRead == 0))
-                {
-                    if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
-                    {
-                        THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
-                    }
+                THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
+            }
 
-                    break;
+            break;
+        }
+
+        THROW_LAST_ERROR_IF(LastError != ERROR_IO_PENDING);
+
+        auto CancelIo = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
+            CancelIoEx(MessageHandle, &Overlapped);
+            GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, TRUE);
+        });
+
+        const DWORD WaitStatus = WaitForMultipleObjects(RTL_NUMBER_OF(WaitHandles), WaitHandles, FALSE, INFINITE);
+        if (WaitStatus == WAIT_OBJECT_0)
+        {
+            Success = GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, FALSE);
+            CancelIo.release();
+            if ((!Success) || (BytesRead == 0))
+            {
+                if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
+                {
+                    THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
                 }
 
-                WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
-
-                const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
-                THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
-            }
-            else if (WaitStatus == (WAIT_OBJECT_0 + 1))
-            {
-                THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &ExitCode));
-
-                // Close the pseudoconsole, this causes all pending data to be flushed.
-                Result->PseudoConsole.reset();
                 break;
             }
-            else
-            {
-                THROW_HR(E_UNEXPECTED);
-            }
+
+            WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
+
+            const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
+            THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
+        }
+        else if (WaitStatus == (WAIT_OBJECT_0 + 1))
+        {
+            THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &ExitCode));
+
+            // Close the pseudoconsole, this causes all pending data to be flushed.
+            Result->PseudoConsole.reset();
+            break;
+        }
+        else
+        {
+            THROW_HR(E_UNEXPECTED);
         }
     }
 

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -440,33 +440,11 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
 
             const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
             THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
-            continue;
         }
-
-        const auto LastError = GetLastError();
-        if ((LastError == ERROR_BROKEN_PIPE) || (LastError == ERROR_HANDLE_EOF))
+        else
         {
-            if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
-            {
-                THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
-            }
-
-            break;
-        }
-
-        THROW_LAST_ERROR_IF(LastError != ERROR_IO_PENDING);
-
-        auto CancelIo = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
-            CancelIoEx(MessageHandle, &Overlapped);
-            GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, TRUE);
-        });
-
-        const DWORD WaitStatus = WaitForMultipleObjects(RTL_NUMBER_OF(WaitHandles), WaitHandles, FALSE, INFINITE);
-        if (WaitStatus == WAIT_OBJECT_0)
-        {
-            Success = GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, FALSE);
-            CancelIo.release();
-            if ((!Success) || (BytesRead == 0))
+            const auto LastError = GetLastError();
+            if ((LastError == ERROR_BROKEN_PIPE) || (LastError == ERROR_HANDLE_EOF))
             {
                 if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
                 {
@@ -476,22 +454,45 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
                 break;
             }
 
-            WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
+            THROW_LAST_ERROR_IF(LastError != ERROR_IO_PENDING);
 
-            const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
-            THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
-        }
-        else if (WaitStatus == (WAIT_OBJECT_0 + 1))
-        {
-            THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &ExitCode));
+            auto CancelIo = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
+                CancelIoEx(MessageHandle, &Overlapped);
+                GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, TRUE);
+            });
 
-            // Close the pseudoconsole, this causes all pending data to be flushed.
-            Result->PseudoConsole.reset();
-            break;
-        }
-        else
-        {
-            THROW_HR(E_UNEXPECTED);
+            const DWORD WaitStatus = WaitForMultipleObjects(RTL_NUMBER_OF(WaitHandles), WaitHandles, FALSE, INFINITE);
+            if (WaitStatus == WAIT_OBJECT_0)
+            {
+                Success = GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, FALSE);
+                CancelIo.release();
+                if ((!Success) || (BytesRead == 0))
+                {
+                    if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
+                    {
+                        THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
+                    }
+
+                    break;
+                }
+
+                WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
+
+                const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
+                THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
+            }
+            else if (WaitStatus == (WAIT_OBJECT_0 + 1))
+            {
+                THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &ExitCode));
+
+                // Close the pseudoconsole, this causes all pending data to be flushed.
+                Result->PseudoConsole.reset();
+                break;
+            }
+            else
+            {
+                THROW_HR(E_UNEXPECTED);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- When `ReadFile` in `ProcessInteropMessages` completes synchronously with zero bytes (socket EOF), the loop had no exit condition and spun at 100% CPU indefinitely.
- The async completion path (via `GetOverlappedResult`) already handled this correctly with a `BytesRead == 0` check, but the synchronous path fell through to the next loop iteration unconditionally.
- Added a synchronous success handler that checks for EOF and processes the window size message, mirroring the existing async path.

## Notes

The fix keeps the sync/async result handling separate to match the codebase's existing style (see `ReadHandle::Schedule`/`Collect` in `HandleIO.cpp`). A future improvement could refactor `ProcessInteropMessages` to use the `MultiHandleWait` + `ReadHandle` infrastructure, which would eliminate the duplication structurally — but that's a larger change better suited for a separate PR.

## Test plan

Unable to build and test locally (Linux/WSL2 environment, no Windows build toolchain). The change is a pure addition of a `BytesRead == 0` check on the synchronous `ReadFile` success path, mirroring the identical check already present on the async path. Requesting CI validation and maintainer review.

Fixes #41173

🤖 Generated with [Claude Code](https://claude.com/claude-code)