### PR TITLE
Add a UserConfig setting to use local wsldevicehost binaries instead of the nuget package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,6 @@ find_nuget_package(Microsoft.Identity.MSAL.WSL.Proxy MSAL /build/native/bin)
 find_nuget_package(Microsoft.RemoteDesktop.Client.MSRDC.SessionHost MSRDC /build/native/bin)
 find_nuget_package(Microsoft.Taef TAEF /)
 find_nuget_package(Microsoft.Windows.ImplementationLibrary WIL /)
-find_nuget_package(Microsoft.WSL.DeviceHost WSL_DEVICE_HOST /build/native)
 find_nuget_package(Microsoft.WSL.Kernel KERNEL /build/native)
 find_nuget_package(Microsoft.WSL.bsdtar BSDTARD /build/native/bin)
 find_nuget_package(Microsoft.WSL.LinuxSdk LINUXSDK /)
@@ -167,6 +166,16 @@ set(SUPPORTED_LANGS cs-CZ;da-DK;de-DE;en-GB;en-US;es-ES;fi-FI;fr-FR;hu-HU;it-IT;
 
 if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/UserConfig.cmake")
     find_package(USER REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR})
+endif()
+
+if (WSL_DEVICEHOST_BIN)
+    set(WSL_VIRTIO_NET_IDL_PATH "${WSL_DEVICEHOST_BIN}/WslDeviceHost.idl")
+    set(WSL_DEVICE_HOST_DLL_PATH "${WSL_DEVICEHOST_BIN}/wsldevicehost.dll")
+    set(WSL_DEVICE_HOST_VERSION "9.0.0-localbuild")
+else()
+    find_nuget_package(Microsoft.WSL.DeviceHost WSL_DEVICE_HOST /build/native)
+    set(WSL_VIRTIO_NET_IDL_PATH "${WSL_DEVICE_HOST_SOURCE_DIR}/idl/WslDeviceHost.idl")
+    set(WSL_DEVICE_HOST_DLL_PATH "${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.dll")
 endif()
 
 # Optional target configuration
@@ -241,7 +250,9 @@ file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.dll ${BIN}/wsldeps.dll)
 file(CREATE_LINK ${WSLDEPS_SOURCE_DIR}/bin/wsldeps.pdb ${BIN}/wsldeps.pdb)
 # wsldevicehost.dll is packaged directly from its NuGet package, so only its PDB
 # needs linking into bin for symbol publishing.
-file(CREATE_LINK ${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.pdb ${BIN}/wsldevicehost.pdb)
+if (NOT WSL_DEVICEHOST_BIN)
+    file(CREATE_LINK ${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.pdb ${BIN}/wsldevicehost.pdb)
+endif()
 
 if (${SKIP_PACKAGE_SIGNING})
     set(PACKAGE_SIGN_COMMAND echo Skipped package signing for:)

--- a/UserConfig.cmake.sample
+++ b/UserConfig.cmake.sample
@@ -2,6 +2,10 @@
 
 message(STATUS "Loading user configuration")
 
+# Uncomment to use locally built wsldevicehost binaries.
+# This folder should contain both wsldevicehost.dll and WslDeviceHost.idl
+# set(WSL_DEVICEHOST_BIN "C:/path/to/devicehost/bin")
+
 # Uncomment to enable development packages (smaller, faster to install)
 # # Note: .vhd files fail to mount via symlink / hardlink, so COPY is needed.
 # set(WSL_DEV_BINARY_PATH "C:/wsldev")

--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -293,7 +293,7 @@
                      which would fail the install. -->
                 <ServiceControl Id="StopService" Stop="both" Remove="uninstall" Name="WSLService" Wait="yes" />
 
-                <File Id="wsldevicehost.dll" Source="${WSL_DEVICE_HOST_SOURCE_DIR}/bin/${TARGET_PLATFORM}/wsldevicehost.dll" />
+                <File Id="wsldevicehost.dll" Source="${WSL_DEVICE_HOST_DLL_PATH}" />
 
                 <!-- WSLC COM app - activated through WSLService -->
                 <RegistryKey Root="HKCR" Key="AppID\{E9B79997-57E3-4201-AECC-6A464E530DD2}">

--- a/src/windows/wsldevicehoststub/inc/CMakeLists.txt
+++ b/src/windows/wsldevicehoststub/inc/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_idl(wsldevicehostidl "${WSL_DEVICE_HOST_SOURCE_DIR}/idl/WslDeviceHost.idl" "")
+add_idl(wsldevicehostidl "${WSL_VIRTIO_NET_IDL_PATH}" "")
 
 set_target_properties(wsldevicehostidl PROPERTIES FOLDER windows)


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change adds a new `UserConfig.cmake`  setting to use locally built wsldevicehost binaries. This makes testing changes in these components a lot easier

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
