### PR TITLE
Add pipeline stage to produce DCAT submission files

### DIFF
--- a/.pipelines/dcat-stage.yml
+++ b/.pipelines/dcat-stage.yml
@@ -1,0 +1,63 @@
+stages:
+  - stage: dcat_prepare
+    displayName: Prepare DCAT submissions
+    dependsOn:
+      - build_x64
+      - build_arm64
+    jobs:
+      - job: prepare
+        displayName: Generate DCAT submission metadata
+        pool:
+          type: windows
+        variables:
+          ob_outputDirectory: '$(Pipeline.Workspace)\dcat-output'
+          ob_artifactBaseName: drop_wsl
+          ob_artifactSuffix: _dcat
+          ob_sdl_checkcflags_enabled: false
+          DcatContentPath: '$(Pipeline.Workspace)\dcat'
+          buildStagePackageVersion: $[ stageDependencies.build_x64.build_x64.outputs['version.WSL_PACKAGE_VERSION'] ]
+        steps:
+          - checkout: releaseScripts
+            path: s\wsl-release-scripts
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download x64 build artifact
+            inputs:
+              artifact: drop_wsl_build
+              path: '$(Pipeline.Workspace)\drop_x64'
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download arm64 build artifact
+            inputs:
+              artifact: drop_wsl_build_arm64
+              path: '$(Pipeline.Workspace)\drop_arm64'
+
+          - task: PowerShell@2
+            displayName: Generate DCAT submission metadata
+            inputs:
+              targetType: inline
+              failOnStderr: true
+              pwsh: true
+              script: |
+                $contentPath = '$(DcatContentPath)'
+                $outputPath = '$(ob_outputDirectory)'
+                $version = '$(buildStagePackageVersion)'
+
+                New-Item -ItemType Directory -Path $contentPath -Force | Out-Null
+                Copy-Item "$(Pipeline.Workspace)\drop_x64\bundle\wsl.$version.x64.msi" $contentPath
+                Copy-Item "$(Pipeline.Workspace)\drop_x64\bundle\wsl.$version.x64.cab" $contentPath
+                Copy-Item "$(Pipeline.Workspace)\drop_arm64\bundle\wsl.$version.arm64.msi" $contentPath
+                Copy-Item "$(Pipeline.Workspace)\drop_arm64\bundle\wsl.$version.arm64.cab" $contentPath
+
+                & "$(Pipeline.Workspace)\s\wsl-release-scripts\scripts\Dcat\New-DcatSubmission.ps1" `
+                    -ContentFolderPath $contentPath `
+                    -Version $version
+
+                $jsonFiles = @(Get-ChildItem -Path $contentPath -Filter *.json)
+                if ($jsonFiles.Count -ne 10) {
+                    throw "Expected 10 JSON files, found $($jsonFiles.Count)."
+                }
+
+                New-Item -ItemType Directory -Path $outputPath -Force | Out-Null
+                Copy-Item $jsonFiles.FullName $outputPath
+                Copy-Item "$(Pipeline.Workspace)\s\wsl-release-scripts\scripts\Dcat\Update-DcatSubmission.ps1" $outputPath

--- a/.pipelines/wsl-build-release-onebranch.yml
+++ b/.pipelines/wsl-build-release-onebranch.yml
@@ -33,6 +33,10 @@ resources:
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
+    - repository: releaseScripts
+      type: git
+      name: Microsoft.WSL/wsl-release-scripts
+      ref: refs/tags/v1
 
 extends:
   template: v2/Microsoft.Official.yml@templates
@@ -74,6 +78,8 @@ extends:
         traceLoggingConfig: $(ReleaseTraceLoggingConfig)
         vsoOrg: microsoft
         vsoProject: Microsoft.WSL
+
+    - template: dcat-stage.yml@self
 
     - template: test-stage.yml@self
       parameters:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds a new stage to the release pipeline for generating the JSON files we need for submission to DCAT. The maintainers of DCAT requested that the schema of these files be kept private, so the script to produce them will live in an internal repo `wsl-release-scripts`. See internal PR 16367081.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Executed the release pipeline (minus all the release steps, and using non-release configuration) and confirmed that the JSON files are produced and have expected content.