### PR TITLE
wslc: Run saved state cleanup as user

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -391,6 +391,7 @@ HcsVirtualMachine::~HcsVirtualMachine()
     {
         try
         {
+            auto runAsUser = wil::impersonate_token(m_userToken.get());
             WI_ASSERT(std::filesystem::is_empty(m_vmSavedStateFile));
             std::filesystem::remove(m_vmSavedStateFile);
         }


### PR DESCRIPTION
## Summary of the Pull Request

Runs VM saved-state file cleanup under the owning user's token, matching the context used when the file is created and accessed elsewhere.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

The saved-state path is created while running as the owning user. This change applies the same user context when checking and removing that file during VM teardown.

## Validation Steps Performed

- Built the full project with `cmake --build . -- -m`.