### PR TITLE
Make DrvFs initialization callback lifetime-safe

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2898,8 +2898,13 @@ void LxssUserSessionImpl::_CreateVm()
 
         m_vmId.store(vmId);
 
+        const auto weakSession = weak_from_this();
+        auto initializeDrvFs = [weakSession, vmId](HANDLE userToken) noexcept {
+            return s_InitializeDrvFs(weakSession, vmId, userToken);
+        };
+
         // Create the utility VM and register for callbacks.
-        m_utilityVm = WslCoreVm::Create(m_userToken, std::move(config), vmId);
+        m_utilityVm = WslCoreVm::Create(m_userToken, std::move(config), vmId, std::move(initializeDrvFs));
 
         if (m_httpProxyStateTracker)
         {
@@ -4157,6 +4162,31 @@ wil::unique_hkey LxssUserSessionImpl::s_OpenLxssUserKey()
 {
     auto runAsUser = wil::CoImpersonateClient();
     return wsl::windows::common::registry::OpenLxssUserKey();
+}
+
+LX_INIT_DRVFS_MOUNT LxssUserSessionImpl::s_InitializeDrvFs(_In_ const std::weak_ptr<LxssUserSessionImpl>& Session, _In_ const GUID& VmId, _In_ HANDLE UserToken) noexcept
+{
+    try
+    {
+        const auto session = Session.lock();
+        if (!session)
+        {
+            return LxInitDrvfsMountNone;
+        }
+
+        std::lock_guard lock(session->m_instanceLock);
+        if (!session->m_utilityVm || !IsEqualGUID(session->m_utilityVm->GetRuntimeId(), VmId))
+        {
+            return LxInitDrvfsMountNone;
+        }
+
+        return session->m_utilityVm->InitializeDrvFs(UserToken) ? LxInitDrvfsMountElevated : LxInitDrvfsMountNonElevated;
+    }
+    catch (...)
+    {
+        LOG_CAUGHT_EXCEPTION();
+        return LxInitDrvfsMountNone;
+    }
 }
 
 bool LxssUserSessionImpl::s_TerminateInstance(_Inout_ LxssUserSessionImpl* UserSession, _In_ GUID DistroGuid, _In_ bool CheckForClients)

--- a/src/windows/service/exe/LxssUserSession.h
+++ b/src/windows/service/exe/LxssUserSession.h
@@ -308,7 +308,7 @@ private:
 /// <summary>
 /// Each user gets its own LxssUserSessionImpl object, This object manages the lifetime of running instances.
 /// </summary>
-class LxssUserSessionImpl
+class LxssUserSessionImpl : public std::enable_shared_from_this<LxssUserSessionImpl>
 {
 public:
     LxssUserSessionImpl(_In_ PSID userSid, _In_ DWORD sessionId, _Inout_ wsl::windows::service::PluginManager& pluginManager);
@@ -760,6 +760,8 @@ private:
     /// Impersonate the user and open the lxss registry key
     /// </summary>
     static wil::unique_hkey s_OpenLxssUserKey();
+
+    static LX_INIT_DRVFS_MOUNT s_InitializeDrvFs(_In_ const std::weak_ptr<LxssUserSessionImpl>& Session, _In_ const GUID& VmId, _In_ HANDLE UserToken) noexcept;
 
     /// <summary>
     /// Ensures the distribution name is valid.

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -75,17 +75,18 @@ RequiredExtraMmioSpaceForPmemFileInMb(_In_ PCWSTR FilePath)
 }
 } // namespace
 
-WslCoreVm::WslCoreVm(_In_ wsl::core::Config&& VmConfig) :
-    m_vmConfig(std::move(VmConfig)), m_traceClient(m_vmConfig.EnableTelemetry)
+WslCoreVm::WslCoreVm(_In_ wsl::core::Config&& VmConfig, _In_ InitializeDrvFsCallback InitializeDrvFs) :
+    m_vmConfig(std::move(VmConfig)), m_initializeDrvFs(std::move(InitializeDrvFs)), m_traceClient(m_vmConfig.EnableTelemetry)
 {
     // Create a job object that will terminate child processes (wslhost.exe, wslrelay.exe)
     // when the VM is destroyed.
     m_processJobObject = wsl::windows::common::helpers::CreateKillOnCloseJob();
 }
 
-std::unique_ptr<WslCoreVm> WslCoreVm::Create(_In_ const wil::shared_handle& UserToken, _In_ wsl::core::Config&& VmConfig, _In_ const GUID& VmId)
+std::unique_ptr<WslCoreVm> WslCoreVm::Create(
+    _In_ const wil::shared_handle& UserToken, _In_ wsl::core::Config&& VmConfig, _In_ const GUID& VmId, _In_ InitializeDrvFsCallback InitializeDrvFs)
 {
-    auto newInstance = std::unique_ptr<WslCoreVm>{new WslCoreVm{std::move(VmConfig)}};
+    auto newInstance = std::unique_ptr<WslCoreVm>{new WslCoreVm{std::move(VmConfig), std::move(InitializeDrvFs)}};
     try
     {
         const auto startTimeMs = GetTickCount64();
@@ -1281,7 +1282,7 @@ std::shared_ptr<LxssRunningInstance> WslCoreVm::CreateInstanceInternal(
         localConfig,
         DefaultUid,
         ClientLifetimeId,
-        std::bind(s_InitializeDrvFs, this, std::placeholders::_1),
+        m_initializeDrvFs,
         featureFlags,
         m_vmConfig.DistributionStartTimeout,
         m_vmConfig.InstanceIdleTimeout,
@@ -2756,20 +2757,6 @@ std::string WslCoreVm::s_GetMountTargetName(_In_ PCWSTR Disk, _In_opt_ PCWSTR Na
     }
 
     return target;
-}
-
-LX_INIT_DRVFS_MOUNT WslCoreVm::s_InitializeDrvFs(_Inout_ WslCoreVm* VmContext, _In_ HANDLE UserToken)
-{
-    try
-    {
-        return VmContext->InitializeDrvFs(UserToken) ? LxInitDrvfsMountElevated : LxInitDrvfsMountNonElevated;
-    }
-    catch (...)
-    {
-        LOG_CAUGHT_EXCEPTION();
-
-        return LxInitDrvfsMountNone;
-    }
 }
 
 void CALLBACK WslCoreVm::s_OnExit(_In_ HCS_EVENT* Event, _In_opt_ void* Context)

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -86,6 +86,8 @@ WslCoreVm::WslCoreVm(_In_ wsl::core::Config&& VmConfig, _In_ InitializeDrvFsCall
 std::unique_ptr<WslCoreVm> WslCoreVm::Create(
     _In_ const wil::shared_handle& UserToken, _In_ wsl::core::Config&& VmConfig, _In_ const GUID& VmId, _In_ InitializeDrvFsCallback InitializeDrvFs)
 {
+    THROW_HR_IF(E_INVALIDARG, !InitializeDrvFs);
+
     auto newInstance = std::unique_ptr<WslCoreVm>{new WslCoreVm{std::move(VmConfig), std::move(InitializeDrvFs)}};
     try
     {

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -51,7 +51,10 @@ class WslCoreVm
     void operator=(const WslCoreVm&) = delete;
 
 public:
-    static std::unique_ptr<WslCoreVm> Create(_In_ const wil::shared_handle& UserToken, _In_ wsl::core::Config&& VmConfig, _In_ const GUID& VmId);
+    using InitializeDrvFsCallback = std::function<LX_INIT_DRVFS_MOUNT(HANDLE)>;
+
+    static std::unique_ptr<WslCoreVm> Create(
+        _In_ const wil::shared_handle& UserToken, _In_ wsl::core::Config&& VmConfig, _In_ const GUID& VmId, _In_ InitializeDrvFsCallback InitializeDrvFs);
 
     ~WslCoreVm() noexcept;
 
@@ -174,7 +177,7 @@ private:
         bool operator==(const VirtioFsShare& other) const;
     };
 
-    WslCoreVm(_In_ wsl::core::Config&& VmConfig);
+    WslCoreVm(_In_ wsl::core::Config&& VmConfig, _In_ InitializeDrvFsCallback InitializeDrvFs);
 
     _Requires_lock_held_(m_guestDeviceLock)
     void AddDrvFsShare(_In_ bool Admin, _In_ HANDLE UserToken);
@@ -256,8 +259,6 @@ private:
 
     static std::string s_GetMountTargetName(_In_ PCWSTR Disk, _In_opt_ PCWSTR Name, _In_ int PartitionIndex);
 
-    static LX_INIT_DRVFS_MOUNT s_InitializeDrvFs(_Inout_ WslCoreVm* VmContext, _In_ HANDLE UserToken);
-
     static void CALLBACK s_OnExit(_In_ HCS_EVENT* Event, _In_opt_ void* Context);
 
     wil::srwlock m_guestDeviceLock;
@@ -280,6 +281,7 @@ private:
     std::wstring m_machineId;
     GUID m_runtimeId;
     wsl::core::Config m_vmConfig;
+    InitializeDrvFsCallback m_initializeDrvFs;
     std::wstring m_comPipe0;
     std::wstring m_comPipe1;
     int m_pageReportingOrder;


### PR DESCRIPTION
## Summary

DrvFs initialization callbacks could outlive the utility VM instance they were created for when VM shutdown or replacement occurred concurrently.

This change:

- routes DrvFs initialization through the owning user session
- serializes callback execution with utility VM shutdown and replacement
- avoids retaining a raw `WslCoreVm` pointer in instance callbacks

## Validation

- Existing WSL1, WSL2, and WSLC test suites pass