### PR TITLE
Report cached build steps in wslc build output

### DIFF
--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -702,9 +702,11 @@ struct BuildKitVertex
     std::string digest;
     std::string name;
     std::string started;
+    std::string completed;
     std::string error;
+    bool cached{};
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(BuildKitVertex, digest, name, started, error);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(BuildKitVertex, digest, name, started, completed, error, cached);
 };
 
 struct BuildKitStatus

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1367,8 +1367,12 @@ try
 
             if (vertex.cached && reportedCached.insert(vertex.digest).second)
             {
-                flushLine();
-                reportProgress(getStepToken(vertex.name) + " CACHED\n");
+                auto stepToken = getStepToken(vertex.name);
+                if (!stepToken.empty())
+                {
+                    flushLine();
+                    reportProgress(stepToken + " CACHED\n");
+                }
             }
 
             if (!vertex.error.empty() && reportedErrors.insert(vertex.digest).second)

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1248,6 +1248,7 @@ try
     std::string allOutput;
     std::string pendingJson;
     std::set<std::string> reportedSteps;
+    std::set<std::string> reportedCached;
     std::set<std::string> reportedErrors;
     std::map<std::string, std::string> digestToStageName;
     bool needsNewline = false; // true when the last log chunk didn't end with \n
@@ -1280,6 +1281,23 @@ try
         }
 
         return {};
+    };
+
+    // Returns the leading step token from a BuildKit vertex name, e.g. "[2/3]" from "[2/3] RUN make".
+    // Falls back to the full name when there is no bracketed prefix.
+    auto getStepToken = [](const std::string& name) -> std::string {
+        if (name.empty() || name[0] != '[')
+        {
+            return name;
+        }
+
+        auto close = name.find(']');
+        if (close == std::string::npos)
+        {
+            return name;
+        }
+
+        return name.substr(0, close + 1);
     };
 
     auto logPrefix = [](const std::string& name) -> std::string {
@@ -1345,6 +1363,12 @@ try
             {
                 flushLine();
                 reportProgress(vertex.name + "\n");
+            }
+
+            if (vertex.cached && reportedCached.insert(vertex.digest).second)
+            {
+                flushLine();
+                reportProgress(getStepToken(vertex.name) + " CACHED\n");
             }
 
             if (!vertex.error.empty() && reportedErrors.insert(vertex.digest).second)

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -1259,12 +1259,18 @@ class WSLCE2EImageBuildTests
         cachedBuild.Verify({.Stdout = L"", .ExitCode = 0});
         const auto cachedId = InspectImage(BuiltImageNoCache.NameAndTag()).Id;
         VERIFY_ARE_EQUAL(firstId, cachedId, L"Repeated build without --no-cache should reuse the cached layer");
+        VERIFY_IS_TRUE(
+            cachedBuild.StderrContainsSubstring(L"[2/2] CACHED"),
+            L"A reused layer must be reported as cached in the build output");
 
         // --no-cache must re-run the non-deterministic step, producing a new id.
         auto noCacheBuild = RunWslc(buildCmd + L" --no-cache");
         noCacheBuild.Verify({.Stdout = L"", .ExitCode = 0});
         const auto noCacheId = InspectImage(BuiltImageNoCache.NameAndTag()).Id;
         VERIFY_ARE_NOT_EQUAL(firstId, noCacheId, L"--no-cache must rebuild the non-deterministic RUN step");
+        VERIFY_IS_FALSE(
+            noCacheBuild.StderrContainsSubstring(L"[2/2] CACHED"),
+            L"A step re-run under --no-cache must not be reported as cached");
     }
 
     // --iidfile writes the built image's ID to the given host path on success, matching docker build


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

`wslc build` never indicated that a layer was reused from the build cache. A fully
cached rebuild produced output byte-identical to a cold build, giving no signal that
anything was reused. This adds a `CACHED` marker under each step served from cache.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The root cause was in the JSON contract with BuildKit rather than in the rendering
code. `BuildKitVertex` in `docker_schema.h` never declared the `cached` field, and
`NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT` only (de)serializes members explicitly
listed in the macro — an unlisted field is dropped silently, with no parse error. The
cache information was therefore discarded before it ever reached the renderer.

Changes:

- **`docker_schema.h`** — add `completed` and `cached` to `BuildKitVertex` and to the
  serialization macro.
- **`WSLCSession.cpp`** — track reported cached vertices in a `reportedCached` set,
  separate from `reportedSteps`, and emit the marker on its own line via a new
  `getStepToken()` helper that extracts `[2/3]` from `[2/3] RUN make`.

The separate set matters for correctness, not just formatting. `reportedSteps.insert(digest)`
succeeds only once per vertex, so an approach that prefixed `CACHED ` onto the step name
had to know the flag at first print. When BuildKit's first update for a vertex has
`started` set but `cached` still false, the later update carrying `cached=true` is
discarded, and the marker is lost. That made the marker appear or vanish based purely on
timing — it worked right after a service restart but failed on same-session warm rebuilds,
which is the common edit-rebuild loop. Decoupling the two sets removes the ordering
dependency: the step prints when it starts, the marker prints whenever the flag arrives.

Output is unchanged for steps that actually execute, so this is additive for non-cached
builds. No new user-facing strings were introduced (`CACHED` matches docker's own
untranslated output).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Extended the existing `WSLCE2E_Image_Build_NoCache_Success` E2E test with a
mutation-resistant assertion pair: `[2/2] CACHED` must be present on the cached rebuild
and absent under `--no-cache`. A regression in either direction fails the test.


Manual validation against real image builds after deploying to the host:

- **Before the change** — two consecutive builds resolving to the same image SHA produced
  byte-identical output, reproducing the bug.
- **Cold build** — steps print normally, no spurious markers.
- **Warm rebuild, same session** — the case the first implementation got wrong; now
  correct.
- **Warm rebuild after service restart** — correct.
- **`--no-cache` control** — no markers, and a different image SHA confirming the steps
  really re-ran.

Observed output on a warm rebuild:


[1/3] FROM docker.io/library/debian:latest
[2/3] RUN echo alpha > /a.txt
[2/3] CACHED
[3/3] RUN echo beta > /b.txt
[3/3] CACHED
