### PR TITLE
CLI: Align network list command to be consistent with Docker behavior

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3397,7 +3397,7 @@ On first run, creates the file with all settings commented out at their defaults
     <value>Network name</value>
   </data>
   <data name="WSLCCLI_NetworkListQuietArgDesc" xml:space="preserve">
-    <value>Outputs the network names only</value>
+    <value>Only display network IDs</value>
   </data>
   <data name="WSLCCLI_NetworkPruneDesc" xml:space="preserve">
     <value>Remove all unused networks.</value>

--- a/src/shared/inc/JsonUtils.h
+++ b/src/shared/inc/JsonUtils.h
@@ -209,13 +209,13 @@ struct adl_serializer<WSLCNetworkInformation>
 {
     static void to_json(json& j, const WSLCNetworkInformation& network)
     {
-        j = json{{"Name", std::string(network.Name)}, {"Id", std::string(network.Id)}, {"Driver", std::string(network.Driver)}};
+        j = json{{"Name", std::string(network.Name)}, {"ID", std::string(network.Id)}, {"Driver", std::string(network.Driver)}};
     }
 
     static void from_json(const json& j, WSLCNetworkInformation& network)
     {
         std::string name = j.at("Name").get<std::string>();
-        std::string id = j.at("Id").get<std::string>();
+        std::string id = j.at("ID").get<std::string>();
         std::string driver = j.at("Driver").get<std::string>();
 
         strncpy_s(network.Name, sizeof(network.Name), name.c_str(), _TRUNCATE);

--- a/src/windows/wslc/commands/NetworkListCommand.cpp
+++ b/src/windows/wslc/commands/NetworkListCommand.cpp
@@ -28,6 +28,7 @@ std::vector<Argument> NetworkListCommand::GetArguments() const
 {
     return {
         Argument::Create(ArgType::Format),
+        Argument::Create(ArgType::NoTrunc),
         Argument::Create(ArgType::Quiet, false, std::nullopt, Localization::WSLCCLI_NetworkListQuietArgDesc()),
     };
 }

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -170,17 +170,18 @@ void ListNetworks(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Networks));
     auto& networks = context.Data.Get<Data::Networks>();
 
-    if (context.Args.GetValue<ArgType::Quiet>())
+    const auto format = context.Args.GetValue<ArgType::Format>(FormatType::Table);
+    const bool quiet = context.Args.GetValue<ArgType::Quiet>();
+    const bool trunc = !context.Args.GetValue<ArgType::NoTrunc>();
+    if (format == FormatType::Table && quiet)
     {
         for (const auto& network : networks)
         {
-            context.Terminal.Output(L"{}\n", MultiByteToWide(network.Name));
+            context.Terminal.Output(L"{}\n", MultiByteToWide(TruncateId(network.Id, trunc)));
         }
 
         return;
     }
-
-    const auto format = context.Args.GetValue<ArgType::Format>(FormatType::Table);
 
     switch (format)
     {
@@ -188,7 +189,9 @@ void ListNetworks(CLIExecutionContext& context)
     {
         for (const auto& network : networks)
         {
-            context.Terminal.Output(L"{}\n", ToJsonW(network, c_jsonCompactIndent));
+            auto json = nlohmann::json(network);
+            json["ID"] = TruncateId(network.Id, trunc);
+            context.Terminal.Output(L"{}\n", ToJsonW(json, c_jsonCompactIndent));
         }
 
         break;
@@ -199,7 +202,7 @@ void ListNetworks(CLIExecutionContext& context)
         for (const auto& network : networks)
         {
             table.WriteRow({
-                MultiByteToWide(TruncateId(network.Id)),
+                MultiByteToWide(TruncateId(network.Id, trunc)),
                 MultiByteToWide(network.Name),
                 MultiByteToWide(network.Driver),
             });

--- a/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
@@ -53,19 +53,55 @@ class WSLCE2ENetworkListTests
             L"Invalid format value: invalid is not a recognized format type. Supported format types are: json, table."));
     }
 
-    WSLC_TEST_METHOD(WSLCE2E_Network_List_QuietOption_OutputsNamesOnly)
+    WSLC_TEST_METHOD(WSLCE2E_Network_List_QuietOption_OutputsIdsOnly)
     {
         auto result = RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName));
         result.Verify({.Stderr = L"", .ExitCode = 0});
         result = RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName2));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
+        result = RunWslc(L"network list --format json");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        std::vector<std::wstring> expectedIds;
+        for (const auto& network : ParseNdjsonOutput(result))
+        {
+            expectedIds.push_back(MultiByteToWide(network.at("ID").get<std::string>()));
+        }
+
         result = RunWslc(L"network list --quiet");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         auto lines = result.GetStdoutLines();
-        VERIFY_ARE_NOT_EQUAL(lines.end(), std::find(lines.begin(), lines.end(), TestNetworkName));
-        VERIFY_ARE_NOT_EQUAL(lines.end(), std::find(lines.begin(), lines.end(), TestNetworkName2));
+        VERIFY_ARE_EQUAL(expectedIds.size(), lines.size());
+        for (const auto& id : expectedIds)
+        {
+            VerifyIdOutput(id, true);
+            VERIFY_ARE_NOT_EQUAL(lines.end(), std::find(lines.begin(), lines.end(), id));
+        }
+
+        VERIFY_ARE_EQUAL(lines.end(), std::find(lines.begin(), lines.end(), TestNetworkName));
+        VERIFY_ARE_EQUAL(lines.end(), std::find(lines.begin(), lines.end(), TestNetworkName2));
+
+        result = RunWslc(L"network list --format json --no-trunc");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        expectedIds.clear();
+        for (const auto& network : ParseNdjsonOutput(result))
+        {
+            expectedIds.push_back(MultiByteToWide(network.at("ID").get<std::string>()));
+        }
+
+        result = RunWslc(L"network list --quiet --no-trunc");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        lines = result.GetStdoutLines();
+        VERIFY_ARE_EQUAL(expectedIds.size(), lines.size());
+        for (const auto& id : expectedIds)
+        {
+            VerifyIdOutput(id, false);
+            VERIFY_ARE_NOT_EQUAL(lines.end(), std::find(lines.begin(), lines.end(), id));
+        }
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Network_List_JsonFormat)
@@ -77,19 +113,46 @@ class WSLCE2ENetworkListTests
 
         result = RunWslc(L"network list --format json");
         result.Verify({.Stderr = L"", .ExitCode = 0});
-
-        auto networks = ParseNdjsonOutputAs<WSLCNetworkInformation>(result);
-        VERIFY_ARE_EQUAL(2U, networks.size());
+        auto networks = ParseNdjsonOutput(result);
 
         std::vector<std::string> names;
         names.reserve(networks.size());
         for (const auto& network : networks)
         {
-            names.push_back(network.Name);
+            VERIFY_ARE_EQUAL(3u, network.size());
+            VERIFY_IS_TRUE(network.contains("ID"));
+            VERIFY_IS_FALSE(network.contains("Id"));
+            VERIFY_IS_TRUE(network.contains("Name"));
+            VERIFY_IS_TRUE(network.contains("Driver"));
+            VerifyIdOutput(MultiByteToWide(network.at("ID").get<std::string>()), true);
+            names.push_back(network.at("Name").get<std::string>());
         }
 
-        VERIFY_ARE_NOT_EQUAL(names.end(), std::find(names.begin(), names.end(), WideToMultiByte(TestNetworkName)));
-        VERIFY_ARE_NOT_EQUAL(names.end(), std::find(names.begin(), names.end(), WideToMultiByte(TestNetworkName2)));
+        VERIFY_ARE_EQUAL(1u, static_cast<size_t>(std::count(names.begin(), names.end(), WideToMultiByte(TestNetworkName))));
+        VERIFY_ARE_EQUAL(1u, static_cast<size_t>(std::count(names.begin(), names.end(), WideToMultiByte(TestNetworkName2))));
+
+        auto quietResult = RunWslc(L"network list --format json --quiet");
+        quietResult.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_ARE_EQUAL(result.Stdout.value(), quietResult.Stdout.value());
+
+        auto fullResult = RunWslc(L"network list --format json --no-trunc");
+        fullResult.Verify({.Stderr = L"", .ExitCode = 0});
+        for (const auto& network : ParseNdjsonOutput(fullResult))
+        {
+            VerifyIdOutput(MultiByteToWide(network.at("ID").get<std::string>()), false);
+        }
+
+        auto fullQuietResult = RunWslc(L"network list --format json --quiet --no-trunc");
+        fullQuietResult.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_ARE_EQUAL(fullResult.Stdout.value(), fullQuietResult.Stdout.value());
+
+        auto fullTableResult = RunWslc(L"network list --no-trunc");
+        fullTableResult.Verify({.Stderr = L"", .ExitCode = 0});
+        for (const auto& network : ParseNdjsonOutput(fullResult))
+        {
+            const auto id = MultiByteToWide(network.at("ID").get<std::string>());
+            VERIFY_IS_TRUE(fullTableResult.StdoutContainsSubstring(id));
+        }
     }
 
 private:


### PR DESCRIPTION
## Summary of the Pull Request

Aligns `wslc network list` output and option behavior with Docker for consistent scripting and tooling compatibility.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
- Changes `--quiet` to output network IDs rather than network names.
- Uses 12-character network IDs by default across table, quiet, and JSON output.
- Adds `--no-trunc` support for full network IDs across all output formats.
- Changes the JSON key from `Id` to Docker-compatible `ID`. The supported JSON fields are now consistently named `ID`, `Name`, and `Driver`.
- Matches Docker's flag precedence so `--format json --quiet` produces the same output as `--format json`.

## Validation Steps Performed

- Network list E2E tests: `bin\x64\Debug\test.bat -f /name:*WSLCE2E_Network_List*`
- Result: 4/4 tests passed.