### PR TITLE
Warn the user if VMP is not installed when create instance fails

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -960,9 +960,13 @@ Falling back to NAT networking.</value>
     <value>Failed to launch the localhost relay process. Error: {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
-  <data name="MessageVirtualMachinePlatformNotInstalled" xml:space="preserve">
+  <data name="MessageVirtualMachinePlatformRequiredForNetworking" xml:space="preserve">
     <value>Failed to start virtual networking - please install the optional component Virtual Machine Platform by running: wsl.exe --install --no-distribution</value>
     <comment>{Locked="--install "}{Locked="--no-distribution"}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageVirtualMachinePlatformNotInstalled" xml:space="preserve">
+    <value>Virtual Machine Platform is not enabled. WSL 2 may not work correctly. To enable it, run: wsl.exe --install --no-distribution</value>
+    <comment>{Locked="WSL 2"}{Locked="wsl.exe"}{Locked="--install "}{Locked="--no-distribution"}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
   <data name="MessageNetworkInitializationFailedFallback2" xml:space="preserve">
     <value>Failed to configure network (networkingMode {}), falling back to networkingMode {}.</value>

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -192,8 +192,7 @@ std::pair<bool, std::vector<std::wstring>> WslInstall::CheckForMissingOptionalCo
         missingComponents.emplace_back(c_optionalFeatureNameWsl);
     }
 
-    if (!IsOptionalComponentInstalled(c_optionalFeatureNameVmp) ||
-        !wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled())
+    if (!IsOptionalComponentInstalled(c_optionalFeatureNameVmp) || !wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled())
     {
         missingComponents.emplace_back(c_optionalFeatureNameVmp);
     }

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -192,7 +192,8 @@ std::pair<bool, std::vector<std::wstring>> WslInstall::CheckForMissingOptionalCo
         missingComponents.emplace_back(c_optionalFeatureNameWsl);
     }
 
-    if (!IsOptionalComponentInstalled(c_optionalFeatureNameVmp))
+    if (!IsOptionalComponentInstalled(c_optionalFeatureNameVmp) ||
+        !wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled())
     {
         missingComponents.emplace_back(c_optionalFeatureNameVmp);
     }

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -19,11 +19,11 @@ Abstract:
 #include "Distribution.h"
 #include "HandleConsoleProgressBar.h"
 #include "svccomm.hpp"
+#include "WmiService.h"
 
 extern HINSTANCE g_dllInstance;
 
 constexpr LPCWSTR c_optionalFeatureInstallStatus = L"InstallStatus";
-constexpr DWORD c_optionalFeatureQueryTimeout = 30'000;
 
 using wsl::shared::Localization;
 using namespace wsl::windows::common::distribution;
@@ -193,7 +193,7 @@ std::pair<bool, std::vector<std::wstring>> WslInstall::CheckForMissingOptionalCo
         missingComponents.emplace_back(c_optionalFeatureNameWsl);
     }
 
-    if (!IsOptionalComponentInstalled(c_optionalFeatureNameVmp) || !wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled())
+    if (!wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled())
     {
         missingComponents.emplace_back(c_optionalFeatureNameVmp);
     }
@@ -254,29 +254,18 @@ void WslInstall::InstallOptionalComponents(const std::vector<std::wstring>& comp
 
 bool WslInstall::IsOptionalComponentInstalled(LPCWSTR component)
 {
-    std::wstring systemDirectory;
-    THROW_IF_FAILED(wil::GetSystemDirectoryW(systemDirectory));
+    constexpr int32_t c_enabled = 1;
 
-    const auto dismPath = std::filesystem::path(std::move(systemDirectory)) / L"dism.exe";
-    const auto commandLine = std::format(L"{} /Online /English /Get-FeatureInfo /FeatureName:{}", dismPath.native(), component);
+    wsl::core::WmiService service(L"ROOT\\CIMV2");
+    wsl::core::WmiEnumerate optionalFeatures(service);
+    const auto query = std::format(L"SELECT InstallState FROM Win32_OptionalFeature WHERE Name = '{}'", component);
+    const auto& results = optionalFeatures.query(query.c_str());
+    const auto result = results.begin();
+    THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), result == results.end(), "Optional component not found: %ls", component);
 
-    wsl::windows::common::SubProcess process(nullptr, commandLine.c_str());
-    const auto result = process.RunAndCaptureOutput(c_optionalFeatureQueryTimeout);
-    THROW_HR_IF_MSG(
-        HRESULT_FROM_WIN32(result.ExitCode), result.ExitCode != ERROR_SUCCESS, "Failed to query optional component: %ls", component);
-
-    constexpr std::wstring_view c_statePrefix = L"State :";
-    for (const auto& line : wsl::shared::string::Split(result.Stdout, L'\n'))
-    {
-        const auto trimmed = wsl::shared::string::TrimAscii<wchar_t>(line);
-        if (wsl::shared::string::StartsWith(trimmed, c_statePrefix))
-        {
-            const auto state = wsl::shared::string::TrimAscii<wchar_t>(trimmed.substr(c_statePrefix.size()));
-            return wsl::shared::string::IsEqual(state, L"Enabled", true);
-        }
-    }
-
-    THROW_HR_MSG(E_UNEXPECTED, "Failed to parse optional component state: %ls", component);
+    int32_t installState{};
+    THROW_HR_IF_MSG(E_UNEXPECTED, !result->get(L"InstallState", &installState), "Invalid optional component state: %ls", component);
+    return installState == c_enabled;
 }
 
 std::pair<std::wstring, GUID> WslInstall::InstallModernDistribution(

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -192,7 +192,7 @@ std::pair<bool, std::vector<std::wstring>> WslInstall::CheckForMissingOptionalCo
         missingComponents.emplace_back(c_optionalFeatureNameWsl);
     }
 
-    if (!wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled())
+    if (!IsOptionalComponentInstalled(c_optionalFeatureNameVmp))
     {
         missingComponents.emplace_back(c_optionalFeatureNameVmp);
     }
@@ -249,6 +249,33 @@ void WslInstall::InstallOptionalComponents(const std::vector<std::wstring>& comp
     const auto key =
         wsl::windows::common::registry::CreateKey(lxssKey.get(), c_optionalFeatureInstallStatus, KEY_ALL_ACCESS, nullptr, REG_OPTION_VOLATILE);
     wsl::windows::common::registry::WriteString(key.get(), nullptr, nullptr, wsl::shared::string::Join(installedComponents, L',').c_str());
+}
+
+bool WslInstall::IsOptionalComponentInstalled(LPCWSTR component)
+{
+    std::wstring systemDirectory;
+    THROW_IF_FAILED(wil::GetSystemDirectoryW(systemDirectory));
+
+    const auto dismPath = std::filesystem::path(std::move(systemDirectory)) / L"dism.exe";
+    const auto commandLine = std::format(L"{} /Online /English /Get-FeatureInfo /FeatureName:{}", dismPath.native(), component);
+
+    wsl::windows::common::SubProcess process(nullptr, commandLine.c_str());
+    const auto result = process.RunAndCaptureOutput();
+    THROW_HR_IF_MSG(
+        HRESULT_FROM_WIN32(result.ExitCode), result.ExitCode != ERROR_SUCCESS, "Failed to query optional component: %ls", component);
+
+    constexpr std::wstring_view c_statePrefix = L"State :";
+    for (const auto& line : wsl::shared::string::Split(result.Stdout, L'\n'))
+    {
+        const auto trimmed = wsl::shared::string::TrimAscii<wchar_t>(line);
+        if (wsl::shared::string::StartsWith(trimmed, c_statePrefix))
+        {
+            const auto state = wsl::shared::string::TrimAscii<wchar_t>(trimmed.substr(c_statePrefix.size()));
+            return wsl::shared::string::IsEqual(state, L"Enabled", true);
+        }
+    }
+
+    THROW_HR_MSG(E_UNEXPECTED, "Failed to parse optional component state: %ls", component);
 }
 
 std::pair<std::wstring, GUID> WslInstall::InstallModernDistribution(

--- a/src/windows/common/WslInstall.cpp
+++ b/src/windows/common/WslInstall.cpp
@@ -23,6 +23,7 @@ Abstract:
 extern HINSTANCE g_dllInstance;
 
 constexpr LPCWSTR c_optionalFeatureInstallStatus = L"InstallStatus";
+constexpr DWORD c_optionalFeatureQueryTimeout = 30'000;
 
 using wsl::shared::Localization;
 using namespace wsl::windows::common::distribution;
@@ -260,7 +261,7 @@ bool WslInstall::IsOptionalComponentInstalled(LPCWSTR component)
     const auto commandLine = std::format(L"{} /Online /English /Get-FeatureInfo /FeatureName:{}", dismPath.native(), component);
 
     wsl::windows::common::SubProcess process(nullptr, commandLine.c_str());
-    const auto result = process.RunAndCaptureOutput();
+    const auto result = process.RunAndCaptureOutput(c_optionalFeatureQueryTimeout);
     THROW_HR_IF_MSG(
         HRESULT_FROM_WIN32(result.ExitCode), result.ExitCode != ERROR_SUCCESS, "Failed to query optional component: %ls", component);
 

--- a/src/windows/common/WslInstall.h
+++ b/src/windows/common/WslInstall.h
@@ -49,6 +49,8 @@ public:
 
     static DWORD InstallOptionalComponent(LPCWSTR component, bool consoleOutput);
 
+    static bool IsOptionalComponentInstalled(LPCWSTR component);
+
     static std::pair<std::wstring, GUID> InstallModernDistribution(
         const wsl::windows::common::distribution::ModernDistributionVersion& distribution,
         const std::optional<ULONG>& version,

--- a/src/windows/common/wslutil.cpp
+++ b/src/windows/common/wslutil.cpp
@@ -22,6 +22,7 @@ Abstract:
 #include "ConsoleProgressBar.h"
 #include "ExecutionContext.h"
 #include "MsiQuery.h"
+#include "WslInstall.h"
 
 using winrt::Windows::Foundation::Uri;
 using winrt::Windows::Management::Deployment::DeploymentOptions;
@@ -1348,10 +1349,20 @@ bool wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled()
 {
     // Note for Windows 11 22H2 and above builds: If hyper-v is installed but VMP platform isn't, HNS and vmcompute are
     // available but calls to HNS will fail if vfpext isn't installed.
-    return wsl::windows::common::helpers::IsServicePresent(L"HNS") &&
-           wsl::windows::common::helpers::IsServicePresent(L"vmcompute") &&
-           (helpers::GetWindowsVersion().BuildNumber < helpers::WindowsBuildNumbers::Nickel ||
-            wsl::windows::common::helpers::IsServicePresent(L"vfpext"));
+    if (!wsl::windows::common::helpers::IsServicePresent(L"HNS") || !wsl::windows::common::helpers::IsServicePresent(L"vmcompute") ||
+        (helpers::GetWindowsVersion().BuildNumber >= helpers::WindowsBuildNumbers::Nickel &&
+         !wsl::windows::common::helpers::IsServicePresent(L"vfpext")))
+    {
+        return false;
+    }
+
+    try
+    {
+        return WslInstall::IsOptionalComponentInstalled(WslInstall::c_optionalFeatureNameVmp);
+    }
+    CATCH_LOG()
+
+    return true;
 }
 
 wil::unique_handle wsl::windows::common::wslutil::OpenCallingProcess(_In_ DWORD access)

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -17,6 +17,8 @@ Abstract:
 #include "LxssUserSession.h"
 #include "LxssInstance.h"
 #include "LxssSecurity.h"
+#include "notifications.h"
+#include "WslInstall.h"
 #include "WslCoreInstance.h"
 #include "resource.h"
 #include <winrt\Windows.ApplicationModel.Background.h>
@@ -2726,6 +2728,20 @@ std::shared_ptr<LxssRunningInstance> LxssUserSessionImpl::_CreateInstance(_In_op
             catch (...)
             {
                 result = wil::ResultFromCaughtException();
+
+                if (version == LXSS_WSL_VERSION_2)
+                {
+                    try
+                    {
+                        if (!WslInstall::IsOptionalComponentInstalled(WslInstall::c_optionalFeatureNameVmp))
+                        {
+                            wsl::windows::common::notifications::DisplayOptionalComponentsNotification();
+                            EMIT_USER_WARNING(wsl::shared::Localization::MessageVirtualMachinePlatformNotInstalled());
+                        }
+                    }
+                    CATCH_LOG()
+                }
+
                 throw;
             }
         }

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -24,6 +24,7 @@ Abstract:
 #include "WslCoreFirewallSupport.h"
 #include "DnsResolver.h"
 #include "ConsommeNetworking.h"
+#include "WslInstall.h"
 
 #include <TraceLoggingProvider.h>
 
@@ -146,6 +147,17 @@ std::unique_ptr<WslCoreVm> WslCoreVm::Create(_In_ const wil::shared_handle& User
 void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken)
 {
     auto signalEarlyTermination = wil::scope_exit([&] { m_terminatingEvent.SetEvent(); });
+
+    // Check if VirtualMachinePlatform is installed.
+    try
+    {
+        if (!WslInstall::IsOptionalComponentInstalled(WslInstall::c_optionalFeatureNameVmp))
+        {
+            wsl::windows::common::notifications::DisplayOptionalComponentsNotification();
+            EMIT_USER_WARNING(wsl::shared::Localization::MessageVirtualMachinePlatformNotInstalled());
+        }
+    }
+    CATCH_LOG()
 
     // create a restricted version of the token.
     m_userToken = UserToken;
@@ -682,7 +694,7 @@ void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken
                 !wsl::windows::common::wslutil::IsVirtualMachinePlatformInstalled())
             {
                 wsl::windows::common::notifications::DisplayOptionalComponentsNotification();
-                EMIT_USER_WARNING(Localization::MessageVirtualMachinePlatformNotInstalled());
+                EMIT_USER_WARNING(Localization::MessageVirtualMachinePlatformRequiredForNetworking());
             }
 
             // Fall back to no networking.

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -24,7 +24,6 @@ Abstract:
 #include "WslCoreFirewallSupport.h"
 #include "DnsResolver.h"
 #include "ConsommeNetworking.h"
-#include "WslInstall.h"
 
 #include <TraceLoggingProvider.h>
 
@@ -147,17 +146,6 @@ std::unique_ptr<WslCoreVm> WslCoreVm::Create(_In_ const wil::shared_handle& User
 void WslCoreVm::Initialize(const GUID& VmId, const wil::shared_handle& UserToken)
 {
     auto signalEarlyTermination = wil::scope_exit([&] { m_terminatingEvent.SetEvent(); });
-
-    // Check if VirtualMachinePlatform is installed.
-    try
-    {
-        if (!WslInstall::IsOptionalComponentInstalled(WslInstall::c_optionalFeatureNameVmp))
-        {
-            wsl::windows::common::notifications::DisplayOptionalComponentsNotification();
-            EMIT_USER_WARNING(wsl::shared::Localization::MessageVirtualMachinePlatformNotInstalled());
-        }
-    }
-    CATCH_LOG()
 
     // create a restricted version of the token.
     m_userToken = UserToken;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

In some rare cases, the VirtualMachinePlatform feature could be left in a broken state, potentially by Windows updates. Where the WSL VM boots normally but hvsockets do not work. Resulting in HCS_E_CONNECTION_TIMEOUT. And it could be resolved by re-enabling the feature. As shown in #41346

This PR adds a VMP component check after a create instance failure. And warns the user if VMP is not enabled. To help the user potentially solving the failure.
This PR also renames the old user message to better reflect its content. And uses its name for this new warning.
This PR also adds the check to the installer step. So, it checks both services and the component when deciding if the component should be installed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #41346
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested locally by injecting a failure into create instance.
<img width="496" height="222" alt="image" src="https://github.com/user-attachments/assets/8efae779-750f-434f-b6cb-8330d4896b8f" />
<img width="1348" height="153" alt="image" src="https://github.com/user-attachments/assets/23661a16-92fe-4d90-a418-b7f2baa013c0" />

