### PR TITLE
Inherit image labels on containers 

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -429,8 +429,10 @@ struct ContainerConfig
     std::optional<std::string> StopSignal;
     std::optional<int> StopTimeout;
     std::optional<HealthConfig> Healthcheck;
+    // Optional because dockerd may emit `"Labels": null` for containers with no merged labels.
+    std::optional<std::map<std::string, std::string>> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Image, User, WorkingDir, Env, Cmd, Entrypoint, StopSignal, StopTimeout, Healthcheck);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Image, User, WorkingDir, Env, Cmd, Entrypoint, StopSignal, StopTimeout, Healthcheck, Labels);
 };
 
 struct InspectMount

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -109,8 +109,9 @@ struct ContainerConfig
     std::string WorkingDir;
     std::optional<int> StopTimeout;
     std::optional<HealthConfig> Healthcheck;
+    std::map<std::string, std::string> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Env, Cmd, Entrypoint, User, WorkingDir, StopTimeout, Healthcheck);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Env, Cmd, Entrypoint, User, WorkingDir, StopTimeout, Healthcheck, Labels);
 };
 
 struct InspectEndpointIPAMConfig

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -47,6 +47,7 @@ using wsl::windows::service::wslc::VMPortMapping;
 using wsl::windows::service::wslc::WSLCContainer;
 using wsl::windows::service::wslc::WSLCContainerImpl;
 using wsl::windows::service::wslc::WSLCContainerMetadata;
+using wsl::windows::service::wslc::WSLCContainerMetadataLabel;
 using wsl::windows::service::wslc::WSLCContainerMetadataV1;
 using wsl::windows::service::wslc::WSLCExecutionContext;
 using wsl::windows::service::wslc::WSLCPortMapping;
@@ -504,6 +505,17 @@ std::string SerializeContainerMetadata(const WSLCContainerMetadataV1& metadata)
     wrapper.V1 = metadata;
 
     return wsl::shared::ToJson(wrapper);
+}
+
+std::map<std::string, std::string> StripInternalLabels(std::map<std::string, std::string> labels)
+{
+    labels.erase(WSLCContainerMetadataLabel);
+    return labels;
+}
+
+std::map<std::string, std::string> StripInternalLabels(std::optional<std::map<std::string, std::string>>&& labels)
+{
+    return StripInternalLabels(std::move(labels).value_or(std::map<std::string, std::string>{}));
 }
 
 void ProcessNamedVolumes(const WSLCContainerOptions& containerOptions, wsl::windows::common::docker_schema::CreateContainer& request)
@@ -1573,7 +1585,8 @@ WslcInspectContainer WSLCContainerImpl::BuildInspectContainer(const DockerInspec
         wslcInspect.Mounts.push_back(std::move(mountInfo));
     }
 
-    // Map labels. m_labels should already exclude internal metadata labels.
+    // Config.Labels is the Docker-shape location; top-level Labels is a legacy alias.
+    wslcInspect.Config.Labels = m_labels;
     wslcInspect.Labels = m_labels;
 
     // Map per-endpoint network settings from Docker inspect data.
@@ -1978,7 +1991,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
             .HostIp = e.VmMapping.IsIPv6() ? "::" : "0.0.0.0", .HostPort = std::to_string(hostPort)});
     }
 
-    auto labels = ParseKeyValuePairs(containerOptions.Labels, containerOptions.LabelsCount, WSLCContainerMetadataLabel);
+    auto requestedLabels = ParseKeyValuePairs(containerOptions.Labels, containerOptions.LabelsCount, WSLCContainerMetadataLabel);
 
     // Build WSLC metadata to store in a label for recovery on Open().
     WSLCContainerMetadataV1 metadata;
@@ -1992,7 +2005,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
     }
 
     request.Labels[WSLCContainerMetadataLabel] = SerializeContainerMetadata(metadata);
-    request.Labels.insert(labels.begin(), labels.end());
+    request.Labels.insert(requestedLabels.begin(), requestedLabels.end());
 
     // Send the request to docker.
     auto result = DockerClient.CreateContainer(request, containerName);
@@ -2055,6 +2068,8 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         namedVolumes.emplace_back(containerOptions.NamedVolumes[i].Name);
     }
 
+    auto mergedLabels = StripInternalLabels(std::move(inspectData.Config.Labels));
+
     auto container = std::make_shared<WSLCContainerImpl>(
         wslcSession,
         virtualMachine,
@@ -2067,7 +2082,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         std::move(namedVolumes),
         volumesManager,
         std::move(mappedPorts),
-        std::move(labels),
+        std::move(mergedLabels),
         std::move(OnDeleted),
         EventTracker,
         DockerClient,
@@ -2107,19 +2122,18 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
         }
     }
 
-    auto labels(dockerContainer.Labels);
-    auto metadataIt = labels.find(WSLCContainerMetadataLabel);
+    auto metadataIt = dockerContainer.Labels.find(WSLCContainerMetadataLabel);
 
     THROW_HR_IF_MSG(
         E_INVALIDARG,
-        metadataIt == labels.end(),
+        metadataIt == dockerContainer.Labels.end(),
         "Cannot open WSLC container %hs: missing WSLC metadata label",
         dockerContainer.Id.c_str());
 
     WI_ASSERT(dockerContainer.State != ContainerState::Running);
 
     auto metadata = ParseContainerMetadata(metadataIt->second.c_str());
-    labels.erase(metadataIt);
+    auto labels = StripInternalLabels(dockerContainer.Labels);
 
     // Docker treats empty NetworkMode as the default (bridge).
     std::string networkMode = dockerContainer.HostConfig.NetworkMode.empty() ? std::string{"bridge"} : dockerContainer.HostConfig.NetworkMode;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -10654,6 +10654,15 @@ class WSLCTests
         // Docker labels do not have a size limit, so test with a very large label value to validate that the API can handle it.
         std::map<std::string, std::string> labels = {{"key1", "value1"}, {"key2", std::string(10000, 'a')}};
 
+        // Contains-style rather than exact-equality so the test stays green if the base image ever ships with its own labels.
+        auto verifyUserLabelsPresent = [&](const std::map<std::string, std::string>& observed) {
+            for (const auto& [key, value] : labels)
+            {
+                VERIFY_IS_TRUE(observed.contains(key));
+                VERIFY_ARE_EQUAL(value, observed.at(key));
+            }
+        };
+
         // Test valid labels
         {
             WSLCContainerLauncher launcher("debian:latest", "test-labels", {"echo", "OK"});
@@ -10664,7 +10673,7 @@ class WSLCTests
             }
 
             auto container = launcher.Launch(*m_defaultSession);
-            VERIFY_ARE_EQUAL(labels, container.Labels());
+            verifyUserLabelsPresent(container.Labels());
 
             // Keep the container alive after the handle is dropped so we can validate labels are persisted across sessions.
             container.SetDeleteOnClose(false);
@@ -10676,7 +10685,14 @@ class WSLCTests
 
             // Validate that labels are correctly loaded.
             auto container = OpenContainer(m_defaultSession.get(), "test-labels");
-            VERIFY_ARE_EQUAL(labels, container.Labels());
+            verifyUserLabelsPresent(container.Labels());
+
+            const std::string c_metadataLabel = "com.microsoft.wsl.container.metadata";
+            const auto inspect = container.Inspect();
+            verifyUserLabelsPresent(inspect.Config.Labels);
+            verifyUserLabelsPresent(inspect.Labels);
+            VERIFY_ARE_EQUAL(inspect.Config.Labels, inspect.Labels);
+            VERIFY_IS_TRUE(inspect.Config.Labels.find(c_metadataLabel) == inspect.Config.Labels.end());
         }
 
         // Test nullptr key
@@ -10733,6 +10749,99 @@ class WSLCTests
 
             auto [hr, container] = launcher.CreateNoThrow(*m_defaultSession);
             VERIFY_ARE_EQUAL(hr, E_INVALIDARG);
+        }
+    }
+
+    // Regression: containers must inherit their base image's LABEL entries (Docker parity), with user --label
+    // winning on key conflict. The dockerd daemon does the merge; wslc reads it back from InspectContainer.
+    WSLC_TEST_METHOD(ContainerLabelsInheritedFromImage)
+    {
+        const std::string c_imageTag = "wslc-test-labels-inherited:latest";
+        const std::string c_imageLabelKey = "com.microsoft.wsl.test.image-label";
+        const std::string c_imageLabelValue = "from-image";
+        const std::string c_sharedLabelKey = "com.microsoft.wsl.test.shared";
+        const std::string c_sharedImageValue = "image-wins-if-no-override";
+        const std::string c_sharedUserValue = "user-wins";
+        const std::string c_userOnlyLabelKey = "com.microsoft.wsl.test.user-only";
+        const std::string c_userOnlyLabelValue = "from-user";
+        const std::string c_metadataLabel = "com.microsoft.wsl.container.metadata";
+        const std::string c_userOverrideContainerName = "test-labels-inherited-user-override";
+
+        auto contextDir = std::filesystem::current_path() / "build-context-labels-inherited";
+        std::filesystem::create_directories(contextDir);
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LOG_IF_FAILED(DeleteImageNoThrow(c_imageTag.c_str(), WSLCDeleteImageFlagsForce).first);
+
+            std::error_code ec;
+            std::filesystem::remove_all(contextDir, ec);
+        });
+
+        {
+            std::ofstream dockerfile(contextDir / "Dockerfile");
+            dockerfile << "FROM debian:latest\n";
+            dockerfile << "LABEL " << c_imageLabelKey << "=" << c_imageLabelValue << "\n";
+            dockerfile << "LABEL " << c_sharedLabelKey << "=" << c_sharedImageValue << "\n";
+        }
+
+        VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, c_imageTag.c_str()));
+        ExpectImagePresent(*m_defaultSession, c_imageTag.c_str());
+
+        // Image-only label survives on the container (bug repro).
+        {
+            WSLCContainerLauncher launcher(c_imageTag.c_str(), "test-labels-inherited-image-only", {"echo", "OK"});
+            auto container = launcher.Launch(*m_defaultSession);
+
+            const auto containerLabels = container.Labels();
+            const auto inspect = container.Inspect();
+
+            VERIFY_IS_TRUE(containerLabels.contains(c_imageLabelKey));
+            VERIFY_ARE_EQUAL(c_imageLabelValue, containerLabels.at(c_imageLabelKey));
+            VERIFY_IS_TRUE(inspect.Config.Labels.contains(c_imageLabelKey));
+            VERIFY_ARE_EQUAL(c_imageLabelValue, inspect.Config.Labels.at(c_imageLabelKey));
+
+            VERIFY_IS_TRUE(containerLabels.find(c_metadataLabel) == containerLabels.end());
+        }
+
+        // Persist across a session reset so the second block exercises the Open() codepath, which reads labels
+        // from the /containers/json list-API — a different deserialization than InspectContainer.Config.Labels.
+        {
+            WSLCContainerLauncher launcher(c_imageTag.c_str(), c_userOverrideContainerName.c_str(), {"echo", "OK"});
+            launcher.AddLabel(c_sharedLabelKey, c_sharedUserValue);
+            launcher.AddLabel(c_userOnlyLabelKey, c_userOnlyLabelValue);
+            auto container = launcher.Launch(*m_defaultSession);
+
+            const auto containerLabels = container.Labels();
+
+            VERIFY_IS_TRUE(containerLabels.contains(c_imageLabelKey));
+            VERIFY_ARE_EQUAL(c_imageLabelValue, containerLabels.at(c_imageLabelKey));
+
+            VERIFY_IS_TRUE(containerLabels.contains(c_sharedLabelKey));
+            VERIFY_ARE_EQUAL(c_sharedUserValue, containerLabels.at(c_sharedLabelKey));
+
+            VERIFY_IS_TRUE(containerLabels.contains(c_userOnlyLabelKey));
+            VERIFY_ARE_EQUAL(c_userOnlyLabelValue, containerLabels.at(c_userOnlyLabelKey));
+
+            container.SetDeleteOnClose(false);
+        }
+
+        {
+            ResetTestSession();
+
+            auto reopened = OpenContainer(m_defaultSession.get(), c_userOverrideContainerName.c_str());
+            const auto reopenedLabels = reopened.Labels();
+
+            VERIFY_IS_TRUE(reopenedLabels.contains(c_imageLabelKey));
+            VERIFY_ARE_EQUAL(c_imageLabelValue, reopenedLabels.at(c_imageLabelKey));
+            VERIFY_IS_TRUE(reopenedLabels.contains(c_sharedLabelKey));
+            VERIFY_ARE_EQUAL(c_sharedUserValue, reopenedLabels.at(c_sharedLabelKey));
+            VERIFY_IS_TRUE(reopenedLabels.contains(c_userOnlyLabelKey));
+            VERIFY_ARE_EQUAL(c_userOnlyLabelValue, reopenedLabels.at(c_userOnlyLabelKey));
+
+            VERIFY_IS_TRUE(reopenedLabels.find(c_metadataLabel) == reopenedLabels.end());
+
+            const auto reopenedInspect = reopened.Inspect();
+            VERIFY_IS_TRUE(reopenedInspect.Config.Labels.contains(c_imageLabelKey));
+            VERIFY_ARE_EQUAL(c_imageLabelValue, reopenedInspect.Config.Labels.at(c_imageLabelKey));
         }
     }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -10658,8 +10658,12 @@ class WSLCTests
         auto verifyUserLabelsPresent = [&](const std::map<std::string, std::string>& observed) {
             for (const auto& [key, value] : labels)
             {
-                VERIFY_IS_TRUE(observed.contains(key));
-                VERIFY_ARE_EQUAL(value, observed.at(key));
+                auto it = observed.find(key);
+                VERIFY_IS_TRUE(it != observed.end());
+                if (it != observed.end())
+                {
+                    VERIFY_ARE_EQUAL(value, it->second);
+                }
             }
         };
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -10677,8 +10677,9 @@ class WSLCTests
             }
 
             auto container = launcher.Launch(*m_defaultSession);
-            verifyUserLabelsPresent(container.Labels());
-            VERIFY_IS_TRUE(container.Labels().find("com.microsoft.wsl.container.metadata") == container.Labels().end());
+            const auto containerLabels = container.Labels();
+            verifyUserLabelsPresent(containerLabels);
+            VERIFY_IS_TRUE(containerLabels.find("com.microsoft.wsl.container.metadata") == containerLabels.end());
 
             // Keep the container alive after the handle is dropped so we can validate labels are persisted across sessions.
             container.SetDeleteOnClose(false);
@@ -10690,10 +10691,11 @@ class WSLCTests
 
             // Validate that labels are correctly loaded.
             auto container = OpenContainer(m_defaultSession.get(), "test-labels");
-            verifyUserLabelsPresent(container.Labels());
+            const auto containerLabels = container.Labels();
+            verifyUserLabelsPresent(containerLabels);
 
             const std::string c_metadataLabel = "com.microsoft.wsl.container.metadata";
-            VERIFY_IS_TRUE(container.Labels().find(c_metadataLabel) == container.Labels().end());
+            VERIFY_IS_TRUE(containerLabels.find(c_metadataLabel) == containerLabels.end());
             const auto inspect = container.Inspect();
             verifyUserLabelsPresent(inspect.Config.Labels);
             verifyUserLabelsPresent(inspect.Labels);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -10674,6 +10674,7 @@ class WSLCTests
 
             auto container = launcher.Launch(*m_defaultSession);
             verifyUserLabelsPresent(container.Labels());
+            VERIFY_IS_TRUE(container.Labels().find("com.microsoft.wsl.container.metadata") == container.Labels().end());
 
             // Keep the container alive after the handle is dropped so we can validate labels are persisted across sessions.
             container.SetDeleteOnClose(false);
@@ -10688,6 +10689,7 @@ class WSLCTests
             verifyUserLabelsPresent(container.Labels());
 
             const std::string c_metadataLabel = "com.microsoft.wsl.container.metadata";
+            VERIFY_IS_TRUE(container.Labels().find(c_metadataLabel) == container.Labels().end());
             const auto inspect = container.Inspect();
             verifyUserLabelsPresent(inspect.Config.Labels);
             verifyUserLabelsPresent(inspect.Labels);

--- a/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
@@ -111,6 +111,50 @@ class WSLCE2EInspectTests
             wsl::shared::FromJson<std::vector<wsl::windows::common::wslc_schema::InspectContainer>>(result.Stdout.value().c_str());
         VERIFY_ARE_EQUAL(1u, inspectData.size());
         VERIFY_ARE_EQUAL(WslcContainerName, wsl::shared::string::MultiByteToWide(inspectData[0].Name));
+
+        // Config.Labels must be present in the emitted JSON even when empty; consumers do `.Config.Labels // {}`
+        // and would silently break if the key went missing.
+        VERIFY_IS_TRUE(result.Stdout.value().find(L"\"Labels\":") != std::wstring::npos);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Inspect_Container_InheritsImageLabels)
+    {
+        auto imageCleanup = wil::scope_exit([&]() { EnsureImageIsDeleted(LabelInheritImage); });
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-inspect-inherit-labels";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto contextDir = testRoot / L"context";
+        std::error_code ec;
+        std::filesystem::create_directories(contextDir, ec);
+        THROW_HR_IF(E_FAIL, ec.value() != 0 || !std::filesystem::exists(contextDir));
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(
+            dockerfilePath,
+            "FROM debian:latest\n"
+            "LABEL com.microsoft.wsl.test.inherit-me=from-image\n"
+            "CMD [\"echo\", \"ok\"]\n");
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" -t {}", contextDir.wstring(), dockerfilePath.wstring(), LabelInheritImage.NameAndTag()));
+        buildResult.Verify({.Stdout = L"", .ExitCode = 0});
+
+        EnsureContainerDoesNotExist(WslcContainerName);
+        auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, LabelInheritImage.NameAndTag()));
+        createResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto result = RunWslc(std::format(L"inspect {}", WslcContainerName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        auto inspectData =
+            wsl::shared::FromJson<std::vector<wsl::windows::common::wslc_schema::InspectContainer>>(result.Stdout.value().c_str());
+        VERIFY_ARE_EQUAL(1u, inspectData.size());
+
+        const auto& configLabels = inspectData[0].Config.Labels;
+        auto inheritedIt = configLabels.find("com.microsoft.wsl.test.inherit-me");
+        VERIFY_IS_TRUE(inheritedIt != configLabels.end());
+        VERIFY_ARE_EQUAL(std::string("from-image"), inheritedIt->second);
+
+        VERIFY_IS_TRUE(configLabels.find("com.microsoft.wsl.container.metadata") == configLabels.end());
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Inspect_Volume_Success)
@@ -318,5 +362,6 @@ private:
     const TestImage& InvalidImage = InvalidTestImage();
     const std::wstring WslcVolumeName = L"wslc-inspect-test-volume";
     const std::wstring WslcNetworkName = L"wslc-inspect-test-network";
+    const TestImage LabelInheritImage{L"wslc-e2e-inspect-inherit-labels", L"latest", L""};
 };
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
@@ -112,9 +112,9 @@ class WSLCE2EInspectTests
         VERIFY_ARE_EQUAL(1u, inspectData.size());
         VERIFY_ARE_EQUAL(WslcContainerName, wsl::shared::string::MultiByteToWide(inspectData[0].Name));
 
-        // Config.Labels must be present in the emitted JSON even when empty; consumers do `.Config.Labels // {}`
-        // and would silently break if the key went missing.
-        VERIFY_IS_TRUE(result.Stdout.value().find(L"\"Labels\":") != std::wstring::npos);
+        // Config.Labels must be present in the emitted JSON even when empty.
+        auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(result.Stdout.value()));
+        VERIFY_IS_TRUE(json.at(0).at("Config").contains("Labels"));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Inspect_Container_InheritsImageLabels)

--- a/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
@@ -114,7 +114,8 @@ class WSLCE2EInspectTests
 
         // Config.Labels must be present in the emitted JSON even when empty.
         auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(result.Stdout.value()));
-        VERIFY_IS_TRUE(json.at(0).at("Config").contains("Labels"));
+        VERIFY_IS_TRUE(json.is_array() && !json.empty());
+        VERIFY_IS_TRUE(json[0].contains("Config") && json[0]["Config"].contains("Labels"));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Inspect_Container_InheritsImageLabels)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
wslc inspect <container> was omitting Config.Labels entirely, and container labels only reflected --label values passed at run/create time - image LABEL entries were never inherited, breaking Docker parity. This blocked VS Code Dev Containers over wslc: the extension reads Feature lifecycle metadata (onCreateCommand/postCreateCommand) from a devcontainer.metadata image label via Config.Labels, so all Feature-contributed hooks were silently skipped, Features contributed by e.g. Nix or direnv would appear installed but never run. This PR reads the daemon's already-merged label set back from InspectContainer and exposes it at Config.Labels, matching Docker's inspect shape.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #41152 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The dockerd daemon (v25.0.3 / API v1.44) merges image Config.Labels into the container's config at create time - image labels fill gaps, user --label values win on conflict. Verified against moby daemon/commit.go:merge(), daemon/inspect.go:ContainerInspectCurrent, and container/view.go:transform() for the create-merge, inspect-API, and list-API paths respectively.
Two separate defects were combining to hide labels:
1. On the wslc side, m_labels stored only the pre-send user labels- the daemon-merged authoritative set was thrown away after CreateContainer returned.
2. wslc_schema::ContainerConfig had no Labels field, so Config.Labels was omitted entirely from inspect output - even the user-provided labels showed up only at top-level Labels.
Changes:
- docker_schema::ContainerConfig - added optional Labels so InspectContainer can deserialize the daemon-merged set. Optional because dockerd may emit "Labels": null (rather than {}) in some code paths - std::optional handles that robustly and matches the sibling Volume.Labels / ImageConfig.Labels fields in the same header
- wslc_schema::ContainerConfig - added Labels so inspect output surfaces them at Config.Labels (Docker parity). Top-level Labels retained as a legacy alias for existing consumers
- WSLCContainer.cpp:
  - New StripInternalLabels helper (map and optional overloads) that removes the internal com.microsoft.wsl.container.metadata label from the public set.
  - Create path now reads labels back from InspectContainer after CreateContainer and passes the merged set to WSLCContainerImpl, mirroring the Open path
  - ConvertInspectContainer populates both Config.Labels and the top-level Labels

Docker parity: single source of truth is the daemon; wslc no longer duplicates the merge logic.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- WSLCTests::ContainerLabels - extended to assert Config.Labels/top-level parity and that the internal metadata label doesn't leak; switched exact-equality to contains-style so it stays green if the base image ever ships with its own labels.
- WSLCTests::ContainerLabelsInheritedFromImage - new. Builds an image with LABEL, verifies image-only inheritance, user --label precedence on conflict, user-only labels merging alongside image labels, and session-reset recovery 
- WSLCE2EInspectTests::WSLCE2E_Inspect_Container_InheritsImageLabels - new CLI e2e test matching the bug repro (wslc build → wslc container create → wslc inspect → assert Config.Labels contains the image label, does not leak metadata label).
- WSLCE2EInspectTests::WSLCE2E_Inspect_Container_Success - extended with a JSON-shape assertion that "Labels": is present in inspect output even for a container with no labels
