### PR TITLE
[release/2.7] Fix VHD ownership during distribution moves

### DIFF
--- a/src/windows/common/WslSecurity.cpp
+++ b/src/windows/common/WslSecurity.cpp
@@ -135,7 +135,7 @@ bool wsl::windows::common::security::IsTokenElevated(_In_ HANDLE token)
     return (GetUserBasicIntegrityLevel(token) == SECURITY_MANDATORY_HIGH_RID);
 }
 
-wil::unique_handle wsl::windows::common::security::GetUserToken(_In_ TOKEN_TYPE tokenType, _In_ RPC_BINDING_HANDLE handle)
+wil::unique_handle wsl::windows::common::security::GetUserToken(_In_ TOKEN_TYPE tokenType, _In_ RPC_BINDING_HANDLE handle, _In_ DWORD additionalAccess)
 {
     wil::unique_handle contextToken;
 
@@ -157,7 +157,12 @@ wil::unique_handle wsl::windows::common::security::GetUserToken(_In_ TOKEN_TYPE 
 
     wil::unique_handle newToken;
     THROW_IF_WIN32_BOOL_FALSE(::DuplicateTokenEx(
-        contextToken.get(), TOKEN_DUPLICATE | TOKEN_IMPERSONATE | TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, nullptr, SecurityImpersonation, tokenType, &newToken));
+        contextToken.get(),
+        TOKEN_DUPLICATE | TOKEN_IMPERSONATE | TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES | additionalAccess,
+        nullptr,
+        SecurityImpersonation,
+        tokenType,
+        &newToken));
 
     return newToken;
 }

--- a/src/windows/common/WslSecurity.h
+++ b/src/windows/common/WslSecurity.h
@@ -100,7 +100,7 @@ DWORD GetUserBasicIntegrityLevel(_In_ HANDLE token);
 /// <summary>
 /// Returns the user token for the current client.
 /// </summary>
-wil::unique_handle GetUserToken(_In_ TOKEN_TYPE tokenType, _In_ RPC_BINDING_HANDLE handle = nullptr);
+wil::unique_handle GetUserToken(_In_ TOKEN_TYPE tokenType, _In_ RPC_BINDING_HANDLE handle = nullptr, _In_ DWORD additionalAccess = 0);
 
 /// <summary>
 /// Queries if the provided token is elevated.

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -923,77 +923,47 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
 
     RETURN_HR_IF(E_NOTIMPL, WI_IsFlagClear(distro.Flags, LXSS_DISTRO_FLAGS_VM_MODE));
 
-    // Build the final vhd path.
-    std::filesystem::path newVhdPath = Location;
-    RETURN_HR_IF(E_INVALIDARG, newVhdPath.empty());
+    std::filesystem::path destDir(Location);
+    RETURN_HR_IF(E_INVALIDARG, destDir.empty());
 
-    newVhdPath /= distro.VhdFilePath.filename();
+    const std::filesystem::path destPath = destDir / distro.VhdFilePath.filename();
 
-    auto impersonate = wil::CoImpersonateClient();
+    // Cross-volume MoveFileEx creates a new file using the impersonation token's
+    // default owner. Normalize that owner to the caller's user SID so elevated moves
+    // do not produce a VHD owned by BUILTIN\Administrators.
+    auto tokenUser = wil::get_token_information<TOKEN_USER>(userToken.get());
+    TOKEN_OWNER tokenOwner{tokenUser->User.Sid};
+    THROW_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, &tokenOwner, sizeof(tokenOwner)));
 
-    // Create the distribution base folder
-    std::error_code error;
-    std::filesystem::create_directories(Location, error);
-    if (error.value())
     {
-        THROW_WIN32(error.value());
+        auto impersonate = wil::impersonate_token(userToken.get());
+
+        std::error_code error;
+        std::filesystem::create_directories(destDir, error);
+        if (error.value())
+        {
+            THROW_WIN32(error.value());
+        }
+
+        THROW_IF_WIN32_BOOL_FALSE(MoveFileExW(distro.VhdFilePath.c_str(), destPath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH));
     }
 
-    // Read the original VHD owner before the move so we can restore it after.
-    // Cross-volume MoveFileEx may set the owner to BUILTIN\Administrators for
-    // elevated callers, which breaks HcsGrantVmAccess (needs WRITE_DAC via
-    // ownership) from non-elevated contexts.
-    PSID originalOwner = nullptr;
-    wil::unique_hlocal originalDescriptor;
-    THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
-        distro.VhdFilePath.c_str(), SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &originalOwner, nullptr, nullptr, nullptr, &originalDescriptor));
-
-    // Move the VHD to the new location.
-    THROW_IF_WIN32_BOOL_FALSE(MoveFileEx(distro.VhdFilePath.c_str(), newVhdPath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH));
-
-    // Restore the original VHD owner on the moved file. Open the file while impersonating
-    // the caller, then use ReOpenFile to add WRITE_OWNER as SYSTEM with SE_RESTORE_NAME
-    // (needed since a cross-volume MoveFileEx may leave the file owned by
-    // BUILTIN\Administrators). ReOpenFile reuses the already-open file object instead of
-    // resolving the path again.
-    auto setVhdOwner = [&originalOwner](const std::filesystem::path& vhdPath) {
-        wil::unique_hfile vhdHandle(CreateFileW(
-            vhdPath.c_str(), READ_CONTROL, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_FLAG_OPEN_REPARSE_POINT, nullptr));
-        THROW_LAST_ERROR_IF(!vhdHandle);
-
-        auto runAsSelf = wil::run_as_self();
-        auto privileges = wsl::windows::common::security::AcquirePrivilege(SE_RESTORE_NAME);
-
-        wil::unique_hfile privilegedHandle(ReOpenFile(
-            vhdHandle.get(), WRITE_OWNER, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, FILE_FLAG_OPEN_REPARSE_POINT));
-        THROW_LAST_ERROR_IF(!privilegedHandle);
-
-        THROW_IF_WIN32_ERROR(::SetSecurityInfo(
-            privilegedHandle.get(), SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, originalOwner, nullptr, nullptr, nullptr));
-    };
-
-    // Install the rollback before fixing up ownership so a failure there (e.g. the caller
-    // lacking access on the moved file) still moves the VHD back instead of leaving the
-    // registration pointing at a file that no longer exists at the old location.
     auto revert = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-        THROW_IF_WIN32_BOOL_FALSE(MoveFileEx(
-            newVhdPath.c_str(), distro.VhdFilePath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH));
+        auto impersonate = wil::impersonate_token(userToken.get());
+        if (!MoveFileExW(destPath.c_str(), distro.VhdFilePath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+        {
+            LOG_LAST_ERROR();
+            return;
+        }
 
-        // Fix ownership on the reverted VHD in case MoveFileEx copied across volumes.
-        LOG_IF_FAILED(wil::ResultFromException([&] { setVhdOwner(distro.VhdFilePath); }));
-
-        // Write the location back to the original path in case the second registry write failed. Otherwise, this is a no-op.
-        registration.Write(Property::BasePath, distro.BasePath.c_str());
+        LOG_IF_FAILED(wil::ResultFromException(
+            WI_DIAGNOSTICS_INFO, [&]() { registration.Write(Property::BasePath, distro.BasePath.c_str()); }));
     });
 
-    setVhdOwner(newVhdPath);
-
-    // Update the registry location
     registration.Write(Property::BasePath, Location);
-    registration.Write(Property::VhdFileName, newVhdPath.filename().c_str());
+    registration.Write(Property::VhdFileName, destPath.filename().c_str());
 
     revert.release();
-
     return S_OK;
 }
 

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -915,7 +915,7 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     RETURN_HR_IF(WSL_E_DISTRO_NOT_STOPPED, m_runningInstances.contains(*DistroGuid));
 
     // Lookup the distribution configuration
-    const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);
+    const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation, nullptr, TOKEN_ADJUST_DEFAULT);
     const auto lxssKey = s_OpenLxssUserKey();
     _ValidateDistributionNameAndPathNotInUse(lxssKey.get(), Location, nullptr);
 

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -915,6 +915,7 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     RETURN_HR_IF(WSL_E_DISTRO_NOT_STOPPED, m_runningInstances.contains(*DistroGuid));
 
     // Lookup the distribution configuration
+    const auto userToken = wsl::windows::common::security::GetUserToken(TokenImpersonation);
     const auto lxssKey = s_OpenLxssUserKey();
     _ValidateDistributionNameAndPathNotInUse(lxssKey.get(), Location, nullptr);
 

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -932,7 +932,14 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     // Cross-volume MoveFileEx creates a new file using the impersonation token's
     // default owner. Normalize that owner to the caller's user SID so elevated moves
     // do not produce a VHD owned by BUILTIN\Administrators.
-    auto originalTokenOwner = wil::get_token_information<TOKEN_OWNER>(userToken.get());
+    PSID originalVhdOwner = nullptr;
+    wil::unique_hlocal originalSecurityDescriptor;
+    {
+        auto impersonate = wil::impersonate_token(userToken.get());
+        THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
+            distro.VhdFilePath.c_str(), SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &originalVhdOwner, nullptr, nullptr, nullptr, &originalSecurityDescriptor));
+    }
+
     auto tokenUser = wil::get_token_information<TOKEN_USER>(userToken.get());
     TOKEN_OWNER tokenOwner{tokenUser->User.Sid};
     THROW_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, &tokenOwner, sizeof(tokenOwner)));
@@ -951,7 +958,8 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     }
 
     auto revert = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-        LOG_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, originalTokenOwner.get(), sizeof(*originalTokenOwner)));
+        TOKEN_OWNER originalOwner{originalVhdOwner};
+        LOG_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, &originalOwner, sizeof(originalOwner)));
 
         auto impersonate = wil::impersonate_token(userToken.get());
         if (!MoveFileExW(destPath.c_str(), distro.VhdFilePath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -932,6 +932,7 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     // Cross-volume MoveFileEx creates a new file using the impersonation token's
     // default owner. Normalize that owner to the caller's user SID so elevated moves
     // do not produce a VHD owned by BUILTIN\Administrators.
+    auto originalTokenOwner = wil::get_token_information<TOKEN_OWNER>(userToken.get());
     auto tokenUser = wil::get_token_information<TOKEN_USER>(userToken.get());
     TOKEN_OWNER tokenOwner{tokenUser->User.Sid};
     THROW_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, &tokenOwner, sizeof(tokenOwner)));
@@ -950,6 +951,8 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     }
 
     auto revert = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+        LOG_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, originalTokenOwner.get(), sizeof(*originalTokenOwner)));
+
         auto impersonate = wil::impersonate_token(userToken.get());
         if (!MoveFileExW(destPath.c_str(), distro.VhdFilePath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
         {

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2875,6 +2875,76 @@ Error code: Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND
         }
     }
 
+    WSL2_TEST_METHOD(MoveVhdWithAdminOwner)
+    {
+        // Regression test for #40716: a same-volume move must succeed when the VHD
+        // is already owned by BUILTIN\Administrators.
+        constexpr auto name = L"move-admin-owner-test-distro";
+        constexpr auto firstFolder = L"move-admin-owner-first";
+        constexpr auto secondFolder = L"move-admin-owner-second";
+
+        // Import a WSL2 distro.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--import {} . \"{}\" --version 2", name, g_testDistroPath)), 0L);
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [name]() {
+            LxsstuLaunchWsl(std::format(L"--unregister {}", name));
+            std::filesystem::remove_all(firstFolder);
+            std::filesystem::remove_all(secondFolder);
+        });
+
+        // Move to first folder so we know where the VHD is.
+        WslShutdown();
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"--manage {} --move {}", name, firstFolder)), 0L);
+
+        auto vhdPath = std::format(L"{}\\ext4.vhdx", firstFolder);
+        VERIFY_IS_TRUE(std::filesystem::exists(vhdPath));
+
+        // Simulate cross-volume MoveFileEx side-effect: change VHD owner to BUILTIN\Administrators.
+        {
+            BYTE adminsSidBuffer[SECURITY_MAX_SID_SIZE];
+            DWORD sidSize = sizeof(adminsSidBuffer);
+            THROW_IF_WIN32_BOOL_FALSE(CreateWellKnownSid(WinBuiltinAdministratorsSid, nullptr, adminsSidBuffer, &sidSize));
+
+            THROW_IF_WIN32_ERROR(SetNamedSecurityInfoW(
+                const_cast<LPWSTR>(vhdPath.c_str()), SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, adminsSidBuffer, nullptr, nullptr, nullptr));
+
+            // Verify it took effect.
+            PSID ownerSid = nullptr;
+            wil::unique_hlocal descriptor;
+            THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
+                vhdPath.c_str(), SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &ownerSid, nullptr, nullptr, nullptr, &descriptor));
+            VERIFY_IS_TRUE(EqualSid(ownerSid, adminsSidBuffer));
+        }
+
+        // Now move again as non-elevated. Before the fix, this would fail with E_ACCESSDENIED
+        // because CreateFileW(WRITE_OWNER) was called under user impersonation.
+        const auto nonElevatedToken = GetNonElevatedToken();
+        WslShutdown();
+        VERIFY_ARE_EQUAL(
+            LxsstuLaunchWsl(std::format(L"--manage {} --move {}", name, secondFolder), nullptr, nullptr, nullptr, nonElevatedToken.get()), 0L);
+
+        auto newVhdPath = std::format(L"{}\\ext4.vhdx", secondFolder);
+        VERIFY_IS_TRUE(std::filesystem::exists(newVhdPath));
+
+        // A same-volume move preserves the VHD owner.
+        {
+            PSID ownerSid = nullptr;
+            wil::unique_hlocal descriptor;
+            THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
+                newVhdPath.c_str(), SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &ownerSid, nullptr, nullptr, nullptr, &descriptor));
+
+            BYTE adminsSidCheck[SECURITY_MAX_SID_SIZE] = {};
+            DWORD sidSize = sizeof(adminsSidCheck);
+            THROW_IF_WIN32_BOOL_FALSE(CreateWellKnownSid(WinBuiltinAdministratorsSid, nullptr, adminsSidCheck, &sidSize));
+            VERIFY_IS_TRUE(EqualSid(ownerSid, adminsSidCheck));
+        }
+
+        // Validate distro still works.
+        WslShutdown();
+        auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"-d {} echo ok", name), 0, nullptr, nonElevatedToken.get());
+        VERIFY_ARE_EQUAL(out, L"ok\n");
+    }
+
     WSL2_TEST_METHOD(Resize)
     {
         constexpr auto name = L"resize-test-distro";


### PR DESCRIPTION
## Summary of the Pull Request

Backports #41333 to `release/2.7`.

Distribution moves now use a duplicated caller token whose default owner is the caller's user SID. Move and rollback filesystem operations run under that token, avoiding a post-move owner rewrite.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

This is a direct backport of the distribution move ownership change from #41333. The test conflict was resolved by retaining the admin-owner regression test, which is not otherwise present on `release/2.7`.

## Validation Steps Performed

- Backport applied cleanly to the implementation; the test conflict was resolved by retaining the upstream regression test.
- `cmake --build . -- -m` was attempted. The build is blocked before compiling the changed service code by vendored GSL warning C4875 being promoted to an error with the installed compiler.
- The original change passed the full PR pipeline on `master`, including x64/ARM64 builds and WSL1/WSL2/WSLC tests.