### PR TITLE
Fix default route classification logic

### DIFF
--- a/src/windows/common/WslCoreNetworkEndpointSettings.h
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.h
@@ -222,8 +222,8 @@ struct EndpointRoute
 
     bool IsDefault() const noexcept
     {
-        return (Family == AF_INET && DestinationPrefixString == LX_INIT_UNSPECIFIED_ADDRESS) ||
-               (Family == AF_INET6 && DestinationPrefixString == LX_INIT_UNSPECIFIED_V6_ADDRESS);
+        return DestinationPrefix.PrefixLength == 0 && ((Family == AF_INET && DestinationPrefixString == LX_INIT_UNSPECIFIED_ADDRESS) ||
+                                                       (Family == AF_INET6 && DestinationPrefixString == LX_INIT_UNSPECIFIED_V6_ADDRESS));
     }
 
     bool IsUnicastAddressRoute() const noexcept

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "Common.h"
 #include "wslpolicies.h"
 #include "hns_schema.h"
+#include "WslCoreNetworkEndpointSettings.h"
 
 #include <mstcpip.h>
 #include <winhttp.h>
@@ -294,6 +295,27 @@ class NetworkTests
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"ln -f -s /init /gns"), (DWORD)0);
 
         return true;
+    }
+
+    TEST_METHOD(DefaultRouteClassification)
+    {
+        const auto makeRoute = [](ADDRESS_FAMILY family, const wchar_t* destination, uint8_t prefixLength) {
+            MIB_IPFORWARD_ROW2 routeRow{};
+            routeRow.DestinationPrefix.Prefix = wsl::windows::common::string::StringToSockAddrInet(destination);
+            routeRow.DestinationPrefix.PrefixLength = prefixLength;
+            routeRow.NextHop.si_family = family;
+            return wsl::core::networking::EndpointRoute(routeRow);
+        };
+
+        VERIFY_IS_TRUE(makeRoute(AF_INET, L"0.0.0.0", 0).IsDefault());
+        VERIFY_IS_FALSE(makeRoute(AF_INET, L"0.0.0.0", 1).IsDefault());
+        VERIFY_IS_FALSE(makeRoute(AF_INET, L"128.0.0.0", 1).IsDefault());
+        VERIFY_IS_FALSE(makeRoute(AF_INET, L"0.0.0.0", 32).IsDefault());
+
+        VERIFY_IS_TRUE(makeRoute(AF_INET6, L"::", 0).IsDefault());
+        VERIFY_IS_FALSE(makeRoute(AF_INET6, L"::", 1).IsDefault());
+        VERIFY_IS_FALSE(makeRoute(AF_INET6, L"8000::", 1).IsDefault());
+        VERIFY_IS_FALSE(makeRoute(AF_INET6, L"::", 128).IsDefault());
     }
 
     WSL2_TEST_METHOD(RemoveAndAddDefaultRoute)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Only 0.0.0.0/0 and ::/0 should be treated as default routes. This PR adds the prefix length == 0 comparison to the condition.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/41272
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Add test:
NetworkTests::NetworkTests::DefaultRouteClassification
