### PR TITLE
Add CSV parsing helpers to shared string library

### DIFF
--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -18,6 +18,7 @@ Abstract:
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <optional>
 #include <gsl/gsl>
 #include <format>
 #include <source_location>
@@ -127,6 +128,135 @@ inline std::vector<std::basic_string<T>> SplitByMultipleSeparators(const std::ba
     }
 
     return Output;
+}
+
+// Splits a single CSV record (RFC 4180) into its fields, matching Go's encoding/csv (which docker
+// buildx uses via go-csvvalue): fields are comma separated, a field may be wrapped in double quotes,
+// a doubled quote inside a quoted field is a literal quote, and a comma inside a quoted field is part
+// of the value. Returns std::nullopt when the record is malformed (an unterminated quoted field, or
+// unexpected text immediately after a closing quote). Note this parses a *single* record; embedded
+// CR/LF are treated as ordinary field characters, not record separators.
+template <class T>
+inline std::optional<std::vector<std::basic_string<T>>> SplitCsvFields(const std::basic_string<T>& Record)
+{
+    constexpr T Quote = static_cast<T>('"');
+    constexpr T Comma = static_cast<T>(',');
+
+    std::vector<std::basic_string<T>> Fields;
+    std::basic_string<T> Field;
+    const size_t Length = Record.size();
+    size_t Index = 0;
+
+    while (true)
+    {
+        Field.clear();
+        if (Index < Length && Record[Index] == Quote)
+        {
+            ++Index;
+            bool Closed = false;
+            while (Index < Length)
+            {
+                if (Record[Index] == Quote)
+                {
+                    // A doubled quote inside a quoted field is a single literal quote.
+                    if (Index + 1 < Length && Record[Index + 1] == Quote)
+                    {
+                        Field.push_back(Quote);
+                        Index += 2;
+                        continue;
+                    }
+
+                    ++Index;
+                    Closed = true;
+                    break;
+                }
+
+                Field.push_back(Record[Index]);
+                ++Index;
+            }
+
+            if (!Closed)
+            {
+                return std::nullopt; // unterminated quoted field
+            }
+
+            // After a closing quote only a comma (end of field) or end of record is valid.
+            if (Index < Length && Record[Index] != Comma)
+            {
+                return std::nullopt;
+            }
+        }
+        else
+        {
+            while (Index < Length && Record[Index] != Comma)
+            {
+                Field.push_back(Record[Index]);
+                ++Index;
+            }
+        }
+
+        Fields.push_back(Field);
+        if (Index >= Length)
+        {
+            break;
+        }
+
+        ++Index; // consume the ',' and start the next field
+    }
+
+    return Fields;
+}
+
+// CSV-escapes a single field: if it contains a comma, double quote, CR, LF, or a leading/trailing
+// space, it is wrapped in double quotes with each embedded quote doubled (matching Go's encoding/csv
+// writer). Otherwise it is returned unchanged. The result parses back via SplitCsvFields.
+template <class T>
+inline std::basic_string<T> CsvEscapeField(const std::basic_string<T>& Field)
+{
+    constexpr T Quote = static_cast<T>('"');
+    const T Special[] = {static_cast<T>(','), Quote, static_cast<T>('\r'), static_cast<T>('\n'), static_cast<T>(0)};
+
+    const bool NeedsQuote = Field.find_first_of(Special) != std::basic_string<T>::npos ||
+                            (!Field.empty() && (Field.front() == static_cast<T>(' ') || Field.back() == static_cast<T>(' ')));
+    if (!NeedsQuote)
+    {
+        return Field;
+    }
+
+    std::basic_string<T> Result;
+    Result.reserve(Field.size() + 2);
+    Result.push_back(Quote);
+    for (const T Ch : Field)
+    {
+        if (Ch == Quote)
+        {
+            Result.push_back(Quote);
+        }
+
+        Result.push_back(Ch);
+    }
+
+    Result.push_back(Quote);
+    return Result;
+}
+
+// Joins fields into a single CSV record, escaping each field as needed (see CsvEscapeField). The
+// result parses back to the original fields via SplitCsvFields.
+template <class T>
+inline std::basic_string<T> JoinCsvFields(const std::vector<std::basic_string<T>>& Fields)
+{
+    std::basic_string<T> Record;
+    for (size_t Index = 0; Index < Fields.size(); ++Index)
+    {
+        if (Index != 0)
+        {
+            Record.push_back(static_cast<T>(','));
+        }
+
+        Record += CsvEscapeField(Fields[Index]);
+    }
+
+    return Record;
 }
 
 inline const char* FromSpan(gsl::span<gsl::byte> Span, size_t Offset = 0)

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -130,12 +130,18 @@ inline std::vector<std::basic_string<T>> SplitByMultipleSeparators(const std::ba
     return Output;
 }
 
-// Splits a single CSV record (RFC 4180) into its fields, matching Go's encoding/csv (which docker
-// buildx uses via go-csvvalue): fields are comma separated, a field may be wrapped in double quotes,
-// a doubled quote inside a quoted field is a literal quote, and a comma inside a quoted field is part
-// of the value. Returns std::nullopt when the record is malformed (an unterminated quoted field, or
-// unexpected text immediately after a closing quote). Note this parses a *single* record; embedded
-// CR/LF are treated as ordinary field characters, not record separators.
+// Splits a single CSV record into fields using the grammar Go's encoding/csv applies to one record
+// (which docker buildx relies on via go-csvvalue), so a spec is parsed the way buildx would:
+//   - fields are separated by commas;
+//   - a field may be wrapped in double quotes, in which case a comma is a literal character and a
+//     doubled quote ("") is a single literal quote;
+//   - an unquoted field may not contain a double quote (Go's non-lazy ErrBareQuote).
+// Returns std::nullopt when the record is malformed: an unterminated quoted field, text immediately
+// after a closing quote, or a bare quote in an unquoted field.
+//
+// Deviation from Go/RFC 4180: this parses exactly one record. Go would treat an unquoted CR/LF as a
+// record separator; here CR/LF are always ordinary field characters (never a record separator), which
+// is what a single-line command-line spec needs.
 template <class T>
 inline std::optional<std::vector<std::basic_string<T>>> SplitCsvFields(const std::basic_string<T>& Record)
 {
@@ -190,6 +196,12 @@ inline std::optional<std::vector<std::basic_string<T>>> SplitCsvFields(const std
         {
             while (Index < Length && Record[Index] != Comma)
             {
+                // Go (non-lazy) rejects a bare double quote in an unquoted field (ErrBareQuote).
+                if (Record[Index] == Quote)
+                {
+                    return std::nullopt;
+                }
+
                 Field.push_back(Record[Index]);
                 ++Index;
             }
@@ -207,9 +219,11 @@ inline std::optional<std::vector<std::basic_string<T>>> SplitCsvFields(const std
     return Fields;
 }
 
-// CSV-escapes a single field: if it contains a comma, double quote, CR, LF, or a leading/trailing
-// space, it is wrapped in double quotes with each embedded quote doubled (matching Go's encoding/csv
-// writer). Otherwise it is returned unchanged. The result parses back via SplitCsvFields.
+// CSV-escapes a single field for round-tripping through JoinCsvFields/SplitCsvFields: if the field
+// contains a comma, a double quote, CR, LF, or a leading/trailing space it is wrapped in double quotes
+// with each embedded quote doubled; otherwise it is returned unchanged. This is not a byte-for-byte
+// match of Go's encoding/csv writer (which quotes only a leading space and leaves an empty field
+// unquoted); it is the minimal quoting needed for every field to parse back via SplitCsvFields.
 template <class T>
 inline std::basic_string<T> CsvEscapeField(const std::basic_string<T>& Field)
 {

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -56,7 +56,15 @@ services::BuildSecret ParseSecretSpec(const std::wstring& spec)
     std::wstring envName;
     std::wstring srcPath;
 
-    for (const auto& part : Split(spec, L','))
+    // Docker parity: buildx parses --secret as a single CSV record (go-csvvalue), so a quoted field
+    // may contain commas (e.g. a 'src=' path). Malformed quoting is rejected like any other bad spec.
+    const auto parts = SplitCsvFields(spec);
+    if (!parts.has_value())
+    {
+        throw ArgumentException(Localization::MessageWslcSecretInvalidSpec(spec, L"malformed quoting"));
+    }
+
+    for (const auto& part : *parts)
     {
         const auto kv = SplitKeyValue(part);
         if (!kv.HadSeparator || kv.Key.empty())

--- a/test/windows/wslc/WSLCCLISecretParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLISecretParserUnitTests.cpp
@@ -182,6 +182,35 @@ class WSLCCLISecretParserUnitTests
         VerifyValidFileSecret(L"id=s,source=" + file.wpath(), L"s", file.wpath());
     }
 
+    TEST_METHOD(Secret_File_QuotedFieldWithCommaInSrcPath)
+    {
+        // Docker parity: buildx parses --secret as a single CSV record, so a whole 'src=' field can be
+        // double-quoted to carry a path containing commas; the comma must stay part of the value rather
+        // than splitting into bogus extra key=value parts. This exercises SplitCsvFields end-to-end
+        // through secret parsing. Note the entire "src=<path>" field is quoted (Go's CSV grammar), not
+        // just the value - a bare quote after 'src=' would be an unquoted-field bare quote (malformed).
+        const auto path =
+            std::filesystem::temp_directory_path() / (L"wslc_ut_secret_" + std::to_wstring(GetCurrentProcessId()) + L"_a,b,c.bin");
+        {
+            std::ofstream file(path, std::ios::binary | std::ios::trunc);
+            VERIFY_IS_TRUE(file.is_open());
+            file << 'x';
+        }
+        auto cleanup = wil::scope_exit([&]() {
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+        });
+
+        const std::wstring spec = L"id=s,\"src=" + path.wstring() + L"\"";
+        auto secret = validation::ParseSecretSpec(spec);
+        VERIFY_ARE_EQUAL(std::wstring(L"s"), secret.Id);
+        VERIFY_IS_TRUE(secret.Value.empty());
+
+        std::error_code ec;
+        const auto expectedCanonical = std::filesystem::weakly_canonical(path, ec);
+        VERIFY_ARE_EQUAL(expectedCanonical.wstring(), secret.SourcePath);
+    }
+
     TEST_METHOD(Secret_File_EmptyFileForwardsPath)
     {
         // An empty file is still a valid file secret: its path is forwarded and mounted (docker delivers

--- a/test/windows/wslc/WSLCCsvSharedUnitTests.cpp
+++ b/test/windows/wslc/WSLCCsvSharedUnitTests.cpp
@@ -110,6 +110,12 @@ class WSLCCsvSharedUnitTests
         VerifyMalformed(L"\"a\"b");
     }
 
+    TEST_METHOD(Split_BareQuoteInUnquotedFieldIsMalformed)
+    {
+        // Go's encoding/csv (non-lazy) rejects a bare double quote in an unquoted field (ErrBareQuote).
+        VerifyMalformed(L"a\"b,c");
+    }
+
     // --- CsvEscapeField ---
 
     TEST_METHOD(Escape_PlainFieldUnchanged)

--- a/test/windows/wslc/WSLCCsvSharedUnitTests.cpp
+++ b/test/windows/wslc/WSLCCsvSharedUnitTests.cpp
@@ -1,0 +1,185 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+/*++
+
+Module Name:
+
+    WSLCCsvSharedUnitTests.cpp
+
+Abstract:
+
+    Unit tests for the shared CSV helpers in wsl::shared::string (SplitCsvFields, CsvEscapeField,
+    JoinCsvFields). These implement the single-record RFC 4180 grammar that docker buildx uses via
+    go-csvvalue / encoding/csv, and back the --output/--secret spec parsers. The tests pin the grammar
+    (quoting, "" escaping, embedded commas, malformed-record rejection) and the escape/join round-trip.
+
+--*/
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCCLITestHelpers.h"
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace WSLCCsvSharedUnitTests {
+
+using WStrings = std::vector<std::wstring>;
+
+class WSLCCsvSharedUnitTests
+{
+    WSLC_TEST_CLASS(WSLCCsvSharedUnitTests)
+
+    static void VerifySplit(const std::wstring& record, const WStrings& expected)
+    {
+        const auto fields = wsl::shared::string::SplitCsvFields(record);
+        VERIFY_IS_TRUE(fields.has_value());
+        if (!fields.has_value())
+        {
+            return;
+        }
+
+        VERIFY_ARE_EQUAL(expected.size(), fields->size());
+        for (size_t i = 0; i < expected.size() && i < fields->size(); ++i)
+        {
+            VERIFY_ARE_EQUAL(expected[i], (*fields)[i]);
+        }
+    }
+
+    static void VerifyMalformed(const std::wstring& record)
+    {
+        VERIFY_IS_FALSE(wsl::shared::string::SplitCsvFields(record).has_value());
+    }
+
+    // --- SplitCsvFields ---
+
+    TEST_METHOD(Split_SimpleFields)
+    {
+        VerifySplit(L"a,b,c", WStrings{L"a", L"b", L"c"});
+    }
+
+    TEST_METHOD(Split_SingleField)
+    {
+        VerifySplit(L"abc", WStrings{L"abc"});
+    }
+
+    TEST_METHOD(Split_EmptyInputIsOneEmptyField)
+    {
+        VerifySplit(L"", WStrings{L""});
+    }
+
+    TEST_METHOD(Split_EmptyFieldsPreserved)
+    {
+        // Unlike wsl::shared::string::Split, empty fields are preserved (they are meaningful in a spec).
+        VerifySplit(L"a,,c", WStrings{L"a", L"", L"c"});
+    }
+
+    TEST_METHOD(Split_LeadingAndTrailingCommas)
+    {
+        VerifySplit(L",a,", WStrings{L"", L"a", L""});
+    }
+
+    TEST_METHOD(Split_QuotedFieldWithComma)
+    {
+        VerifySplit(L"\"a,b\",c", WStrings{L"a,b", L"c"});
+    }
+
+    TEST_METHOD(Split_QuotedFieldWithEscapedQuote)
+    {
+        // A doubled quote inside a quoted field is a single literal quote.
+        VerifySplit(L"\"a\"\"b\"", WStrings{L"a\"b"});
+    }
+
+    TEST_METHOD(Split_QuotedEmptyField)
+    {
+        VerifySplit(L"\"\",x", WStrings{L"", L"x"});
+    }
+
+    TEST_METHOD(Split_QuotedThenPlainField)
+    {
+        VerifySplit(L"\"a\",b", WStrings{L"a", L"b"});
+    }
+
+    TEST_METHOD(Split_UnterminatedQuoteIsMalformed)
+    {
+        VerifyMalformed(L"\"abc");
+    }
+
+    TEST_METHOD(Split_TextAfterClosingQuoteIsMalformed)
+    {
+        VerifyMalformed(L"\"a\"b");
+    }
+
+    // --- CsvEscapeField ---
+
+    TEST_METHOD(Escape_PlainFieldUnchanged)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L"abc"), wsl::shared::string::CsvEscapeField(std::wstring(L"abc")));
+    }
+
+    TEST_METHOD(Escape_EmptyFieldUnchanged)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L""), wsl::shared::string::CsvEscapeField(std::wstring(L"")));
+    }
+
+    TEST_METHOD(Escape_CommaQuoted)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L"\"a,b\""), wsl::shared::string::CsvEscapeField(std::wstring(L"a,b")));
+    }
+
+    TEST_METHOD(Escape_QuoteDoubledAndQuoted)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L"\"a\"\"b\""), wsl::shared::string::CsvEscapeField(std::wstring(L"a\"b")));
+    }
+
+    TEST_METHOD(Escape_NewlineQuoted)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L"\"a\nb\""), wsl::shared::string::CsvEscapeField(std::wstring(L"a\nb")));
+    }
+
+    TEST_METHOD(Escape_LeadingOrTrailingSpaceQuoted)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L"\" a\""), wsl::shared::string::CsvEscapeField(std::wstring(L" a")));
+        VERIFY_ARE_EQUAL(std::wstring(L"\"a \""), wsl::shared::string::CsvEscapeField(std::wstring(L"a ")));
+    }
+
+    // --- JoinCsvFields ---
+
+    TEST_METHOD(Join_PlainFields)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L"a,b,c"), wsl::shared::string::JoinCsvFields(WStrings{L"a", L"b", L"c"}));
+    }
+
+    TEST_METHOD(Join_EscapesFieldContainingComma)
+    {
+        VERIFY_ARE_EQUAL(std::wstring(L"\"a,b\",c"), wsl::shared::string::JoinCsvFields(WStrings{L"a,b", L"c"}));
+    }
+
+    // --- Round-trip: SplitCsvFields(JoinCsvFields(x)) == x ---
+
+    TEST_METHOD(RoundTrip_JoinThenSplitPreservesFields)
+    {
+        const WStrings inputs{L"type=image", L"annotation.foo=a,b,c", L"name=x", L"quote=a\"b", L""};
+        const auto joined = wsl::shared::string::JoinCsvFields(inputs);
+        VerifySplit(joined, inputs);
+    }
+
+    // --- Template works for narrow (char) strings too ---
+
+    TEST_METHOD(Narrow_SplitAndJoinRoundTrip)
+    {
+        const std::vector<std::string> inputs{"a,b", "c", "d\"e"};
+        const auto joined = wsl::shared::string::JoinCsvFields(inputs);
+        VERIFY_ARE_EQUAL(std::string("\"a,b\",c,\"d\"\"e\""), joined);
+
+        const auto fields = wsl::shared::string::SplitCsvFields(joined);
+        VERIFY_IS_TRUE(fields.has_value());
+        VERIFY_ARE_EQUAL(inputs.size(), fields->size());
+        for (size_t i = 0; i < inputs.size() && i < fields->size(); ++i)
+        {
+            VERIFY_ARE_EQUAL(inputs[i], (*fields)[i]);
+        }
+    }
+};
+
+} // namespace WSLCCsvSharedUnitTests


### PR DESCRIPTION
This pull request adds robust CSV parsing and escaping utilities to the shared string library, updates secret spec parsing for Docker compatibility, and introduces comprehensive unit tests to ensure correctness and round-trip fidelity. The main goal is to match Docker's `buildx` handling of CSV values (via Go's `encoding/csv`), ensuring correct parsing of quoted fields, embedded commas, and malformed input.

**CSV parsing and escaping utilities:**

* Added a template function `SplitCsvFields` to parse a single CSV record according to RFC 4180 and Go's `encoding/csv`, handling quoted fields, embedded commas, escaped quotes, and malformed input detection.
* Added `CsvEscapeField` to escape individual fields for CSV output, quoting fields as needed and doubling embedded quotes, and `JoinCsvFields` to join fields into a CSV record, ensuring round-trip parseability.
* Included `<optional>` to support the use of `std::optional` in parsing functions.

**Integration with secret spec parsing:**

* Updated `ParseSecretSpec` to use `SplitCsvFields`, ensuring Docker-compatible parsing of `--secret` specs, including proper handling of quoted fields and malformed input rejection.

**Testing:**

* Added a new test file `WSLCCsvSharedUnitTests.cpp` with unit tests covering all aspects of the CSV parsing and escaping logic, including round-trip tests and malformed input handling, for both wide and narrow string types.
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
