### PR TITLE
Coordinate console state across concurrent WSL clients

### DIFF
--- a/src/windows/common/ConsoleState.cpp
+++ b/src/windows/common/ConsoleState.cpp
@@ -79,7 +79,7 @@ std::optional<DWORD> TryGetConsoleMode(_In_ HANDLE Handle)
 
 namespace wsl::windows::common {
 
-ConsoleState::ConsoleState(RestorePolicy Policy) : m_restorePolicy(Policy)
+ConsoleState::ConsoleState(RestorePolicy Policy, const SvcComm* Service) : m_restorePolicy(Policy), m_service(Service)
 {
     m_InputHandle.reset(
         CreateFileW(L"CONIN$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr));
@@ -102,6 +102,59 @@ void ConsoleState::SetInteractiveMode()
 {
     if (m_interactiveModeConfigured)
     {
+        return;
+    }
+
+    // Cross-process coordination is used only by opted-in wsl.exe launches with a console.
+    if ((m_restorePolicy == RestorePolicy::OnlyIfUnchanged) && m_service && m_InputHandle)
+    {
+        bool initialize{};
+        LXSS_CONSOLE_STATE configuredState{};
+        m_service->AcquireConsoleStateLease(m_InputHandle.get(), m_leaseId, initialize, configuredState);
+        m_leaseAcquired = true;
+
+        // Release removes an unfinished Initializing entry if setup fails.
+        auto releaseLease = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { RestoreLeasedConsoleState(); });
+        if (!initialize)
+        {
+            const auto currentState = CaptureConsoleState();
+            auto restoreCurrentState = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { ApplyConsoleState(currentState); });
+            ApplyConsoleState(configuredState);
+            m_interactiveModeConfigured = true;
+            restoreCurrentState.release();
+            releaseLease.release();
+            return;
+        }
+
+        const auto baselineState = CaptureConsoleState();
+
+        // The first lease configures the console and publishes the exact resulting state.
+        if (WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_INPUT_CODE_PAGE))
+        {
+            m_SavedInputCodePage = baselineState.InputCodePage;
+        }
+        if (WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_INPUT_MODE))
+        {
+            m_SavedInputMode = baselineState.InputMode;
+        }
+        if (WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_OUTPUT_CODE_PAGE))
+        {
+            m_SavedOutputCodePage = baselineState.OutputCodePage;
+        }
+        if (WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_OUTPUT_MODE))
+        {
+            m_SavedOutputMode = baselineState.OutputMode;
+        }
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { RestoreConsoleState(); });
+        ConfigureInteractiveMode();
+
+        const auto actualConfiguredState = CaptureConsoleState();
+        m_service->CommitConsoleStateLease(m_leaseId, baselineState, actualConfiguredState);
+
+        m_interactiveModeConfigured = true;
+        cleanup.release();
+        releaseLease.release();
         return;
     }
 
@@ -159,10 +212,145 @@ void ConsoleState::SetInteractiveMode()
     cleanup.release();
 }
 
+void ConsoleState::ConfigureInteractiveMode()
+{
+    if (m_InputHandle)
+    {
+        LOG_IF_WIN32_BOOL_FALSE(SetConsoleCP(CP_UTF8));
+        DWORD mode{};
+        THROW_LAST_ERROR_IF(!GetConsoleMode(m_InputHandle.get(), &mode));
+        WI_SetAllFlags(mode, ENABLE_WINDOW_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT);
+        WI_ClearAllFlags(mode, ENABLE_ECHO_INPUT | ENABLE_INSERT_MODE | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+        ChangeConsoleMode(m_InputHandle.get(), mode);
+    }
+
+    if (m_OutputHandle)
+    {
+        LOG_IF_WIN32_BOOL_FALSE(SetConsoleOutputCP(CP_UTF8));
+        DWORD mode{};
+        THROW_LAST_ERROR_IF(!GetConsoleMode(m_OutputHandle.get(), &mode));
+        WI_SetAllFlags(mode, ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN);
+        ChangeConsoleMode(m_OutputHandle.get(), mode);
+    }
+}
+
+LXSS_CONSOLE_STATE ConsoleState::CaptureConsoleState() const
+{
+    LXSS_CONSOLE_STATE state{};
+    if (m_InputHandle)
+    {
+        state.InputCodePage = GetConsoleCP();
+        WI_SetFlag(state.Flags, LXSS_CONSOLE_STATE_INPUT_CODE_PAGE);
+        if (const auto mode = TryGetConsoleMode(m_InputHandle.get()))
+        {
+            state.InputMode = mode.value();
+            WI_SetFlag(state.Flags, LXSS_CONSOLE_STATE_INPUT_MODE);
+        }
+    }
+
+    if (m_OutputHandle)
+    {
+        state.OutputCodePage = GetConsoleOutputCP();
+        WI_SetFlag(state.Flags, LXSS_CONSOLE_STATE_OUTPUT_CODE_PAGE);
+        if (const auto mode = TryGetConsoleMode(m_OutputHandle.get()))
+        {
+            state.OutputMode = mode.value();
+            WI_SetFlag(state.Flags, LXSS_CONSOLE_STATE_OUTPUT_MODE);
+        }
+    }
+
+    return state;
+}
+
+void ConsoleState::ApplyConsoleState(_In_ const LXSS_CONSOLE_STATE& State)
+{
+    if (m_InputHandle)
+    {
+        if (WI_IsFlagSet(State.Flags, LXSS_CONSOLE_STATE_INPUT_CODE_PAGE))
+        {
+            LOG_IF_WIN32_BOOL_FALSE(SetConsoleCP(State.InputCodePage));
+        }
+        if (WI_IsFlagSet(State.Flags, LXSS_CONSOLE_STATE_INPUT_MODE))
+        {
+            ChangeConsoleMode(m_InputHandle.get(), State.InputMode);
+        }
+    }
+
+    if (m_OutputHandle)
+    {
+        if (WI_IsFlagSet(State.Flags, LXSS_CONSOLE_STATE_OUTPUT_CODE_PAGE))
+        {
+            LOG_IF_WIN32_BOOL_FALSE(SetConsoleOutputCP(State.OutputCodePage));
+        }
+        if (WI_IsFlagSet(State.Flags, LXSS_CONSOLE_STATE_OUTPUT_MODE))
+        {
+            ChangeConsoleMode(m_OutputHandle.get(), State.OutputMode);
+        }
+    }
+}
+
 ConsoleState::~ConsoleState()
 {
-    RestoreConsoleState();
+    if (m_leaseAcquired)
+    {
+        RestoreLeasedConsoleState();
+    }
+    else
+    {
+        RestoreConsoleState();
+    }
 }
+
+void ConsoleState::RestoreLeasedConsoleState()
+try
+{
+    if (!m_leaseAcquired)
+    {
+        return;
+    }
+
+    LXSS_CONSOLE_STATE baselineState{};
+    LXSS_CONSOLE_STATE configuredState{};
+    const auto restore = m_service->ReleaseConsoleStateLease(m_leaseId, baselineState, configuredState);
+    m_leaseAcquired = false;
+    if (!restore)
+    {
+        return;
+    }
+
+    // Always unblock waiters, even if the console disconnects while it is being restored.
+    auto complete = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { m_service->CompleteConsoleStateLease(m_leaseId); });
+    if (m_InputHandle)
+    {
+        if (WI_IsFlagSet(configuredState.Flags, LXSS_CONSOLE_STATE_INPUT_CODE_PAGE) &&
+            WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_INPUT_CODE_PAGE) && (GetConsoleCP() == configuredState.InputCodePage))
+        {
+            LOG_IF_WIN32_BOOL_FALSE(SetConsoleCP(baselineState.InputCodePage));
+        }
+        if (WI_IsFlagSet(configuredState.Flags, LXSS_CONSOLE_STATE_INPUT_MODE) &&
+            WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_INPUT_MODE) &&
+            (TryGetConsoleMode(m_InputHandle.get()) == configuredState.InputMode))
+        {
+            TrySetConsoleMode(m_InputHandle.get(), baselineState.InputMode);
+        }
+    }
+
+    if (m_OutputHandle)
+    {
+        if (WI_IsFlagSet(configuredState.Flags, LXSS_CONSOLE_STATE_OUTPUT_CODE_PAGE) &&
+            WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_OUTPUT_CODE_PAGE) && (GetConsoleOutputCP() == configuredState.OutputCodePage))
+        {
+            LOG_IF_WIN32_BOOL_FALSE(SetConsoleOutputCP(baselineState.OutputCodePage));
+        }
+        if (WI_IsFlagSet(configuredState.Flags, LXSS_CONSOLE_STATE_OUTPUT_MODE) &&
+            WI_IsFlagSet(baselineState.Flags, LXSS_CONSOLE_STATE_OUTPUT_MODE) &&
+            (TryGetConsoleMode(m_OutputHandle.get()) == configuredState.OutputMode))
+        {
+            TrySetConsoleMode(m_OutputHandle.get(), baselineState.OutputMode);
+        }
+    }
+}
+CATCH_LOG()
 
 void ConsoleState::RestoreConsoleState()
 {

--- a/src/windows/common/ConsoleState.h
+++ b/src/windows/common/ConsoleState.h
@@ -20,6 +20,8 @@ Abstract:
 
 namespace wsl::windows::common {
 
+class SvcComm;
+
 // Controls when ConsoleState attempts to restore the original console state.
 enum class RestorePolicy
 {
@@ -34,7 +36,7 @@ enum class RestorePolicy
 class ConsoleState
 {
 public:
-    explicit ConsoleState(RestorePolicy Policy = RestorePolicy::Always);
+    explicit ConsoleState(RestorePolicy Policy = RestorePolicy::Always, const SvcComm* Service = nullptr);
     ~ConsoleState();
     ConsoleState(const ConsoleState&) = delete;
     ConsoleState& operator=(const ConsoleState&) = delete;
@@ -45,11 +47,18 @@ public:
     void SetInteractiveMode();
 
 private:
+    void ApplyConsoleState(_In_ const LXSS_CONSOLE_STATE& State);
+    LXSS_CONSOLE_STATE CaptureConsoleState() const;
+    void ConfigureInteractiveMode();
     void RestoreConsoleState();
+    void RestoreLeasedConsoleState();
 
     wil::unique_hfile m_InputHandle;
     wil::unique_hfile m_OutputHandle;
     RestorePolicy m_restorePolicy;
+    const SvcComm* m_service{};
+    GUID m_leaseId{};
+    bool m_leaseAcquired{false};
     bool m_interactiveModeConfigured{false};
     std::optional<DWORD> m_SavedInputMode{};
     std::optional<DWORD> m_ConfiguredInputMode{};

--- a/src/windows/common/svccomm.cpp
+++ b/src/windows/common/svccomm.cpp
@@ -190,6 +190,40 @@ wsl::windows::common::SvcComm::~SvcComm()
 {
 }
 
+void wsl::windows::common::SvcComm::AcquireConsoleStateLease(
+    _In_ HANDLE ConsoleHandle, _Out_ GUID& LeaseId, _Out_ bool& Initialize, _Out_ LXSS_CONSOLE_STATE& ConfiguredState) const
+{
+    WI_ASSERT(IS_VALID_HANDLE(ConsoleHandle));
+
+    // Use the process console connection handle for cross-process identification.
+    // CONIN$ handles can be used for mode operations but cannot be duplicated into the service.
+    const HANDLE console = NtCurrentTeb()->ProcessEnvironmentBlock->ProcessParameters->Reserved2[0];
+    THROW_HR_IF(E_UNEXPECTED, !IS_VALID_HANDLE(console));
+
+    BOOLEAN initialize{};
+    THROW_IF_FAILED(m_userSession->AcquireConsoleStateLease(HandleToUlong(console), &LeaseId, &initialize, &ConfiguredState));
+    Initialize = initialize;
+}
+
+void wsl::windows::common::SvcComm::CommitConsoleStateLease(
+    _In_ const GUID& LeaseId, _In_ const LXSS_CONSOLE_STATE& BaselineState, _In_ const LXSS_CONSOLE_STATE& ConfiguredState) const
+{
+    THROW_IF_FAILED(m_userSession->CommitConsoleStateLease(&LeaseId, &BaselineState, &ConfiguredState));
+}
+
+bool wsl::windows::common::SvcComm::ReleaseConsoleStateLease(
+    _In_ const GUID& LeaseId, _Out_ LXSS_CONSOLE_STATE& BaselineState, _Out_ LXSS_CONSOLE_STATE& ConfiguredState) const
+{
+    BOOLEAN restore{};
+    THROW_IF_FAILED(m_userSession->ReleaseConsoleStateLease(&LeaseId, &restore, &BaselineState, &ConfiguredState));
+    return restore;
+}
+
+void wsl::windows::common::SvcComm::CompleteConsoleStateLease(_In_ const GUID& LeaseId) const
+{
+    THROW_IF_FAILED(m_userSession->CompleteConsoleStateLease(&LeaseId));
+}
+
 void wsl::windows::common::SvcComm::ConfigureDistribution(_In_opt_ LPCGUID DistroGuid, _In_ ULONG DefaultUid, _In_ ULONG Flags) const
 {
     ClientExecutionContext context;
@@ -294,7 +328,7 @@ wsl::windows::common::SvcComm::LaunchProcess(
     // Create the process.
     //
 
-    ConsoleState Io{RestorePolicySetting};
+    ConsoleState Io{RestorePolicySetting, this};
     Io.SetInteractiveMode();
     COORD WindowSize = Io.GetWindowSize();
     ULONG Flags = LXSS_CREATE_INSTANCE_FLAGS_ALLOW_FS_UPGRADE;

--- a/src/windows/common/svccomm.hpp
+++ b/src/windows/common/svccomm.hpp
@@ -35,6 +35,11 @@ public:
     SvcComm();
     ~SvcComm();
 
+    void AcquireConsoleStateLease(_In_ HANDLE ConsoleHandle, _Out_ GUID& LeaseId, _Out_ bool& Initialize, _Out_ LXSS_CONSOLE_STATE& ConfiguredState) const;
+    void CommitConsoleStateLease(_In_ const GUID& LeaseId, _In_ const LXSS_CONSOLE_STATE& BaselineState, _In_ const LXSS_CONSOLE_STATE& ConfiguredState) const;
+    bool ReleaseConsoleStateLease(_In_ const GUID& LeaseId, _Out_ LXSS_CONSOLE_STATE& BaselineState, _Out_ LXSS_CONSOLE_STATE& ConfiguredState) const;
+    void CompleteConsoleStateLease(_In_ const GUID& LeaseId) const;
+
     void ConfigureDistribution(_In_opt_ LPCGUID DistroGuid, _In_ ULONG DefaultUid, _In_ ULONG Flags) const;
 
     void CreateInstance(_In_opt_ LPCGUID DistroGuid = nullptr, _In_ ULONG Flags = LXSS_CREATE_INSTANCE_FLAGS_ALLOW_FS_UPGRADE);

--- a/src/windows/service/exe/CMakeLists.txt
+++ b/src/windows/service/exe/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    ConsoleStateManager.cpp
     DistributionRegistration.cpp
     LxssUserCallback.cpp
     LxssUserSession.cpp
@@ -30,6 +31,7 @@ set(SOURCES
 
 set(HEADERS
     ../../inc/comservicehelper.h
+    ConsoleStateManager.h
     DistributionRegistration.h
     LxssUserCallback.h
     LxssUserSession.h

--- a/src/windows/service/exe/ConsoleStateManager.cpp
+++ b/src/windows/service/exe/ConsoleStateManager.cpp
@@ -1,0 +1,145 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ConsoleStateManager.cpp
+
+Abstract:
+
+    This file contains definitions for coordinating console state leases.
+
+--*/
+
+#include "precomp.h"
+#include "ConsoleStateManager.h"
+
+void ConsoleStateManager::Acquire(_In_ HANDLE ConsoleHandle, _Out_ GUID& LeaseId, _Out_ bool& Initialize, _Out_ LXSS_CONSOLE_STATE& ConfiguredState)
+{
+    ULONG consoleId{};
+    wil::unique_handle conhostHandle;
+    GetConsoleInfo(ConsoleHandle, consoleId, conhostHandle);
+    THROW_IF_FAILED(CoCreateGuid(&LeaseId));
+
+    std::unique_lock lock(m_lock);
+    for (;;)
+    {
+        auto entry = m_entries.find(consoleId);
+        if (entry == m_entries.end())
+        {
+            Entry newEntry;
+            newEntry.ConhostHandle = std::move(conhostHandle);
+            newEntry.Leases.emplace(LeaseId);
+            m_entries.emplace(consoleId, std::move(newEntry));
+            Initialize = true;
+            ConfiguredState = {};
+            return;
+        }
+
+        if (entry->second.CurrentState == State::Active)
+        {
+            entry->second.Leases.emplace(LeaseId);
+            Initialize = false;
+            ConfiguredState = entry->second.ConfiguredState;
+            return;
+        }
+
+        m_stateChanged.wait(lock, [&] {
+            const auto current = m_entries.find(consoleId);
+            return (current == m_entries.end()) || (current->second.CurrentState == State::Active);
+        });
+    }
+}
+
+void ConsoleStateManager::Commit(_In_ const GUID& LeaseId, _In_ const LXSS_CONSOLE_STATE& BaselineState, _In_ const LXSS_CONSOLE_STATE& ConfiguredState)
+{
+    std::lock_guard lock(m_lock);
+    const auto entry = FindLease(LeaseId);
+    THROW_HR_IF(E_UNEXPECTED, (entry == m_entries.end()) || (entry->second.CurrentState != State::Initializing));
+
+    entry->second.BaselineState = BaselineState;
+    entry->second.ConfiguredState = ConfiguredState;
+    entry->second.CurrentState = State::Active;
+    m_stateChanged.notify_all();
+}
+
+bool ConsoleStateManager::Release(_In_ const GUID& LeaseId, _Out_ LXSS_CONSOLE_STATE& BaselineState, _Out_ LXSS_CONSOLE_STATE& ConfiguredState)
+{
+    std::lock_guard lock(m_lock);
+    const auto entry = FindLease(LeaseId);
+    THROW_HR_IF(E_UNEXPECTED, entry == m_entries.end());
+
+    if (entry->second.CurrentState == State::Initializing)
+    {
+        m_entries.erase(entry);
+        m_stateChanged.notify_all();
+        return false;
+    }
+
+    THROW_HR_IF(E_UNEXPECTED, entry->second.CurrentState != State::Active);
+    WI_VERIFY(entry->second.Leases.erase(LeaseId) == 1);
+    if (!entry->second.Leases.empty())
+    {
+        return false;
+    }
+
+    entry->second.CurrentState = State::Restoring;
+    entry->second.Restorer = LeaseId;
+    BaselineState = entry->second.BaselineState;
+    ConfiguredState = entry->second.ConfiguredState;
+    return true;
+}
+
+void ConsoleStateManager::Complete(_In_ const GUID& LeaseId)
+{
+    std::lock_guard lock(m_lock);
+    for (auto entry = m_entries.begin(); entry != m_entries.end(); ++entry)
+    {
+        if ((entry->second.CurrentState == State::Restoring) && IsEqualGUID(entry->second.Restorer, LeaseId))
+        {
+            m_entries.erase(entry);
+            m_stateChanged.notify_all();
+            return;
+        }
+    }
+
+    THROW_HR(E_UNEXPECTED);
+}
+
+ConsoleStateManager::EntryIterator ConsoleStateManager::FindLease(_In_ const GUID& LeaseId)
+{
+    return std::find_if(
+        m_entries.begin(), m_entries.end(), [&](const auto& entry) { return entry.second.Leases.contains(LeaseId); });
+}
+
+ULONG ConsoleStateManager::GetConhostServerId(_In_ HANDLE ConsoleHandle)
+{
+    IO_STATUS_BLOCK ioStatus{};
+    HANDLE serverPid{};
+
+    // The IOCTL requires a handle-sized output buffer, but returns a process identifier.
+    THROW_IF_NTSTATUS_FAILED(NtDeviceIoControlFile(
+        ConsoleHandle, nullptr, nullptr, nullptr, &ioStatus, IOCTL_CONDRV_GET_SERVER_PID, nullptr, 0, &serverPid, sizeof(serverPid)));
+
+    return HandleToUlong(serverPid);
+}
+
+void ConsoleStateManager::GetConsoleInfo(_In_ HANDLE ConsoleHandle, _Out_ ULONG& ConsoleId, _Out_ wil::unique_handle& ConhostHandle)
+{
+    THROW_HR_IF(E_INVALIDARG, !ConsoleHandle || (ConsoleHandle == INVALID_HANDLE_VALUE));
+
+    FILE_FS_DEVICE_INFORMATION deviceInformation{};
+    IO_STATUS_BLOCK ioStatus{};
+    THROW_IF_NTSTATUS_FAILED(
+        NtQueryVolumeInformationFile(ConsoleHandle, &ioStatus, &deviceInformation, sizeof(deviceInformation), FileFsDeviceInformation));
+    THROW_HR_IF(E_INVALIDARG, deviceInformation.DeviceType != FILE_DEVICE_CONSOLE);
+
+    ConsoleId = GetConhostServerId(ConsoleHandle);
+    ConhostHandle.reset(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, ConsoleId));
+    THROW_LAST_ERROR_IF(!ConhostHandle);
+
+    // Validate the identifier after opening the process to close the PID-reuse window.
+    THROW_HR_IF(E_UNEXPECTED, ConsoleId != GetConhostServerId(ConsoleHandle));
+    WI_ASSERT(ConsoleId != 0);
+}

--- a/src/windows/service/exe/ConsoleStateManager.h
+++ b/src/windows/service/exe/ConsoleStateManager.h
@@ -1,0 +1,58 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    ConsoleStateManager.h
+
+Abstract:
+
+    This file contains declarations for coordinating console state leases.
+
+--*/
+
+#pragma once
+
+#include <condition_variable>
+#include <set>
+
+class ConsoleStateManager
+{
+public:
+    void Acquire(_In_ HANDLE ConsoleHandle, _Out_ GUID& LeaseId, _Out_ bool& Initialize, _Out_ LXSS_CONSOLE_STATE& ConfiguredState);
+    void Commit(_In_ const GUID& LeaseId, _In_ const LXSS_CONSOLE_STATE& BaselineState, _In_ const LXSS_CONSOLE_STATE& ConfiguredState);
+    bool Release(_In_ const GUID& LeaseId, _Out_ LXSS_CONSOLE_STATE& BaselineState, _Out_ LXSS_CONSOLE_STATE& ConfiguredState);
+    void Complete(_In_ const GUID& LeaseId);
+
+    static void GetConsoleInfo(_In_ HANDLE ConsoleHandle, _Out_ ULONG& ConsoleId, _Out_ wil::unique_handle& ConhostHandle);
+
+private:
+    enum class State
+    {
+        Initializing,
+        Active,
+        Restoring
+    };
+
+    struct Entry
+    {
+        wil::unique_handle ConhostHandle;
+        State CurrentState{State::Initializing};
+        std::set<GUID, wsl::windows::common::helpers::GuidLess> Leases;
+        GUID Restorer{};
+        LXSS_CONSOLE_STATE BaselineState{};
+        LXSS_CONSOLE_STATE ConfiguredState{};
+    };
+
+    using EntryIterator = std::map<ULONG, Entry>::iterator;
+
+    _Requires_lock_held_(m_lock)
+    EntryIterator FindLease(_In_ const GUID& LeaseId);
+
+    static ULONG GetConhostServerId(_In_ HANDLE ConsoleHandle);
+
+    std::mutex m_lock;
+    std::condition_variable m_stateChanged;
+    _Guarded_by_(m_lock) std::map<ULONG, Entry> m_entries;
+};

--- a/src/windows/service/exe/LxssConsoleManager.cpp
+++ b/src/windows/service/exe/LxssConsoleManager.cpp
@@ -129,22 +129,6 @@ void ConsoleManager::_UnregisterProcess(_In_ const wil::unique_handle& ConsoleHa
     }
 }
 
-ULONG ConsoleManager::s_GetConhostServerId(_In_ HANDLE ConsoleHandle)
-{
-    IO_STATUS_BLOCK IoStatus;
-    HANDLE ServerPid;
-
-    //
-    // N.B.: The ioctl for getting server pid requires a handle as its buffer,
-    //       but it isn't really a handle but a process id.
-    //
-
-    THROW_IF_NTSTATUS_FAILED(NtDeviceIoControlFile(
-        ConsoleHandle, NULL, NULL, NULL, &IoStatus, IOCTL_CONDRV_GET_SERVER_PID, NULL, 0, &ServerPid, sizeof(ServerPid)));
-
-    return HandleToUlong(ServerPid);
-}
-
 void ConsoleManager::_OnProcessDisconnect(_In_ ULONG ConsoleId, _In_ bool Elevated)
 {
     wil::unique_handle firstClient;
@@ -171,48 +155,14 @@ void ConsoleManager::_OnProcessDisconnect(_In_ ULONG ConsoleId, _In_ bool Elevat
 
 void ConsoleManager::_GetConsoleInfo(_In_ const wil::unique_handle& ConsoleHandle, _Out_ ULONG& ConsoleId, _Out_ wil::unique_handle& ConhostHandle)
 {
-    FILE_FS_DEVICE_INFORMATION FsDeviceInformation;
-    IO_STATUS_BLOCK IoStatus;
-
-    //
-    // If no console handle was provided, use zero as the identifier.
-    //
-
+    // A missing console uses a shared identifier for the legacy session-leader path.
     if (!ConsoleHandle)
     {
         ConsoleId = 0;
         return;
     }
 
-    THROW_IF_NTSTATUS_FAILED(NtQueryVolumeInformationFile(
-        ConsoleHandle.get(), &IoStatus, &FsDeviceInformation, sizeof(FsDeviceInformation), FileFsDeviceInformation));
-
-    if (FsDeviceInformation.DeviceType != FILE_DEVICE_CONSOLE)
-    {
-        THROW_HR(E_UNEXPECTED);
-    }
-
-    ConsoleId = s_GetConhostServerId(ConsoleHandle.get());
-
-    //
-    // Open the conhost console process so it doesn't get closed and recycled while the process is
-    // running.
-    //
-
-    ConhostHandle.reset(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, ConsoleId));
-    THROW_LAST_ERROR_IF(!ConhostHandle);
-
-    //
-    // The conhost id needs to be queried again since it could get recycled between
-    // the query and the open.
-    //
-
-    if (ConsoleId != s_GetConhostServerId(ConsoleHandle.get()))
-    {
-        THROW_HR(E_UNEXPECTED);
-    }
-
-    WI_ASSERT(ConsoleId != 0);
+    ConsoleStateManager::GetConsoleInfo(ConsoleHandle.get(), ConsoleId, ConhostHandle);
 }
 
 bool ConsoleManager::s_OnProcessTerminated(_In_ ConsoleManager* Self, _In_ ULONG ConsoleId, _In_ bool Elevated)

--- a/src/windows/service/exe/LxssConsoleManager.h
+++ b/src/windows/service/exe/LxssConsoleManager.h
@@ -16,6 +16,7 @@ Abstract:
 #include "precomp.h"
 #include "LxssCreateProcess.h"
 #include "Lifetime.h"
+#include "ConsoleStateManager.h"
 
 class ConsoleManager : public std::enable_shared_from_this<ConsoleManager>
 {
@@ -64,8 +65,6 @@ private:
     void _OnProcessDisconnect(_In_ ULONG ConsoleId, _In_ bool Elevated);
 
     static void _GetConsoleInfo(_In_ const wil::unique_handle& ConsoleHandle, _Out_ ULONG& ConsoleId, _Out_ wil::unique_handle& ConhostHandle);
-
-    static ULONG s_GetConhostServerId(_In_ HANDLE ConsoleHandle);
 
     std::mutex m_mappingListLock;
 

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -53,6 +53,60 @@ LxssUserSession::LxssUserSession(_In_ const std::weak_ptr<LxssUserSessionImpl>& 
     return;
 }
 
+HRESULT STDMETHODCALLTYPE LxssUserSession::AcquireConsoleStateLease(
+    _In_ ULONG ConsoleHandle, _Out_ GUID* LeaseId, _Out_ BOOLEAN* Initialize, _Out_ LXSS_CONSOLE_STATE* ConfiguredState)
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !ConsoleHandle || !LeaseId || !Initialize || !ConfiguredState);
+    const auto session = m_session.lock();
+    RETURN_HR_IF(RPC_E_DISCONNECTED, !session);
+
+    wil::unique_handle consoleHandle{wsl::windows::common::wslutil::DuplicateHandleFromCallingProcess(ULongToHandle(ConsoleHandle))};
+    bool initialize{};
+    session->AcquireConsoleStateLease(consoleHandle.get(), *LeaseId, initialize, *ConfiguredState);
+    *Initialize = initialize;
+    return S_OK;
+}
+CATCH_RETURN()
+
+HRESULT STDMETHODCALLTYPE LxssUserSession::CommitConsoleStateLease(
+    _In_ LPCGUID LeaseId, _In_ const LXSS_CONSOLE_STATE* BaselineState, _In_ const LXSS_CONSOLE_STATE* ConfiguredState)
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !LeaseId || !BaselineState || !ConfiguredState);
+    const auto session = m_session.lock();
+    RETURN_HR_IF(RPC_E_DISCONNECTED, !session);
+
+    session->CommitConsoleStateLease(*LeaseId, *BaselineState, *ConfiguredState);
+    return S_OK;
+}
+CATCH_RETURN()
+
+HRESULT STDMETHODCALLTYPE LxssUserSession::ReleaseConsoleStateLease(
+    _In_ LPCGUID LeaseId, _Out_ BOOLEAN* Restore, _Out_ LXSS_CONSOLE_STATE* BaselineState, _Out_ LXSS_CONSOLE_STATE* ConfiguredState)
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !LeaseId || !Restore || !BaselineState || !ConfiguredState);
+    const auto session = m_session.lock();
+    RETURN_HR_IF(RPC_E_DISCONNECTED, !session);
+
+    *Restore = session->ReleaseConsoleStateLease(*LeaseId, *BaselineState, *ConfiguredState);
+    return S_OK;
+}
+CATCH_RETURN()
+
+HRESULT STDMETHODCALLTYPE LxssUserSession::CompleteConsoleStateLease(_In_ LPCGUID LeaseId)
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !LeaseId);
+    const auto session = m_session.lock();
+    RETURN_HR_IF(RPC_E_DISCONNECTED, !session);
+
+    session->CompleteConsoleStateLease(*LeaseId);
+    return S_OK;
+}
+CATCH_RETURN()
+
 HRESULT STDMETHODCALLTYPE LxssUserSession::ConfigureDistribution(_In_opt_ LPCGUID DistroGuid, _In_ ULONG DefaultUid, _In_ ULONG Flags, _Out_ LXSS_ERROR_INFO* Error)
 try
 {
@@ -676,6 +730,29 @@ LxssUserSessionImpl::~LxssUserSessionImpl()
 
     // Ensure that if there are no running instances.
     WI_ASSERT(m_runningInstances.empty());
+}
+
+void LxssUserSessionImpl::AcquireConsoleStateLease(
+    _In_ HANDLE ConsoleHandle, _Out_ GUID& LeaseId, _Out_ bool& Initialize, _Out_ LXSS_CONSOLE_STATE& ConfiguredState)
+{
+    m_consoleStateManager.Acquire(ConsoleHandle, LeaseId, Initialize, ConfiguredState);
+}
+
+void LxssUserSessionImpl::CommitConsoleStateLease(
+    _In_ const GUID& LeaseId, _In_ const LXSS_CONSOLE_STATE& BaselineState, _In_ const LXSS_CONSOLE_STATE& ConfiguredState)
+{
+    m_consoleStateManager.Commit(LeaseId, BaselineState, ConfiguredState);
+}
+
+bool LxssUserSessionImpl::ReleaseConsoleStateLease(
+    _In_ const GUID& LeaseId, _Out_ LXSS_CONSOLE_STATE& BaselineState, _Out_ LXSS_CONSOLE_STATE& ConfiguredState)
+{
+    return m_consoleStateManager.Release(LeaseId, BaselineState, ConfiguredState);
+}
+
+void LxssUserSessionImpl::CompleteConsoleStateLease(_In_ const GUID& LeaseId)
+{
+    m_consoleStateManager.Complete(LeaseId);
 }
 
 HRESULT LxssUserSessionImpl::AttachDisk(_In_ LPCWSTR Disk, _In_ ULONG Flags)

--- a/src/windows/service/exe/LxssUserSession.h
+++ b/src/windows/service/exe/LxssUserSession.h
@@ -23,6 +23,7 @@ Abstract:
 #include "PluginManager.h"
 #include "Lifetime.h"
 #include "DistributionRegistration.h"
+#include "ConsoleStateManager.h"
 
 #define WSL_NEW_DISTRO_LXFS L"NewDistributionLxFs"
 #define WSL_DISTRO_CONFIG_DEFAULT_UID L"DefaultUid"
@@ -72,6 +73,12 @@ public:
     LxssUserSession(_In_ const std::weak_ptr<LxssUserSessionImpl>& Session);
     LxssUserSession(const LxssUserSession&) = delete;
     LxssUserSession& operator=(const LxssUserSession&) = delete;
+
+    IFACEMETHOD(AcquireConsoleStateLease)(_In_ ULONG ConsoleHandle, _Out_ GUID* LeaseId, _Out_ BOOLEAN* Initialize, _Out_ LXSS_CONSOLE_STATE* ConfiguredState) override;
+    IFACEMETHOD(CommitConsoleStateLease)(_In_ LPCGUID LeaseId, _In_ const LXSS_CONSOLE_STATE* BaselineState, _In_ const LXSS_CONSOLE_STATE* ConfiguredState) override;
+    IFACEMETHOD(ReleaseConsoleStateLease)(
+        _In_ LPCGUID LeaseId, _Out_ BOOLEAN* Restore, _Out_ LXSS_CONSOLE_STATE* BaselineState, _Out_ LXSS_CONSOLE_STATE* ConfiguredState) override;
+    IFACEMETHOD(CompleteConsoleStateLease)(_In_ LPCGUID LeaseId) override;
 
     /// <summary>
     /// Configures a distribution.
@@ -315,6 +322,11 @@ public:
     virtual ~LxssUserSessionImpl();
     LxssUserSessionImpl(const LxssUserSessionImpl&) = delete;
     LxssUserSessionImpl& operator=(const LxssUserSessionImpl&) = delete;
+
+    void AcquireConsoleStateLease(_In_ HANDLE ConsoleHandle, _Out_ GUID& LeaseId, _Out_ bool& Initialize, _Out_ LXSS_CONSOLE_STATE& ConfiguredState);
+    void CommitConsoleStateLease(_In_ const GUID& LeaseId, _In_ const LXSS_CONSOLE_STATE& BaselineState, _In_ const LXSS_CONSOLE_STATE& ConfiguredState);
+    bool ReleaseConsoleStateLease(_In_ const GUID& LeaseId, _Out_ LXSS_CONSOLE_STATE& BaselineState, _Out_ LXSS_CONSOLE_STATE& ConfiguredState);
+    void CompleteConsoleStateLease(_In_ const GUID& LeaseId);
 
     /// <summary>
     /// Configures a distribution.
@@ -787,6 +799,8 @@ private:
     static VOID CALLBACK s_VmIdleTerminate(_Inout_ PTP_CALLBACK_INSTANCE, _Inout_opt_ PVOID Context, _Inout_ PTP_TIMER Timer);
 
     static LRESULT CALLBACK s_TimezoneWindowProc(HWND windowHandle, UINT messageCode, WPARAM wParameter, LPARAM lParameter);
+
+    ConsoleStateManager m_consoleStateManager;
 
     /// <summary>
     /// Lock for protecting various lists.

--- a/src/windows/service/inc/wslservice.idl
+++ b/src/windows/service/inc/wslservice.idl
@@ -91,6 +91,20 @@ struct _LXSS_ERROR_INFO {
     ULONG WarningsPipe;
 } LXSS_ERROR_INFO, *PLXSS_ERROR_INFO;
 
+cpp_quote("#define LXSS_CONSOLE_STATE_INPUT_MODE 0x1")
+cpp_quote("#define LXSS_CONSOLE_STATE_INPUT_CODE_PAGE 0x2")
+cpp_quote("#define LXSS_CONSOLE_STATE_OUTPUT_MODE 0x4")
+cpp_quote("#define LXSS_CONSOLE_STATE_OUTPUT_CODE_PAGE 0x8")
+
+typedef
+struct _LXSS_CONSOLE_STATE {
+    ULONG Flags;
+    ULONG InputMode;
+    ULONG InputCodePage;
+    ULONG OutputMode;
+    ULONG OutputCodePage;
+} LXSS_CONSOLE_STATE, *PLXSS_CONSOLE_STATE;
+
 cpp_quote("#define LXSS_DISTRO_VERSION_LEGACY 0")
 cpp_quote("#define LXSS_DISTRO_VERSION_1 1")
 cpp_quote("#define LXSS_DISTRO_VERSION_2 2")
@@ -344,8 +358,28 @@ interface ILxssUserSession : IUnknown
 
     HRESULT MoveDistribution(
         [in] LPCGUID DistroGuid,
-        [in] LPCWSTR DistributionName, 
+        [in] LPCWSTR DistributionName,
         [ in, out ] LXSS_ERROR_INFO * Error);
+
+    HRESULT AcquireConsoleStateLease(
+        [in] ULONG ConsoleHandle,
+        [out] GUID* LeaseId,
+        [out] BOOLEAN* Initialize,
+        [out] LXSS_CONSOLE_STATE* ConfiguredState);
+
+    HRESULT CommitConsoleStateLease(
+        [in] LPCGUID LeaseId,
+        [in] const LXSS_CONSOLE_STATE* BaselineState,
+        [in] const LXSS_CONSOLE_STATE* ConfiguredState);
+
+    HRESULT ReleaseConsoleStateLease(
+        [in] LPCGUID LeaseId,
+        [out] BOOLEAN* Restore,
+        [out] LXSS_CONSOLE_STATE* BaselineState,
+        [out] LXSS_CONSOLE_STATE* ConfiguredState);
+
+    HRESULT CompleteConsoleStateLease(
+        [in] LPCGUID LeaseId);
 };
 
 

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -217,20 +217,54 @@ class SimpleTests
         }
     }
 
+    struct ConsoleSnapshot
+    {
+        DWORD InputMode;
+        UINT InputCodePage;
+        DWORD OutputMode;
+        UINT OutputCodePage;
+    };
+
+    static ConsoleSnapshot GetConsoleSnapshot(HANDLE conin, HANDLE conout)
+    {
+        ConsoleSnapshot state{};
+        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin, &state.InputMode));
+        state.InputCodePage = GetConsoleCP();
+        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conout, &state.OutputMode));
+        state.OutputCodePage = GetConsoleOutputCP();
+        return state;
+    }
+
+    static void SetConsoleSnapshot(HANDLE conin, HANDLE conout, const ConsoleSnapshot& state)
+    {
+        LOG_LAST_ERROR_IF(!SetConsoleCP(state.InputCodePage));
+        LOG_LAST_ERROR_IF(!SetConsoleMode(conin, state.InputMode));
+        LOG_LAST_ERROR_IF(!SetConsoleOutputCP(state.OutputCodePage));
+        LOG_LAST_ERROR_IF(!SetConsoleMode(conout, state.OutputMode));
+    }
+
+    static void VerifyConsoleSnapshot(const ConsoleSnapshot& expected, const ConsoleSnapshot& actual)
+    {
+        VERIFY_ARE_EQUAL(expected.InputMode, actual.InputMode);
+        VERIFY_ARE_EQUAL(expected.InputCodePage, actual.InputCodePage);
+        VERIFY_ARE_EQUAL(expected.OutputMode, actual.OutputMode);
+        VERIFY_ARE_EQUAL(expected.OutputCodePage, actual.OutputCodePage);
+    }
+
     TEST_METHOD(ConsoleState_WslProcesses_SharedConsole_OutOfOrderRestore)
     {
         wil::unique_hfile conin{CreateFileW(
             L"CONIN$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr)};
-        if (!conin)
+        wil::unique_hfile conout{CreateFileW(
+            L"CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr)};
+        if (!conin || !conout)
         {
-            LogSkipped("Skipping ConsoleState WSL process test: CONIN$ is not available (no attached console)");
+            LogSkipped("Skipping ConsoleState WSL process test: console handles are not available");
             return;
         }
 
-        DWORD baseline{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &baseline));
-        const DWORD scopeExitRestore = baseline;
-        auto restoreBaseline = wil::scope_exit([&] { ::SetConsoleMode(conin.get(), scopeExitRestore); });
+        const auto baseline = GetConsoleSnapshot(conin.get(), conout.get());
+        auto restoreBaseline = wil::scope_exit([&] { SetConsoleSnapshot(conin.get(), conout.get(), baseline); });
 
         auto [aOutRead, aOutWrite] = CreateSubprocessPipe(false, true);
         auto [aInRead, aInWrite] = CreateSubprocessPipe(true, false);
@@ -241,10 +275,7 @@ class SimpleTests
 
         PartialHandleRead outputA(aOutRead.get());
         outputA.Expect("ready");
-
-        DWORD configured{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &configured));
-        VERIFY_ARE_NOT_EQUAL(baseline, configured);
+        const auto configured = GetConsoleSnapshot(conin.get(), conout.get());
 
         auto [bOutRead, bOutWrite] = CreateSubprocessPipe(false, true);
         auto [bInRead, bInWrite] = CreateSubprocessPipe(true, false);
@@ -255,6 +286,7 @@ class SimpleTests
 
         PartialHandleRead outputB(bOutRead.get());
         outputB.Expect("ready");
+        VerifyConsoleSnapshot(configured, GetConsoleSnapshot(conin.get(), conout.get()));
 
         SignalControllableProcessExit(aInWrite);
         VERIFY_ARE_EQUAL(0u, WaitForProcessExit(processA.get(), 15000));
@@ -263,20 +295,11 @@ class SimpleTests
             static_cast<DWORD>(WAIT_TIMEOUT),
             WaitForSingleObject(processB.get(), 0),
             L"Process B must still be alive when process A exits for out-of-order restore coverage");
-
-        DWORD afterA{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &afterA));
-        VERIFY_IS_TRUE(
-            (afterA == baseline) || (afterA == configured),
-            L"Out-of-order process teardown may restore baseline early; "
-            L"only the final mode after all clients exit is guaranteed");
+        VerifyConsoleSnapshot(configured, GetConsoleSnapshot(conin.get(), conout.get()));
 
         SignalControllableProcessExit(bInWrite);
         VERIFY_ARE_EQUAL(0u, WaitForProcessExit(processB.get(), 15000));
-
-        DWORD finalMode{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &finalMode));
-        VERIFY_ARE_EQUAL(baseline, finalMode);
+        VerifyConsoleSnapshot(baseline, GetConsoleSnapshot(conin.get(), conout.get()));
     }
 
     TEST_METHOD(ConsoleState_WslProcesses_SeparateConsoles_Isolation)

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -7565,6 +7565,40 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         }
     }
 
+    struct ConsoleSnapshot
+    {
+        DWORD InputMode;
+        UINT InputCodePage;
+        DWORD OutputMode;
+        UINT OutputCodePage;
+    };
+
+    static ConsoleSnapshot GetConsoleSnapshot(HANDLE conin, HANDLE conout)
+    {
+        ConsoleSnapshot state{};
+        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin, &state.InputMode));
+        state.InputCodePage = GetConsoleCP();
+        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conout, &state.OutputMode));
+        state.OutputCodePage = GetConsoleOutputCP();
+        return state;
+    }
+
+    static void SetConsoleSnapshot(HANDLE conin, HANDLE conout, const ConsoleSnapshot& state)
+    {
+        LOG_LAST_ERROR_IF(!SetConsoleCP(state.InputCodePage));
+        LOG_LAST_ERROR_IF(!SetConsoleMode(conin, state.InputMode));
+        LOG_LAST_ERROR_IF(!SetConsoleOutputCP(state.OutputCodePage));
+        LOG_LAST_ERROR_IF(!SetConsoleMode(conout, state.OutputMode));
+    }
+
+    static void VerifyConsoleSnapshot(const ConsoleSnapshot& expected, const ConsoleSnapshot& actual)
+    {
+        VERIFY_ARE_EQUAL(expected.InputMode, actual.InputMode);
+        VERIFY_ARE_EQUAL(expected.InputCodePage, actual.InputCodePage);
+        VERIFY_ARE_EQUAL(expected.OutputMode, actual.OutputMode);
+        VERIFY_ARE_EQUAL(expected.OutputCodePage, actual.OutputCodePage);
+    }
+
     static std::optional<DWORD> TrySetDifferentValidInputMode(HANDLE conin, DWORD currentMode)
     {
         const std::array<DWORD, 4> candidates = {
@@ -7675,42 +7709,31 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
     {
         wil::unique_hfile conin{CreateFileW(
             L"CONIN$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr)};
-        if (!conin)
+        wil::unique_hfile conout{CreateFileW(
+            L"CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr)};
+        if (!conin || !conout)
         {
-            LogSkipped("Skipping ConsoleState concurrent-client test: CONIN$ is not available (no attached console)");
+            LogSkipped("Skipping ConsoleState concurrent-client test: console handles are not available");
             return;
         }
 
-        DWORD baseline{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &baseline));
-        const DWORD scopeExitRestore = baseline;
-        auto restoreBaseline = wil::scope_exit([&] { ::SetConsoleMode(conin.get(), scopeExitRestore); });
+        const auto baseline = GetConsoleSnapshot(conin.get(), conout.get());
+        auto restoreBaseline = wil::scope_exit([&] { SetConsoleSnapshot(conin.get(), conout.get(), baseline); });
+        wsl::windows::common::SvcComm service;
 
-        auto first = std::make_unique<wsl::windows::common::ConsoleState>(wsl::windows::common::RestorePolicy::OnlyIfUnchanged);
+        auto first = std::make_unique<wsl::windows::common::ConsoleState>(wsl::windows::common::RestorePolicy::OnlyIfUnchanged, &service);
         first->SetInteractiveMode();
+        const auto configured = GetConsoleSnapshot(conin.get(), conout.get());
 
-        DWORD configured{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &configured));
-
-        auto second = std::make_unique<wsl::windows::common::ConsoleState>(wsl::windows::common::RestorePolicy::OnlyIfUnchanged);
+        auto second = std::make_unique<wsl::windows::common::ConsoleState>(wsl::windows::common::RestorePolicy::OnlyIfUnchanged, &service);
         second->SetInteractiveMode();
+        VerifyConsoleSnapshot(configured, GetConsoleSnapshot(conin.get(), conout.get()));
 
         first.reset();
-
-        DWORD afterFirstExit{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &afterFirstExit));
-        VERIFY_IS_TRUE(
-            (afterFirstExit == baseline) || (afterFirstExit == configured),
-            L"Out-of-order teardown may restore baseline early; only the final mode after all clients exit is guaranteed");
+        VerifyConsoleSnapshot(configured, GetConsoleSnapshot(conin.get(), conout.get()));
 
         second.reset();
-
-        DWORD finalMode{};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(conin.get(), &finalMode));
-        VERIFY_ARE_EQUAL(
-            baseline,
-            finalMode,
-            L"RestorePolicy::OnlyIfUnchanged must leave the final mode at the original baseline after out-of-order teardown");
+        VerifyConsoleSnapshot(baseline, GetConsoleSnapshot(conin.get(), conout.get()));
     }
 
     TEST_METHOD(DownloadToHiddenSystemTempFolder)


### PR DESCRIPTION
## Summary

- coordinate console-state ownership across overlapping WSL clients attached to the same console
- keep the configured mode active until the last client exits
- conditionally restore the original input/output modes and code pages without overwriting external changes
- add unit and process-level coverage for out-of-order client teardown

## Context

This is a follow-up to #41209 and addresses the overlapping-client intermediate-state concern raised in the review discussion. It is intentionally stacked on commit `0cd50878` from that PR so the diff contains only the coordination layer.

## Validation

- built Debug `msixinstallerpackage` and `wsltests`
- focused concurrent-client unit test: passed
- real two-process shared-console test: passed
- all `*ConsoleState*` tests: 5/5 passed
- repeated the overlap scenario in the active Claude Code console: passed twice
- `git diff --check`: passed

Crash and `TerminateProcess` recovery remain outside this change's scope; this coordinates normal cooperative client teardown.