### PR TITLE
Warn before opening downloaded WSL distributions

### DIFF
--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -139,6 +139,10 @@
                         <Verb Id="open" Command="open" TargetFile="wsl.exe" Argument="--install --prompt-before-exit --from-file &quot;%1&quot;" />
                     </Extension>
                 </ProgId>
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Classes\WSLDistributionTar">
+                    <!-- FTA_AlwaysUnsafe -->
+                    <RegistryValue Name="EditFlags" Value="131072" Type="integer" />
+                </RegistryKey>
             </Component>
 
             <Component Id="wslservice" Guid="F0C8D6BA-1502-41E7-BF72-D93DFA134735" UninstallWhenSuperseded="yes" DisableRegistryReflection="yes" Bitness="always64">


### PR DESCRIPTION
## Summary
- mark the `WSLDistributionTar` ProgId with `FTA_AlwaysUnsafe`
- show the standard Attachment Manager warning before opening internet-zone `.wsl` files

## References
- [`FILETYPEATTRIBUTEFLAGS`](https://learn.microsoft.com/windows/win32/api/shlwapi/ne-shlwapi-filetypeattributeflags) documents `FTA_AlwaysUnsafe` as `0x00020000` for a ProgId's `EditFlags` value
- [`AssocIsDangerous`](https://learn.microsoft.com/windows/win32/api/shlwapi/nf-shlwapi-associsdangerous) documents that the Shell checks `FTA_AlwaysUnsafe` when determining file-type risk and performing zone checks

## Testing
- generated the Visual Studio solution with `cmake .`
- completed a full build with `cmake --build . -- -m`
- deployed the generated `bin\X64\Debug\wsl.msi`
- verified `HKCR\WSLDistributionTar\EditFlags` is `0x00020000`
- confirmed a `.wsl` file with `ZoneId=3` displays the warning and Cancel prevents it from being opened