### PR TITLE
Fix BidirectionalRelay half-close handling

### DIFF
--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -316,7 +316,7 @@ void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In
     const HANDLE waitObjects[] = {leftOverlapped.hEvent, rightOverlapped.hEvent};
     for (;;)
     {
-        if ((LeftHandle == nullptr) || (RightHandle == nullptr))
+        if ((LeftHandle == nullptr) && (RightHandle == nullptr))
         {
             break;
         }
@@ -584,6 +584,12 @@ try
                 DWORD BytesRead{};
                 if (ReadFile(e.Handle, e.Buffer.data(), static_cast<DWORD>(e.Buffer.size()), &BytesRead, &e.Overlapped))
                 {
+                    if (BytesRead == 0)
+                    {
+                        e.State = Eof;
+                        continue;
+                    }
+
                     // IO is available.
                     Write(i, gsl::make_span(e.Buffer.data(), BytesRead));
 

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -297,6 +297,8 @@ void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In
 
     bool leftReadPending = false;
     bool rightReadPending = false;
+    bool leftReadClosed = false;
+    bool rightReadClosed = false;
     auto cancelReads = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
         DWORD bytes;
         if (leftReadPending)
@@ -316,13 +318,13 @@ void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In
     const HANDLE waitObjects[] = {leftOverlapped.hEvent, rightOverlapped.hEvent};
     for (;;)
     {
-        if ((LeftHandle == nullptr) && (RightHandle == nullptr))
+        if (leftReadClosed && rightReadClosed)
         {
             break;
         }
 
         DWORD leftBytesRead = 0;
-        if (!leftReadPending && LeftHandle)
+        if (!leftReadPending && !leftReadClosed && LeftHandle)
         {
             if (!ReadFile(LeftHandle, leftReadSpan.data(), gsl::narrow_cast<DWORD>(leftReadSpan.size()), &leftBytesRead, &leftOverlapped))
             {
@@ -333,7 +335,7 @@ void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In
         }
 
         DWORD rightBytesRead = 0;
-        if (!rightReadPending && RightHandle)
+        if (!rightReadPending && !rightReadClosed && RightHandle)
         {
             if (!ReadFile(RightHandle, rightReadSpan.data(), gsl::narrow_cast<DWORD>(rightReadSpan.size()), &rightBytesRead, &rightOverlapped))
             {
@@ -352,7 +354,7 @@ void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In
             leftReadPending = false;
             if (leftBytesRead == 0)
             {
-                LeftHandle = nullptr;
+                leftReadClosed = true;
                 if (WI_IsFlagSet(Flags, RelayFlags::RightIsSocket))
                 {
                     LOG_LAST_ERROR_IF(shutdown(reinterpret_cast<SOCKET>(RightHandle), SD_SEND) == SOCKET_ERROR);
@@ -380,7 +382,7 @@ void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In
             rightReadPending = false;
             if (rightBytesRead == 0)
             {
-                RightHandle = nullptr;
+                rightReadClosed = true;
                 if (WI_IsFlagSet(Flags, RelayFlags::LeftIsSocket))
                 {
                     LOG_LAST_ERROR_IF(shutdown(reinterpret_cast<SOCKET>(LeftHandle), SD_SEND) == SOCKET_ERROR);
@@ -584,12 +586,6 @@ try
                 DWORD BytesRead{};
                 if (ReadFile(e.Handle, e.Buffer.data(), static_cast<DWORD>(e.Buffer.size()), &BytesRead, &e.Overlapped))
                 {
-                    if (BytesRead == 0)
-                    {
-                        e.State = Eof;
-                        continue;
-                    }
-
                     // IO is available.
                     Write(i, gsl::make_span(e.Buffer.data(), BytesRead));
 

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -297,8 +297,8 @@ void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In
 
     bool leftReadPending = false;
     bool rightReadPending = false;
-    bool leftReadClosed = false;
-    bool rightReadClosed = false;
+    bool leftReadClosed = (LeftHandle == nullptr);
+    bool rightReadClosed = (RightHandle == nullptr);
     auto cancelReads = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
         DWORD bytes;
         if (leftReadPending)


### PR DESCRIPTION
## Summary

`BidirectionalRelay` exited as soon as **one** side closed (`||`), dropping any buffered data the other side still had to send. Changed to `&&` so both directions drain before exit, matching the guest-side fix in `localhost_relay.cpp`.

This completes end-to-end half-close handling: a Windows client that calls `shutdown(SD_SEND)` can now reliably receive the Linux server's response.
#41326


