### PR TITLE
Add Config.Image on container inspect

### DIFF
--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -102,6 +102,7 @@ struct HealthConfig
 
 struct ContainerConfig
 {
+    std::string Image;
     std::optional<std::vector<std::string>> Env;
     std::optional<std::vector<std::string>> Cmd;
     std::optional<std::vector<std::string>> Entrypoint;
@@ -111,7 +112,7 @@ struct ContainerConfig
     std::optional<HealthConfig> Healthcheck;
     std::map<std::string, std::string> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Env, Cmd, Entrypoint, User, WorkingDir, StopTimeout, Healthcheck, Labels);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerConfig, Image, Env, Cmd, Entrypoint, User, WorkingDir, StopTimeout, Healthcheck, Labels);
 };
 
 struct InspectEndpointIPAMConfig

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -1566,6 +1566,7 @@ WslcInspectContainer WSLCContainerImpl::BuildInspectContainer(const DockerInspec
         }
     }
 
+    wslcInspect.Config.Image = m_image;
     wslcInspect.Config.Env = dockerInspect.Config.Env;
     wslcInspect.Config.Cmd = dockerInspect.Config.Cmd;
     wslcInspect.Config.Entrypoint = dockerInspect.Config.Entrypoint;

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -10686,6 +10686,7 @@ class WSLCTests
     {
         // Docker labels do not have a size limit, so test with a very large label value to validate that the API can handle it.
         std::map<std::string, std::string> labels = {{"key1", "value1"}, {"key2", std::string(10000, 'a')}};
+        const std::string c_image = "debian:latest";
 
         // Contains-style rather than exact-equality so the test stays green if the base image ever ships with its own labels.
         auto verifyUserLabelsPresent = [&](const std::map<std::string, std::string>& observed) {
@@ -10714,6 +10715,10 @@ class WSLCTests
             verifyUserLabelsPresent(containerLabels);
             VERIFY_IS_TRUE(containerLabels.find("com.microsoft.wsl.container.metadata") == containerLabels.end());
 
+            const auto inspect = container.Inspect();
+            VERIFY_ARE_EQUAL(c_image, inspect.Config.Image);
+            VERIFY_ARE_EQUAL(inspect.Image, inspect.Config.Image);
+
             // Keep the container alive after the handle is dropped so we can validate labels are persisted across sessions.
             container.SetDeleteOnClose(false);
         }
@@ -10734,6 +10739,8 @@ class WSLCTests
             verifyUserLabelsPresent(inspect.Labels);
             VERIFY_ARE_EQUAL(inspect.Config.Labels, inspect.Labels);
             VERIFY_IS_TRUE(inspect.Config.Labels.find(c_metadataLabel) == inspect.Config.Labels.end());
+            VERIFY_ARE_EQUAL(c_image, inspect.Config.Image);
+            VERIFY_ARE_EQUAL(inspect.Image, inspect.Config.Image);
         }
 
         // Test nullptr key

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -10703,7 +10703,7 @@ class WSLCTests
 
         // Test valid labels
         {
-            WSLCContainerLauncher launcher("debian:latest", "test-labels", {"echo", "OK"});
+            WSLCContainerLauncher launcher(c_image, "test-labels", {"echo", "OK"});
 
             for (const auto& [key, value] : labels)
             {

--- a/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
@@ -160,6 +160,8 @@ class WSLCE2EInspectTests
         auto json = nlohmann::json::parse(wsl::shared::string::WideToMultiByte(result.Stdout.value()));
         VERIFY_IS_TRUE(json.is_array() && !json.empty());
         VERIFY_IS_TRUE(json[0].contains("Config") && json[0]["Config"].contains("Labels"));
+        VERIFY_IS_TRUE(json[0]["Config"].contains("Image"));
+        VERIFY_ARE_EQUAL(wsl::shared::string::WideToMultiByte(DebianImage.NameAndTag()), json[0]["Config"]["Image"].get<std::string>());
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Inspect_Container_InheritsImageLabels)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When you run wslc inspect <container>, the image name is shown at the top level of the JSON (Image) but not inside the Config object. Docker's own docker inspect shows it in both places. VS Code Dev Containers reads it from Config.Image, so with wslc, it can't find the image reference and silently fails to attach. This PR adds Config.Image to wslc inspect output, matching Docker's shape.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #41321 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Small follow-up to the earlier "container labels inheritance" fix. Same idea, different field.
Today wslc uses it to fill the top-level Image field in inspect output, but the Config object doesn't get it. Docker puts it in both places, and tools like VS Code Dev Containers rely on the Config.Image one, so they see nothing and quietly stop working.
- Added an Image field to wslc_schema::ContainerConfig
- In BuildInspectContainer, set Config.Image from the same m_image value we already use for the top-level Image field. Both stay in sync
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Extended WSLCTests::ContainerLabels to also check that Config.Image equals the image the container was launched with, both right after Create and after a session restart (Open path). Also asserts that the top-level Image and Config.Image stay in sync
- Extended WSLCE2EInspectTests::WSLCE2E_Inspect_Container_Success to assert that Config.Image appears in the emitted JSON and holds the expected image reference
