### PR TITLE
Retry distro file deletion under ACCESS_DENIED during distro unregistration

### DIFF
--- a/src/shared/inc/retryshared.h
+++ b/src/shared/inc/retryshared.h
@@ -40,4 +40,19 @@ T RetryWithTimeout(const std::function<T()>& routine, TPeriod retryPeriod, TTime
     }
 }
 
+#ifdef WIN32
+
+template <typename T, typename TPeriod, typename TTimeout>
+T RetryWithTimeout(const std::function<T()>& routine, TPeriod retryPeriod, TTimeout timeout, std::vector<HRESULT>&& retryErrors)
+{
+    auto pred = [retryErrors = std::move(retryErrors)]() {
+        auto hr = HRESULT_FROM_WIN32(GetLastError());
+        return std::find(retryErrors.begin(), retryErrors.end(), hr) != retryErrors.end();
+    };
+
+    return RetryWithTimeout(routine, retryPeriod, timeout, pred);
+}
+
+#endif
+
 } // namespace wsl::shared::retry

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -3040,7 +3040,7 @@ void LxssUserSessionImpl::_DeleteDistributionLockHeld(_In_ const LXSS_DISTRO_CON
                         [&]() { THROW_IF_WIN32_BOOL_FALSE(DeleteFileW(Configuration.VhdFilePath.c_str())); },
                         std::chrono::milliseconds(100),
                         std::chrono::seconds(10),
-                        []() { return wil::ResultFromCaughtException() == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION); });
+                        {HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION), HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED)});
                 }
                 CATCH_LOG_MSG("Failed to delete %ls", Configuration.VhdFilePath.c_str())
             }
@@ -3066,7 +3066,7 @@ void LxssUserSessionImpl::_DeleteDistributionLockHeld(_In_ const LXSS_DISTRO_CON
                     [&]() { THROW_IF_WIN32_BOOL_FALSE(DeleteFileW(Configuration.ShortcutPath->c_str())); },
                     std::chrono::milliseconds(100),
                     std::chrono::seconds(10),
-                    []() { return wil::ResultFromCaughtException() == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION); });
+                    {HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION), HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED)});
             }
             CATCH_LOG_MSG("Failed to delete %ls", Configuration.ShortcutPath->c_str())
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We've seen a test failure where we failed to delete the distro shortcut with ACCESS_DENIED. This change updates the deletion logic to retry under that error code as well

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
