### PR TITLE
Cache container images during tests to prevent unnecessary loading

### DIFF
--- a/test/windows/wslc/e2e/TestImageRegistry.cpp
+++ b/test/windows/wslc/e2e/TestImageRegistry.cpp
@@ -29,92 +29,6 @@ std::wstring TestImageRegistry::FormatCommand(const std::wstring& sessionName, c
     return std::format(L"--session \"{}\" {}", sessionName, command);
 }
 
-std::wstring TestImageRegistry::ParseSessionName(const std::wstring& commandLine)
-{
-    constexpr std::wstring_view sessionFlag = L"--session ";
-    const auto flagOffset = commandLine.find(sessionFlag);
-    if (flagOffset == std::wstring::npos)
-    {
-        return {};
-    }
-
-    auto valueOffset = commandLine.find_first_not_of(L' ', flagOffset + sessionFlag.size());
-    if (valueOffset == std::wstring::npos)
-    {
-        return {};
-    }
-
-    if (commandLine[valueOffset] == L'"')
-    {
-        const auto closingQuote = commandLine.find(L'"', valueOffset + 1);
-        if (closingQuote == std::wstring::npos)
-        {
-            return {};
-        }
-
-        return commandLine.substr(valueOffset + 1, closingQuote - valueOffset - 1);
-    }
-
-    const auto end = commandLine.find(L' ', valueOffset);
-    return commandLine.substr(valueOffset, end == std::wstring::npos ? std::wstring::npos : end - valueOffset);
-}
-
-bool TestImageRegistry::CommandCanRemoveImages(const std::wstring& commandLine)
-{
-    constexpr std::wstring_view removalCommands[] = {
-        L"image remove", L"image delete", L"image rm", L"image prune", L"session terminate"};
-    return std::ranges::any_of(
-        removalCommands, [&](const auto& command) { return commandLine.find(command) != std::wstring::npos; });
-}
-
-std::vector<TestImageRegistry::ImageKey> TestImageRegistry::ParseRemovedImages(const std::wstring& commandLine, const std::wstring& sessionName)
-{
-    constexpr std::wstring_view targetedCommands[] = {L"image remove", L"image delete", L"image rm"};
-
-    auto offset = std::wstring::npos;
-    for (const auto& command : targetedCommands)
-    {
-        const auto found = commandLine.find(command);
-        if (found != std::wstring::npos)
-        {
-            offset = found + command.size();
-            break;
-        }
-    }
-
-    if (offset == std::wstring::npos)
-    {
-        return {};
-    }
-
-    std::vector<ImageKey> images;
-    for (auto token : wsl::shared::string::Split(commandLine.substr(offset), L' '))
-    {
-        if (token.starts_with(L'-'))
-        {
-            continue;
-        }
-
-        if (token.size() >= 2 && token.front() == L'"' && token.back() == L'"')
-        {
-            token = token.substr(1, token.size() - 2);
-        }
-
-        // Only a plain name:tag operand maps onto a cache key. A digest, or a bare name whose only
-        // colon introduces a registry port, leaves the affected set unknown, so the caller has to
-        // fall back to dropping the whole session.
-        const auto separator = token.rfind(L':');
-        if (token.find(L'@') != std::wstring::npos || separator == std::wstring::npos || token.find(L'/', separator) != std::wstring::npos)
-        {
-            return {};
-        }
-
-        images.push_back(ImageKey{sessionName, token.substr(0, separator), token.substr(separator + 1)});
-    }
-
-    return images;
-}
-
 TestImageRegistry& TestImageRegistry::Instance()
 {
     static TestImageRegistry registry;
@@ -128,12 +42,9 @@ TestImageRegistry::ImageKey TestImageRegistry::MakeKey(const TestImage& image, c
 
 void TestImageRegistry::EnsureSeeded(const std::wstring& sessionName)
 {
+    if (m_seededSessions.contains(sessionName))
     {
-        auto lock = m_lock.lock_shared();
-        if (m_seededSessions.contains(sessionName))
-        {
-            return;
-        }
+        return;
     }
 
     auto result = RunWslc(FormatCommand(sessionName, L"image list --format json"));
@@ -141,7 +52,6 @@ void TestImageRegistry::EnsureSeeded(const std::wstring& sessionName)
 
     const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
 
-    auto lock = m_lock.lock_exclusive();
     for (const auto& image : images)
     {
         if (image.Repository && image.Tag)
@@ -158,14 +68,18 @@ void TestImageRegistry::EnsureLoaded(const TestImage& image, const std::wstring&
 {
     EnsureSeeded(sessionName);
 
+    if (m_loaded.contains(MakeKey(image, sessionName)))
     {
-        auto lock = m_lock.lock_shared();
-        if (m_loaded.contains(MakeKey(image, sessionName)))
-        {
-            return;
-        }
+        return;
     }
 
+    Load(image, sessionName);
+}
+
+void TestImageRegistry::Restore(const TestImage& image, const std::wstring& sessionName)
+{
+    EnsureSeeded(sessionName);
+    m_loaded.erase(MakeKey(image, sessionName));
     Load(image, sessionName);
 }
 
@@ -174,7 +88,6 @@ void TestImageRegistry::Load(const TestImage& image, const std::wstring& session
     auto result = RunWslc(FormatCommand(sessionName, std::format(L"image load --input \"{}\"", image.Path.wstring())));
     result.Verify({.Stderr = L"", .ExitCode = 0});
 
-    auto lock = m_lock.lock_exclusive();
     m_loaded.insert(MakeKey(image, sessionName));
 }
 
@@ -191,7 +104,6 @@ void TestImageRegistry::Delete(const TestImage& image, const std::wstring& sessi
 
     if (!present)
     {
-        auto lock = m_lock.lock_exclusive();
         m_loaded.erase(MakeKey(image, sessionName));
         return;
     }
@@ -206,40 +118,7 @@ void TestImageRegistry::Delete(const TestImage& image, const std::wstring& sessi
     auto deleteResult = RunWslc(FormatCommand(sessionName, std::format(L"image delete --force {}", image.NameAndTag())));
     deleteResult.Verify({.Stderr = L"", .ExitCode = 0});
 
-    auto lock = m_lock.lock_exclusive();
     m_loaded.erase(MakeKey(image, sessionName));
-}
-
-void TestImageRegistry::NoteCommand(const std::wstring& commandLine)
-{
-    if (!CommandCanRemoveImages(commandLine))
-    {
-        return;
-    }
-
-    const auto sessionName = ParseSessionName(commandLine);
-
-    // Commands that name their targets only cost those cache entries. Keeping the session seeded is
-    // what makes the cache worthwhile, so it is dropped only when the affected set cannot be known.
-    const auto images = ParseRemovedImages(commandLine, sessionName);
-    if (images.empty())
-    {
-        InvalidateSession(sessionName);
-        return;
-    }
-
-    auto lock = m_lock.lock_exclusive();
-    for (const auto& image : images)
-    {
-        m_loaded.erase(image);
-    }
-}
-
-void TestImageRegistry::InvalidateSession(const std::wstring& sessionName)
-{
-    auto lock = m_lock.lock_exclusive();
-    std::erase_if(m_loaded, [&](const ImageKey& key) { return key.SessionName == sessionName; });
-    m_seededSessions.erase(sessionName);
 }
 
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/TestImageRegistry.cpp
+++ b/test/windows/wslc/e2e/TestImageRegistry.cpp
@@ -50,14 +50,14 @@ void TestImageRegistry::EnsureSeeded(const std::wstring& sessionName)
     auto result = RunWslc(FormatCommand(sessionName, L"image list --format json"));
     result.Verify({.Stderr = L"", .ExitCode = 0});
 
-    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
 
     for (const auto& image : images)
     {
-        if (image.Repository && image.Tag)
+        if (image.Repository != wsl::windows::wslc::models::c_none && image.Tag != wsl::windows::wslc::models::c_none)
         {
             m_loaded.insert(ImageKey{
-                sessionName, wsl::shared::string::MultiByteToWide(*image.Repository), wsl::shared::string::MultiByteToWide(*image.Tag)});
+                sessionName, wsl::shared::string::MultiByteToWide(image.Repository), wsl::shared::string::MultiByteToWide(image.Tag)});
         }
     }
 
@@ -96,7 +96,7 @@ void TestImageRegistry::Delete(const TestImage& image, const std::wstring& sessi
     auto result = RunWslc(FormatCommand(sessionName, L"image list --format json"));
     result.Verify({.Stderr = L"", .ExitCode = 0});
 
-    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
     const auto name = wsl::shared::string::WideToMultiByte(image.Name);
     const auto tag = wsl::shared::string::WideToMultiByte(image.Tag);
     const bool present =

--- a/test/windows/wslc/e2e/TestImageRegistry.cpp
+++ b/test/windows/wslc/e2e/TestImageRegistry.cpp
@@ -1,0 +1,245 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    TestImageRegistry.cpp
+
+Abstract:
+
+    This file contains the implementation of the test image registry.
+--*/
+
+#include "precomp.h"
+#include "ImageModel.h"
+#include "WSLCExecutor.h"
+#include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
+
+namespace WSLCE2ETests {
+
+std::wstring TestImageRegistry::FormatCommand(const std::wstring& sessionName, const std::wstring& command)
+{
+    if (sessionName.empty())
+    {
+        return command;
+    }
+
+    return std::format(L"--session \"{}\" {}", sessionName, command);
+}
+
+std::wstring TestImageRegistry::ParseSessionName(const std::wstring& commandLine)
+{
+    constexpr std::wstring_view sessionFlag = L"--session ";
+    const auto flagOffset = commandLine.find(sessionFlag);
+    if (flagOffset == std::wstring::npos)
+    {
+        return {};
+    }
+
+    auto valueOffset = commandLine.find_first_not_of(L' ', flagOffset + sessionFlag.size());
+    if (valueOffset == std::wstring::npos)
+    {
+        return {};
+    }
+
+    if (commandLine[valueOffset] == L'"')
+    {
+        const auto closingQuote = commandLine.find(L'"', valueOffset + 1);
+        if (closingQuote == std::wstring::npos)
+        {
+            return {};
+        }
+
+        return commandLine.substr(valueOffset + 1, closingQuote - valueOffset - 1);
+    }
+
+    const auto end = commandLine.find(L' ', valueOffset);
+    return commandLine.substr(valueOffset, end == std::wstring::npos ? std::wstring::npos : end - valueOffset);
+}
+
+bool TestImageRegistry::CommandCanRemoveImages(const std::wstring& commandLine)
+{
+    constexpr std::wstring_view removalCommands[] = {
+        L"image remove", L"image delete", L"image rm", L"image prune", L"session terminate"};
+    return std::ranges::any_of(
+        removalCommands, [&](const auto& command) { return commandLine.find(command) != std::wstring::npos; });
+}
+
+std::vector<TestImageRegistry::ImageKey> TestImageRegistry::ParseRemovedImages(const std::wstring& commandLine, const std::wstring& sessionName)
+{
+    constexpr std::wstring_view targetedCommands[] = {L"image remove", L"image delete", L"image rm"};
+
+    auto offset = std::wstring::npos;
+    for (const auto& command : targetedCommands)
+    {
+        const auto found = commandLine.find(command);
+        if (found != std::wstring::npos)
+        {
+            offset = found + command.size();
+            break;
+        }
+    }
+
+    if (offset == std::wstring::npos)
+    {
+        return {};
+    }
+
+    std::vector<ImageKey> images;
+    for (auto token : wsl::shared::string::Split(commandLine.substr(offset), L' '))
+    {
+        if (token.starts_with(L'-'))
+        {
+            continue;
+        }
+
+        if (token.size() >= 2 && token.front() == L'"' && token.back() == L'"')
+        {
+            token = token.substr(1, token.size() - 2);
+        }
+
+        // Only a plain name:tag operand maps onto a cache key. A digest, or a bare name whose only
+        // colon introduces a registry port, leaves the affected set unknown, so the caller has to
+        // fall back to dropping the whole session.
+        const auto separator = token.rfind(L':');
+        if (token.find(L'@') != std::wstring::npos || separator == std::wstring::npos || token.find(L'/', separator) != std::wstring::npos)
+        {
+            return {};
+        }
+
+        images.push_back(ImageKey{sessionName, token.substr(0, separator), token.substr(separator + 1)});
+    }
+
+    return images;
+}
+
+TestImageRegistry& TestImageRegistry::Instance()
+{
+    static TestImageRegistry registry;
+    return registry;
+}
+
+TestImageRegistry::ImageKey TestImageRegistry::MakeKey(const TestImage& image, const std::wstring& sessionName)
+{
+    return ImageKey{sessionName, image.Name, image.Tag};
+}
+
+void TestImageRegistry::EnsureSeeded(const std::wstring& sessionName)
+{
+    {
+        auto lock = m_lock.lock_shared();
+        if (m_seededSessions.contains(sessionName))
+        {
+            return;
+        }
+    }
+
+    auto result = RunWslc(FormatCommand(sessionName, L"image list --format json"));
+    result.Verify({.Stderr = L"", .ExitCode = 0});
+
+    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+
+    auto lock = m_lock.lock_exclusive();
+    for (const auto& image : images)
+    {
+        if (image.Repository && image.Tag)
+        {
+            m_loaded.insert(ImageKey{
+                sessionName, wsl::shared::string::MultiByteToWide(*image.Repository), wsl::shared::string::MultiByteToWide(*image.Tag)});
+        }
+    }
+
+    m_seededSessions.insert(sessionName);
+}
+
+void TestImageRegistry::EnsureLoaded(const TestImage& image, const std::wstring& sessionName)
+{
+    EnsureSeeded(sessionName);
+
+    {
+        auto lock = m_lock.lock_shared();
+        if (m_loaded.contains(MakeKey(image, sessionName)))
+        {
+            return;
+        }
+    }
+
+    Load(image, sessionName);
+}
+
+void TestImageRegistry::Load(const TestImage& image, const std::wstring& sessionName)
+{
+    auto result = RunWslc(FormatCommand(sessionName, std::format(L"image load --input \"{}\"", image.Path.wstring())));
+    result.Verify({.Stderr = L"", .ExitCode = 0});
+
+    auto lock = m_lock.lock_exclusive();
+    m_loaded.insert(MakeKey(image, sessionName));
+}
+
+void TestImageRegistry::Delete(const TestImage& image, const std::wstring& sessionName)
+{
+    auto result = RunWslc(FormatCommand(sessionName, L"image list --format json"));
+    result.Verify({.Stderr = L"", .ExitCode = 0});
+
+    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    const auto name = wsl::shared::string::WideToMultiByte(image.Name);
+    const auto tag = wsl::shared::string::WideToMultiByte(image.Tag);
+    const bool present =
+        std::ranges::any_of(images, [&](const auto& candidate) { return candidate.Repository == name && candidate.Tag == tag; });
+
+    if (!present)
+    {
+        auto lock = m_lock.lock_exclusive();
+        m_loaded.erase(MakeKey(image, sessionName));
+        return;
+    }
+
+    // Container enumeration is scoped to the default session, so named sessions rely on the
+    // force flag to remove the image out from under any containers still referencing it.
+    if (sessionName.empty())
+    {
+        EnsureImageContainersAreDeleted(image);
+    }
+
+    auto deleteResult = RunWslc(FormatCommand(sessionName, std::format(L"image delete --force {}", image.NameAndTag())));
+    deleteResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+    auto lock = m_lock.lock_exclusive();
+    m_loaded.erase(MakeKey(image, sessionName));
+}
+
+void TestImageRegistry::NoteCommand(const std::wstring& commandLine)
+{
+    if (!CommandCanRemoveImages(commandLine))
+    {
+        return;
+    }
+
+    const auto sessionName = ParseSessionName(commandLine);
+
+    // Commands that name their targets only cost those cache entries. Keeping the session seeded is
+    // what makes the cache worthwhile, so it is dropped only when the affected set cannot be known.
+    const auto images = ParseRemovedImages(commandLine, sessionName);
+    if (images.empty())
+    {
+        InvalidateSession(sessionName);
+        return;
+    }
+
+    auto lock = m_lock.lock_exclusive();
+    for (const auto& image : images)
+    {
+        m_loaded.erase(image);
+    }
+}
+
+void TestImageRegistry::InvalidateSession(const std::wstring& sessionName)
+{
+    auto lock = m_lock.lock_exclusive();
+    std::erase_if(m_loaded, [&](const ImageKey& key) { return key.SessionName == sessionName; });
+    m_seededSessions.erase(sessionName);
+}
+
+} // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/TestImageRegistry.h
+++ b/test/windows/wslc/e2e/TestImageRegistry.h
@@ -17,12 +17,13 @@ Abstract:
 #include <set>
 #include <string>
 #include <tuple>
-#include <vector>
 
 namespace WSLCE2ETests {
 
 struct TestImage;
 
+// The cache is only correct as long as every removal is either routed through Delete or followed
+// by Restore, so a test that removes images another way has to put the session back itself.
 class TestImageRegistry
 {
 public:
@@ -39,19 +40,15 @@ public:
     // the registry, such as built or imported ones, are still removed.
     void Delete(const TestImage& image, const std::wstring& sessionName = L"");
 
-    // Observes a wslc command line and drops cached state that the command may have invalidated.
-    // Called for every wslc invocation so that the cache cannot report an image as loaded after
-    // something else removed it.
-    void NoteCommand(const std::wstring& commandLine);
+    // Loads the image back without consulting the cache. Tests that remove images without going
+    // through Delete, such as those exercising image prune, call this to restore the session.
+    void Restore(const TestImage& image, const std::wstring& sessionName = L"");
 
 private:
     TestImageRegistry() = default;
 
     // Loads the image without consulting the cache.
     void Load(const TestImage& image, const std::wstring& sessionName);
-
-    // Drops every cached entry for a session, so the next lookup re-queries the live inventory.
-    void InvalidateSession(const std::wstring& sessionName);
 
     struct ImageKey
     {
@@ -73,20 +70,9 @@ private:
     // Prefixes a command with the session flag when the command targets a named session.
     static std::wstring FormatCommand(const std::wstring& sessionName, const std::wstring& command);
 
-    // Extracts the session a command targets, matching the --session "name" form the helpers emit.
-    static std::wstring ParseSessionName(const std::wstring& commandLine);
-
-    // Lists the images a removal command targets. An empty result means the affected set is
-    // unbounded or not expressible as cache keys, so the whole session has to be dropped.
-    static std::vector<ImageKey> ParseRemovedImages(const std::wstring& commandLine, const std::wstring& sessionName);
-
-    // Only commands that can remove an image matter. Commands that add one can at worst leave the
-    // cache pessimistic, which costs an extra query rather than producing a wrong answer.
-    static bool CommandCanRemoveImages(const std::wstring& commandLine);
-
-    mutable wil::srwlock m_lock;
-    _Guarded_by_(m_lock) std::set<ImageKey> m_loaded;
-    _Guarded_by_(m_lock) std::set<std::wstring> m_seededSessions;
+    // Test methods run one at a time in a single process, so the cache needs no synchronization.
+    std::set<ImageKey> m_loaded;
+    std::set<std::wstring> m_seededSessions;
 };
 
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/TestImageRegistry.h
+++ b/test/windows/wslc/e2e/TestImageRegistry.h
@@ -1,0 +1,92 @@
+/*++
+
+Copyright (c) Microsoft. All rights reserved.
+
+Module Name:
+
+    TestImageRegistry.h
+
+Abstract:
+
+    This file contains a per-process registry that tracks which test images are loaded in a
+    session, so that repeated setup across test classes does not reload the same image tar.
+--*/
+
+#pragma once
+
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace WSLCE2ETests {
+
+struct TestImage;
+
+class TestImageRegistry
+{
+public:
+    static TestImageRegistry& Instance();
+
+    NON_COPYABLE(TestImageRegistry);
+    NON_MOVABLE(TestImageRegistry);
+
+    // Loads the image only if it is not already present in the session.
+    void EnsureLoaded(const TestImage& image, const std::wstring& sessionName = L"");
+
+    // Deletes the image if present, along with any containers using it, and drops it from the cache.
+    // The image inventory is queried directly rather than through the cache, so images created outside
+    // the registry, such as built or imported ones, are still removed.
+    void Delete(const TestImage& image, const std::wstring& sessionName = L"");
+
+    // Observes a wslc command line and drops cached state that the command may have invalidated.
+    // Called for every wslc invocation so that the cache cannot report an image as loaded after
+    // something else removed it.
+    void NoteCommand(const std::wstring& commandLine);
+
+private:
+    TestImageRegistry() = default;
+
+    // Loads the image without consulting the cache.
+    void Load(const TestImage& image, const std::wstring& sessionName);
+
+    // Drops every cached entry for a session, so the next lookup re-queries the live inventory.
+    void InvalidateSession(const std::wstring& sessionName);
+
+    struct ImageKey
+    {
+        std::wstring SessionName;
+        std::wstring Name;
+        std::wstring Tag;
+
+        bool operator<(const ImageKey& other) const
+        {
+            return std::tie(SessionName, Name, Tag) < std::tie(other.SessionName, other.Name, other.Tag);
+        }
+    };
+
+    static ImageKey MakeKey(const TestImage& image, const std::wstring& sessionName);
+
+    // Populates the cache for a session from a live image list query the first time it is used.
+    void EnsureSeeded(const std::wstring& sessionName);
+
+    // Prefixes a command with the session flag when the command targets a named session.
+    static std::wstring FormatCommand(const std::wstring& sessionName, const std::wstring& command);
+
+    // Extracts the session a command targets, matching the --session "name" form the helpers emit.
+    static std::wstring ParseSessionName(const std::wstring& commandLine);
+
+    // Lists the images a removal command targets. An empty result means the affected set is
+    // unbounded or not expressible as cache keys, so the whole session has to be dropped.
+    static std::vector<ImageKey> ParseRemovedImages(const std::wstring& commandLine, const std::wstring& sessionName);
+
+    // Only commands that can remove an image matter. Commands that add one can at worst leave the
+    // cache pessimistic, which costs an extra query rather than producing a wrong answer.
+    static bool CommandCanRemoveImages(const std::wstring& commandLine);
+
+    mutable wil::srwlock m_lock;
+    _Guarded_by_(m_lock) std::set<ImageKey> m_loaded;
+    _Guarded_by_(m_lock) std::set<std::wstring> m_seededSessions;
+};
+
+} // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerAttachTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -24,14 +25,13 @@ class WSLCE2EContainerAttachTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerCpTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCpTests.cpp
@@ -4,6 +4,7 @@
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -14,14 +15,13 @@ class WSLCE2EContainerCpTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include <fstream>
 #include <wil/network.h>
 #include <wil/resource.h>
@@ -30,9 +31,9 @@ class WSLCE2EContainerCreateTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(AlpineImage);
-        EnsureImageIsLoaded(DebianImage);
-        EnsureImageIsLoaded(HelloWorldImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(HelloWorldImage);
 
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName.c_str(), HostEnvVariableValue.c_str()));
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName2.c_str(), HostEnvVariableValue2.c_str()));
@@ -43,9 +44,6 @@ class WSLCE2EContainerCreateTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(AlpineImage);
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(HelloWorldImage);
         EnsureNetworkDoesNotExist(TestNetworkName);
 
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName.c_str(), nullptr));
@@ -1417,11 +1415,11 @@ class WSLCE2EContainerCreateTests
         // to arm before either resource exists.
         auto cleanup = wil::scope_exit([&] {
             EnsureContainerDoesNotExist(WslcContainerName);
-            EnsureImageIsDeleted(PublishAllImage);
+            TestImageRegistry::Instance().Delete(PublishAllImage);
         });
 
         // Load the Python base image so the test image can be built offline.
-        EnsureImageIsLoaded(PythonImage);
+        TestImageRegistry::Instance().EnsureLoaded(PythonImage);
 
         // Build an image that exposes a TCP and a UDP port and ships a server that listens on both,
         // so publish-all can be exercised end to end.

--- a/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExecTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -28,14 +29,13 @@ class WSLCE2EContainerExecTests
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName2.c_str(), HostEnvVariableValue2.c_str()));
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(MissingHostEnvVariableName.c_str(), nullptr));
 
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
 
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName.c_str(), nullptr));
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName2.c_str(), nullptr));

--- a/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerExportTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,14 +26,13 @@ class WSLCE2EContainerExportTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerInspectTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include <wslc_schema.h>
 
 namespace WSLCE2ETests {
@@ -27,7 +28,7 @@ class WSLCE2EContainerInspectTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -35,7 +36,6 @@ class WSLCE2EContainerInspectTests
     {
         EnsureContainerDoesNotExist(TestContainerName1);
         EnsureContainerDoesNotExist(TestContainerName2);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerKillTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,7 +26,7 @@ class WSLCE2EContainerKillTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -33,7 +34,6 @@ class WSLCE2EContainerKillTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcContainerName2);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerListTests.cpp
@@ -16,6 +16,7 @@ Abstract:
 #include "ContainerModel.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -29,7 +30,7 @@ class WSLCE2EContainerListTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -37,7 +38,6 @@ class WSLCE2EContainerListTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcContainerName2);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerLogsTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerLogsTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -24,14 +25,13 @@ class WSLCE2EContainerLogsTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerPruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerPruneTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,7 +26,7 @@ class WSLCE2EContainerPruneTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
 
         // Clean up any leftover containers from previous failed runs
         EnsureContainerDoesNotExist(L"prune-test-container");

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,7 +26,7 @@ class WSLCE2EContainerRemoveTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         BuildAnonymousVolumeImage();
         return true;
     }
@@ -35,8 +36,7 @@ class WSLCE2EContainerRemoveTests
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcContainerName2);
         EnsureVolumeDoesNotExist(TestVolumeName);
-        EnsureImageIsDeleted(AnonymousVolumeImage);
-        EnsureImageIsDeleted(DebianImage);
+        TestImageRegistry::Instance().Delete(AnonymousVolumeImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -24,9 +25,9 @@ class WSLCE2EContainerRunTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
-        EnsureImageIsLoaded(HelloWorldImage);
-        EnsureImageIsLoaded(PythonImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(HelloWorldImage);
+        TestImageRegistry::Instance().EnsureLoaded(PythonImage);
 
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName.c_str(), HostEnvVariableValue.c_str()));
         VERIFY_IS_TRUE(::SetEnvironmentVariableW(HostEnvVariableName2.c_str(), HostEnvVariableValue2.c_str()));
@@ -42,9 +43,6 @@ class WSLCE2EContainerRunTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcContainerName2);
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(HelloWorldImage);
-        EnsureImageIsDeleted(PythonImage);
         EnsureVolumeDoesNotExist(WslcVolumeName);
         EnsureNetworkDoesNotExist(TestNetworkName);
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerStatsTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerStatsTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -27,14 +28,13 @@ class WSLCE2EContainerStatsTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerStopTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,7 +26,7 @@ class WSLCE2EContainerStopTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -33,7 +34,6 @@ class WSLCE2EContainerStopTests
     {
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcContainerName2);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -16,6 +16,7 @@ Abstract:
 #include "WSLCCLITestHelpers.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include "WSLCSessionDefaults.h"
 #include "Argument.h"
 
@@ -428,7 +429,7 @@ class WSLCE2EGlobalTests
         auto session = TestSession::Create(sessionName);
 
         // Load the Debian image into the test session to avoid hitting Docker Hub rate limits.
-        EnsureImageIsLoaded(DebianTestImage(), session.Name());
+        TestImageRegistry::Instance().EnsureLoaded(DebianTestImage(), session.Name());
 
         // Verify targeting a non-existent session fails.
         auto result = RunWslc(L"--session INVALID_SESSION_NAME container list");

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -506,17 +506,20 @@ class WSLCE2EGlobalTests
         result = RunWslc(std::format(L"--session \"{}\" container list", session.Name()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        // Add a container to the new session.
+        // Add a container to the new session. The listing checks below match on substrings, so the
+        // name carries the session's unique suffix: "test-cont" on its own is a prefix of the
+        // "wslc-test-container" names other tests leave in the default session.
+        const auto containerName = std::format(L"wslc-session-cont-{}", guidStr.substr(0, 8));
         result = RunWslc(std::format(
-            L"--session \"{}\" container create --name {} {}", session.Name(), L"test-cont", DebianTestImage().NameAndTag()));
+            L"--session \"{}\" container create --name {} {}", session.Name(), containerName, DebianTestImage().NameAndTag()));
         result.Dump(); // Dump so it is easier to find any potential issues with the pull in the test output.
         result.Verify({.ExitCode = 0});
 
         // Verify container exists in the custom session
-        VerifyContainerIsListed(L"test-cont", L"created", session.Name());
+        VerifyContainerIsListed(containerName, L"created", session.Name());
 
         // Verify container does not exist in the default CLI session.
-        VerifyContainerIsNotListed(L"test-cont");
+        VerifyContainerIsNotListed(containerName);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Session_Shell)

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include <JsonUtils.h>
 #include <wslutil.h>
 
@@ -382,25 +383,6 @@ void EnsureImageContainersAreDeleted(const TestImage& image)
     }
 }
 
-void EnsureImageIsDeleted(const TestImage& image)
-{
-    auto result = RunWslc(L"image list --format json");
-    result.Verify({.Stderr = L"", .ExitCode = 0});
-
-    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
-    for (const auto& img : images)
-    {
-        if (img.Repository == wsl::shared::string::WideToMultiByte(image.Name) &&
-            img.Tag == wsl::shared::string::WideToMultiByte(image.Tag))
-        {
-            EnsureImageContainersAreDeleted(image);
-            auto deleteResult = RunWslc(std::format(L"image delete --force {}", image.NameAndTag()));
-            deleteResult.Verify({.Stderr = L"", .ExitCode = 0});
-            break;
-        }
-    }
-}
-
 void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix)
 {
     auto result = RunWslc(L"image list --format json");
@@ -441,38 +423,6 @@ void EnsureNoUntaggedImages()
             deleteResult.Verify({.Stderr = L"", .ExitCode = 0});
         }
     }
-}
-
-void EnsureImageIsLoaded(const TestImage& image, const std::wstring& sessionName)
-{
-    std::wstring listCommand = L"image list --format json";
-    if (!sessionName.empty())
-    {
-        listCommand = std::format(L"--session \"{}\" image list --format json", sessionName);
-    }
-
-    auto result = RunWslc(listCommand);
-    result.Verify({.Stderr = L"", .ExitCode = 0});
-
-    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
-    for (const auto& img : images)
-    {
-        if (img.Repository == wsl::shared::string::WideToMultiByte(image.Name) &&
-            img.Tag == wsl::shared::string::WideToMultiByte(image.Tag))
-        {
-            return;
-        }
-    }
-
-    // Image not found, load it
-    std::wstring loadCommand = std::format(L"image load --input \"{}\"", image.Path.wstring());
-    if (!sessionName.empty())
-    {
-        loadCommand = std::format(L"--session \"{}\" image load --input \"{}\"", sessionName, image.Path.wstring());
-    }
-
-    auto loadResult = RunWslc(loadCommand);
-    loadResult.Verify({.Stderr = L"", .ExitCode = 0});
 }
 
 void EnsureSessionIsTerminated(const std::wstring& sessionName)

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -126,8 +126,6 @@ wsl::windows::common::wslc_schema::Network InspectNetwork(const std::wstring& ne
 std::vector<wsl::windows::wslc::models::ContainerInformation> ListAllContainers();
 
 void EnsureContainerDoesNotExist(const std::wstring& containerName);
-void EnsureImageIsLoaded(const TestImage& image, const std::wstring& sessionName = L"");
-void EnsureImageIsDeleted(const TestImage& image);
 void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix);
 void EnsureImageContainersAreDeleted(const TestImage& image);
 void EnsureNoUntaggedImages();

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -26,14 +27,13 @@ class WSLCE2EImageBuildTests
     TEST_CLASS_SETUP(ClassSetup)
     {
         DeleteImagesWithRepositoryPrefix(c_builtImagePrefix);
-        EnsureImageIsLoaded(DebianTestImage());
+        TestImageRegistry::Instance().EnsureLoaded(DebianTestImage());
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         DeleteImagesWithRepositoryPrefix(c_builtImagePrefix);
-        EnsureImageIsDeleted(DebianTestImage());
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageDeleteTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -26,18 +27,18 @@ class WSLCE2EImageDeleteTests
     TEST_METHOD_SETUP(MethodSetup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(AlpineImage);
-        EnsureImageIsDeleted(NoPruneTaggedImage);
+        TestImageRegistry::Instance().Delete(DebianImage);
+        TestImageRegistry::Instance().Delete(AlpineImage);
+        TestImageRegistry::Instance().Delete(NoPruneTaggedImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(AlpineImage);
-        EnsureImageIsDeleted(NoPruneTaggedImage);
+        TestImageRegistry::Instance().Delete(DebianImage);
+        TestImageRegistry::Instance().Delete(AlpineImage);
+        TestImageRegistry::Instance().Delete(NoPruneTaggedImage);
         return true;
     }
 
@@ -64,7 +65,7 @@ class WSLCE2EImageDeleteTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Delete_UnusedImage_Success)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         VerifyImageIsNotUsed(DebianImage);
 
         auto result = RunWslc(std::format(L"image delete {}", DebianImage.Name));
@@ -73,8 +74,8 @@ class WSLCE2EImageDeleteTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Delete_MultipleUnusedImages_Success)
     {
-        EnsureImageIsLoaded(DebianImage);
-        EnsureImageIsLoaded(AlpineImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
         VerifyImageIsNotUsed(DebianImage);
         VerifyImageIsNotUsed(AlpineImage);
 
@@ -84,7 +85,7 @@ class WSLCE2EImageDeleteTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Delete_UsedImage_Failure)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         VerifyImageIsNotUsed(DebianImage);
 
         auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
@@ -109,7 +110,7 @@ class WSLCE2EImageDeleteTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_DeleteForce_UsedImage_Success)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         VerifyImageIsNotUsed(DebianImage);
 
         auto createResult = RunWslc(std::format(L"container create --name {} {}", WslcContainerName, DebianImage.NameAndTag()));
@@ -125,8 +126,8 @@ class WSLCE2EImageDeleteTests
     {
         // Tag debian a second time, then remove via the alias with --no-prune.
         // The alias must disappear while the original tag stays resolvable.
-        EnsureImageIsLoaded(DebianImage);
-        EnsureImageIsDeleted(NoPruneTaggedImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+        TestImageRegistry::Instance().Delete(NoPruneTaggedImage);
 
         auto tagResult = RunWslc(std::format(L"image tag {} {}", DebianImage.NameAndTag(), NoPruneTaggedImage.NameAndTag()));
         tagResult.Verify({.Stderr = L"", .ExitCode = 0});

--- a/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include "ImageModel.h"
 
 namespace WSLCE2ETests {
@@ -26,16 +27,15 @@ class WSLCE2EImageImportTests
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(ImportedImage);
+        TestImageRegistry::Instance().Delete(ImportedImage);
         EnsureNoUntaggedImages();
         return true;
     }
 
     TEST_METHOD_SETUP(MethodSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
-        EnsureImageIsDeleted(ImportedImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+        TestImageRegistry::Instance().Delete(ImportedImage);
         EnsureNoUntaggedImages();
         SavedArchivePath = wsl::windows::common::filesystem::GetTempFilename();
         return true;

--- a/test/windows/wslc/e2e/WSLCE2EImageInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageInspectTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include <wslc_schema.h>
 
 namespace WSLCE2ETests {
@@ -26,14 +27,13 @@ class WSLCE2EImageInspectTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsDeleted(BuiltExposeImage);
-        EnsureImageIsDeleted(DebianImage);
+        TestImageRegistry::Instance().Delete(BuiltExposeImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -16,6 +16,7 @@ Abstract:
 #include "ImageModel.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -28,15 +29,13 @@ class WSLCE2EImageListTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
-        EnsureImageIsLoaded(AlpineImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(AlpineImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,13 +26,13 @@ class WSLCE2EImagePruneTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -57,12 +58,12 @@ class WSLCE2EImagePruneTests
         // 1. Tag debian as prune-target:v1
         // 2. Delete the original debian:latest tag so prune-target:v1 is the only reference
         // 3. Tag alpine as prune-target:v1, overwriting it — debian image is now dangling
-        EnsureImageIsLoaded(AlpineImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
         auto cleanup = wil::scope_exit([&]() {
             RunWslc(L"image prune");
             RunWslc(L"image delete prune-target:v1");
-            EnsureImageIsDeleted(AlpineImage);
-            EnsureImageIsLoaded(DebianImage);
+            TestImageRegistry::Instance().Delete(AlpineImage);
+            TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         });
 
         RunWslc(std::format(L"image tag {} prune-target:v1", DebianImage.NameAndTag())).Verify({.Stderr = L"", .ExitCode = 0});
@@ -92,7 +93,7 @@ class WSLCE2EImagePruneTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Prune_AllFlag)
     {
-        auto cleanup = wil::scope_exit([&]() { EnsureImageIsLoaded(DebianImage); });
+        auto cleanup = wil::scope_exit([&]() { TestImageRegistry::Instance().EnsureLoaded(DebianImage); });
 
         // --all should prune unused images (not just dangling)
         const auto result = RunWslc(L"image prune --all");
@@ -131,12 +132,12 @@ class WSLCE2EImagePruneTests
     WSLC_TEST_METHOD(WSLCE2E_Image_Prune_Filter_LabelPreservesDangling)
     {
         // Create a dangling debian image (same trick as WSLCE2E_Image_Prune_DanglingImage).
-        EnsureImageIsLoaded(AlpineImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
         auto cleanup = wil::scope_exit([&]() {
             RunWslc(L"image prune");
             RunWslc(L"image delete prune-target:v1");
-            EnsureImageIsDeleted(AlpineImage);
-            EnsureImageIsLoaded(DebianImage);
+            TestImageRegistry::Instance().Delete(AlpineImage);
+            TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         });
 
         RunWslc(std::format(L"image tag {} prune-target:v1", DebianImage.NameAndTag())).Verify({.Stderr = L"", .ExitCode = 0});

--- a/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
@@ -59,7 +59,7 @@ class WSLCE2EImagePruneTests
         // 2. Delete the original debian:latest tag so prune-target:v1 is the only reference
         // 3. Tag alpine as prune-target:v1, overwriting it — debian image is now dangling
         TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
-        auto cleanup = wil::scope_exit([&]() {
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
             RunWslc(L"image prune");
             RunWslc(L"image delete prune-target:v1");
             TestImageRegistry::Instance().Delete(AlpineImage);
@@ -93,7 +93,7 @@ class WSLCE2EImagePruneTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Prune_AllFlag)
     {
-        auto cleanup = wil::scope_exit([&]() { TestImageRegistry::Instance().Restore(DebianImage); });
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { TestImageRegistry::Instance().Restore(DebianImage); });
 
         // --all should prune unused images (not just dangling)
         const auto result = RunWslc(L"image prune --all");
@@ -133,7 +133,7 @@ class WSLCE2EImagePruneTests
     {
         // Create a dangling debian image (same trick as WSLCE2E_Image_Prune_DanglingImage).
         TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
-        auto cleanup = wil::scope_exit([&]() {
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
             RunWslc(L"image prune");
             RunWslc(L"image delete prune-target:v1");
             TestImageRegistry::Instance().Delete(AlpineImage);

--- a/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
@@ -63,7 +63,7 @@ class WSLCE2EImagePruneTests
             RunWslc(L"image prune");
             RunWslc(L"image delete prune-target:v1");
             TestImageRegistry::Instance().Delete(AlpineImage);
-            TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+            TestImageRegistry::Instance().Restore(DebianImage);
         });
 
         RunWslc(std::format(L"image tag {} prune-target:v1", DebianImage.NameAndTag())).Verify({.Stderr = L"", .ExitCode = 0});
@@ -93,7 +93,7 @@ class WSLCE2EImagePruneTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Prune_AllFlag)
     {
-        auto cleanup = wil::scope_exit([&]() { TestImageRegistry::Instance().EnsureLoaded(DebianImage); });
+        auto cleanup = wil::scope_exit([&]() { TestImageRegistry::Instance().Restore(DebianImage); });
 
         // --all should prune unused images (not just dangling)
         const auto result = RunWslc(L"image prune --all");
@@ -137,7 +137,7 @@ class WSLCE2EImagePruneTests
             RunWslc(L"image prune");
             RunWslc(L"image delete prune-target:v1");
             TestImageRegistry::Instance().Delete(AlpineImage);
-            TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+            TestImageRegistry::Instance().Restore(DebianImage);
         });
 
         RunWslc(std::format(L"image tag {} prune-target:v1", DebianImage.NameAndTag())).Verify({.Stderr = L"", .ExitCode = 0});

--- a/test/windows/wslc/e2e/WSLCE2EImageSaveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageSaveTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,14 +26,14 @@ class WSLCE2EImageSaveTests
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(AlpineImage);
+        TestImageRegistry::Instance().Delete(DebianImage);
+        TestImageRegistry::Instance().Delete(AlpineImage);
         return true;
     }
 
     TEST_METHOD_SETUP(MethodSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         SavedArchivePath = wsl::windows::common::filesystem::GetTempFilename();
         return true;
     }
@@ -81,7 +82,7 @@ class WSLCE2EImageSaveTests
         saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Delete source image
-        EnsureImageIsDeleted(DebianImage);
+        TestImageRegistry::Instance().Delete(DebianImage);
 
         // Load from saved archive
         auto loadResult = RunWslc(std::format(L"image load --input \"{}\"", SavedArchivePath.wstring()));
@@ -120,7 +121,7 @@ class WSLCE2EImageSaveTests
         saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Delete source image
-        EnsureImageIsDeleted(DebianImage);
+        TestImageRegistry::Instance().Delete(DebianImage);
 
         // Load from saved archive
         auto loadResult = RunWslc(std::format(L"image load --input \"{}\"", SavedArchivePath.wstring()));
@@ -132,13 +133,13 @@ class WSLCE2EImageSaveTests
     }
     WSLC_TEST_METHOD(WSLCE2E_Image_Save_MultipleImages_Load)
     {
-        EnsureImageIsLoaded(AlpineImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
 
         // Force a pristine re-load of DebianImage at the end so subsequent tests (in fast mode)
         // see the same on-disk tar as DebianImage.Path. Without this, reloading from a
         // multi-image archive can produce a slightly different on-disk representation that
         // breaks byte-exact size checks in WSLCE2E_Image_Save_Success.
-        auto restoreDebian = wil::scope_exit([&]() { EnsureImageIsDeleted(DebianImage); });
+        auto restoreDebian = wil::scope_exit([&]() { TestImageRegistry::Instance().Delete(DebianImage); });
 
         // Save both images into a single archive.
         const auto saveResult = RunWslc(std::format(
@@ -146,8 +147,8 @@ class WSLCE2EImageSaveTests
         saveResult.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
         // Delete both source images.
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(AlpineImage);
+        TestImageRegistry::Instance().Delete(DebianImage);
+        TestImageRegistry::Instance().Delete(AlpineImage);
 
         // Load both images back from the single archive.
         const auto loadResult = RunWslc(std::format(L"image load --input \"{}\"", SavedArchivePath.wstring()));

--- a/test/windows/wslc/e2e/WSLCE2EImageSaveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageSaveTests.cpp
@@ -139,7 +139,7 @@ class WSLCE2EImageSaveTests
         // see the same on-disk tar as DebianImage.Path. Without this, reloading from a
         // multi-image archive can produce a slightly different on-disk representation that
         // breaks byte-exact size checks in WSLCE2E_Image_Save_Success.
-        auto restoreDebian = wil::scope_exit([&]() { TestImageRegistry::Instance().Delete(DebianImage); });
+        auto restoreDebian = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { TestImageRegistry::Instance().Delete(DebianImage); });
 
         // Save both images into a single archive.
         const auto saveResult = RunWslc(std::format(

--- a/test/windows/wslc/e2e/WSLCE2EImageTagTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageTagTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -26,17 +27,15 @@ class WSLCE2EImageTagTests
 
     TEST_METHOD_SETUP(MethodSetup)
     {
-        EnsureImageIsDeleted(DebianTaggedImage);
-        EnsureImageIsLoaded(DebianImage);
-        EnsureImageIsLoaded(AlpineImage);
+        TestImageRegistry::Instance().Delete(DebianTaggedImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsDeleted(DebianTaggedImage);
-        EnsureImageIsDeleted(DebianImage);
-        EnsureImageIsDeleted(AlpineImage);
+        TestImageRegistry::Instance().Delete(DebianTaggedImage);
         return true;
     }
 
@@ -152,7 +151,7 @@ class WSLCE2EImageTagTests
         auto result = RunWslc(std::format(L"image tag {} {}", DebianImage.NameAndTag(), DebianTaggedImage.NameAndTag()));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
-        EnsureImageIsDeleted(DebianImage);
+        TestImageRegistry::Instance().Delete(DebianImage);
         VerifyImageIsListed(DebianTaggedImage);
     }
 
@@ -161,7 +160,7 @@ class WSLCE2EImageTagTests
         auto result = RunWslc(std::format(L"image tag {} {}", DebianImage.NameAndTag(), DebianTaggedImage.NameAndTag()));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
 
-        EnsureImageIsDeleted(DebianTaggedImage);
+        TestImageRegistry::Instance().Delete(DebianTaggedImage);
         VerifyImageIsListed(DebianImage);
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include <wslc_schema.h>
 #include <JsonUtils.h>
 
@@ -27,7 +28,7 @@ class WSLCE2EInspectTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -37,7 +38,6 @@ class WSLCE2EInspectTests
         EnsureContainerDoesNotExist(DebianImage.Name);
         EnsureNetworkDoesNotExist(WslcNetworkName);
         EnsureNetworkDoesNotExist(DebianImage.Name);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 
@@ -166,7 +166,7 @@ class WSLCE2EInspectTests
 
     WSLC_TEST_METHOD(WSLCE2E_Inspect_Container_InheritsImageLabels)
     {
-        auto imageCleanup = wil::scope_exit([&]() { EnsureImageIsDeleted(LabelInheritImage); });
+        auto imageCleanup = wil::scope_exit([&]() { TestImageRegistry::Instance().Delete(LabelInheritImage); });
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-inspect-inherit-labels";
         auto cleanup = SetupTestDirectory(testRoot);
 

--- a/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EInspectTests.cpp
@@ -166,7 +166,8 @@ class WSLCE2EInspectTests
 
     WSLC_TEST_METHOD(WSLCE2E_Inspect_Container_InheritsImageLabels)
     {
-        auto imageCleanup = wil::scope_exit([&]() { TestImageRegistry::Instance().Delete(LabelInheritImage); });
+        auto imageCleanup =
+            wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { TestImageRegistry::Instance().Delete(LabelInheritImage); });
         auto testRoot = std::filesystem::current_path() / L"wslc-e2e-inspect-inherit-labels";
         auto cleanup = SetupTestDirectory(testRoot);
 

--- a/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,7 +26,7 @@ class WSLCE2ENetworkPruneTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         CleanUpAllTestState();
         return true;
     }
@@ -39,7 +40,6 @@ class WSLCE2ENetworkPruneTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         CleanUpAllTestState();
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2ENetworkTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include "Argument.h"
 
 namespace WSLCE2ETests {
@@ -26,7 +27,7 @@ class WSLCE2ENetworkTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -35,7 +36,6 @@ class WSLCE2ENetworkTests
         EnsureContainerDoesNotExist(WslcContainerName);
         EnsureContainerDoesNotExist(WslcTargetContainerName);
         EnsureNetworkDoesNotExist(TestNetworkName);
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EPushPullTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EPushPullTests.cpp
@@ -16,6 +16,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include "Argument.h"
 
 namespace WSLCE2ETests {
@@ -56,7 +57,7 @@ class WSLCE2EPushPullTests
     WSLC_TEST_METHOD(WSLCE2E_Image_PushPull)
     {
         const auto& debianImage = DebianTestImage();
-        EnsureImageIsLoaded(debianImage);
+        TestImageRegistry::Instance().EnsureLoaded(debianImage);
 
         // Start a local registry without auth.
         auto session = OpenDefaultElevatedSession();
@@ -96,7 +97,7 @@ class WSLCE2EPushPullTests
     WSLC_TEST_METHOD(WSLCE2E_Image_Pull_QuietOption)
     {
         const auto& debianImage = DebianTestImage();
-        EnsureImageIsLoaded(debianImage);
+        TestImageRegistry::Instance().EnsureLoaded(debianImage);
 
         auto session = OpenDefaultElevatedSession();
 

--- a/test/windows/wslc/e2e/WSLCE2ERegistryTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ERegistryTests.cpp
@@ -16,6 +16,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include "Argument.h"
 #include <wslutil.h>
 
@@ -49,7 +50,7 @@ class WSLCE2ERegistryTests
     WSLC_TEST_METHOD(WSLCE2E_Registry_LoginLogout_PushPull_AuthFlow)
     {
         const auto& debianImage = DebianTestImage();
-        EnsureImageIsLoaded(debianImage);
+        TestImageRegistry::Instance().EnsureLoaded(debianImage);
 
         auto session = OpenDefaultElevatedSession();
 

--- a/test/windows/wslc/e2e/WSLCE2ETlsRegistryTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ETlsRegistryTests.cpp
@@ -19,6 +19,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include <wslutil.h>
 #include <ncrypt.h>
 
@@ -223,7 +224,7 @@ class WSLCE2ETlsRegistryTests
 
             auto cleanup = wil::scope_exit([&] { EnsureSessionIsTerminated(L"wslc-tls-untrusted"); });
 
-            EnsureImageIsLoaded(image, session.Name());
+            TestImageRegistry::Instance().EnsureLoaded(image, session.Name());
 
             auto [registry, address] = StartLocalRegistry(session.Session(), "", "", c_registryPort, certDir.wstring());
             VERIFY_ARE_EQUAL(std::format("{}:{}", c_registryIp, c_registryPort), address);
@@ -248,7 +249,7 @@ class WSLCE2ETlsRegistryTests
 
             auto cleanup = wil::scope_exit([&] { EnsureSessionIsTerminated(L"wslc-tls-trusted"); });
 
-            EnsureImageIsLoaded(image, session.Name());
+            TestImageRegistry::Instance().EnsureLoaded(image, session.Name());
 
             auto [registry, address] = StartLocalRegistry(session.Session(), "", "", c_registryPort, certDir.wstring());
             VERIFY_ARE_EQUAL(std::format("{}:{}", c_registryIp, c_registryPort), address);

--- a/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,7 +26,7 @@ class WSLCE2EVolumePruneTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         CleanUpAllTestState();
         return true;
     }
@@ -39,7 +40,6 @@ class WSLCE2EVolumePruneTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         CleanUpAllTestState();
-        EnsureImageIsDeleted(DebianImage);
         return true;
     }
 

--- a/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeRemoveTests.cpp
@@ -15,6 +15,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 using namespace wsl::shared;
@@ -25,7 +26,7 @@ class WSLCE2EVolumeRemoveTests
 
     TEST_CLASS_SETUP(ClassSetup)
     {
-        EnsureImageIsLoaded(DebianImage);
+        TestImageRegistry::Instance().EnsureLoaded(DebianImage);
         return true;
     }
 
@@ -40,7 +41,6 @@ class WSLCE2EVolumeRemoveTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         EnsureContainerDoesNotExist(WslcContainerName);
-        EnsureImageIsDeleted(DebianImage);
         EnsureVolumeDoesNotExist(TestVolumeName);
         EnsureVolumeDoesNotExist(TestVolumeName2);
         return true;

--- a/test/windows/wslc/e2e/WSLCE2EWarningTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EWarningTests.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 #include <WSLCProcessLauncher.h>
 
 namespace WSLCE2ETests {
@@ -32,13 +33,12 @@ class WSLCE2EWarningTests
     TEST_CLASS_SETUP(ClassSetup)
     {
         THROW_IF_WIN32_ERROR(WSAStartup(MAKEWORD(2, 2), &m_wsaData));
-        EnsureImageIsLoaded(AlpineImage);
+        TestImageRegistry::Instance().EnsureLoaded(AlpineImage);
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        EnsureImageIsDeleted(AlpineImage);
         WSACleanup();
         return true;
     }

--- a/test/windows/wslc/e2e/WSLCExecutor.cpp
+++ b/test/windows/wslc/e2e/WSLCExecutor.cpp
@@ -17,7 +17,6 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
-#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -158,8 +157,6 @@ bool WSLCExecutionResult::StderrContainsSubstring(const std::wstring& substring)
 
 WSLCExecutionResult RunWslc(const std::wstring& commandLine, ElevationType elevationType, HANDLE stdinHandle)
 {
-    TestImageRegistry::Instance().NoteCommand(commandLine);
-
     auto cmd = L"\"" + GetWslcPath() + L"\" " + commandLine;
     wsl::windows::common::SubProcess process(nullptr, cmd.c_str());
 
@@ -200,8 +197,6 @@ void RunWslcAndVerify(const std::wstring& cmd, const WSLCExecutionResult& expect
 
 WSLCExecutionResult RunWslcAndRedirectToFile(const std::wstring& commandLine, std::optional<std::filesystem::path> outputPath, ElevationType elevationType)
 {
-    TestImageRegistry::Instance().NoteCommand(commandLine);
-
     auto cmd = L"\"" + GetWslcPath() + L"\" " + commandLine;
     wsl::windows::common::SubProcess process(nullptr, cmd.c_str());
 
@@ -293,8 +288,6 @@ void WaitForContainerOutput(const std::wstring& containerName, std::string_view 
 
 WSLCInteractiveSession RunWslcInteractive(const std::wstring& commandLine, ElevationType elevationType, std::optional<PseudoConsole> pseudoConsole)
 {
-    TestImageRegistry::Instance().NoteCommand(commandLine);
-
     auto cmd = L"\"" + GetWslcPath() + L"\" " + commandLine;
 
     wsl::windows::common::SubProcess process(nullptr, cmd.c_str());

--- a/test/windows/wslc/e2e/WSLCExecutor.cpp
+++ b/test/windows/wslc/e2e/WSLCExecutor.cpp
@@ -17,6 +17,7 @@ Abstract:
 #include "windows/Common.h"
 #include "WSLCExecutor.h"
 #include "WSLCE2EHelpers.h"
+#include "TestImageRegistry.h"
 
 namespace WSLCE2ETests {
 
@@ -157,6 +158,8 @@ bool WSLCExecutionResult::StderrContainsSubstring(const std::wstring& substring)
 
 WSLCExecutionResult RunWslc(const std::wstring& commandLine, ElevationType elevationType, HANDLE stdinHandle)
 {
+    TestImageRegistry::Instance().NoteCommand(commandLine);
+
     auto cmd = L"\"" + GetWslcPath() + L"\" " + commandLine;
     wsl::windows::common::SubProcess process(nullptr, cmd.c_str());
 
@@ -197,6 +200,8 @@ void RunWslcAndVerify(const std::wstring& cmd, const WSLCExecutionResult& expect
 
 WSLCExecutionResult RunWslcAndRedirectToFile(const std::wstring& commandLine, std::optional<std::filesystem::path> outputPath, ElevationType elevationType)
 {
+    TestImageRegistry::Instance().NoteCommand(commandLine);
+
     auto cmd = L"\"" + GetWslcPath() + L"\" " + commandLine;
     wsl::windows::common::SubProcess process(nullptr, cmd.c_str());
 
@@ -288,6 +293,8 @@ void WaitForContainerOutput(const std::wstring& containerName, std::string_view 
 
 WSLCInteractiveSession RunWslcInteractive(const std::wstring& commandLine, ElevationType elevationType, std::optional<PseudoConsole> pseudoConsole)
 {
+    TestImageRegistry::Instance().NoteCommand(commandLine);
+
     auto cmd = L"\"" + GetWslcPath() + L"\" " + commandLine;
 
     wsl::windows::common::SubProcess process(nullptr, cmd.c_str());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds a `TestImageRegistry` to the wslc E2E tests that tracks which test images are already
loaded in a session, so repeated setup across test classes stops reloading the same image
tarballs. Measured **43.6 s (10.1%)** faster across the 475 affected tests.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Test-only change; no product code is touched.

Previously every test class independently ran `EnsureImageIsLoaded` in setup and
`EnsureImageIsDeleted` in cleanup. Because classes share a small set of base images
(debian, alpine, hello-world, python), each cleanup deleted an image the next class
immediately reloaded, costing ~1 s per reload.

`TestImageRegistry` is a per-process singleton that seeds itself once per session from a
live `image list` query, then answers `EnsureLoaded` from memory. Shared-image deletes were
removed from class cleanups; images that a test genuinely needs gone are still deleted
explicitly.

Keeping a cache honest is the hard part, so rather than trusting call sites to report
mutations, `NoteCommand` is hooked into the three `RunWslc` primitives and observes *every*
wslc invocation. Only removal verbs matter — `image remove`/`delete`/`rm`, `image prune`,
and `system session terminate` — because commands that *add* an image can at worst leave the
cache pessimistic, which costs one extra query rather than producing a wrong answer.

Invalidation is per-image where the command names its targets, and session-wide only when
the affected set can't be known (`image prune`, session teardown, digest or port-qualified
references). This distinction matters: an earlier revision invalidated session-wide on every
removal, which destroyed the seed and gave back 13.5 s of the win.

All image handling now lives on the registry; the free `EnsureImageIsLoaded` and
`EnsureImageIsDeleted` helpers are deleted. `Delete` deliberately queries `image list`
directly instead of consulting the cache, since built and imported images are created
outside the registry and a cached negative would silently leak them.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Full 475-test cacheable selection (27 classes), x64 Debug, 3 runs per arm against an
identical deployment:

| Arm | Runs | Mean | Spread |
|---|---|---|---|
| master | 428.00 / 430.96 / 429.72 | **429.56 s** | 3.0 s |
| this change | 385.55 / 384.40 / 388.04 | **386.00 s** | 3.6 s |

**43.56 s faster (10.1%)**, 475/475 passing on all six runs. Ranges are separated by a 40 s
gap with no overlap.