### PR TITLE
mountutil: skip empty tokens in mount option parser

### DIFF
--- a/src/linux/mountutil/mountflags.cpp
+++ b/src/linux/mountutil/mountflags.cpp
@@ -2,13 +2,9 @@
 #include <string>
 #include <string_view>
 #include <cerrno>
-#include <cstdio>
-#include <functional>
 #include <sys/types.h>
 #include <sys/mount.h>
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <dirent.h>
 #include <unistd.h>
 #include <lxdef.h>
 #include <lxwil.h>
@@ -142,6 +138,11 @@ ParsedOptions MountParseFlags(std::string_view options)
     {
         // Get the next option and check if it's a flag.
         auto option = NextToken(options, ',');
+        if (option.empty())
+        {
+            continue;
+        }
+
         auto flag = FindOption(option);
         if (flag == nullptr)
         {


### PR DESCRIPTION
mountutil: skip empty option tokens and clean up includes

Empty tokens in comma-separated mount options (e.g. from "foo,,bar")
were being propagated into the mount data string as empty entries,
which can confuse downstream filesystem option parsers. Skip them
during parsing.

Also remove the duplicate <sys/types.h> and unused <functional>
and <dirent.h> includes.