### PR TITLE
Preserve token owner during distribution move rollback

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -949,7 +949,14 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     // Cross-volume MoveFileEx creates a new file using the impersonation token's
     // default owner. Normalize that owner to the caller's user SID so elevated moves
     // do not produce a VHD owned by BUILTIN\Administrators.
-    auto originalTokenOwner = wil::get_token_information<TOKEN_OWNER>(userToken.get());
+    PSID originalVhdOwner = nullptr;
+    wil::unique_hlocal originalSecurityDescriptor;
+    {
+        auto impersonate = wil::impersonate_token(userToken.get());
+        THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
+            distro.VhdFilePath.c_str(), SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &originalVhdOwner, nullptr, nullptr, nullptr, &originalSecurityDescriptor));
+    }
+
     auto tokenUser = wil::get_token_information<TOKEN_USER>(userToken.get());
     TOKEN_OWNER tokenOwner{tokenUser->User.Sid};
     THROW_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, &tokenOwner, sizeof(tokenOwner)));
@@ -968,7 +975,8 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     }
 
     auto revert = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-        LOG_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, originalTokenOwner.get(), sizeof(*originalTokenOwner)));
+        TOKEN_OWNER originalOwner{originalVhdOwner};
+        LOG_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, &originalOwner, sizeof(originalOwner)));
 
         auto impersonate = wil::impersonate_token(userToken.get());
         if (!MoveFileExW(destPath.c_str(), distro.VhdFilePath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -949,6 +949,7 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     // Cross-volume MoveFileEx creates a new file using the impersonation token's
     // default owner. Normalize that owner to the caller's user SID so elevated moves
     // do not produce a VHD owned by BUILTIN\Administrators.
+    auto originalTokenOwner = wil::get_token_information<TOKEN_OWNER>(userToken.get());
     auto tokenUser = wil::get_token_information<TOKEN_USER>(userToken.get());
     TOKEN_OWNER tokenOwner{tokenUser->User.Sid};
     THROW_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, &tokenOwner, sizeof(tokenOwner)));
@@ -967,6 +968,8 @@ HRESULT LxssUserSessionImpl::MoveDistribution(_In_ LPCGUID DistroGuid, _In_ LPCW
     }
 
     auto revert = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+        LOG_IF_WIN32_BOOL_FALSE(SetTokenInformation(userToken.get(), TokenOwner, originalTokenOwner.get(), sizeof(*originalTokenOwner)));
+
         auto impersonate = wil::impersonate_token(userToken.get());
         if (!MoveFileExW(destPath.c_str(), distro.VhdFilePath.c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
         {


### PR DESCRIPTION
## Summary of the Pull Request

Preserves the source VHD's owner when rolling back a distribution move.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Follow-up to #41333. Before moving the VHD, capture its current owner SID under caller impersonation. If the operation must be rolled back, use that SID as the duplicated token's default owner before the reverse `MoveFileExW` operation.

This keeps the normal forward move owned by the caller's user SID while ensuring a cross-volume rollback recreates the VHD with its pre-move owner.

## Validation Steps Performed

- `FormatSource.ps1`
- `cmake --build . -- -m`
- `bin\x64\Debug\test.bat -f /name:*MoveVhd*` was attempted; shared module setup failed while setting the default `test_distro`, before either selected test executed.