### PR TITLE
Address review follow-up on WSLContainerRegistryAllowlist policy

### DIFF
--- a/src/windows/inc/wslpolicies.h
+++ b/src/windows/inc/wslpolicies.h
@@ -214,28 +214,11 @@ struct RegistryAllowlistSnapshot
     std::vector<std::wstring> Hosts{};
 };
 
-// Reads the allowlist in one shot. Empty entries are skipped (matches EnumerateRegistryAllowlist).
-// Throws with an "invalid policy" user error when the sub-key exists but can't be read (bad ACL,
-// corrupted values, etc.) so the caller fails closed.
-inline RegistryAllowlistSnapshot ReadRegistryAllowlistSnapshot(HKEY policiesKey)
+// subKey must be the WSLContainerRegistryAllowlist sub-key, not the policies root.
+inline RegistryAllowlistSnapshot ReadRegistryAllowlistSnapshot(HKEY subKey)
 {
-    if (policiesKey == nullptr)
-    {
-        return {};
-    }
-
-    wil::unique_hkey subKey;
-    const auto openResult = RegOpenKeyExW(policiesKey, c_wslContainerRegistryAllowlist, 0, KEY_READ, &subKey);
-    if (openResult == ERROR_PATH_NOT_FOUND || openResult == ERROR_FILE_NOT_FOUND)
-    {
-        return {};
-    }
-
-    THROW_HR_WITH_USER_ERROR_IF(
-        HRESULT_FROM_WIN32(openResult), wsl::shared::Localization::MessageRegistryAllowlistPolicyInvalid(), openResult != ERROR_SUCCESS);
-
     RegistryAllowlistSnapshot snapshot;
-    for (auto& [name, value] : wsl::windows::common::registry::EnumStringValues(subKey.get()))
+    for (auto& [name, value] : wsl::windows::common::registry::EnumStringValues(subKey))
     {
         if (value.empty())
         {
@@ -253,12 +236,12 @@ inline RegistryAllowlistSnapshot ReadRegistryAllowlistSnapshot(HKEY policiesKey)
     return snapshot;
 }
 
-// Convenience for callers with no open policies key. Throws MessageRegistryAllowlistPolicyInvalid
-// when the policies key can't be opened.
+// Throws MessageRegistryAllowlistPolicyInvalid on an unreadable sub-key so callers fail closed.
 inline RegistryAllowlistSnapshot ReadRegistryAllowlistSnapshotFromPoliciesRoot()
 {
-    wil::unique_hkey policiesKey;
-    const auto openResult = RegOpenKeyExW(HKEY_LOCAL_MACHINE, c_registryKey, 0, KEY_READ, &policiesKey);
+    const auto subKeyPath = std::wstring{c_registryKey} + L"\\" + c_wslContainerRegistryAllowlist;
+    wil::unique_hkey subKey;
+    const auto openResult = RegOpenKeyExW(HKEY_LOCAL_MACHINE, subKeyPath.c_str(), 0, KEY_READ, &subKey);
     if (openResult == ERROR_PATH_NOT_FOUND || openResult == ERROR_FILE_NOT_FOUND)
     {
         return {};
@@ -267,7 +250,7 @@ inline RegistryAllowlistSnapshot ReadRegistryAllowlistSnapshotFromPoliciesRoot()
     THROW_HR_WITH_USER_ERROR_IF(
         HRESULT_FROM_WIN32(openResult), wsl::shared::Localization::MessageRegistryAllowlistPolicyInvalid(), openResult != ERROR_SUCCESS);
 
-    return ReadRegistryAllowlistSnapshot(policiesKey.get());
+    return ReadRegistryAllowlistSnapshot(subKey.get());
 }
 
 } // namespace wsl::windows::policies

--- a/src/windows/inc/wslpolicies.h
+++ b/src/windows/inc/wslpolicies.h
@@ -214,8 +214,9 @@ struct RegistryAllowlistSnapshot
     std::vector<std::wstring> Hosts{};
 };
 
-// subKey must be the WSLContainerRegistryAllowlist sub-key, not the policies root.
+// subKey must be the WSLContainerRegistryAllowlist sub-key; enumeration failures throw MessageRegistryAllowlistPolicyInvalid.
 inline RegistryAllowlistSnapshot ReadRegistryAllowlistSnapshot(HKEY subKey)
+try
 {
     RegistryAllowlistSnapshot snapshot;
     for (auto& [name, value] : wsl::windows::common::registry::EnumStringValues(subKey))
@@ -234,6 +235,11 @@ inline RegistryAllowlistSnapshot ReadRegistryAllowlistSnapshot(HKEY subKey)
     }
 
     return snapshot;
+}
+catch (...)
+{
+    LOG_CAUGHT_EXCEPTION();
+    THROW_HR_WITH_USER_ERROR(wil::ResultFromCaughtException(), wsl::shared::Localization::MessageRegistryAllowlistPolicyInvalid());
 }
 
 // Throws MessageRegistryAllowlistPolicyInvalid on an unreadable sub-key so callers fail closed.

--- a/test/windows/PolicyTests.cpp
+++ b/test/windows/PolicyTests.cpp
@@ -481,6 +481,14 @@ class PolicyTest
         VERIFY_ARE_EQUAL(expected, stderrText);
     }
 
+    // Two variants: BuildKit echoes the caller's Dockerfile spelling in the "failed to solve" prefix.
+    static constexpr auto c_denialPatternExplicitAlpine =
+        "*failed to solve: docker.io/library/alpine:latest: could not resolve image due to policy: "
+        "source \"docker-image://docker.io/library/alpine:latest\" denied by policy: source denied by policy*";
+    static constexpr auto c_denialPatternImplicitAlpine =
+        "*failed to solve: alpine:latest: could not resolve image due to policy: "
+        "source \"docker-image://docker.io/library/alpine:latest\" denied by policy: source denied by policy*";
+
     // Verifies WSLContainerRegistryAllowlist blocks `wslc image build` when the FROM base image
     // isn't in the allowlist. Matches the `RegistryAllowlistDenies` pull test.
     WSLC_TEST_METHOD(RegistryAllowlistBlocksImageBuild)
@@ -490,11 +498,7 @@ class PolicyTest
         auto [exitCode, output] = RunImageBuild(L"FROM docker.io/library/alpine:latest\n", L"wsl-policy-build-blocked");
 
         VERIFY_ARE_NOT_EQUAL(0, exitCode);
-        if (output.find(L"docker.io") == std::wstring::npos || output.find(L"denied by policy") == std::wstring::npos)
-        {
-            LogError("Expected BuildKit source-policy denial mentioning docker.io, got: '%ls'", output.c_str());
-            VERIFY_FAIL();
-        }
+        VerifyPatternMatch(wsl::shared::string::WideToMultiByte(output), c_denialPatternExplicitAlpine);
     }
 
     // Positive path: build must proceed when FROM is on the allowlist.
@@ -537,11 +541,7 @@ class PolicyTest
         auto [exitCode, output] = RunImageBuild(dockerfile, L"wsl-policy-build-copyfrom");
 
         VERIFY_ARE_NOT_EQUAL(0, exitCode);
-        if (output.find(L"docker.io") == std::wstring::npos || output.find(L"denied by policy") == std::wstring::npos)
-        {
-            LogError("Expected COPY --from=docker.io/... to be blocked, got: '%ls'", output.c_str());
-            VERIFY_FAIL();
-        }
+        VerifyPatternMatch(wsl::shared::string::WideToMultiByte(output), c_denialPatternExplicitAlpine);
     }
 
     WSLC_TEST_METHOD(RegistryAllowlistBlocksImageBuildImplicitDockerIo)
@@ -551,12 +551,7 @@ class PolicyTest
         auto [exitCode, output] = RunImageBuild(L"FROM alpine:latest\n", L"wsl-policy-build-implicit");
 
         VERIFY_ARE_NOT_EQUAL(0, exitCode);
-        if (output.find(L"denied by policy") == std::wstring::npos ||
-            (output.find(L"docker.io") == std::wstring::npos && output.find(L"alpine") == std::wstring::npos))
-        {
-            LogError("Expected bare `FROM alpine:latest` to be blocked, got: '%ls'", output.c_str());
-            VERIFY_FAIL();
-        }
+        VerifyPatternMatch(wsl::shared::string::WideToMultiByte(output), c_denialPatternImplicitAlpine);
     }
 
     // Runs `wslc image build` with the supplied Dockerfile content and returns the exit code
@@ -648,23 +643,12 @@ class PolicyTest
         }
     }
 
-    // Pure-function tests for ReadRegistryAllowlistSnapshot (used by `wslc image build` to
-    // decide between fail-open-no-policy, generate-source-policy, and fail-closed paths).
+    // The (HKEY) overload is exercised transitively via FromPoliciesRoot.
     TEST_METHOD(ReadRegistryAllowlistSnapshot_Logic)
     {
-        // Null policies key -> NotConfigured, no hosts.
-        {
-            const auto snapshot = ReadRegistryAllowlistSnapshot(nullptr);
-            VERIFY_IS_TRUE(snapshot.State == RegistryAllowlistState::NotConfigured);
-            VERIFY_IS_TRUE(snapshot.Hosts.empty());
-        }
-
-        const auto policiesKey = OpenPoliciesKey();
-        VERIFY_IS_TRUE(!!policiesKey);
-
         // No sub-key -> NotConfigured.
         {
-            const auto snapshot = ReadRegistryAllowlistSnapshot(policiesKey.get());
+            const auto snapshot = ReadRegistryAllowlistSnapshotFromPoliciesRoot();
             VERIFY_IS_TRUE(snapshot.State == RegistryAllowlistState::NotConfigured);
             VERIFY_IS_TRUE(snapshot.Hosts.empty());
         }
@@ -673,7 +657,7 @@ class PolicyTest
         // items must not silently deny every registry).
         {
             auto revert = SetRegistryAllowlist({L"", L""});
-            const auto snapshot = ReadRegistryAllowlistSnapshot(policiesKey.get());
+            const auto snapshot = ReadRegistryAllowlistSnapshotFromPoliciesRoot();
             VERIFY_IS_TRUE(snapshot.State == RegistryAllowlistState::NotConfigured);
             VERIFY_IS_TRUE(snapshot.Hosts.empty());
         }
@@ -681,25 +665,9 @@ class PolicyTest
         // Sub-key with hosts -> Configured, hosts populated in order.
         {
             auto revert = SetRegistryAllowlist({L"mcr.microsoft.com", L"Docker.IO"});
-            const auto snapshot = ReadRegistryAllowlistSnapshot(policiesKey.get());
+            const auto snapshot = ReadRegistryAllowlistSnapshotFromPoliciesRoot();
             VERIFY_IS_TRUE(snapshot.State == RegistryAllowlistState::Configured);
             VERIFY_ARE_EQUAL(size_t{2}, snapshot.Hosts.size());
-        }
-    }
-
-    TEST_METHOD(ReadRegistryAllowlistSnapshotFromPoliciesRoot_Logic)
-    {
-        {
-            const auto snapshot = ReadRegistryAllowlistSnapshotFromPoliciesRoot();
-            VERIFY_IS_TRUE(snapshot.State == RegistryAllowlistState::NotConfigured);
-            VERIFY_IS_TRUE(snapshot.Hosts.empty());
-        }
-
-        {
-            auto revert = SetRegistryAllowlist({L"mcr.microsoft.com"});
-            const auto snapshot = ReadRegistryAllowlistSnapshotFromPoliciesRoot();
-            VERIFY_IS_TRUE(snapshot.State == RegistryAllowlistState::Configured);
-            VERIFY_ARE_EQUAL(size_t{1}, snapshot.Hosts.size());
         }
     }
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Follow-up to #41211 addressing review nits: open the allowlist sub-key directly, throw an "invalid policy" error at the read site, and tighten build-block test assertions to full-message pattern match.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Follow-up to #41211
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- ReadRegistryAllowlistSnapshotFromPoliciesRoot now opens the WSLContainerRegistryAllowlist sub-key directly in a single RegOpenKeyExW, then passes it to ReadRegistryAllowlistSnapshot(HKEY subKey)
- Invalid-policy failure is thrown at the read site with MessageRegistryAllowlistPolicyInvalid instead of translated later in BuildImage
- PolicyTests.cpp build-block assertions replaced with VerifyPatternMatch on the exact BuildKit denial line
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
