### PR TITLE
Add timeout to create process accepts

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -1478,7 +1478,7 @@ Return Value:
 
     for (auto& Socket : Sockets)
     {
-        Socket.reset(UtilAcceptVsock(ListenSocket, SocketAddress));
+        Socket.reset(UtilAcceptVsock(ListenSocket, SocketAddress, SESSION_LEADER_ACCEPT_TIMEOUT_MS));
         if (Socket.get() < 0)
         {
             Result = -1;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When creating a process, if the Windows side fails to create all 5/6 connections, the Linux side will block forever at accept. This leaks relay processes and hv socket connections.

This PR applies a 30s timeout to the accept calls to allow the process to exit on potential failure.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/41242
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested by injecting a failure after the first connect call:
<img width="1452" height="333" alt="image" src="https://github.com/user-attachments/assets/a73ee420-c808-474c-8ca4-1dc49953bd23" />
Before the fix, the leaked processes live forever. After the fix, those processes exit after 30 seconds.