### PR TITLE
Preserve caller impersonation in SetSparse

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -1757,8 +1757,9 @@ CATCH_RETURN()
 HRESULT LxssUserSessionImpl::SetSparse(_In_ LPCGUID DistroGuid, _In_ BOOLEAN Sparse, _In_ BOOLEAN AllowUnsafe)
 try
 {
-    auto runAsUser = wil::CoImpersonateClient();
-    const wil::unique_hkey lxssKey = s_OpenLxssUserKey();
+    const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);
+    auto runAsUser = wil::impersonate_token(userToken.get());
+    const wil::unique_hkey lxssKey = wsl::windows::common::registry::OpenLxssUserKey();
     std::lock_guard lock(m_instanceLock);
 
     const auto registration = DistributionRegistration::Open(lxssKey.get(), *DistroGuid);


### PR DESCRIPTION
## Summary
- capture the caller token before opening distribution state
- use an explicit token impersonation scope for the SetSparse operation
- avoid nested COM impersonation scopes