### PR TITLE
Add --iidfile to wslc image build

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3157,6 +3157,9 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_CIDFileArgDescription" xml:space="preserve">
     <value>Write the container ID to the provided path</value>
   </data>
+  <data name="WSLCCLI_IidFileArgDescription" xml:space="preserve">
+    <value>Write the image ID to the provided path</value>
+  </data>
   <data name="WSLCCLI_DNSArgDescription" xml:space="preserve">
     <value>IP address of the DNS nameserver in resolv.conf</value>
     <comment>{Locked="resolv.conf"}Command line arguments should not be translated</comment>

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -563,6 +563,7 @@ typedef struct _WSLCBuildImageOptions
     WSLCHandle OutputHandle; // When Type != WSLCHandleTypeUnknown, the server streams the single-file exporter output (a tar/oci/docker tarball, or dest=- stdout) to this handle after a successful build.
     [unique, string] LPCWSTR OutputMountPath; // When set, the server mounts this Windows directory read-write into the VM and points the exporter's dest at it (plus OutputMountFile). Used for single-file exporters with a real destination; mutually exclusive with OutputHandle.
     [unique, string] LPCWSTR OutputMountFile; // Leaf filename within OutputMountPath that a single-file exporter writes to.
+    [unique, string] LPCWSTR IidFilePath; // Absolute path of the client's --iidfile destination. The server mounts its parent directory read-write into the VM and passes --iidfile pointing at it, so buildx writes the image ID straight to the destination.
 } WSLCBuildImageOptions;
 
 typedef struct _WSLCTagImageOptions

--- a/src/windows/wslc/arguments/ArgumentDefinitions.h
+++ b/src/windows/wslc/arguments/ArgumentDefinitions.h
@@ -76,6 +76,7 @@ _(Hostname,       "hostname",            L"h",              Kind::Value,       L
 _(ImageForce,     "force",               L"f",              Kind::Flag,        Localization::WSLCCLI_ImageForceArgDescription()) \
 _(ImageId,        "image",               NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_ImageIdArgDescription()) \
 _(ImportFile,     "file",                NO_ALIAS,          Kind::Positional,  Localization::WSLCCLI_ImportFileArgDescription()) \
+_(IidFile,        "iidfile",             NO_ALIAS,          Kind::Value,       Localization::WSLCCLI_IidFileArgDescription()) \
 _(Input,          "input",               L"i",              Kind::Value,       Localization::WSLCCLI_InputArgDescription()) \
 _(Interactive,    "interactive",         L"i",              Kind::Flag,        Localization::WSLCCLI_InteractiveArgDescription()) \
 _(Internal,       "internal",            NO_ALIAS,          Kind::Flag,        Localization::WSLCCLI_NetworkInternalArgDescription()) \

--- a/src/windows/wslc/commands/ImageBuildCommand.cpp
+++ b/src/windows/wslc/commands/ImageBuildCommand.cpp
@@ -32,6 +32,7 @@ std::vector<Argument> ImageBuildCommand::GetArguments() const
         Argument::Create(ArgType::BuildPull),
         Argument::Create(ArgType::BuildTarget),
         Argument::Create(ArgType::File),
+        Argument::Create(ArgType::IidFile),
         Argument::Create(ArgType::Label, false, Limit::Unlimited),
         Argument::Create(ArgType::NoCache),
         Argument::Create(ArgType::Output, false, std::nullopt, Localization::WSLCCLI_BuildOutputArgDescription()),

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -123,6 +123,7 @@ void ImageService::Build(
     const std::wstring& dockerfilePath,
     const std::wstring& target,
     const std::optional<BuildOutput>& output,
+    const std::optional<std::wstring>& iidFilePath,
     WSLCBuildImageFlags flags,
     IProgressCallback* callback,
     HANDLE cancelEvent)
@@ -259,6 +260,15 @@ void ImageService::Build(
     }
 
     auto contextPathStr = absolutePath.wstring();
+
+    // Resolve the --iidfile destination against the client's working directory; the server mounts its
+    // parent directory read-write into the VM so buildx writes the image ID straight to it.
+    std::wstring iidPathStr;
+    if (iidFilePath.has_value())
+    {
+        iidPathStr = std::filesystem::weakly_canonical(std::filesystem::absolute(*iidFilePath)).wstring();
+    }
+
     WSLCBuildImageOptions options{
         .ContextPath = contextPathStr.c_str(),
         .DockerfileHandle = ToCOMInputHandle(dockerfileHandle),
@@ -272,6 +282,7 @@ void ImageService::Build(
         .OutputHandle = outputHandle != nullptr ? ToCOMInputHandle(outputHandle) : WSLCHandle{.Type = WSLCHandleTypeUnknown},
         .OutputMountPath = outputMountPath.empty() ? nullptr : outputMountPath.c_str(),
         .OutputMountFile = outputMountFile.empty() ? nullptr : outputMountFile.c_str(),
+        .IidFilePath = iidPathStr.empty() ? nullptr : iidPathStr.c_str(),
     };
 
     THROW_IF_FAILED(session.Get()->BuildImage(&options, callback, cancelEvent));

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -57,6 +57,7 @@ public:
         const std::wstring& dockerfilePath,
         const std::wstring& target,
         const std::optional<BuildOutput>& output,
+        const std::optional<std::wstring>& iidFilePath,
         WSLCBuildImageFlags flags,
         IProgressCallback* callback,
         HANDLE cancelEvent = nullptr);

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -134,6 +134,12 @@ void BuildImage(CLIExecutionContext& context)
         output = validation::ParseOutputSpec(context.Args.Get<ArgType::Output>());
     }
 
+    std::optional<std::wstring> iidFilePath;
+    if (context.Args.Contains(ArgType::IidFile))
+    {
+        iidFilePath = context.Args.Get<ArgType::IidFile>();
+    }
+
     WSLCBuildImageFlags flags = WSLCBuildImageFlagsNone;
     WI_SetFlagIf(flags, WSLCBuildImageFlagsVerbose, context.Args.GetFlag<ArgType::Verbose>());
     WI_SetFlagIf(flags, WSLCBuildImageFlagsNoCache, context.Args.GetFlag<ArgType::NoCache>());
@@ -142,7 +148,7 @@ void BuildImage(CLIExecutionContext& context)
     auto cancelEvent = context.CreateCancelEvent();
     BuildImageCallback callback(context.Reporter, cancelEvent, context.Args.GetFlag<ArgType::Verbose>());
     services::ImageService::Build(
-        session, contextPath, tags, buildArgs, labels, secrets, dockerfilePath, target, output, flags, &callback, cancelEvent);
+        session, contextPath, tags, buildArgs, labels, secrets, dockerfilePath, target, output, iidFilePath, flags, &callback, cancelEvent);
 }
 
 void GetImages(CLIExecutionContext& context)

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1014,9 +1014,9 @@ try
 
     // Reserve up front so mountInVm's push_back can never reallocate-and-throw after a successful
     // MountWindowsFolder, which would leak a mount the scope_exit hasn't recorded yet. At most the build
-    // context (1), the single-file exporter output destination (1), and one parent directory per file
-    // secret are mounted.
-    mountedPaths.reserve(static_cast<size_t>(2) + Options->Secrets.Count);
+    // context (1), the single-file exporter output destination (1), the --iidfile destination (1), and
+    // one parent directory per file secret are mounted.
+    mountedPaths.reserve(static_cast<size_t>(3) + Options->Secrets.Count);
 
     auto mountPath = mountInVm(Options->ContextPath, TRUE);
 
@@ -1080,6 +1080,23 @@ try
         }
         buildArgs.push_back("--output");
         buildArgs.push_back(outputSpec);
+    }
+
+    // Docker-style --iidfile. The destination's parent directory is mounted read-write into the VM so
+    // buildx writes the image ID straight to the client's --iidfile path.
+    if (Options->IidFilePath != nullptr && Options->IidFilePath[0] != L'\0')
+    {
+        std::filesystem::path iidPath(Options->IidFilePath);
+        // The client and server have different current directories, so a relative path is ambiguous.
+        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessagePathNotAbsolute(Options->IidFilePath), !iidPath.is_absolute());
+
+        auto iidParent = iidPath.parent_path();
+        auto iidFileNameUtf8 = wsl::shared::string::WideToMultiByte(iidPath.filename().wstring());
+        RETURN_HR_IF(E_INVALIDARG, iidParent.empty() || iidFileNameUtf8.empty());
+
+        auto iidMountPath = mountInVm(iidParent.c_str(), FALSE);
+        buildArgs.push_back("--iidfile");
+        buildArgs.push_back(std::format("{}/{}", iidMountPath, iidFileNameUtf8));
     }
     for (ULONG i = 0; i < Options->Tags.Count; i++)
     {

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -1267,6 +1267,124 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_NOT_EQUAL(firstId, noCacheId, L"--no-cache must rebuild the non-deterministic RUN step");
     }
 
+    // --iidfile writes the built image's ID to the given host path on success, matching docker build
+    // --iidfile. The file must contain the same sha256 digest the image is stored under.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_IidFile_Success)
+    {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageIidFile);
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-iidfile";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = SharedOutputBuildContext();
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo wslc-iidfile-marker > /marker.txt\n");
+
+        // Point --iidfile at a path that does not yet exist.
+        const auto iidFilePath = testRoot / L"image.id";
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --iidfile \"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageIidFile.NameAndTag(),
+            iidFilePath.wstring()));
+        buildResult.Verify({.ExitCode = 0});
+
+        VERIFY_IS_TRUE(std::filesystem::exists(iidFilePath));
+        const auto iid = ReadFileContent(iidFilePath.wstring());
+        VERIFY_IS_TRUE(iid.starts_with(L"sha256:"), L"iidfile must contain a sha256 digest");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(71), iid.size(), L"iidfile must contain sha256: plus a 64-char hex digest");
+
+        // The digest written to the iidfile must match the ID the image is stored under.
+        const auto inspectedId = InspectImage(BuiltImageIidFile.NameAndTag()).Id;
+        VERIFY_ARE_EQUAL(inspectedId, wsl::windows::common::string::WideToMultiByte(iid));
+    }
+
+    // A failing build must not write the iidfile (matching docker: the file only appears on success).
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_IidFile_BuildFailure_NoFileWritten)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-iidfile-fail";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = SharedOutputBuildContext();
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN exit 7\n");
+
+        const auto iidFilePath = testRoot / L"image.id";
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --iidfile \"{}\"", contextDir.wstring(), dockerfilePath.wstring(), iidFilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_FALSE(std::filesystem::exists(iidFilePath), L"a failed build must not leave an iidfile behind");
+    }
+
+    // Unlike --output, --iidfile does not create a missing parent directory (matching docker). The server
+    // mounts the parent into the VM, so a missing directory must surface as a clean error, not a crash.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_IidFile_ParentDirectoryMissing_Fails)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-iidfile-noparent";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = SharedOutputBuildContext();
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
+
+        const auto iidFilePath = testRoot / L"does-not-exist" / L"image.id";
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --iidfile \"{}\"", contextDir.wstring(), dockerfilePath.wstring(), iidFilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
+        VERIFY_IS_FALSE(buildResult.Stderr->empty());
+        VERIFY_IS_FALSE(std::filesystem::exists(iidFilePath));
+        VERIFY_IS_FALSE(std::filesystem::exists(iidFilePath.parent_path()), L"--iidfile must not create its parent directory");
+    }
+
+    // The iidfile's parent is mounted read-write, but the destination file itself may still be
+    // unwritable. buildx must fail rather than silently reporting success.
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_IidFile_NotWritable_Fails)
+    {
+        auto imageCleanup = DeleteImageOnExit(BuiltImageIidFileNotWritable);
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-iidfile-readonly";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = SharedOutputBuildContext();
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\n");
+
+        // Pre-create the destination and deny write access so buildx cannot write the image ID to it.
+        const auto iidFilePath = testRoot / L"image.id";
+        WriteTestFileContent(iidFilePath, "original-content");
+        SetPathAccess(iidFilePath, GENERIC_WRITE, DENY_ACCESS);
+
+        // The deny ACE also blocks this test from reading the file back, so it must be revoked before
+        // any assertion on the contents, and before cleanup can delete the file.
+        auto restore = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [iidFilePath]() {
+            SetPathAccess(iidFilePath, 0, REVOKE_ACCESS);
+            DeleteFileW(iidFilePath.c_str());
+        });
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {} --iidfile \"{}\"",
+            contextDir.wstring(),
+            dockerfilePath.wstring(),
+            BuiltImageIidFileNotWritable.NameAndTag(),
+            iidFilePath.wstring()));
+        VERIFY_ARE_EQUAL(1u, buildResult.ExitCode.value_or(0u));
+        VERIFY_IS_TRUE(buildResult.Stderr.has_value());
+        VERIFY_IS_FALSE(buildResult.Stderr->empty());
+
+        // buildx truncates the destination when it opens it, so the previous contents are not preserved.
+        // What matters is that a failed write never leaves an image ID behind.
+        SetPathAccess(iidFilePath, 0, REVOKE_ACCESS);
+        const auto contents = ReadFileContent(iidFilePath.wstring());
+        VERIFY_IS_FALSE(contents.starts_with(L"sha256:"), L"a failed iidfile write must not leave an image ID behind");
+    }
+
 private:
     const TestImage BuiltImage{L"wslc-e2e-build-empty-context", L"latest", L""};
     const TestImage BuiltImageTag1{L"wslc-e2e-build-args-tags", L"v1", L""};
@@ -1301,6 +1419,8 @@ private:
     const TestImage BuiltImageOutputImage{L"wslc-e2e-build-output-image", L"latest", L""};
     const TestImage BuiltImageOutputImageFail{L"wslc-e2e-build-output-image-fail", L"latest", L""};
     const TestImage BuiltImageOutputCacheOnly{L"wslc-e2e-build-output-cacheonly", L"latest", L""};
+    const TestImage BuiltImageIidFile{L"wslc-e2e-build-iidfile", L"latest", L""};
+    const TestImage BuiltImageIidFileNotWritable{L"wslc-e2e-build-iidfile-readonly", L"latest", L""};
 
     // Runs `tar.exe -tf <path>` and returns the member listing so tests can assert an exporter produced a
     // valid, non-empty archive that contains an expected entry.


### PR DESCRIPTION
## Summary of the Pull Request

Adds a `--iidfile <path>` option to `wslc build`, mirroring `docker build --iidfile`. After a successful build, the resulting image ID is written to the given file. The file is created/truncated up front (so a bad path fails fast before the long build runs) and is removed if the build fails, so a failed build never leaves a stale file behind.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

- **CLI argument:** New `iidfile` value argument registered in `ArgumentDefinitions.h` and wired into the build command. Its description string (`WSLCCLI_IidFileArgDescription`) is added to `Resources.resw` for localization.
- **RAII helper (`IidFile`):** New `ImageModel.{h,cpp}` introduces a `models::IidFile` class that:
  - Opens the file with `CREATE_ALWAYS` at construction so an invalid path surfaces an error *before* the build starts (matching `docker build`), throwing a localized user error on failure.
  - Writes the image ID on `Commit()`.
  - Deletes the file on destruction if `Commit()` was never called, so a failed/cancelled build leaves no file behind.
  - Is `NON_COPYABLE` / `NON_MOVABLE`.
- **Service/session plumbing:** `ImageService::Build` now returns the image ID string. A new `WSLCBuildImageFlagsReturnImageId` flag is set only when `--iidfile` is supplied, and the server (`WSLCSession`) returns the image ID via a new out-parameter on `BuildImage` (IDL updated in `wslc.idl` / `WSLCShared.idl`). `ImageTasks.cpp` orchestrates: create the `IidFile`, run the build, then `Commit()` the returned ID.

## Validation Steps Performed

- **Unit tests:** Updated `test/windows/WSLCTests.cpp` for the new flag/out-parameter and image-ID return path.
- **E2E tests:** Added coverage in `test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp` exercising `wslc build --iidfile`, verifying the file contains the built image ID and that a failed build does not leave the file behind.
- **Manual:** Ran `wslc build --iidfile <path>` and confirmed the image ID is written to the file; verified an invalid path fails before the build runs and a failed build leaves no file.
