### PR TITLE
Normalize NULL char* to <null> in Linux logging

### DIFF
--- a/src/linux/init/common.h
+++ b/src/linux/init/common.h
@@ -45,6 +45,7 @@ Abstract:
 #include <poll.h>
 #include <utility>
 #include <format>
+#include <type_traits>
 #include <new>
 #include <thread>
 #include <vector>
@@ -98,10 +99,28 @@ extern struct sigaction g_SavedSignalActions[_NSIG];
         } \
     }
 
+template <typename T>
+T&& NormalizeLogArgument(T&& Argument)
+{
+    using ArgumentType = std::remove_cv_t<std::remove_reference_t<T>>;
+
+    if constexpr (std::is_same_v<ArgumentType, char*> || std::is_same_v<ArgumentType, const char*>)
+    {
+        if (Argument == nullptr)
+        {
+            static char NullString[] = "<null>";
+            static ArgumentType NullArgument = NullString;
+            return static_cast<T&&>(NullArgument);
+        }
+    }
+
+    return std::forward<T>(Argument);
+}
+
 template <typename... Args>
 auto LogImpl(int fd, const std::format_string<Args...>& format, Args&&... args)
 {
-    auto logline = std::format(format, std::forward<Args>(args)...);
+    auto logline = std::format(format, NormalizeLogArgument(std::forward<Args>(args))...);
     if (logline.empty())
     {
         return;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The Linux logging uses std::format to construct the log string. And std::format expects valid C strings for char* / const char* types. There is one confirmed instance of passing NULL to the log macros in WSL:
When mounting modules.vhd and system.vhd. The options paramter is NULL. If the mount fails, it's passed directly to the log macro. Which could result in a segfault.

This PR normalizes all NULL char* / const char* to "<null>" in the log implementation to avoid passing NULL to std::format.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested locally by adding temporary log NULL code. 
Before the fix:
```
> wsl
Operation aborted
Error code: Wsl/Service/CreateInstance/CreateVm/E_ABORT
```
After the fix:
In dmesg:
```
[    0.331626] WSL (1 - ): NULL_LOG_TEST: value=<null>
```