### PR TITLE
Fix excessive /proc/<pid>/mountinfo query in p9 server

### DIFF
--- a/src/linux/plan9/p9file.cpp
+++ b/src/linux/plan9/p9file.cpp
@@ -187,8 +187,8 @@ File::File(std::shared_ptr<const Root> root) : m_Root{root}
 {
 }
 
-// Copies a file. This does not clone the open file state, just the name and qid.
-File::File(const File& file) : m_FileName{file.m_FileName}, m_Root{file.m_Root}, m_Qid{file.m_Qid}
+// Copies a file. This does not clone the open file state, just the name and metadata.
+File::File(const File& file) : m_FileName{file.m_FileName}, m_Root{file.m_Root}, m_Qid{file.m_Qid}, m_Device{file.m_Device}
 {
 }
 

--- a/src/linux/plan9/p9util.cpp
+++ b/src/linux/plan9/p9util.cpp
@@ -257,7 +257,6 @@ FsUserContext::~FsUserContext()
         }
     }
     CATCH_LOG()
-
 }
 
 } // namespace p9fs::util

--- a/src/linux/plan9/p9util.cpp
+++ b/src/linux/plan9/p9util.cpp
@@ -257,6 +257,7 @@ FsUserContext::~FsUserContext()
         }
     }
     CATCH_LOG()
+
 }
 
 } // namespace p9fs::util


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Every cloned-fid walk incorrectly treated its first path component as a mount crossing because `File`’s copy constructor did not preserve `m_Device`. Consequently, ordinary `Twalk` and `Twopen` requests opened and searched `/proc/<tid>/mountinfo`, even when the path stayed on the same filesystem.

This PR adds `m_Device` to the copy constructor to fix this.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/41301 (partially)
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested locally:
1. Created 100 files on the distro’s root filesystem.
2. Attached strace to the Plan 9 server, tracing `open` and `openat`.
3. Opened each file once through `\\wsl.localhost`.
4. Counted accesses to `/proc/<tid>/mountinfo`.

Before the fix: 100 requests caused 100 mountinfo opens
After the fix: 100 identical requests caused 0 mountinfo opens