### PR TITLE
Fix potential spin in interop message relay

### DIFF
--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -421,62 +421,56 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
     DWORD ExitCode = 1;
     for (;;)
     {
-        DWORD BytesRead;
+        DWORD BytesRead{};
         LX_INIT_WINDOW_SIZE_CHANGED WindowSizeMessage;
         bool Success = ReadFile(MessageHandle, &WindowSizeMessage, sizeof(WindowSizeMessage), &BytesRead, &Overlapped);
         if (!Success)
         {
             const auto LastError = GetLastError();
-            if ((LastError == ERROR_BROKEN_PIPE) || (LastError == ERROR_HANDLE_EOF))
+            if ((LastError != ERROR_BROKEN_PIPE) && (LastError != ERROR_HANDLE_EOF))
             {
-                if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
+                THROW_LAST_ERROR_IF(LastError != ERROR_IO_PENDING);
+
+                auto CancelIo = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
+                    CancelIoEx(MessageHandle, &Overlapped);
+                    GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, TRUE);
+                });
+
+                const DWORD WaitStatus = WaitForMultipleObjects(RTL_NUMBER_OF(WaitHandles), WaitHandles, FALSE, INFINITE);
+                if (WaitStatus == WAIT_OBJECT_0)
                 {
-                    THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
+                    Success = GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, FALSE);
+                    CancelIo.release();
                 }
-
-                break;
-            }
-
-            THROW_LAST_ERROR_IF(LastError != ERROR_IO_PENDING);
-
-            auto CancelIo = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
-                CancelIoEx(MessageHandle, &Overlapped);
-                GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, TRUE);
-            });
-
-            const DWORD WaitStatus = WaitForMultipleObjects(RTL_NUMBER_OF(WaitHandles), WaitHandles, FALSE, INFINITE);
-            if (WaitStatus == WAIT_OBJECT_0)
-            {
-                Success = GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, FALSE);
-                CancelIo.release();
-                if ((!Success) || (BytesRead == 0))
+                else if (WaitStatus == (WAIT_OBJECT_0 + 1))
                 {
-                    if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
-                    {
-                        THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
-                    }
+                    THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &ExitCode));
 
+                    // Close the pseudoconsole, this causes all pending data to be flushed.
+                    Result->PseudoConsole.reset();
                     break;
                 }
-
-                WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
-
-                const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
-                THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
-            }
-            else if (WaitStatus == (WAIT_OBJECT_0 + 1))
-            {
-                THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &ExitCode));
-
-                // Close the pseudoconsole, this causes all pending data to be flushed.
-                Result->PseudoConsole.reset();
-                break;
-            }
-            else
-            {
-                THROW_HR(E_UNEXPECTED);
+                else
+                {
+                    THROW_HR(E_UNEXPECTED);
+                }
             }
         }
+
+        if ((!Success) || (BytesRead == 0))
+        {
+            if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
+            {
+                THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
+            }
+
+            break;
+        }
+
+        WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
+
+        const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
+        THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
     }
 
     return ExitCode;

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -14,6 +14,7 @@ Abstract:
 
 #include "precomp.h"
 #include "interop.hpp"
+#include "HandleIO.h"
 #include "helpers.hpp"
 #include "socket.hpp"
 #include "hvsocket.hpp"
@@ -408,82 +409,70 @@ std::string FormatCommandLine(gsl::span<gsl::byte> CommandLineData, USHORT Comma
 DWORD
 ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* Result)
 {
-    OVERLAPPED Overlapped = {0};
-    const wil::unique_event OverlappedEvent(wil::EventOptions::ManualReset);
-    Overlapped.hEvent = OverlappedEvent.get();
-    const HANDLE WaitHandles[] = {Overlapped.hEvent, Result->Process.get()};
+    namespace io = wsl::windows::common::io;
 
-    // Read messages from the message handle. Break out of the loop if the pipe
-    // is connection is closed or the process exits.
-    //
-    // N.B. ReadFile will automatically reset the event in the overlapped
-    //      structure.
-    DWORD ExitCode = 1;
-    DWORD Offset = 0;
-    LX_INIT_WINDOW_SIZE_CHANGED WindowSizeMessage;
-    for (;;)
-    {
-        DWORD BytesRead{};
-        bool Success = ReadFile(
-            MessageHandle, reinterpret_cast<BYTE*>(&WindowSizeMessage) + Offset, sizeof(WindowSizeMessage) - Offset, &BytesRead, &Overlapped);
-        if (!Success)
-        {
-            const auto LastError = GetLastError();
-            if ((LastError != ERROR_BROKEN_PIPE) && (LastError != ERROR_HANDLE_EOF))
-            {
-                THROW_LAST_ERROR_IF(LastError != ERROR_IO_PENDING);
+    DWORD exitCode = 1;
+    size_t pendingSize = 0;
+    LX_INIT_WINDOW_SIZE_CHANGED pendingMessage{};
 
-                auto CancelIo = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
-                    CancelIoEx(MessageHandle, &Overlapped);
-                    GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, TRUE);
-                });
+    auto processExit = [&] {
+        THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &exitCode));
 
-                const DWORD WaitStatus = WaitForMultipleObjects(RTL_NUMBER_OF(WaitHandles), WaitHandles, FALSE, INFINITE);
-                if (WaitStatus == WAIT_OBJECT_0)
+        // Close the pseudoconsole, this causes all pending data to be flushed.
+        Result->PseudoConsole.reset();
+    };
+
+    io::MultiHandleWait wait;
+    wait.AddHandle(
+        std::make_unique<io::ReadHandle>(
+            io::HandleWrapper{MessageHandle},
+            [&](const gsl::span<char>& input) {
+                if (input.empty())
                 {
-                    Success = GetOverlappedResult(MessageHandle, &Overlapped, &BytesRead, FALSE);
-                    CancelIo.release();
+                    const DWORD waitStatus = WaitForSingleObject(Result->Process.get(), 0);
+                    if (waitStatus == WAIT_OBJECT_0)
+                    {
+                        processExit();
+                    }
+                    else
+                    {
+                        THROW_HR_IF(E_UNEXPECTED, waitStatus != WAIT_TIMEOUT);
+                        if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
+                        {
+                            THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
+                        }
+                    }
+
+                    return;
                 }
-                else if (WaitStatus == (WAIT_OBJECT_0 + 1))
+
+                auto remaining = input;
+                while (!remaining.empty())
                 {
-                    THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &ExitCode));
+                    const size_t bytesToCopy = (std::min)(remaining.size(), sizeof(pendingMessage) - pendingSize);
+                    std::copy_n(remaining.data(), bytesToCopy, reinterpret_cast<char*>(&pendingMessage) + pendingSize);
+                    pendingSize += bytesToCopy;
+                    remaining = remaining.subspan(bytesToCopy);
 
-                    // Close the pseudoconsole, this causes all pending data to be flushed.
-                    Result->PseudoConsole.reset();
-                    break;
+                    if (pendingSize == sizeof(pendingMessage))
+                    {
+                        THROW_HR_IF(
+                            E_UNEXPECTED,
+                            (pendingMessage.Header.MessageType != LxInitMessageWindowSizeChanged) ||
+                                (pendingMessage.Header.MessageSize != sizeof(pendingMessage)));
+
+                        const COORD size{static_cast<SHORT>(pendingMessage.Columns), static_cast<SHORT>(pendingMessage.Rows)};
+                        THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), size));
+                        pendingSize = 0;
+                    }
                 }
-                else
-                {
-                    THROW_HR(E_UNEXPECTED);
-                }
-            }
-        }
+            }),
+        io::MultiHandleWait::CancelOnCompleted);
 
-        if ((!Success) || (BytesRead == 0))
-        {
-            if (WI_IsFlagClear(Result->Flags, LX_INIT_CREATE_PROCESS_RESULT_FLAG_GUI_APPLICATION))
-            {
-                THROW_IF_WIN32_BOOL_FALSE(TerminateProcess(Result->Process.get(), 1));
-            }
+    wait.AddHandle(std::make_unique<io::EventHandle>(io::HandleWrapper{Result->Process.get()}, processExit), io::MultiHandleWait::CancelOnCompleted);
 
-            break;
-        }
-
-        Offset += BytesRead;
-        if (Offset != sizeof(WindowSizeMessage))
-        {
-            continue;
-        }
-
-        WI_ASSERT(WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged);
-
-        const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
-        THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
-
-        Offset = 0;
-    }
-
-    return ExitCode;
+    wait.Run(std::nullopt);
+    return exitCode;
 }
 
 } // namespace

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -412,8 +412,9 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
     namespace io = wsl::windows::common::io;
 
     DWORD exitCode = 1;
-    size_t pendingSize = 0;
-    LX_INIT_WINDOW_SIZE_CHANGED pendingMessage{};
+    std::vector<char> pending;
+
+    static_assert(sizeof(LX_INIT_WINDOW_SIZE_CHANGED) % alignof(LX_INIT_WINDOW_SIZE_CHANGED) == 0);
 
     auto processExit = [&] {
         THROW_IF_WIN32_BOOL_FALSE(GetExitCodeProcess(Result->Process.get(), &exitCode));
@@ -446,26 +447,30 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
                     return;
                 }
 
+                std::vector<char> stitchedInput;
                 auto remaining = input;
-                while (!remaining.empty())
+                if (!pending.empty())
                 {
-                    const size_t bytesToCopy = (std::min)(remaining.size(), sizeof(pendingMessage) - pendingSize);
-                    std::copy_n(remaining.data(), bytesToCopy, reinterpret_cast<char*>(&pendingMessage) + pendingSize);
-                    pendingSize += bytesToCopy;
-                    remaining = remaining.subspan(bytesToCopy);
-
-                    if (pendingSize == sizeof(pendingMessage))
-                    {
-                        THROW_HR_IF(
-                            E_UNEXPECTED,
-                            (pendingMessage.Header.MessageType != LxInitMessageWindowSizeChanged) ||
-                                (pendingMessage.Header.MessageSize != sizeof(pendingMessage)));
-
-                        const COORD size{static_cast<SHORT>(pendingMessage.Columns), static_cast<SHORT>(pendingMessage.Rows)};
-                        THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), size));
-                        pendingSize = 0;
-                    }
+                    stitchedInput.reserve(pending.size() + input.size());
+                    stitchedInput.insert(stitchedInput.end(), pending.begin(), pending.end());
+                    stitchedInput.insert(stitchedInput.end(), input.begin(), input.end());
+                    pending.clear();
+                    remaining = gsl::make_span(stitchedInput);
                 }
+
+                while (remaining.size() >= sizeof(LX_INIT_WINDOW_SIZE_CHANGED))
+                {
+                    const auto* message = gslhelpers::get_struct<const LX_INIT_WINDOW_SIZE_CHANGED>(remaining);
+                    THROW_HR_IF(
+                        E_UNEXPECTED,
+                        (message->Header.MessageType != LxInitMessageWindowSizeChanged) || (message->Header.MessageSize != sizeof(*message)));
+
+                    const COORD size{static_cast<SHORT>(message->Columns), static_cast<SHORT>(message->Rows)};
+                    THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), size));
+                    remaining = remaining.subspan(sizeof(*message));
+                }
+
+                pending.assign(remaining.begin(), remaining.end());
             }),
         io::MultiHandleWait::CancelOnCompleted);
 

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -470,7 +470,6 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
         io::MultiHandleWait::CancelOnCompleted);
 
     wait.AddHandle(std::make_unique<io::EventHandle>(io::HandleWrapper{Result->Process.get()}, processExit), io::MultiHandleWait::CancelOnCompleted);
-
     wait.Run(std::nullopt);
     return exitCode;
 }

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -419,11 +419,13 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
     // N.B. ReadFile will automatically reset the event in the overlapped
     //      structure.
     DWORD ExitCode = 1;
+    DWORD Offset = 0;
+    LX_INIT_WINDOW_SIZE_CHANGED WindowSizeMessage;
     for (;;)
     {
         DWORD BytesRead{};
-        LX_INIT_WINDOW_SIZE_CHANGED WindowSizeMessage;
-        bool Success = ReadFile(MessageHandle, &WindowSizeMessage, sizeof(WindowSizeMessage), &BytesRead, &Overlapped);
+        bool Success = ReadFile(
+            MessageHandle, reinterpret_cast<BYTE*>(&WindowSizeMessage) + Offset, sizeof(WindowSizeMessage) - Offset, &BytesRead, &Overlapped);
         if (!Success)
         {
             const auto LastError = GetLastError();
@@ -467,10 +469,18 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
             break;
         }
 
-        WI_ASSERT((BytesRead == sizeof(WindowSizeMessage)) && (WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged));
+        Offset += BytesRead;
+        if (Offset != sizeof(WindowSizeMessage))
+        {
+            continue;
+        }
+
+        WI_ASSERT(WindowSizeMessage.Header.MessageType == LxInitMessageWindowSizeChanged);
 
         const COORD Size{static_cast<SHORT>(WindowSizeMessage.Columns), static_cast<SHORT>(WindowSizeMessage.Rows)};
         THROW_IF_FAILED(ResizePseudoConsole(Result->PseudoConsole.get(), Size));
+
+        Offset = 0;
     }
 
     return ExitCode;

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -470,6 +470,7 @@ ProcessInteropMessages(_In_ HANDLE MessageHandle, _Inout_ CreateProcessResult* R
         io::MultiHandleWait::CancelOnCompleted);
 
     wait.AddHandle(std::make_unique<io::EventHandle>(io::HandleWrapper{Result->Process.get()}, processExit), io::MultiHandleWait::CancelOnCompleted);
+
     wait.Run(std::nullopt);
     return exitCode;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The original logic ignores the success result of the initial `ReadFile` call. If the connection is a socket and its close is not captured by `GetOverlappedResult`. It could cause this `ReadFile` call to return success with bytes read == 0. This will put this loop into a spin.

This PR refactors the loop with `io::MultiHandleWait`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/WSL/issues/41173
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

This issue is triggered by a race condition. I'm not able to repro the original issue on my machine.
The normal function was tested locally.