### PR TITLE
Add RLCPlus-9 and RLCPlus-10 (Rocky Linux Plus, CIQ)

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -95,26 +95,26 @@
                 }
             }
         ],
-	"RLCPlus": [
-    {
-        "Name": "RLCPlus-9",
-        "FriendlyName": "Rocky Linux Plus 9 (CIQ)",
-        "Default": false,
-        "Amd64Url": {
-            "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-9-WSL-9-20260812.0.x86_64.wsl",
-            "Sha256": "202ba60ac09205b3bb574f69bcad69c5c2463fd243019fc1067437a4bc9af939"
-        },
-        "Arm64Url": {
-            "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-9-WSL-9-20260812.0.aarch64.wsl",
-            "Sha256": "5b24a384fdfbf004e75441d5e7ade4ef9579e52d58223741b195c41075a28b1b"
-        }
-    },
-    {
-        "Name": "RLCPlus-10",
-        "FriendlyName": "Rocky Linux Plus 10 (CIQ)",
-        "Default": true,
-        "Amd64Url": {
-            "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-10-WSL-10-20260812.0.x86_64.wsl",
+        "RLCPlus": [
+            {
+                "Name": "RLCPlus-9",
+                "FriendlyName": "Rocky Linux Plus 9 (CIQ)",
+                "Default": false,
+                "Amd64Url": {
+                    "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-9-WSL-9-20260812.0.x86_64.wsl",
+                    "Sha256": "202ba60ac09205b3bb574f69bcad69c5c2463fd243019fc1067437a4bc9af939"
+                },
+                "Arm64Url": {
+                    "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-9-WSL-9-20260812.0.aarch64.wsl",
+                    "Sha256": "5b24a384fdfbf004e75441d5e7ade4ef9579e52d58223741b195c41075a28b1b"
+                }
+            },
+            {
+                "Name": "RLCPlus-10",
+                "FriendlyName": "Rocky Linux Plus 10 (CIQ)",
+                "Default": true,
+                "Amd64Url": {
+                    "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-10-WSL-10-20260812.0.x86_64.wsl",
             "Sha256": "2b181172c9aa3160a803d5ecaee517d237f59b41eb21848ee60699b89d5b8d84"
         },
         "Arm64Url": {

--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -95,6 +95,34 @@
                 }
             }
         ],
+	"RLCPlus": [
+    {
+        "Name": "RLCPlus-9",
+        "FriendlyName": "Rocky Linux Plus 9 (CIQ)",
+        "Default": false,
+        "Amd64Url": {
+            "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-9-WSL-9-20260812.0.x86_64.wsl",
+            "Sha256": "202ba60ac09205b3bb574f69bcad69c5c2463fd243019fc1067437a4bc9af939"
+        },
+        "Arm64Url": {
+            "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-9-WSL-9-20260812.0.aarch64.wsl",
+            "Sha256": "5b24a384fdfbf004e75441d5e7ade4ef9579e52d58223741b195c41075a28b1b"
+        }
+    },
+    {
+        "Name": "RLCPlus-10",
+        "FriendlyName": "Rocky Linux Plus 10 (CIQ)",
+        "Default": true,
+        "Amd64Url": {
+            "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-10-WSL-10-20260812.0.x86_64.wsl",
+            "Sha256": "2b181172c9aa3160a803d5ecaee517d237f59b41eb21848ee60699b89d5b8d84"
+        },
+        "Arm64Url": {
+            "Url": "https://github.com/ctrliq/rlcplus-wsl-images/releases/download/v20260812/RLCPlus-10-WSL-10-20260812.0.aarch64.wsl",
+            "Sha256": "b87c820232b2ce1b76be3643be615c4fee7ebc6bb31de4ac222d52b58d9cdd67"
+        }
+    }
+],
         "SUSE": [
             {
                 "Name": "SUSE-Linux-Enterprise-15-SP7",


### PR DESCRIPTION
Summary of the Pull Request

Adds RLCPlus-9 and RLCPlus-10 — Rocky Linux Plus, CIQ's free enterprise Linux offering built on Rocky Linux — to the WSL distribution manifest, for both x86_64 and aarch64. RLCPlus-10 is set as the default version.

PR Checklist
 Closes: N/A - new distro addition, not tied to an existing issue
 Communication: No prior discussion with core contributors on this specific PR. CIQ Rocky Linux Security Team is a current member of the linux-distros security mailing list (https://oss-security.openwall.org/wiki/mailing-lists/distros), which the WSL distro packaging documentation references as a membership criterion.
 Tests: No automated tests apply (manifest-only change); manual validation performed and detailed below. validate-modern.py passes clean against this branch with no errors.
 Localization: N/A - no new end-user-facing strings introduced beyond the existing FriendlyName field pattern used by other entries.
 Dev docs: N/A - no dev-facing documentation changes needed.
 Documentation updated: Not yet filed against MicrosoftDocs/wsl - happy to follow up there if maintainers want a docs PR alongside this one.
Detailed Description of the Pull Request / Additional comments

Both RLCPlus-9 and RLCPlus-10 images are built from CIQ's RLC+ GenericCloud qcow2 releases. The build masks NetworkManager/NetworkManager-wait-online/tmp.mount (per the packaging guidance), and additionally masks cloud-init and its related units, since the GenericCloud source image expects a cloud datasource that doesn't exist under WSL - without masking it, first boot hangs indefinitely waiting for a datasource that never arrives.

Build tooling, overlay configuration, and full documentation are public at https://github.com/ctrliq/rlcplus-wsl-images.

Validation Steps Performed

All four combinations (9/10 x x86_64/aarch64) were built and fully boot-tested on real hardware (x86_64 on a Windows desktop, aarch64 on a Snapdragon X2 Plus machine). For each, verified:

Clean install via wsl --install --from-file
OOBE first-run user creation and passwordless sudo
NetworkManager correctly masked, with WSL's own networking still fully functional
Shortcut icon renders correctly in Windows Terminal
/etc/os-release and uname -a confirm correct distro identity and architecture

validate-modern.py --compare-with-branch origin/master run locally against this branch passes with no errors (only the same category of "discouraged system unit" warnings already present on existing, merged entries like Ubuntu).