### PR TITLE
CLI: Unify interactive input and output in Reporter

### DIFF
--- a/src/windows/wslc/commands/RegistryCommand.cpp
+++ b/src/windows/wslc/commands/RegistryCommand.cpp
@@ -17,55 +17,10 @@ Abstract:
 #include "RegistryTasks.h"
 #include "SessionTasks.h"
 #include "Task.h"
-#include <iostream>
 
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::task;
 using namespace wsl::shared;
-
-namespace {
-
-std::wstring Prompt(wsl::windows::wslc::Reporter& reporter, const std::wstring& label, bool maskInput)
-{
-    // Write without a trailing newline so the cursor stays inline (matching Docker's behavior).
-    reporter.Info(L"{}", label);
-
-    HANDLE input = GetStdHandle(STD_INPUT_HANDLE);
-    DWORD previousMode = 0;
-    const bool canMask = maskInput && (input != INVALID_HANDLE_VALUE) && GetConsoleMode(input, &previousMode);
-
-    // Armed before echo is disabled and built from a direct lambda (no allocation, can't throw) so a
-    // failure while masking still restores the console. Only acts once echo was actually disabled.
-    bool echoDisabled = false;
-    auto restoreConsole = wil::scope_exit([input, previousMode, &echoDisabled, &reporter]() {
-        if (!echoDisabled)
-        {
-            return;
-        }
-
-        SetConsoleMode(input, previousMode);
-        // Runs from a noexcept scope_exit destructor, possibly during unwinding, so swallow any
-        // output failure to avoid std::terminate.
-        try
-        {
-            reporter.Info(L"\n");
-        }
-        CATCH_LOG()
-    });
-
-    if (canMask)
-    {
-        THROW_IF_WIN32_BOOL_FALSE(SetConsoleMode(input, previousMode & ~ENABLE_ECHO_INPUT));
-        echoDisabled = true;
-    }
-
-    std::wstring value;
-    std::getline(std::wcin, value);
-
-    return value;
-}
-
-} // namespace
 
 namespace wsl::windows::wslc {
 
@@ -134,10 +89,15 @@ void RegistryLoginCommand::ValidateArgumentsInternal(const ArgMap& execArgs) con
 
 void RegistryLoginCommand::ExecuteInternal(CLIExecutionContext& context) const
 {
-    // Prompt for username if not provided.
+    // Interactive prompts write to stdout (Level::Output) to align with the container
+    // CLI ecosystem: Docker (cli.Out()), containerd/nerdctl (cmd.OutOrStdout()), and
+    // Apple container (Swift print) all prompt on stdout. This diverges from general
+    // Unix tools (sudo, ssh, git, gh) that prompt on stderr/tty to keep stdout pipeable,
+    // but WSLC follows Docker's CLI semantics.
     if (!context.Args.Contains(ArgType::Username))
     {
-        context.Args.Add(ArgType::Username, Prompt(context.Reporter, Localization::WSLCCLI_LoginUsernamePrompt(), false));
+        context.Args.Add(
+            ArgType::Username, context.Reporter.PromptForLine(Reporter::Level::Output, Localization::WSLCCLI_LoginUsernamePrompt(), false));
     }
 
     // Resolve password: --password, --password-stdin, or interactive prompt.
@@ -145,18 +105,13 @@ void RegistryLoginCommand::ExecuteInternal(CLIExecutionContext& context) const
     {
         if (context.Args.GetFlag<ArgType::PasswordStdin>())
         {
-            std::wstring line;
-            std::getline(std::wcin, line);
-            if (!line.empty() && line.back() == L'\r')
-            {
-                line.pop_back();
-            }
-
-            context.Args.Add(ArgType::Password, std::move(line));
+            context.Args.Add(ArgType::Password, context.Reporter.ReadLine().value_or(std::wstring{}));
         }
         else
         {
-            context.Args.Add(ArgType::Password, Prompt(context.Reporter, Localization::WSLCCLI_LoginPasswordPrompt(), true));
+            context.Args.Add(
+                ArgType::Password,
+                context.Reporter.PromptForLine(Reporter::Level::Output, Localization::WSLCCLI_LoginPasswordPrompt(), true));
         }
     }
 

--- a/src/windows/wslc/commands/RegistryCommand.cpp
+++ b/src/windows/wslc/commands/RegistryCommand.cpp
@@ -89,11 +89,6 @@ void RegistryLoginCommand::ValidateArgumentsInternal(const ArgMap& execArgs) con
 
 void RegistryLoginCommand::ExecuteInternal(CLIExecutionContext& context) const
 {
-    // Interactive prompts write to stdout (Level::Output) to align with the container
-    // CLI ecosystem: Docker (cli.Out()), containerd/nerdctl (cmd.OutOrStdout()), and
-    // Apple container (Swift print) all prompt on stdout. This diverges from general
-    // Unix tools (sudo, ssh, git, gh) that prompt on stderr/tty to keep stdout pipeable,
-    // but WSLC follows Docker's CLI semantics.
     if (!context.Args.Contains(ArgType::Username))
     {
         auto username = context.Reporter.PromptForLine(Localization::WSLCCLI_LoginUsernamePrompt());

--- a/src/windows/wslc/commands/RegistryCommand.cpp
+++ b/src/windows/wslc/commands/RegistryCommand.cpp
@@ -96,8 +96,8 @@ void RegistryLoginCommand::ExecuteInternal(CLIExecutionContext& context) const
     // but WSLC follows Docker's CLI semantics.
     if (!context.Args.Contains(ArgType::Username))
     {
-        context.Args.Add(
-            ArgType::Username, context.Reporter.PromptForLine(Reporter::Level::Output, Localization::WSLCCLI_LoginUsernamePrompt(), false));
+        auto username = context.Reporter.PromptForLine(Localization::WSLCCLI_LoginUsernamePrompt());
+        context.Args.Add(ArgType::Username, std::move(username));
     }
 
     // Resolve password: --password, --password-stdin, or interactive prompt.
@@ -109,9 +109,8 @@ void RegistryLoginCommand::ExecuteInternal(CLIExecutionContext& context) const
         }
         else
         {
-            context.Args.Add(
-                ArgType::Password,
-                context.Reporter.PromptForLine(Reporter::Level::Output, Localization::WSLCCLI_LoginPasswordPrompt(), true));
+            auto password = context.Reporter.PromptForLine(Localization::WSLCCLI_LoginPasswordPrompt(), true);
+            context.Args.Add(ArgType::Password, std::move(password));
         }
     }
 

--- a/src/windows/wslc/core/InputChannel.cpp
+++ b/src/windows/wslc/core/InputChannel.cpp
@@ -1,0 +1,106 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    InputChannel.cpp
+
+Abstract:
+
+    Implementation of InputChannel.
+
+--*/
+#include "precomp.h"
+#include "InputChannel.h"
+
+#include <wil/resource.h>
+
+namespace wsl::windows::wslc {
+
+InputChannel::InputChannel(HANDLE consoleHandle, FILE* readFile) : m_file(readFile)
+{
+    DWORD mode = 0;
+    if (consoleHandle != INVALID_HANDLE_VALUE && consoleHandle != nullptr && GetConsoleMode(consoleHandle, &mode))
+    {
+        m_consoleHandle = consoleHandle;
+    }
+}
+
+InputChannel::InputChannel(FILE* readFile, bool interactiveOverride) :
+    m_file(readFile), m_interactiveOverride(interactiveOverride)
+{
+}
+
+bool InputChannel::IsInteractive() const noexcept
+{
+    if (m_consoleHandle != nullptr)
+    {
+        DWORD mode = 0;
+        return GetConsoleMode(m_consoleHandle, &mode) != FALSE;
+    }
+
+    return m_interactiveOverride;
+}
+
+std::optional<std::wstring> InputChannel::ReadLine(bool mask) const
+{
+    if (m_file == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    // Disable console echo while reading when masking is requested and input is a
+    // real console. Armed only after echo is actually disabled so the restore is a
+    // no-op otherwise; runs on every exit path including exceptions.
+    DWORD previousMode = 0;
+    bool echoDisabled = false;
+    auto restoreEcho = wil::scope_exit([&]() {
+        if (echoDisabled)
+        {
+            SetConsoleMode(m_consoleHandle, previousMode);
+        }
+    });
+
+    if (mask && m_consoleHandle != nullptr && GetConsoleMode(m_consoleHandle, &previousMode))
+    {
+        // Fail rather than echo a secret if the mode cannot be changed.
+        THROW_IF_WIN32_BOOL_FALSE(SetConsoleMode(m_consoleHandle, previousMode & ~ENABLE_ECHO_INPUT));
+        echoDisabled = true;
+    }
+
+    std::wstring line;
+    bool anyRead = false;
+    for (;;)
+    {
+        const wint_t ch = fgetwc(m_file);
+        if (ch == WEOF)
+        {
+            break;
+        }
+
+        anyRead = true;
+        if (ch == L'\n')
+        {
+            break;
+        }
+
+        line.push_back(static_cast<wchar_t>(ch));
+    }
+
+    if (!anyRead)
+    {
+        return std::nullopt;
+    }
+
+    // The read stops at LF; strip a paired CR so callers get a bare line regardless
+    // of the input's line-ending convention.
+    if (!line.empty() && line.back() == L'\r')
+    {
+        line.pop_back();
+    }
+
+    return line;
+}
+
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/core/InputChannel.cpp
+++ b/src/windows/wslc/core/InputChannel.cpp
@@ -58,7 +58,7 @@ std::optional<std::wstring> InputChannel::ReadLine(bool mask) const
     auto restoreEcho = wil::scope_exit([&]() {
         if (echoDisabled)
         {
-            SetConsoleMode(m_consoleHandle, previousMode);
+            LOG_IF_WIN32_BOOL_FALSE(SetConsoleMode(m_consoleHandle, previousMode));
         }
     });
 

--- a/src/windows/wslc/core/InputChannel.h
+++ b/src/windows/wslc/core/InputChannel.h
@@ -1,0 +1,56 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    InputChannel.h
+
+Abstract:
+
+    Byte source used by Reporter for user input. Reads a line at a time from the
+    console (or a redirected file/pipe). For console sources the channel can mask
+    echo while reading (password entry) and reports whether input is interactive.
+
+--*/
+#pragma once
+
+#include "defs.h"
+
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <Windows.h>
+
+namespace wsl::windows::wslc {
+
+class InputChannel
+{
+public:
+    NON_COPYABLE(InputChannel);
+    NON_MOVABLE(InputChannel);
+
+    // Console path: probes the handle for console mode (masking, interactivity);
+    // reads are always drawn from readFile (the CRT stdin stream).
+    InputChannel(HANDLE consoleHandle, FILE* readFile);
+
+    // FILE* path with explicit interactivity override (for tests). No console
+    // handle, so masking is a no-op and interactivity is whatever is passed.
+    InputChannel(FILE* readFile, bool interactiveOverride);
+
+    // True when input is attached to a console (a prompt can be shown, echo can be masked).
+    bool IsInteractive() const noexcept;
+
+    // Reads a single line, stripping the trailing CR and/or LF. Returns nullopt at
+    // end of input with nothing read (so an empty line and EOF are distinguishable).
+    // When mask is true and input is an interactive console, console echo is disabled
+    // for the duration of the read (restored on return, including on exception).
+    std::optional<std::wstring> ReadLine(bool mask) const;
+
+private:
+    HANDLE m_consoleHandle = nullptr;
+    FILE* m_file = nullptr;
+    bool m_interactiveOverride = false;
+};
+
+} // namespace wsl::windows::wslc

--- a/src/windows/wslc/core/OutputChannel.cpp
+++ b/src/windows/wslc/core/OutputChannel.cpp
@@ -60,6 +60,15 @@ void OutputChannel::WriteString(std::wstring_view text) const
     }
 }
 
+void OutputChannel::Flush() const
+{
+    if (m_file != nullptr && fflush(m_file) != 0)
+    {
+        const int err = errno;
+        LOG_HR_MSG(HRESULT_FROM_WIN32(ERROR_WRITE_FAULT), "fflush of redirected output failed (errno=%d)", err);
+    }
+}
+
 std::optional<int> OutputChannel::GetConsoleWidth() const
 {
     if (m_consoleHandle == nullptr)

--- a/src/windows/wslc/core/OutputChannel.h
+++ b/src/windows/wslc/core/OutputChannel.h
@@ -38,6 +38,10 @@ public:
 
     void WriteString(std::wstring_view text) const;
 
+    // Flushes buffered output so a prompt is visible before a blocking read. No-op for
+    // console destinations (WriteConsoleW is unbuffered); flushes the CRT stream otherwise.
+    void Flush() const;
+
     // Console write width minus one (autowrap guard), or nullopt when redirected.
     std::optional<int> GetConsoleWidth() const;
 

--- a/src/windows/wslc/core/Reporter.cpp
+++ b/src/windows/wslc/core/Reporter.cpp
@@ -18,12 +18,13 @@ namespace wsl::windows::wslc {
 
 using namespace wsl::windows::common::vt;
 
-Reporter::Reporter() : m_out(GetStdHandle(STD_OUTPUT_HANDLE), stdout), m_err(GetStdHandle(STD_ERROR_HANDLE), stderr)
+Reporter::Reporter() :
+    m_out(GetStdHandle(STD_OUTPUT_HANDLE), stdout), m_err(GetStdHandle(STD_ERROR_HANDLE), stderr), m_in(GetStdHandle(STD_INPUT_HANDLE), stdin)
 {
 }
 
-Reporter::Reporter(FILE* outFile, bool outVtEnabled, FILE* errFile, bool errVtEnabled) :
-    m_out(outFile, outVtEnabled), m_err(errFile, errVtEnabled)
+Reporter::Reporter(FILE* outFile, bool outVtEnabled, FILE* errFile, bool errVtEnabled, FILE* inFile, bool inInteractive) :
+    m_out(outFile, outVtEnabled), m_err(errFile, errVtEnabled), m_in(inFile, inInteractive)
 {
 }
 
@@ -58,6 +59,24 @@ bool Reporter::IsColorEnabled(Level level) const noexcept
 std::optional<int> Reporter::GetConsoleWidth(Level level) const
 {
     return ChannelFor(level).GetConsoleWidth();
+}
+
+std::wstring Reporter::PromptForLine(Level level, std::wstring_view label, bool mask)
+{
+    // Write the label without a trailing newline so the cursor stays inline (matching
+    // Docker's prompt behavior).
+    Write(level, L"{}", label);
+
+    const bool willMask = mask && m_in.IsInteractive();
+    auto line = m_in.ReadLine(mask);
+
+    // When echo was masked the user's Enter was not echoed, so advance the line here.
+    if (willMask)
+    {
+        Write(level, L"\n");
+    }
+
+    return line.value_or(std::wstring{});
 }
 
 } // namespace wsl::windows::wslc

--- a/src/windows/wslc/core/Reporter.cpp
+++ b/src/windows/wslc/core/Reporter.cpp
@@ -64,8 +64,9 @@ std::optional<int> Reporter::GetConsoleWidth(Level level) const
 std::wstring Reporter::PromptForLine(Level level, std::wstring_view label, bool mask)
 {
     // Write the label without a trailing newline so the cursor stays inline (matching
-    // Docker's prompt behavior).
+    // Docker's prompt behavior), then flush so it reaches the user before the blocking read.
     Write(level, L"{}", label);
+    ChannelFor(level).Flush();
 
     const bool willMask = mask && m_in.IsInteractive();
     auto line = m_in.ReadLine(mask);

--- a/src/windows/wslc/core/Reporter.h
+++ b/src/windows/wslc/core/Reporter.h
@@ -122,11 +122,13 @@ struct Reporter
     // When mask is true and input is interactive, echo is disabled during the read and a
     // trailing newline is emitted afterward (the un-echoed Enter). Returns the line, or an
     // empty string at end of input.
-    //
-    // By convention WSLC prompts pass Level::Output (stdout): Docker, containerd/nerdctl,
-    // and Apple container all prompt on stdout, so WSLC follows that container-CLI norm.
     std::wstring PromptForLine(Level level, std::wstring_view label, bool mask);
 
+    // Convenience overload that defaults prompts to stdout (Level::Output) to align with the
+    // container CLI ecosystem: Docker (cli.Out()), containerd/nerdctl (cmd.OutOrStdout()), and
+    // Apple container (Swift print) all prompt on stdout. This diverges from general Unix tools
+    // (sudo, ssh, git, gh) that prompt on stderr/tty to keep stdout pipeable, but WSLC follows
+    // Docker's CLI semantics.
     std::wstring PromptForLine(std::wstring_view label, bool mask = false)
     {
         return PromptForLine(Level::Output, label, mask);

--- a/src/windows/wslc/core/Reporter.h
+++ b/src/windows/wslc/core/Reporter.h
@@ -127,6 +127,11 @@ struct Reporter
     // and Apple container all prompt on stdout, so WSLC follows that container-CLI norm.
     std::wstring PromptForLine(Level level, std::wstring_view label, bool mask);
 
+    std::wstring PromptForLine(std::wstring_view label, bool mask = false)
+    {
+        return PromptForLine(Level::Output, label, mask);
+    }
+
     bool IsVTEnabled(Level level) const noexcept;
 
     bool IsColorEnabled(Level level) const noexcept;

--- a/src/windows/wslc/core/Reporter.h
+++ b/src/windows/wslc/core/Reporter.h
@@ -8,14 +8,15 @@ Module Name:
 
 Abstract:
 
-    Level-filtered, std::format-style user-facing output for the WSLC CLI.
-    Sequence arguments are stripped when VT is off; color Sequences are also
-    stripped when color is disabled, while cursor-move Sequences still pass
-    through.
+    Level-filtered, std::format-style user-facing output for the WSLC CLI, plus
+    line-oriented user input (prompts). Sequence arguments are stripped when VT is
+    off; color Sequences are also stripped when color is disabled, while cursor-move
+    Sequences still pass through.
 
 --*/
 #pragma once
 
+#include "InputChannel.h"
 #include "OutputChannel.h"
 #include "VTSupport.h"
 
@@ -67,7 +68,7 @@ struct Reporter
     };
 
     Reporter();
-    Reporter(FILE* outFile, bool outVtEnabled, FILE* errFile, bool errVtEnabled);
+    Reporter(FILE* outFile, bool outVtEnabled, FILE* errFile, bool errVtEnabled, FILE* inFile = nullptr, bool inInteractive = false);
 
     NON_COPYABLE(Reporter);
     NON_MOVABLE(Reporter);
@@ -101,6 +102,30 @@ struct Reporter
     {
         EmitFormatted(Level::Error, std::move(fmt), std::forward<Args>(args)...);
     }
+
+    // True when user input is attached to an interactive console (a prompt can be
+    // shown and echo can be masked); false when input is redirected from a file or pipe.
+    bool IsInputInteractive() const noexcept
+    {
+        return m_in.IsInteractive();
+    }
+
+    // Reads a single line of user input, stripping the trailing CR and/or LF. Returns
+    // nullopt at end of input with nothing read. When mask is true and input is an
+    // interactive console, echo is disabled for the duration of the read.
+    std::optional<std::wstring> ReadLine(bool mask = false)
+    {
+        return m_in.ReadLine(mask);
+    }
+
+    // Writes label (no trailing newline) at the given level, then reads a line of input.
+    // When mask is true and input is interactive, echo is disabled during the read and a
+    // trailing newline is emitted afterward (the un-echoed Enter). Returns the line, or an
+    // empty string at end of input.
+    //
+    // By convention WSLC prompts pass Level::Output (stdout): Docker, containerd/nerdctl,
+    // and Apple container all prompt on stdout, so WSLC follows that container-CLI norm.
+    std::wstring PromptForLine(Level level, std::wstring_view label, bool mask);
 
     bool IsVTEnabled(Level level) const noexcept;
 
@@ -159,6 +184,7 @@ private:
 
     OutputChannel m_out;
     OutputChannel m_err;
+    InputChannel m_in;
     bool m_noColor = false;
 };
 

--- a/test/windows/wslc/WSLCCLIReporterUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIReporterUnitTests.cpp
@@ -8,7 +8,7 @@ Module Name:
 
 Abstract:
 
-    Unit tests for OutputChannel and Reporter.
+    Unit tests for OutputChannel, InputChannel, and Reporter.
 
 --*/
 
@@ -16,6 +16,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCCLITestHelpers.h"
 
+#include "InputChannel.h"
 #include "OutputChannel.h"
 #include "Reporter.h"
 
@@ -36,6 +37,21 @@ struct SplitCaptureReporter
     Reporter reporter;
 
     explicit SplitCaptureReporter(bool vtEnabled = false) : reporter(outPipe.file(), vtEnabled, errPipe.file(), vtEnabled)
+    {
+    }
+};
+
+// Reporter wired with a preloaded input pipe plus split output capture, so prompt
+// input and the label/newline it writes can be asserted together.
+struct InputCaptureReporter
+{
+    CapturePipe outPipe;
+    CapturePipe errPipe;
+    InputPipe inPipe;
+    Reporter reporter;
+
+    explicit InputCaptureReporter(const std::wstring& input, bool interactive = false) :
+        inPipe(input), reporter(outPipe.file(), false, errPipe.file(), false, inPipe.file(), interactive)
     {
     }
 };
@@ -308,6 +324,243 @@ class WSLCCLIReporterUnitTests
             const auto expected = std::format(fmt, empty, 42, 255u, empty, empty, empty, empty);
             VERIFY_ARE_EQUAL(expected, cap.captured());
         }
+    }
+
+    TEST_METHOD(InputChannel_ReadLineReturnsNulloptAtEof)
+    {
+        InputPipe pipe{L""};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_IS_FALSE(channel.ReadLine(false).has_value());
+    }
+
+    TEST_METHOD(InputChannel_ReadLineSplitsOnNewline)
+    {
+        InputPipe pipe{L"user\npass\n"};
+        const InputChannel channel{pipe.file(), false};
+
+        auto first = channel.ReadLine(false);
+        VERIFY_IS_TRUE(first.has_value());
+        VERIFY_ARE_EQUAL(std::wstring{L"user"}, first.value());
+
+        auto second = channel.ReadLine(false);
+        VERIFY_IS_TRUE(second.has_value());
+        VERIFY_ARE_EQUAL(std::wstring{L"pass"}, second.value());
+
+        VERIFY_IS_FALSE(channel.ReadLine(false).has_value());
+    }
+
+    TEST_METHOD(InputChannel_ReadLineStripsCarriageReturn)
+    {
+        InputPipe pipe{L"user\r\npass\r\n"};
+        const InputChannel channel{pipe.file(), false};
+
+        VERIFY_ARE_EQUAL(std::wstring{L"user"}, channel.ReadLine(false).value_or(L"<eof>"));
+        VERIFY_ARE_EQUAL(std::wstring{L"pass"}, channel.ReadLine(false).value_or(L"<eof>"));
+    }
+
+    TEST_METHOD(InputChannel_ReadLineReturnsEmptyStringForBlankLine)
+    {
+        // A bare empty line is distinct from EOF: value present but empty.
+        InputPipe pipe{L"\nsecond\n"};
+        const InputChannel channel{pipe.file(), false};
+
+        auto blank = channel.ReadLine(false);
+        VERIFY_IS_TRUE(blank.has_value());
+        VERIFY_ARE_EQUAL(std::wstring{L""}, blank.value());
+
+        VERIFY_ARE_EQUAL(std::wstring{L"second"}, channel.ReadLine(false).value_or(L"<eof>"));
+    }
+
+    TEST_METHOD(InputChannel_ReadLineReturnsFinalLineWithoutTrailingNewline)
+    {
+        InputPipe pipe{L"only"};
+        const InputChannel channel{pipe.file(), false};
+
+        VERIFY_ARE_EQUAL(std::wstring{L"only"}, channel.ReadLine(false).value_or(L"<eof>"));
+        VERIFY_IS_FALSE(channel.ReadLine(false).has_value());
+    }
+
+    TEST_METHOD(InputChannel_IsInteractiveReflectsOverrideForNonConsole)
+    {
+        InputPipe pipe{L"x\n"};
+        const InputChannel notInteractive{pipe.file(), false};
+        VERIFY_IS_FALSE(notInteractive.IsInteractive());
+
+        InputPipe pipe2{L"x\n"};
+        const InputChannel interactive{pipe2.file(), true};
+        VERIFY_IS_TRUE(interactive.IsInteractive());
+    }
+
+    TEST_METHOD(InputChannel_ReadLineWithMaskReadsWhenNoConsole)
+    {
+        // Masking is a no-op without a real console; the read still succeeds.
+        InputPipe pipe{L"secret\n"};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_ARE_EQUAL(std::wstring{L"secret"}, channel.ReadLine(true).value_or(L"<eof>"));
+    }
+
+    TEST_METHOD(InputChannel_ReadLineOnNullFileReturnsNullopt)
+    {
+        const InputChannel channel{static_cast<FILE*>(nullptr), false};
+        VERIFY_IS_FALSE(channel.ReadLine(false).has_value());
+    }
+
+    TEST_METHOD(InputChannel_ReadLinePreservesInteriorAndSurroundingWhitespace)
+    {
+        // Only the trailing CR/LF is stripped. Leading, interior, and trailing spaces
+        // and tabs are preserved verbatim (WSLC does not trim, unlike Docker's prompt).
+        InputPipe pipe{L"  spaced \t value  \n"};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_ARE_EQUAL(std::wstring{L"  spaced \t value  "}, channel.ReadLine(false).value_or(L"<eof>"));
+    }
+
+    TEST_METHOD(InputChannel_ReadLineStripsLoneTrailingCarriageReturnAtEof)
+    {
+        // A lone trailing CR (no following LF) is not collapsed by the stream's CRLF
+        // translation, so it reaches ReadLine and exercises the trailing-CR strip.
+        InputPipe pipe{L"value\r"};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_ARE_EQUAL(std::wstring{L"value"}, channel.ReadLine(false).value_or(L"<eof>"));
+        VERIFY_IS_FALSE(channel.ReadLine(false).has_value());
+    }
+
+    TEST_METHOD(InputChannel_ReadLinePreservesEmbeddedCarriageReturn)
+    {
+        // Only a trailing CR is stripped; a CR in the middle of a line is preserved.
+        InputPipe pipe{L"a\rb\n"};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_ARE_EQUAL(std::wstring{L"a\rb"}, channel.ReadLine(false).value_or(L"<eof>"));
+    }
+
+    TEST_METHOD(InputChannel_ReadLineDecodesUnicode)
+    {
+        // UTF-8 bytes on the wire decode back to the original wide characters.
+        const std::wstring expected = L"\u00e9\u4e2d\u6587\u2013user";
+        InputPipe pipe{expected + L"\n"};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_ARE_EQUAL(expected, channel.ReadLine(false).value_or(L"<eof>"));
+    }
+
+    TEST_METHOD(InputChannel_ReadLineHandlesLongLine)
+    {
+        // Lines longer than any internal buffer are read in full (fgetwc loop).
+        const std::wstring expected(8192, L'z');
+        InputPipe pipe{expected + L"\n"};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_ARE_EQUAL(expected, channel.ReadLine(false).value_or(L"<eof>"));
+    }
+
+    TEST_METHOD(InputChannel_ReadLineReturnsNulloptAfterAllLinesConsumed)
+    {
+        InputPipe pipe{L"one\ntwo\n"};
+        const InputChannel channel{pipe.file(), false};
+        VERIFY_ARE_EQUAL(std::wstring{L"one"}, channel.ReadLine(false).value_or(L"<eof>"));
+        VERIFY_ARE_EQUAL(std::wstring{L"two"}, channel.ReadLine(false).value_or(L"<eof>"));
+        VERIFY_IS_FALSE(channel.ReadLine(false).has_value());
+        // Further reads keep returning nullopt (idempotent at EOF).
+        VERIFY_IS_FALSE(channel.ReadLine(false).has_value());
+    }
+
+    TEST_METHOD(Reporter_ReadLineReturnsInput)
+    {
+        InputCaptureReporter cap{L"line1\nline2\n"};
+        VERIFY_ARE_EQUAL(std::wstring{L"line1"}, cap.reporter.ReadLine().value_or(L"<eof>"));
+        VERIFY_ARE_EQUAL(std::wstring{L"line2"}, cap.reporter.ReadLine().value_or(L"<eof>"));
+        VERIFY_IS_FALSE(cap.reporter.ReadLine().has_value());
+    }
+
+    TEST_METHOD(Reporter_IsInputInteractiveReflectsChannel)
+    {
+        InputCaptureReporter pipeInput{L"x\n", /*interactive*/ false};
+        VERIFY_IS_FALSE(pipeInput.reporter.IsInputInteractive());
+
+        InputCaptureReporter consoleInput{L"x\n", /*interactive*/ true};
+        VERIFY_IS_TRUE(consoleInput.reporter.IsInputInteractive());
+    }
+
+    TEST_METHOD(Reporter_PromptForLineWritesLabelToStdoutAndReturnsInput)
+    {
+        InputCaptureReporter cap{L"myuser\n"};
+
+        const auto result = cap.reporter.PromptForLine(Reporter::Level::Output, L"Username: ", false);
+        VERIFY_ARE_EQUAL(std::wstring{L"myuser"}, result);
+
+        // Label lands on stdout (Docker convention); nothing on stderr; no trailing
+        // newline because the input was not masked.
+        VERIFY_ARE_EQUAL(std::wstring{L"Username: "}, cap.outPipe.captured());
+        VERIFY_ARE_EQUAL(std::wstring{L""}, cap.errPipe.captured());
+    }
+
+    TEST_METHOD(Reporter_PromptForLineMaskedInteractiveEmitsTrailingNewline)
+    {
+        // Interactive override makes willMask true, so the un-echoed Enter is advanced
+        // with a trailing newline after the label.
+        InputCaptureReporter cap{L"secret\n", /*interactive*/ true};
+
+        const auto result = cap.reporter.PromptForLine(Reporter::Level::Output, L"Password: ", true);
+        VERIFY_ARE_EQUAL(std::wstring{L"secret"}, result);
+        VERIFY_ARE_EQUAL(std::wstring{L"Password: \n"}, cap.outPipe.captured());
+    }
+
+    TEST_METHOD(Reporter_PromptForLineMaskedNonInteractiveEmitsNoTrailingNewline)
+    {
+        // Redirected input is not interactive, so no masking and no trailing newline.
+        InputCaptureReporter cap{L"secret\n", /*interactive*/ false};
+
+        const auto result = cap.reporter.PromptForLine(Reporter::Level::Output, L"Password: ", true);
+        VERIFY_ARE_EQUAL(std::wstring{L"secret"}, result);
+        VERIFY_ARE_EQUAL(std::wstring{L"Password: "}, cap.outPipe.captured());
+    }
+
+    TEST_METHOD(Reporter_PromptForLineReturnsEmptyStringAtEof)
+    {
+        InputCaptureReporter cap{L""};
+        const auto result = cap.reporter.PromptForLine(Reporter::Level::Output, L"Username: ", false);
+        VERIFY_ARE_EQUAL(std::wstring{L""}, result);
+        VERIFY_ARE_EQUAL(std::wstring{L"Username: "}, cap.outPipe.captured());
+    }
+
+    TEST_METHOD(Reporter_PromptForLineEmitsLabelVerbatimWithFormatCharacters)
+    {
+        // The label is passed as a formatting argument, not a format string, so brace
+        // and percent characters in it must never be interpreted (no format injection).
+        InputCaptureReporter cap{L"answer\n"};
+        const std::wstring label = L"Value {} {0} {name} 100% ${var}: ";
+
+        const auto result = cap.reporter.PromptForLine(Reporter::Level::Output, label, false);
+        VERIFY_ARE_EQUAL(std::wstring{L"answer"}, result);
+        VERIFY_ARE_EQUAL(label, cap.outPipe.captured());
+    }
+
+    TEST_METHOD(Reporter_PromptForLineDoesNotTrimPasswordWhitespace)
+    {
+        // Secrets are opaque: interior and surrounding whitespace is preserved so a
+        // password like "  a b  " is returned exactly as typed.
+        InputCaptureReporter cap{L"  a b  \n", /*interactive*/ true};
+
+        const auto result = cap.reporter.PromptForLine(Reporter::Level::Output, L"Password: ", true);
+        VERIFY_ARE_EQUAL(std::wstring{L"  a b  "}, result);
+        VERIFY_ARE_EQUAL(std::wstring{L"Password: \n"}, cap.outPipe.captured());
+    }
+
+    TEST_METHOD(Reporter_PromptForLineReturnsUnicodeInput)
+    {
+        const std::wstring expected = L"\u00fcser\u00f1ame";
+        InputCaptureReporter cap{expected + L"\n"};
+
+        const auto result = cap.reporter.PromptForLine(Reporter::Level::Output, L"Username: ", false);
+        VERIFY_ARE_EQUAL(expected, result);
+    }
+
+    TEST_METHOD(Reporter_ReadLineMaskDefaultsToUnmasked)
+    {
+        // ReadLine(bool mask = false): the default reads without masking and returns
+        // the line, used by the --password-stdin path.
+        InputCaptureReporter cap{L"piped-secret\n"};
+        VERIFY_ARE_EQUAL(std::wstring{L"piped-secret"}, cap.reporter.ReadLine().value_or(L"<eof>"));
+        // Nothing is written for a bare ReadLine (no prompt label).
+        VERIFY_ARE_EQUAL(std::wstring{L""}, cap.outPipe.captured());
+        VERIFY_ARE_EQUAL(std::wstring{L""}, cap.errPipe.captured());
     }
 };
 

--- a/test/windows/wslc/WSLCCLITestHelpers.h
+++ b/test/windows/wslc/WSLCCLITestHelpers.h
@@ -19,6 +19,7 @@ Abstract:
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 #include <Windows.h>
 #include <WexTestClass.h>
@@ -128,6 +129,71 @@ private:
     wil::unique_file m_file;
     wil::unique_hfile m_readPipe;
     std::unique_ptr<PartialHandleRead> m_reader;
+};
+
+// RAII pipe preloaded with input for tests. A background thread feeds the content
+// (UTF-8) into the pipe while the test drains the read end, mirroring how real stdin
+// is filled by a separate producer. A synchronous write of the whole content on the
+// reading thread would deadlock once the content exceeds the pipe buffer
+// (OpenAnonymousPipe defaults to 4096 bytes), so the feeder runs concurrently and
+// closes the write end when done, letting file() read the content then hit EOF. The
+// read FILE* is configured like real stdin (_O_U8TEXT) and passed to
+// InputChannel/Reporter.
+struct InputPipe
+{
+    explicit InputPipe(const std::wstring& content)
+    {
+        auto [r, w] = wsl::windows::common::wslutil::OpenAnonymousPipe(0, false, false);
+
+        wil::unique_handle readHandle{r.release()};
+        m_file = FileFromHandle(readHandle, "r");
+
+        const int fd = _fileno(m_file.get());
+        WI_VERIFY(_setmode(fd, _O_U8TEXT) != -1);
+
+        // Feed the content from a background thread so the reader can drain while the
+        // writer fills. Closing the write end signals EOF. No VERIFY/THROW macros run
+        // here since this executes on a separate thread; a broken pipe (the reader
+        // closed early) simply stops the feed.
+        m_writer = std::thread([writeEnd = std::move(w), utf8 = WStringToUTF8(content)]() mutable {
+            size_t offset = 0;
+            while (offset < utf8.size())
+            {
+                DWORD written = 0;
+                if (!WriteFile(writeEnd.get(), utf8.data() + offset, static_cast<DWORD>(utf8.size() - offset), &written, nullptr))
+                {
+                    break;
+                }
+
+                offset += written;
+            }
+
+            writeEnd.reset();
+        });
+    }
+
+    ~InputPipe()
+    {
+        // Close the read end first so a feeder still blocked on a full pipe unblocks
+        // with a broken pipe, then join it.
+        m_file.reset();
+        if (m_writer.joinable())
+        {
+            m_writer.join();
+        }
+    }
+
+    NON_COPYABLE(InputPipe);
+    NON_MOVABLE(InputPipe);
+
+    FILE* file() const
+    {
+        return m_file.get();
+    }
+
+private:
+    wil::unique_file m_file;
+    std::thread m_writer;
 };
 
 // Reporter wired to a single capture pipe for full output capture.

--- a/test/windows/wslc/e2e/WSLCE2ERegistryTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ERegistryTests.cpp
@@ -203,9 +203,9 @@ class WSLCE2ERegistryTests
             // Login with interactive prompts (no flags).
             {
                 auto interactive = RunWslcInteractive(std::format(L"login {}", registryAddressW));
-                interactive.ExpectStderr("Username: ");
+                interactive.ExpectStdout("Username: ");
                 interactive.WriteLine(c_username);
-                interactive.ExpectStderr("Password: ");
+                interactive.ExpectStdout("Password: ");
                 interactive.WriteLine(c_password);
                 auto exitCode = interactive.Wait();
                 VERIFY_ARE_EQUAL(0, exitCode, L"Interactive login should succeed");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Unifies interactive user input with user-facing output under the WSLC CLI's `Reporter`. Previously `Reporter` only handled output, and interactive input (prompting, echo masking) was handled ad hoc inside commands like `wslc registry login`, where console handling does not belong. This moves that logic into a single, testable owner so commands can prompt consistently instead of reimplementing console handling, and `registry login` is simplified to just ask the `Reporter` for input. Prompts for input were changed from stderr to stdout intentionally (see detailed description for reasoning).

Note that `Reporter` is planned to be renamed in a follow-up PR to reflect that it now provides unified input/output management for the CLI; the current name is kept here to keep the diff focused and does not yet fully describe the expanded responsibility.

Sample output from manual testing with stderr redirected to show prompts still function as expected consistent with other CLIs:
<img width="954" height="187" alt="image" src="https://github.com/user-attachments/assets/23d236e1-78ae-4cfa-a0ff-1f6b64f85b2d" />
(note these commands failed expectedly but the purpose was to verify the input behavior on a real console; the tests verify the command)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- New `InputChannel`: reads a line at a time from the console or a redirected file/pipe. On an interactive console it can mask echo (for password entry) and report whether input is interactive; it distinguishes an empty line from end of input.
- `Reporter` now owns an input channel alongside its output channels and exposes:
  - `IsInputInteractive()` to check whether a prompt can be shown.
  - `ReadLine(mask)` to read a single line, optionally masking echo.
  - `PromptForLine(label, mask)` to write a label and read the response in one call.
- `wslc registry login` now uses `PromptForLine` for the username and (masked) password prompts, replacing the previous inline prompting.
- Updated the interactive-login E2E assertions from stderr to stdout to match the new prompt stream.
- Unit tests and test helpers covering the input channel and the reporter's prompt/read paths.

### Prompt default output stream

Interactive login prompts now write to stdout. Previously they were emitted at Info level, which routes to stderr; this PR moves them to stdout (`Level::Output`). This is an intentional behavior change, not a regression.

For most CLIs stderr is arguably the more correct target for prompts, since it keeps stdout clean for piped or captured output. Two practical reasons favor stdout here:
1. The container CLI ecosystem prompts on stdout: Docker (`cli.Out()`), containerd/nerdctl (`cmd.OutOrStdout()`), and Apple container all prompt there, so WSLC matches the tools its users expect.
2. Redirecting stderr to a log file (`command 2> file`) is common; with prompts on stderr that redirect would send the prompt to the file and leave the user at an apparently blank line. Keeping prompts on stdout avoids that.

The interactive-login E2E assertions were updated from stderr to stdout to match.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Unit tests, including the new input tests that were added, pass.
- E2E Registry tests pass, including the ones for interactive input testing.
- Manual invocation of deployed CLI of the registry login command to verify behavior on a real console.