### PR TITLE
 Add --filter support to volume list

### DIFF
--- a/src/windows/wslc/commands/VolumeListCommand.cpp
+++ b/src/windows/wslc/commands/VolumeListCommand.cpp
@@ -27,6 +27,7 @@ namespace wsl::windows::wslc {
 std::vector<Argument> VolumeListCommand::GetArguments() const
 {
     return {
+        Argument::Create(ArgType::Filter, false, Limit::Unlimited),
         Argument::Create(ArgType::Format),
         Argument::Create(ArgType::Quiet, false, std::nullopt, Localization::WSLCCLI_VolumeListQuietArgDesc()),
     };

--- a/src/windows/wslc/services/VolumeService.cpp
+++ b/src/windows/wslc/services/VolumeService.cpp
@@ -60,11 +60,19 @@ void VolumeService::Delete(models::Session& session, const std::string& name)
     THROW_IF_FAILED(session.Get()->DeleteVolume(name.c_str()));
 }
 
-std::vector<WSLCVolumeInformation> VolumeService::List(models::Session& session)
+std::vector<WSLCVolumeInformation> VolumeService::List(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
 {
+    std::vector<WSLCFilter> filterEntries;
+    filterEntries.reserve(filters.size());
+    for (const auto& [key, value] : filters)
+    {
+        filterEntries.push_back({.Key = key.c_str(), .Value = value.c_str()});
+    }
+
     wil::unique_cotaskmem_array_ptr<WSLCVolumeInformation> rawVolumes;
     ULONG count = 0;
-    THROW_IF_FAILED(session.Get()->ListVolumes(nullptr, 0, &rawVolumes, &count));
+    THROW_IF_FAILED(session.Get()->ListVolumes(
+        filterEntries.empty() ? nullptr : filterEntries.data(), static_cast<ULONG>(filterEntries.size()), &rawVolumes, &count));
 
     std::vector<WSLCVolumeInformation> volumes;
     volumes.reserve(count);

--- a/src/windows/wslc/services/VolumeService.h
+++ b/src/windows/wslc/services/VolumeService.h
@@ -24,7 +24,7 @@ struct VolumeService
 {
     static WSLCVolumeInformation Create(models::Session& session, const models::CreateVolumeOptions& createOptions);
     static void Delete(models::Session& session, const std::string& name);
-    static std::vector<WSLCVolumeInformation> List(models::Session& session);
+    static std::vector<WSLCVolumeInformation> List(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
     static wsl::windows::common::wslc_schema::InspectVolume Inspect(models::Session& session, const std::string& name);
     static models::PruneVolumesResult Prune(
         Terminal& terminal, models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters = {});

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -124,7 +124,8 @@ void GetVolumes(CLIExecutionContext& context)
 {
     WI_ASSERT(context.Data.Contains(Data::Session));
     auto& session = context.Data.Get<Data::Session>();
-    context.Data.Add<Data::Volumes>(VolumeService::List(session));
+    auto filters = context.Args.GetAllValues<ArgType::Filter>();
+    context.Data.Add<Data::Volumes>(VolumeService::List(session, filters));
 }
 
 void InspectVolumes(CLIExecutionContext& context)

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -256,7 +256,7 @@ private:
         return result.GetStdoutLines();
     }
 
-    // A before/after diff is the only option: `volume list` has no --filter and reports no labels.
+    // Anonymous volumes have auto-generated names, so a before/after diff is the way to identify the new one.
     static std::wstring GetNewAnonymousVolumeName(const std::vector<std::wstring>& before)
     {
         std::vector<std::wstring> added;

--- a/test/windows/wslc/e2e/WSLCE2EVolumeListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeListTests.cpp
@@ -30,6 +30,10 @@ class WSLCE2EVolumeListTests
     {
         EnsureVolumeDoesNotExist(TestVolumeName);
         EnsureVolumeDoesNotExist(TestVolumeName2);
+        for (const auto& name : FilterTestVolumeNames)
+        {
+            EnsureVolumeDoesNotExist(name);
+        }
         return true;
     }
 
@@ -37,6 +41,10 @@ class WSLCE2EVolumeListTests
     {
         EnsureVolumeDoesNotExist(TestVolumeName);
         EnsureVolumeDoesNotExist(TestVolumeName2);
+        for (const auto& name : FilterTestVolumeNames)
+        {
+            EnsureVolumeDoesNotExist(name);
+        }
         return true;
     }
 
@@ -94,8 +102,167 @@ class WSLCE2EVolumeListTests
         VERIFY_ARE_NOT_EQUAL(names.end(), std::find(names.begin(), names.end(), WideToMultiByte(TestVolumeName2)));
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_MalformedValue)
+    {
+        const auto result = RunWslc(L"volume list --filter label");
+        result.Verify({.Stdout = L"", .ExitCode = 1});
+        VERIFY_IS_TRUE(result.StderrContainsSubstring(Localization::WSLCCLI_InvalidFilterError(L"label")));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_InvalidKey)
+    {
+        // Filter keys are validated by the Docker daemon, which rejects unknown keys.
+        const auto result = RunWslc(L"volume list --filter color=blue");
+        VERIFY_ARE_EQUAL(1, result.ExitCode);
+        VERIFY_IS_TRUE(result.Stderr.has_value());
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, result.Stderr->find(L"invalid filter 'color'"));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_InvalidDanglingValue)
+    {
+        // Dangling values are validated by the Docker daemon, which rejects non-boolean values.
+        const auto result = RunWslc(L"volume list --filter dangling=maybe");
+        VERIFY_ARE_EQUAL(1, result.ExitCode);
+        VERIFY_IS_TRUE(result.Stderr.has_value());
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, result.Stderr->find(L"invalid filter 'dangling=maybe'"));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_Driver)
+    {
+        const std::wstring alpha = L"wslc-flt-vlist-driver-alpha";
+        const std::wstring beta = L"wslc-flt-vlist-driver-beta";
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureVolumeDoesNotExist(alpha);
+            EnsureVolumeDoesNotExist(beta);
+        });
+
+        auto result = RunWslc(std::format(L"volume create --driver vhd --opt SizeBytes={} {}", DefaultVolumeSizeBytes, alpha));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        result = RunWslc(std::format(L"volume create --driver guest {}", beta));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        {
+            const auto names = GetFilteredVolumeNames(L"--filter driver=vhd");
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_FALSE(names.contains(WideToMultiByte(beta)));
+        }
+
+        {
+            const auto names = GetFilteredVolumeNames(L"--filter driver=guest");
+            VERIFY_IS_FALSE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(beta)));
+        }
+
+        // Docker's own driver names (e.g. "local") never match wslc-managed volumes.
+        {
+            const auto names = GetFilteredVolumeNames(L"--filter driver=local");
+            VERIFY_IS_FALSE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_FALSE(names.contains(WideToMultiByte(beta)));
+        }
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_Label)
+    {
+        const std::wstring alpha = L"wslc-flt-vlist-label-alpha";
+        const std::wstring beta = L"wslc-flt-vlist-label-beta";
+        const std::wstring scopeKey = L"wslc.e2e.list_filter_label";
+        const std::wstring scopeValue = L"1";
+
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureVolumeDoesNotExist(alpha);
+            EnsureVolumeDoesNotExist(beta);
+        });
+
+        auto result = RunWslc(std::format(L"volume create --label {}={} --label env=prod {}", scopeKey, scopeValue, alpha));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        result = RunWslc(std::format(L"volume create --label {}={} {}", scopeKey, scopeValue, beta));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        {
+            const auto names = GetFilteredVolumeNames(std::format(L"--filter label={}", scopeKey));
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(beta)));
+        }
+
+        {
+            const auto names = GetFilteredVolumeNames(std::format(L"--filter label={}={} --filter label=env=prod", scopeKey, scopeValue));
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_FALSE(names.contains(WideToMultiByte(beta)));
+        }
+
+        {
+            const auto names = GetFilteredVolumeNames(std::format(L"--filter label={} --filter label=env=prod", scopeKey));
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_FALSE(names.contains(WideToMultiByte(beta)));
+        }
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_JsonEmptyIsExactlyEmpty)
+    {
+        const std::wstring alpha = L"wslc-flt-vlist-empty-alpha";
+        auto cleanup = wil::scope_exit([&]() { EnsureVolumeDoesNotExist(alpha); });
+
+        auto result = RunWslc(std::format(L"volume create {}", alpha));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        // NDJSON with zero rows must be exactly empty stdout — not "[]", not "\n".
+        result = RunWslc(L"volume list --format json --filter name=wslc-flt-vlist-no-such-volume-zzz");
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_Name)
+    {
+        const std::wstring alpha = L"wslc-flt-vlist-name-alpha";
+        const std::wstring beta = L"wslc-flt-vlist-name-beta";
+        auto cleanup = wil::scope_exit([&]() {
+            EnsureVolumeDoesNotExist(alpha);
+            EnsureVolumeDoesNotExist(beta);
+        });
+
+        auto result = RunWslc(std::format(L"volume create {}", alpha));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        result = RunWslc(std::format(L"volume create {}", beta));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        {
+            const auto names = GetFilteredVolumeNames(L"--filter name=wslc-flt-vlist-name-");
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(beta)));
+        }
+
+        {
+            const auto names = GetFilteredVolumeNames(L"--filter name=name-alpha");
+            VERIFY_IS_TRUE(names.contains(WideToMultiByte(alpha)));
+            VERIFY_IS_FALSE(names.contains(WideToMultiByte(beta)));
+        }
+    }
+
 private:
+    static std::set<std::string> GetFilteredVolumeNames(const std::wstring& filterArgs)
+    {
+        auto result = RunWslc(std::format(L"volume list --format json {}", filterArgs));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto volumes = ParseNdjsonOutputAs<WSLCVolumeInformation>(result);
+        std::set<std::string> names;
+        for (const auto& v : volumes)
+        {
+            names.insert(v.Name);
+        }
+        return names;
+    }
+
     const std::wstring TestVolumeName = L"wslc-e2e-volume-list";
     const std::wstring TestVolumeName2 = L"wslc-e2e-volume-list-2";
+    const int DefaultVolumeSizeBytes = 3 * 1024 * 1024;
+    const std::vector<std::wstring> FilterTestVolumeNames = {
+        L"wslc-flt-vlist-driver-alpha",
+        L"wslc-flt-vlist-driver-beta",
+        L"wslc-flt-vlist-label-alpha",
+        L"wslc-flt-vlist-label-beta",
+        L"wslc-flt-vlist-empty-alpha",
+        L"wslc-flt-vlist-name-alpha",
+        L"wslc-flt-vlist-name-beta",
+    };
 };
 } // namespace WSLCE2ETests

--- a/test/windows/wslc/e2e/WSLCE2EVolumeListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeListTests.cpp
@@ -124,7 +124,7 @@ class WSLCE2EVolumeListTests
         const auto result = RunWslc(L"volume list --filter dangling=maybe");
         VERIFY_ARE_EQUAL(1, result.ExitCode);
         VERIFY_IS_TRUE(result.Stderr.has_value());
-        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, result.Stderr->find(L"invalid filter 'dangling=maybe'"));
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, result.Stderr->find(L"invalid filter 'dangling=[maybe]'"));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_Driver)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
wslc volume list didn't support the filter flag, so users couldn't narrow down the volume list by things like name, driver, label, or dangling status. This change adds the filter flag with the same filter options that Docker supports.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Most of the plumbing was already there, the COM interface, the session code, and the docker HTTP client all accept filters (the volume prune command already uses them). This PR just wires the CLI side through so volume list can use them too.
What changed:
- volume list now accepts --filter with the same keys as Docker: name, driver, label, and dangling
- VolumeService::List learned to take filters (default empty, so existing callers keep working)
- GetVolumes task reads any --filter args and passes them through

A couple of things worth calling out:
- The driver filter matches wslc driver names (vhd, guest), not Docker's internal driver names like local. This is pre-existing behavior, but it now has a test locking it down
- wslc volume list only shows volumes wslc manages. Volumes created via docker volume create outside wslc still won't appear even if they match the filter, this matches how the unfiltered list already behaves

Follow-ups (out of scope for this PR):
- Enrich --format json output, right now it only emits Name and Driver; Docker also emits Mountpoint, Scope, Labels, etc
- Deterministic ordering, the list is currently returned in hash order because it iterates an unordered_map
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
