### PR TITLE
CLI: Make argument validation idempotent and adjust global argument freezing

### DIFF
--- a/src/windows/wslc/arguments/ArgMap.h
+++ b/src/windows/wslc/arguments/ArgMap.h
@@ -117,6 +117,11 @@ public:
         return m_validated.count(type);
     }
 
+    bool IsValidated(ArgType type) const
+    {
+        return m_validatedTypes.count(type) != 0;
+    }
+
     // Drops `type`'s memoized validation state (converted cache and validated record) so it never
     // outlives the raw data.
     void InvalidateValidated(ArgType type)
@@ -128,6 +133,11 @@ public:
     // Records `type` as validated for its current raw values so reads skip re-validation.
     void MarkValidated(ArgType type)
     {
+        if (IsValidated(type))
+        {
+            return;
+        }
+
         ThrowIfImmutable(type, "mark the argument as validated");
         m_validatedTypes.insert(type);
     }
@@ -231,7 +241,7 @@ private:
     // demand, and its errors reported, exactly like a command-line value.
     void EnsureValidated(ArgType type)
     {
-        if (m_validatedTypes.count(type) != 0)
+        if (IsValidated(type))
         {
             return;
         }

--- a/src/windows/wslc/arguments/ArgumentValidation.cpp
+++ b/src/windows/wslc/arguments/ArgumentValidation.cpp
@@ -72,6 +72,11 @@ namespace {
 // validated on success.
 void Argument::Validate(ArgMap& execArgs) const
 {
+    if (execArgs.IsValidated(m_argType))
+    {
+        return;
+    }
+
     switch (m_argType)
     {
     case ArgType::BuildLabel:

--- a/src/windows/wslc/core/CLIExecutionContext.cpp
+++ b/src/windows/wslc/core/CLIExecutionContext.cpp
@@ -16,13 +16,11 @@ HANDLE CLIExecutionContext::CreateCancelEvent()
     return CancelEvent.get();
 }
 
-// This method should be idempotent.
-void CLIExecutionContext::ApplyGlobalOptions()
+void CLIExecutionContext::ApplyGlobalEnvironmentOptions()
 {
-    if (GlobalArgs.GetValue<ArgType::NoColor>())
-    {
-        Terminal.SetNoColor(true);
-    }
+    // NoColor is environment-only and resolved before any output. Freezing it keeps the terminal
+    // color state consistent for the entire invocation.
+    Terminal.SetNoColor(GlobalArgs.GetValue<ArgType::NoColor>());
 }
 
 } // namespace wsl::windows::wslc::execution

--- a/src/windows/wslc/core/CLIExecutionContext.h
+++ b/src/windows/wslc/core/CLIExecutionContext.h
@@ -50,9 +50,8 @@ struct CLIExecutionContext : public wsl::windows::common::ExecutionContext
 
     HANDLE CreateCancelEvent();
 
-    // Single chokepoint that turns parsed GlobalArgs into process-wide effects
-    // (debug logging, VT color, ...). Idempotent.
-    void ApplyGlobalOptions();
+    // Applies and freezes environment-only global options before command-line parsing reports errors.
+    void ApplyGlobalEnvironmentOptions();
 };
 
 } // namespace wsl::windows::wslc::execution

--- a/src/windows/wslc/core/Main.cpp
+++ b/src/windows/wslc/core/Main.cpp
@@ -92,7 +92,7 @@ try
     // throw can't reroute through the colored-help error path.
     auto envDefs = command->GetGlobalsAndEnvArguments();
     ApplyEnvironmentOptions(context.GlobalArgs, envDefs);
-    context.ApplyGlobalOptions();
+    context.ApplyGlobalEnvironmentOptions();
 
     // Past this point, environment variable options are in effect.
 
@@ -119,9 +119,8 @@ try
             /*stopOnUnknown*/ true,
             /*overridableDefaults*/ envDefs);
         command->ValidateArguments(context.GlobalArgs, envDefs, /*runInternalHook*/ false);
-        context.ApplyGlobalOptions();
 
-        // Past this point, global options are in effect.
+        // Past this point, global option parsing and validation are complete.
 
         // Pass 2 - Subcommand and leaf command resolution.
         std::unique_ptr<Command> subCommand = command->FindSubCommand(invocation);

--- a/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
@@ -613,6 +613,11 @@ class WSLCCLIArgumentUnitTests
         ArgMap args;
         args.Add(ArgType::Signal, std::wstring(L"SIGTERM"));
         VERIFY_ARE_EQUAL(args.GetValue<ArgType::Signal>(), WSLCSignalSIGTERM);
+        VERIFY_ARE_EQUAL(args.CountValidated(ArgType::Signal), static_cast<size_t>(1));
+
+        Argument::Create(ArgType::Signal).Validate(args);
+        args.MarkValidated(ArgType::Signal);
+        VERIFY_ARE_EQUAL(args.CountValidated(ArgType::Signal), static_cast<size_t>(1));
 
         const auto verifyImmutableFailure = [](const auto& operation) {
             VERIFY_THROWS_SPECIFIC(operation(), wil::ResultException, [](const wil::ResultException& e) {
@@ -624,7 +629,6 @@ class WSLCCLIArgumentUnitTests
         verifyImmutableFailure([&] { args.Remove(ArgType::Signal); });
         verifyImmutableFailure([&] { args.InvalidateValidated(ArgType::Signal); });
         verifyImmutableFailure([&] { args.AddValidated<ArgType::Signal>(WSLCSignalSIGKILL); });
-        verifyImmutableFailure([&] { args.MarkValidated(ArgType::Signal); });
 
         // Immutability is per argument; other arguments remain writable until they are read.
         args.Add(ArgType::StopTimeout, std::wstring(L"30"));

--- a/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
@@ -53,6 +53,32 @@ class WSLCCLIExecutionUnitTests
         return true;
     }
 
+    TEST_METHOD(GlobalEnvironmentOptions_NoColorIsAppliedAndFrozen)
+    {
+        {
+            CLIExecutionContext context;
+
+            context.ApplyGlobalEnvironmentOptions();
+            VERIFY_IS_FALSE(context.Terminal.IsNoColor());
+
+            VERIFY_THROWS_SPECIFIC(context.GlobalArgs.Add<ArgType::NoColor>(true), wil::ResultException, [](const wil::ResultException& e) {
+                return e.GetErrorCode() == E_ILLEGAL_METHOD_CALL;
+            });
+        }
+
+        {
+            CLIExecutionContext present;
+            present.GlobalArgs.Add<ArgType::NoColor>(true);
+            present.ApplyGlobalEnvironmentOptions();
+            VERIFY_IS_TRUE(present.Terminal.IsNoColor());
+
+            VERIFY_NO_THROW(Argument::Create(ArgType::NoColor).Validate(present.GlobalArgs));
+            VERIFY_THROWS_SPECIFIC(present.GlobalArgs.Remove(ArgType::NoColor), wil::ResultException, [](const wil::ResultException& e) {
+                return e.GetErrorCode() == E_ILLEGAL_METHOD_CALL;
+            });
+        }
+    }
+
     // Test: Verify EnumVariantMap on DataMap for Context Data
     TEST_METHOD(EnumVariantMap_DataMapValidation)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This is a follow-up from the argument validation changes and future-proofs global arguments that may be added later. Makes WSLC validation idempotent and freezes the environment-derived `NO_COLOR` setting when applied.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Prevents repeated validation from duplicating cached converted values.
- Applies global environment options before output can be produced.
- Freezes `NO_COLOR` after it is read, preventing inconsistent terminal color state.
- Adds coverage for repeated validation and `NO_COLOR` immutability.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- `*WSLCCLIArgumentUnitTests*` - 18/18 passed.
