### PR TITLE
Fix unqualified WEX::Logging::Log breaking release builds

### DIFF
--- a/test/windows/InstallerTests.cpp
+++ b/test/windows/InstallerTests.cpp
@@ -751,7 +751,7 @@ class InstallerTests
     TEST_METHOD(MsiUpgradeFailureRestoresFiles)
     {
 #ifdef WSL_OFFICIAL_BUILD
-        Log::Comment(L"TestSkipped: This test case requires the test-only WslTestForceInstallFailure CA");
+        WEX::Logging::Log::Comment(L"TestSkipped: This test case requires the test-only WslTestForceInstallFailure CA");
         return;
 #else
         // End-to-end rollback test: install an older version, then attempt a major


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves an unqualified use a `WEX::Logging::Log`, which breaks release builds (under a WSL_OFFICIAL_BUILD ifdef) 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
