### PR TITLE
Fix force shutdown deadlock race

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2213,7 +2213,7 @@ HRESULT LxssUserSessionImpl::Shutdown(_In_ bool PreventNewInstances, ShutdownBeh
 
             // Terminate the utility VM.
             _VmTerminate();
-            m_suppressVmTerminationCallback.store(false);
+            resetVmTerminationCallback.reset();
 
             // Reset the proxy state.
             // We don't clear it in _VMTerminate because we want to cache results if possible.

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -2152,11 +2152,15 @@ HRESULT LxssUserSessionImpl::Shutdown(_In_ bool PreventNewInstances, ShutdownBeh
 {
     try
     {
+        auto resetVmTerminationCallback = wil::scope_exit([&]() { m_suppressVmTerminationCallback.store(false); });
+
         auto forceTerminate = [this]() {
             auto vmId = m_vmId.load();
             if (!IsEqualGUID(vmId, GUID_NULL))
             {
                 auto vmIdStr = wsl::shared::string::GuidToString<wchar_t>(vmId, wsl::shared::string::GuidToStringFlags::Uppercase);
+
+                m_suppressVmTerminationCallback.store(true);
 
                 auto result = wil::ResultFromException([&]() {
                     auto computeSystem = wsl::windows::common::hcs::OpenComputeSystem(vmIdStr.c_str(), GENERIC_ALL);
@@ -2209,6 +2213,7 @@ HRESULT LxssUserSessionImpl::Shutdown(_In_ bool PreventNewInstances, ShutdownBeh
 
             // Terminate the utility VM.
             _VmTerminate();
+            m_suppressVmTerminationCallback.store(false);
 
             // Reset the proxy state.
             // We don't clear it in _VMTerminate because we want to cache results if possible.
@@ -4235,6 +4240,11 @@ void LxssUserSessionImpl::s_VmTerminated(_Inout_ LxssUserSessionImpl* UserSessio
 try
 {
     UNREFERENCED_PARAMETER(VmId);
+
+    if (UserSession->m_suppressVmTerminationCallback.load())
+    {
+        return;
+    }
 
     UserSession->TerminateByClientId(LXSS_CLIENT_ID_WILDCARD);
     return;

--- a/src/windows/service/exe/LxssUserSession.h
+++ b/src/windows/service/exe/LxssUserSession.h
@@ -817,6 +817,11 @@ private:
     std::atomic<GUID> m_vmId{GUID_NULL};
 
     /// <summary>
+    /// True when the VM termination callback should not perform session cleanup.
+    /// </summary>
+    std::atomic<bool> m_suppressVmTerminationCallback{false};
+
+    /// <summary>
     /// Contains the user sid for the session.
     /// </summary>
     SE_SID m_userSid;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

During force shutdown, the shutdown is called before the WslCoreVm destructor clears the m_onExit callback. The shutdown operation will trigger the HCS OnExit callback. If that callback is triggered before the m_onExit callback is cleared, the m_onExit callback still gets called. Then it waits for the m_instanceLock which is already locked by the shutdown call. Meanwhile the shutdown call will wait for the HCS OnExit callback to return in _VmTerminate via the HcsCloseComputeSystem call. Which creates a deadlock and blocks the wsl service.

This PR adds an atomic flag to disable the caller provided callback.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

The original issue was confirmed with a local repro and a dump. Since this involves a race condition, it's not suitable as a e2e regression test.

The fix is validated with local pressure test:
Before the fix: deadlock 15/20
After the fix: deadlock: 0/20
