### PR TITLE
Bind KdRelay to loopback

### DIFF
--- a/src/windows/wslrelay/main.cpp
+++ b/src/windows/wslrelay/main.cpp
@@ -118,7 +118,7 @@ try
         sockaddr_in address{};
         address.sin_family = AF_INET;
         address.sin_port = htons(port);
-        address.sin_addr.s_addr = htonl(INADDR_ANY);
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
         THROW_LAST_ERROR_IF(bind(listenSocket.get(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) == SOCKET_ERROR);
 
         THROW_LAST_ERROR_IF(listen(listenSocket.get(), 1) == SOCKET_ERROR);


### PR DESCRIPTION
Restrict the KdRelay listener to local connections by binding to the loopback address instead of the wildcard address.