### PR TITLE
CLI: Fix shm-size and all text-to-byte size conversion and align them all to Docker

### DIFF
--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -1053,30 +1053,6 @@ struct CaseInsensitiveCompare
     }
 };
 
-inline std::wstring FormatBytes(uint64_t bytes)
-{
-    constexpr double c_kB = 1000.0;
-    constexpr double c_MB = 1000.0 * 1000.0;
-    constexpr double c_GB = 1000.0 * 1000.0 * 1000.0;
-
-    if (bytes >= static_cast<uint64_t>(c_GB))
-    {
-        return std::format(L"{:.2f} GB", bytes / c_GB);
-    }
-    else if (bytes >= static_cast<uint64_t>(c_MB))
-    {
-        return std::format(L"{:.2f} MB", bytes / c_MB);
-    }
-    else if (bytes >= static_cast<uint64_t>(c_kB))
-    {
-        return std::format(L"{:.2f} KB", bytes / c_kB);
-    }
-    else
-    {
-        return std::format(L"{} B", bytes);
-    }
-}
-
 template <typename TChar>
 inline std::basic_string<TChar> Trim(const std::basic_string<TChar>& input)
 {

--- a/src/windows/common/WSLCUserSettings.cpp
+++ b/src/windows/common/WSLCUserSettings.cpp
@@ -72,9 +72,14 @@ namespace details {
 
     std::optional<uint32_t> ParseSettingsMemoryValue(const std::string& value)
     {
-        auto parsed = wsl::shared::string::ParseMemorySize(value.c_str());
-        auto converted = parsed.has_value() ? *parsed / _1MB : 0; // To Mb, and anything less than 1Mb is considered invalid.
-        return converted > 0 ? std::optional{static_cast<uint32_t>(converted)} : std::nullopt;
+        const auto parsed = ParseStorageSize(MultiByteToWide(value), StorageSizeUnit::Binary);
+        const auto converted = parsed.has_value() ? *parsed / _1MB : 0;
+        if (converted == 0 || converted > std::numeric_limits<uint32_t>::max())
+        {
+            return std::nullopt;
+        }
+
+        return static_cast<uint32_t>(converted);
     }
 
 #define WSLC_VALIDATE_SETTING(_setting_) \

--- a/src/windows/common/WSLCUserSettings.cpp
+++ b/src/windows/common/WSLCUserSettings.cpp
@@ -72,7 +72,10 @@ namespace details {
 
     std::optional<uint32_t> ParseSettingsMemoryValue(const std::string& value)
     {
-        const auto parsed = ParseStorageSize(MultiByteToWide(value), StorageSizeUnit::Binary);
+
+        // WSLC settings accept leading whitespace for compatibility with existing settings files.
+        const auto wideValue = MultiByteToWide(value);
+        const auto parsed = ParseStorageSize(StripLeadingWhitespace(wideValue), StorageSizeUnit::Binary);
         const auto converted = parsed.has_value() ? *parsed / _1MB : 0;
         if (converted == 0 || converted > std::numeric_limits<uint32_t>::max())
         {

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -13,6 +13,9 @@ Abstract:
 --*/
 
 #include "precomp.h"
+#include <charconv>
+#include <cmath>
+#include <limits>
 
 std::vector<std::string> wsl::windows::common::string::InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize)
 {
@@ -284,6 +287,108 @@ std::string wsl::windows::common::string::WideToMultiByte(_In_opt_ LPCWSTR Sourc
 std::string wsl::windows::common::string::WideToMultiByte(_In_ std::wstring_view Source)
 {
     return WideToMultiByte(Source.data(), Source.length());
+}
+
+std::optional<uint64_t> wsl::windows::common::string::ParseStorageSize(std::wstring_view String, StorageSizeUnit Unit)
+{
+    std::wstring_view number;
+    std::wstring_view suffix;
+    const auto space = String.find(L' ');
+    if (space != std::wstring_view::npos)
+    {
+        number = String.substr(0, space);
+        suffix = String.substr(space + 1);
+    }
+    else
+    {
+        const auto numberEnd = String.find_last_of(L"0123456789.");
+        if (numberEnd == std::wstring_view::npos)
+        {
+            return {};
+        }
+
+        number = String.substr(0, numberEnd + 1);
+        suffix = String.substr(numberEnd + 1);
+    }
+
+    auto narrowNumber = WideToMultiByte(number);
+    if (!narrowNumber.empty() && narrowNumber.front() == '+')
+    {
+        narrowNumber.erase(0, 1);
+    }
+
+    double value{};
+    const auto result = std::from_chars(narrowNumber.data(), narrowNumber.data() + narrowNumber.size(), value, std::chars_format::general);
+    if (result.ec != std::errc() || result.ptr != narrowNumber.data() + narrowNumber.size() || !std::isfinite(value) || value < 0)
+    {
+        return {};
+    }
+
+    uint64_t multiplier = 1;
+    if (!suffix.empty())
+    {
+        auto normalizedSuffix = wsl::shared::string::AsciiToLower(suffix);
+        if (normalizedSuffix != L"b")
+        {
+            if (normalizedSuffix.size() > 3 || (normalizedSuffix.size() == 2 && normalizedSuffix[1] != L'b') ||
+                (normalizedSuffix.size() == 3 && normalizedSuffix.substr(1) != L"ib"))
+            {
+                return {};
+            }
+
+            constexpr std::wstring_view c_memoryUnits = L"kmgtp";
+            const auto unitIndex = c_memoryUnits.find(normalizedSuffix[0]);
+            if (unitIndex == std::wstring_view::npos)
+            {
+                return {};
+            }
+
+            const uint64_t base = Unit == StorageSizeUnit::Decimal ? 1000 : 1024;
+            for (size_t index = 0; index <= unitIndex; ++index)
+            {
+                multiplier *= base;
+            }
+        }
+    }
+
+    const double bytes = value * static_cast<double>(multiplier);
+    if (!std::isfinite(bytes) || bytes >= static_cast<double>(std::numeric_limits<uint64_t>::max()))
+    {
+        return {};
+    }
+
+    return static_cast<uint64_t>(bytes);
+}
+
+std::wstring wsl::windows::common::string::FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace)
+{
+    constexpr size_t c_unitCount = 7;
+    constexpr std::array<std::wstring_view, c_unitCount> c_decimalUnits{L"B", L"KB", L"MB", L"GB", L"TB", L"PB", L"EB"};
+    constexpr std::array<std::wstring_view, c_unitCount> c_binaryUnits{L"B", L"KiB", L"MiB", L"GiB", L"TiB", L"PiB", L"EiB"};
+
+    const double base = Unit == StorageSizeUnit::Decimal ? 1000.0 : 1024.0;
+    const auto& units = Unit == StorageSizeUnit::Decimal ? c_decimalUnits : c_binaryUnits;
+
+    double value = static_cast<double>(Bytes);
+    size_t unitIndex = 0;
+    while (value >= base && unitIndex + 1 < c_unitCount)
+    {
+        value /= base;
+        ++unitIndex;
+    }
+
+    if (unitIndex == 0)
+    {
+        return IncludeSpace ? std::format(L"{} {}", Bytes, units[unitIndex]) : std::format(L"{}{}", Bytes, units[unitIndex]);
+    }
+
+    return IncludeSpace ? std::format(L"{:.{}f} {}", value, DecimalPlaces, units[unitIndex])
+                        : std::format(L"{:.{}f}{}", value, DecimalPlaces, units[unitIndex]);
+}
+
+std::wstring wsl::windows::common::string::FormatBytes(uint64_t Bytes)
+{
+    return FormatStorageSize(Bytes, StorageSizeUnit::Decimal, 2, true);
 }
 
 std::wstring wsl::windows::common::string::TruncateId(_In_ std::wstring_view id, bool shortenLength)

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -362,9 +362,9 @@ std::optional<uint64_t> wsl::windows::common::string::ParseStorageSize(std::wstr
 
 std::wstring wsl::windows::common::string::FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace)
 {
-    constexpr size_t c_unitCount = 7;
-    constexpr std::array<std::wstring_view, c_unitCount> c_decimalUnits{L"B", L"KB", L"MB", L"GB", L"TB", L"PB", L"EB"};
-    constexpr std::array<std::wstring_view, c_unitCount> c_binaryUnits{L"B", L"KiB", L"MiB", L"GiB", L"TiB", L"PiB", L"EiB"};
+    constexpr size_t c_unitCount = 6;
+    constexpr std::array<std::wstring_view, c_unitCount> c_decimalUnits{L"B", L"KB", L"MB", L"GB", L"TB", L"PB"};
+    constexpr std::array<std::wstring_view, c_unitCount> c_binaryUnits{L"B", L"KiB", L"MiB", L"GiB", L"TiB", L"PiB"};
 
     const double base = Unit == StorageSizeUnit::Decimal ? 1000.0 : 1024.0;
     const auto& units = Unit == StorageSizeUnit::Decimal ? c_decimalUnits : c_binaryUnits;

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -317,13 +317,6 @@ std::optional<uint64_t> wsl::windows::common::string::ParseStorageSize(std::wstr
         narrowNumber.erase(0, 1);
     }
 
-    double value{};
-    const auto result = std::from_chars(narrowNumber.data(), narrowNumber.data() + narrowNumber.size(), value, std::chars_format::general);
-    if (result.ec != std::errc() || result.ptr != narrowNumber.data() + narrowNumber.size() || !std::isfinite(value) || value < 0)
-    {
-        return {};
-    }
-
     uint64_t multiplier = 1;
     if (!suffix.empty())
     {
@@ -349,6 +342,27 @@ std::optional<uint64_t> wsl::windows::common::string::ParseStorageSize(std::wstr
                 multiplier *= base;
             }
         }
+    }
+
+    if (!narrowNumber.empty() && narrowNumber.find_first_not_of("0123456789") == std::string::npos)
+    {
+        uint64_t value{};
+        const auto result = std::from_chars(narrowNumber.data(), narrowNumber.data() + narrowNumber.size(), value);
+        if (result.ec != std::errc() || result.ptr != narrowNumber.data() + narrowNumber.size() ||
+            value > std::numeric_limits<uint64_t>::max() / multiplier)
+        {
+            return {};
+        }
+
+        return value * multiplier;
+    }
+
+    // Fractional and exponent forms require floating-point parsing and may lose precision above 2^53.
+    double value{};
+    const auto result = std::from_chars(narrowNumber.data(), narrowNumber.data() + narrowNumber.size(), value, std::chars_format::general);
+    if (result.ec != std::errc() || result.ptr != narrowNumber.data() + narrowNumber.size() || !std::isfinite(value) || value < 0)
+    {
+        return {};
     }
 
     const double bytes = value * static_cast<double>(multiplier);

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -377,13 +377,8 @@ std::wstring wsl::windows::common::string::FormatStorageSize(uint64_t Bytes, Sto
         ++unitIndex;
     }
 
-    if (unitIndex == 0)
-    {
-        return IncludeSpace ? std::format(L"{} {}", Bytes, units[unitIndex]) : std::format(L"{}{}", Bytes, units[unitIndex]);
-    }
-
-    return IncludeSpace ? std::format(L"{:.{}f} {}", value, DecimalPlaces, units[unitIndex])
-                        : std::format(L"{:.{}f}{}", value, DecimalPlaces, units[unitIndex]);
+    const auto formattedValue = unitIndex == 0 ? std::to_wstring(Bytes) : std::format(L"{:.{}f}", value, DecimalPlaces);
+    return std::format(L"{}{}{}", formattedValue, IncludeSpace ? L" " : L"", units[unitIndex]);
 }
 
 std::wstring wsl::windows::common::string::FormatBytes(uint64_t Bytes)

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -23,6 +23,18 @@ using SOCKADDR_INET = union _SOCKADDR_INET;
 
 namespace wsl::windows::common::string {
 
+enum class StorageSizeUnit
+{
+    Decimal,
+    Binary
+};
+
+std::optional<uint64_t> ParseStorageSize(std::wstring_view String, StorageSizeUnit Unit);
+
+std::wstring FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace = false);
+
+std::wstring FormatBytes(uint64_t Bytes);
+
 std::vector<std::string> InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize);
 
 bool IsPathComponentEqual(const std::wstring_view String1, const std::wstring_view String2);

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -82,11 +82,12 @@ struct Ulimit
 struct InspectHostConfig
 {
     std::string NetworkMode;
+    std::int64_t ShmSize{};
     std::int64_t Memory{};
     std::int64_t NanoCpus{};
     std::vector<Ulimit> Ulimits;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectHostConfig, NetworkMode, Memory, NanoCpus, Ulimits);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectHostConfig, NetworkMode, ShmSize, Memory, NanoCpus, Ulimits);
 };
 
 struct HealthConfig

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -82,12 +82,11 @@ struct Ulimit
 struct InspectHostConfig
 {
     std::string NetworkMode;
-    std::int64_t ShmSize{};
     std::int64_t Memory{};
     std::int64_t NanoCpus{};
     std::vector<Ulimit> Ulimits;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectHostConfig, NetworkMode, ShmSize, Memory, NanoCpus, Ulimits);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectHostConfig, NetworkMode, Memory, NanoCpus, Ulimits);
 };
 
 struct HealthConfig

--- a/src/windows/wslc/arguments/SpecParsing.cpp
+++ b/src/windows/wslc/arguments/SpecParsing.cpp
@@ -814,13 +814,14 @@ models::InspectType GetInspectTypeFromString(const std::wstring& input, const st
 
 int64_t GetMemorySizeFromString(const std::wstring& input, const std::wstring& argName)
 {
-    auto parsed = wsl::shared::string::ParseMemorySize(input.c_str());
-    if (!parsed.has_value())
+    const auto bytes =
+        wsl::windows::common::string::ParseStorageSize(std::wstring_view{input}, wsl::windows::common::string::StorageSizeUnit::Binary);
+    if (!bytes.has_value() || bytes.value() > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
     {
         throw ArgumentException(Localization::WSLCCLI_InvalidMemorySizeError(argName, input));
     }
 
-    return static_cast<int64_t>(parsed.value());
+    return static_cast<int64_t>(bytes.value());
 }
 
 // Parses duration string into nanoseconds.

--- a/src/windows/wslc/arguments/SpecParsing.h
+++ b/src/windows/wslc/arguments/SpecParsing.h
@@ -104,7 +104,7 @@ models::ProgressMode GetProgressModeFromString(const std::wstring& input, const 
 // Parses an inspect target ("image"/"container"/"network"/"volume") into an InspectType.
 models::InspectType GetInspectTypeFromString(const std::wstring& input, const std::wstring& argName);
 
-// Parses a memory size (e.g. "512m", "1g") into a byte count.
+// Parses a Docker-style memory size (e.g. "512m", "1.5g") into a byte count.
 int64_t GetMemorySizeFromString(const std::wstring& input, const std::wstring& argName = {});
 
 // Parses a Go-style duration (e.g. "1.5h", "500ms") into nanoseconds.

--- a/src/windows/wslc/services/ImageProgressCallback.cpp
+++ b/src/windows/wslc/services/ImageProgressCallback.cpp
@@ -20,6 +20,7 @@ Abstract:
 namespace wsl::windows::wslc::services {
 using namespace wsl::shared;
 using namespace wsl::windows::common::vt;
+using wsl::windows::common::string::FormatBytes;
 
 auto ImageProgressCallback::MoveToLine(int line)
 {
@@ -132,18 +133,18 @@ std::wstring ImageProgressCallback::GenerateStatusLine(LPCSTR status, LPCSTR id,
 
         // Docker's reported total is an estimate of the compressed layer size, so the actual bytes
         // transferred can exceed it. Drop the total in that case to avoid displaying a count over 100%.
-        auto progress = wsl::shared::string::FormatBytes(current);
+        auto progress = FormatBytes(current);
 
         if (current <= total)
         {
-            progress += std::format(L"/{}", wsl::shared::string::FormatBytes(total));
+            progress += std::format(L"/{}", FormatBytes(total));
         }
 
         line = std::format(L"{}: {} [{}] {}", safeId, safeStatus, bar, progress);
     }
     else if (current != 0)
     {
-        line = std::format(L"{}: {} {}", safeId, safeStatus, wsl::shared::string::FormatBytes(current));
+        line = std::format(L"{}: {} {}", safeId, safeStatus, FormatBytes(current));
     }
     else
     {

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -34,34 +34,11 @@ using namespace wsl::windows::common::wslutil;
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::models;
 using namespace wsl::windows::wslc::services;
+using wsl::windows::common::string::FormatBytes;
+using wsl::windows::common::string::FormatStorageSize;
+using wsl::windows::common::string::StorageSizeUnit;
 
 namespace {
-
-std::string FormatBytes(uint64_t bytes)
-{
-    constexpr uint64_t c_kib = 1024;
-    constexpr uint64_t c_mib = 1024 * c_kib;
-    constexpr uint64_t c_gib = 1024 * c_mib;
-
-    if (bytes >= c_gib)
-    {
-        return std::format("{:.2f} GiB", static_cast<double>(bytes) / static_cast<double>(c_gib));
-    }
-    else if (bytes >= c_mib)
-    {
-        return std::format("{:.2f} MiB", static_cast<double>(bytes) / static_cast<double>(c_mib));
-    }
-    else if (bytes >= c_kib)
-    {
-        return std::format("{:.2f} KiB", static_cast<double>(bytes) / static_cast<double>(c_kib));
-    }
-    else
-    {
-        // Bytes are always whole numbers, so decimal places are intentionally omitted here.
-        // This matches the behaviour of `docker stats`.
-        return std::format("{} B", bytes);
-    }
-}
 
 nlohmann::json ComputeContainerStatsJson(const wsl::windows::common::docker_schema::ContainerStats& stats)
 {
@@ -120,15 +97,18 @@ nlohmann::json ComputeContainerStatsJson(const wsl::windows::common::docker_sche
     }
 
     const auto& containerName = stats.name.empty() ? stats.id : stats.name;
+    const auto formatBinaryBytes = [](uint64_t bytes) {
+        return WideToMultiByte(FormatStorageSize(bytes, StorageSizeUnit::Binary, 2, true));
+    };
 
     return {
         {"ID", stats.id},
         {"Name", containerName},
         {"CPUPerc", std::format("{:.2f}%", cpuPercent)},
-        {"MemUsage", std::format("{} / {}", FormatBytes(stats.memory_stats.usage), FormatBytes(stats.memory_stats.limit))},
+        {"MemUsage", std::format("{} / {}", formatBinaryBytes(stats.memory_stats.usage), formatBinaryBytes(stats.memory_stats.limit))},
         {"MemPerc", std::format("{:.2f}%", memPercent)},
-        {"NetIO", std::format("{} / {}", FormatBytes(netRxBytes), FormatBytes(netTxBytes))},
-        {"BlockIO", std::format("{} / {}", FormatBytes(blkReadBytes), FormatBytes(blkWriteBytes))},
+        {"NetIO", std::format("{} / {}", formatBinaryBytes(netRxBytes), formatBinaryBytes(netTxBytes))},
+        {"BlockIO", std::format("{} / {}", formatBinaryBytes(blkReadBytes), formatBinaryBytes(blkWriteBytes))},
         {"PIDs", stats.pids_stats.current},
     };
 }
@@ -1082,7 +1062,6 @@ void PruneContainers(CLIExecutionContext& context)
     }
 
     context.Terminal.Output(L"\n");
-    context.Terminal.Output(
-        L"{}\n", Localization::WSLCCLI_ContainerPruneSpaceReclaimedBytes(wsl::shared::string::FormatBytes(result.SpaceReclaimed)));
+    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_ContainerPruneSpaceReclaimedBytes(FormatBytes(result.SpaceReclaimed)));
 }
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -32,6 +32,7 @@ using namespace wsl::windows::common::wslutil;
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::models;
 using namespace wsl::windows::wslc::services;
+using wsl::windows::common::string::FormatBytes;
 
 namespace wsl::windows::wslc::task {
 
@@ -405,7 +406,6 @@ void PruneImages(CLIExecutionContext& context)
     }
 
     context.Terminal.Output(L"\n");
-    context.Terminal.Output(
-        L"{}\n", Localization::WSLCCLI_ImagePruneSpaceReclaimedBytes(wsl::shared::string::FormatBytes(result.SpaceReclaimed)));
+    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_ImagePruneSpaceReclaimedBytes(FormatBytes(result.SpaceReclaimed)));
 }
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -27,6 +27,7 @@ using namespace wsl::windows::common::wslutil;
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::models;
 using namespace wsl::windows::wslc::services;
+using wsl::windows::common::string::FormatBytes;
 
 namespace wsl::windows::wslc::task {
 
@@ -215,6 +216,6 @@ void PruneVolumes(CLIExecutionContext& context)
     }
 
     context.Terminal.Output(L"\n");
-    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_VolumePruneSpaceReclaimed(wsl::shared::string::FormatBytes(result.SpaceReclaimed)));
+    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_VolumePruneSpaceReclaimed(FormatBytes(result.SpaceReclaimed)));
 }
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -30,6 +30,7 @@ using io::MultiHandleWait;
 using io::OverlappedIOHandle;
 using io::WriteHandle;
 using wsl::shared::Localization;
+using wsl::windows::common::string::FormatBytes;
 using wsl::windows::service::wslc::UserCOMCallback;
 using wsl::windows::service::wslc::UserHandle;
 using wsl::windows::service::wslc::WSLCExecutionContext;
@@ -1431,8 +1432,8 @@ try
             {
                 auto currentBytes = static_cast<ULONGLONG>(std::max<int64_t>(entry.current, 0));
                 auto totalBytes = static_cast<ULONGLONG>(std::max<int64_t>(entry.total, 0));
-                auto current = wsl::shared::string::FormatBytes(currentBytes);
-                auto total = wsl::shared::string::FormatBytes(totalBytes);
+                auto current = FormatBytes(currentBytes);
+                auto total = FormatBytes(totalBytes);
                 reportProgress(std::format("{}{} {} / {}", logPrefix(it->second), entry.id, current, total), entry.id.c_str(), currentBytes, totalBytes);
             }
             else if (reportedSteps.insert(entry.id).second)

--- a/test/windows/CMakeLists.txt
+++ b/test/windows/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Plan9Tests.cpp
     DrvFsTests.cpp
     FilesystemUnitTests.cpp
+    StringUnitTests.cpp
     Common.cpp
     PluginTests.cpp
     PolicyTests.cpp

--- a/test/windows/SimpleTests.cpp
+++ b/test/windows/SimpleTests.cpp
@@ -223,33 +223,6 @@ class SimpleTests
             VERIFY_ARE_EQUAL(expected, wsl::shared::string::ParseBool(wideString.c_str(), true));
         }
 
-        // Test wsl::shared::string::ParseMemoryString
-        const std::vector<std::pair<LPCSTR, std::optional<uint64_t>>> testCases{
-            {"0", 0},
-            {"1", 1},
-            {" 1", 1},
-            {"1B", 1},
-            {"1K", 1024},
-            {"1KB", 1024},
-            {"2M", 2 * 1024 * 1024},
-            {"100MB", 100 * 1024 * 1024},
-            {"9G", 9 * 1024ULL * 1024ULL * 1024ULL},
-            {"44GB", 44 * 1024ULL * 1024ULL * 1024ULL},
-            {"1TB", 1ULL << 40},
-            {"2T", 2ULL << 40},
-            {"1 B", std::nullopt},
-            {nullptr, std::nullopt},
-            {"", std::nullopt},
-            {"foo", std::nullopt}};
-
-        for (const auto& [input, expected] : testCases)
-        {
-            VERIFY_ARE_EQUAL(wsl::shared::string::ParseMemorySize(input), expected);
-
-            const auto wideInput = wsl::shared::string::MultiByteToWide(input);
-            VERIFY_ARE_EQUAL(wsl::shared::string::ParseMemorySize(wideInput.c_str()), expected);
-        }
-
         // Test wsl::shared::string GUID helpers
         const GUID guid = {0x1234567a, 0x1234, 0x5678, {0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}};
         const std::string guidString = "{1234567a-1234-5678-1234-567812345678}";

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -197,7 +197,7 @@ class StringUnitTests
             {119'856'765, StorageSizeUnit::Decimal, 2, false, L"119.86MB"},
             {1'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00TB"},
             {1'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00PB"},
-            {1'000'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00EB"},
+            {1'000'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1000.00PB"},
             {1'023, StorageSizeUnit::Binary, 2, true, L"1023 B"},
             {1'024, StorageSizeUnit::Binary, 0, false, L"1KiB"},
             {1'536, StorageSizeUnit::Binary, 1, false, L"1.5KiB"},
@@ -205,7 +205,7 @@ class StringUnitTests
             {1'610'612'736, StorageSizeUnit::Binary, 1, false, L"1.5GiB"},
             {1ULL << 40, StorageSizeUnit::Binary, 2, false, L"1.00TiB"},
             {1ULL << 50, StorageSizeUnit::Binary, 2, false, L"1.00PiB"},
-            {1ULL << 60, StorageSizeUnit::Binary, 2, false, L"1.00EiB"},
+            {1ULL << 60, StorageSizeUnit::Binary, 2, false, L"1024.00PiB"},
         };
 
         for (const auto& TestCase : TestCases)
@@ -228,6 +228,8 @@ class StringUnitTests
         VerifyRoundTrip(32, StorageSizeUnit::Decimal, 0, true);
         VerifyRoundTrip(1'500, StorageSizeUnit::Decimal, 1);
         VerifyRoundTrip(1'536, StorageSizeUnit::Binary, 1);
+        VerifyRoundTrip(1'000'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2);
+        VerifyRoundTrip(1ULL << 60, StorageSizeUnit::Binary, 2);
 
         uint64_t decimalFactor = 1'000;
         uint64_t binaryFactor = 1'024;

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -31,7 +31,7 @@ struct StorageSizeTextRoundTripCase
 void VerifyDockerStorageSize(const std::string& Input, StorageSizeUnit Unit, std::optional<uint64_t> Expected)
 {
     const auto wideInput = wsl::shared::string::MultiByteToWide(Input);
-    VERIFY_ARE_EQUAL(ParseStorageSize(wideInput, Unit), Expected);
+    VERIFY_ARE_EQUAL(Expected, ParseStorageSize(wideInput, Unit));
 }
 
 std::vector<std::string> DockerSuffixes(char Unit)
@@ -98,10 +98,10 @@ class StringUnitTests
 
         for (const auto& [Input, Expected] : TestCases)
         {
-            VERIFY_ARE_EQUAL(wsl::shared::string::ParseMemorySize(Input), Expected);
+            VERIFY_ARE_EQUAL(Expected, wsl::shared::string::ParseMemorySize(Input));
 
             const auto wideInput = wsl::shared::string::MultiByteToWide(Input);
-            VERIFY_ARE_EQUAL(wsl::shared::string::ParseMemorySize(wideInput.c_str()), Expected);
+            VERIFY_ARE_EQUAL(Expected, wsl::shared::string::ParseMemorySize(wideInput.c_str()));
         }
     }
 
@@ -143,6 +143,13 @@ class StringUnitTests
             VerifyDockerStorageSize("32.B", Unit, 32);
             VerifyDockerStorageSize("32. b", Unit, 32);
             VerifyDockerStorageSize("32. B", Unit, 32);
+            VerifyDockerStorageSize("9007199254740991", Unit, 9'007'199'254'740'991);
+            VerifyDockerStorageSize("9007199254740992", Unit, 9'007'199'254'740'992);
+            VerifyDockerStorageSize("9007199254740993", Unit, 9'007'199'254'740'993);
+            VerifyDockerStorageSize("9223372036854775806", Unit, 9'223'372'036'854'775'806);
+            VerifyDockerStorageSize("9223372036854775807", Unit, 9'223'372'036'854'775'807);
+            VerifyDockerStorageSize("9223372036854775808", Unit, 9'223'372'036'854'775'808ULL);
+            VerifyDockerStorageSize("18446744073709551615", Unit, std::numeric_limits<uint64_t>::max());
         }
 
         VerifyDockerStorageSize("32.5kB", StorageSizeUnit::Decimal, 32'500);
@@ -151,6 +158,10 @@ class StringUnitTests
         VerifyDockerStorageSize(".3kB", StorageSizeUnit::Decimal, 300);
         VerifyDockerStorageSize("32.3 mb", StorageSizeUnit::Binary, 33'869'004);
         VerifyDockerStorageSize("0.3MB", StorageSizeUnit::Binary, 314'572);
+        VerifyDockerStorageSize("18446744073709551K", StorageSizeUnit::Decimal, 18'446'744'073'709'551'000ULL);
+        VerifyDockerStorageSize("18446744073709552K", StorageSizeUnit::Decimal, std::nullopt);
+        VerifyDockerStorageSize("18014398509481983K", StorageSizeUnit::Binary, 18'446'744'073'709'550'592ULL);
+        VerifyDockerStorageSize("18014398509481984K", StorageSizeUnit::Binary, std::nullopt);
     }
 
     TEST_METHOD(ParseStorageSize_DockerInvalidForms)
@@ -210,18 +221,17 @@ class StringUnitTests
 
         for (const auto& TestCase : TestCases)
         {
-            VERIFY_ARE_EQUAL(
-                FormatStorageSize(TestCase.Bytes, TestCase.Unit, TestCase.DecimalPlaces, TestCase.IncludeSpace), TestCase.Expected);
+            VERIFY_ARE_EQUAL(TestCase.Expected, FormatStorageSize(TestCase.Bytes, TestCase.Unit, TestCase.DecimalPlaces, TestCase.IncludeSpace));
         }
 
-        VERIFY_ARE_EQUAL(FormatBytes(119'856'765), std::wstring{L"119.86 MB"});
+        VERIFY_ARE_EQUAL(std::wstring{L"119.86 MB"}, FormatBytes(119'856'765));
     }
 
     TEST_METHOD(StorageSize_BytesToTextRoundTrips)
     {
         const auto VerifyRoundTrip = [](uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace = false) {
             const auto text = FormatStorageSize(Bytes, Unit, DecimalPlaces, IncludeSpace);
-            VERIFY_ARE_EQUAL(ParseStorageSize(text, Unit), std::optional<uint64_t>{Bytes});
+            VERIFY_ARE_EQUAL(std::optional<uint64_t>{Bytes}, ParseStorageSize(text, Unit));
         };
 
         VerifyRoundTrip(0, StorageSizeUnit::Decimal, 0);
@@ -265,8 +275,8 @@ class StringUnitTests
             VERIFY_IS_TRUE(bytes.has_value());
 
             const auto text = FormatStorageSize(bytes.value(), TestCase.Unit, TestCase.DecimalPlaces, TestCase.IncludeSpace);
-            VERIFY_ARE_EQUAL(text, TestCase.Text);
-            VERIFY_ARE_EQUAL(ParseStorageSize(text, TestCase.Unit), bytes);
+            VERIFY_ARE_EQUAL(TestCase.Text, text);
+            VERIFY_ARE_EQUAL(bytes, ParseStorageSize(text, TestCase.Unit));
         }
     }
 };

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -1,0 +1,271 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#include "precomp.h"
+#include "Common.h"
+#include "string.hpp"
+
+using wsl::windows::common::string::FormatBytes;
+using wsl::windows::common::string::FormatStorageSize;
+using wsl::windows::common::string::ParseStorageSize;
+using wsl::windows::common::string::StorageSizeUnit;
+
+namespace {
+
+struct StorageSizeFormatCase
+{
+    uint64_t Bytes;
+    StorageSizeUnit Unit;
+    uint32_t DecimalPlaces;
+    bool IncludeSpace;
+    std::wstring Expected;
+};
+
+struct StorageSizeTextRoundTripCase
+{
+    std::wstring Text;
+    StorageSizeUnit Unit;
+    uint32_t DecimalPlaces;
+    bool IncludeSpace;
+};
+
+void VerifyDockerStorageSize(const std::string& Input, StorageSizeUnit Unit, std::optional<uint64_t> Expected)
+{
+    const auto wideInput = wsl::shared::string::MultiByteToWide(Input);
+    VERIFY_ARE_EQUAL(ParseStorageSize(wideInput, Unit), Expected);
+}
+
+std::vector<std::string> DockerSuffixes(char Unit)
+{
+    const auto UpperUnit = static_cast<char>(std::toupper(static_cast<unsigned char>(Unit)));
+    return {
+        {Unit},
+        {UpperUnit},
+        {Unit, 'b'},
+        {Unit, 'B'},
+        {UpperUnit, 'b'},
+        {UpperUnit, 'B'},
+        {Unit, 'i', 'b'},
+        {Unit, 'i', 'B'},
+        {Unit, 'I', 'b'},
+        {Unit, 'I', 'B'},
+        {UpperUnit, 'i', 'b'},
+        {UpperUnit, 'i', 'B'},
+        {UpperUnit, 'I', 'b'},
+        {UpperUnit, 'I', 'B'},
+    };
+}
+
+void VerifyDockerStorageUnits(StorageSizeUnit Unit, uint64_t Base)
+{
+    uint64_t Factor = Base;
+    for (const auto UnitName : {'k', 'm', 'g', 't', 'p'})
+    {
+        for (const auto& Suffix : DockerSuffixes(UnitName))
+        {
+            VerifyDockerStorageSize("32" + Suffix, Unit, 32 * Factor);
+        }
+
+        Factor *= Base;
+    }
+}
+
+} // namespace
+
+namespace StringUnitTests {
+class StringUnitTests
+{
+    WSL_TEST_CLASS(StringUnitTests)
+
+    TEST_METHOD(ParseMemorySize_LegacyForms)
+    {
+        const std::vector<std::pair<LPCSTR, std::optional<uint64_t>>> TestCases{
+            {"0", 0},
+            {"1", 1},
+            {" 1", 1},
+            {"1B", 1},
+            {"1K", 1024},
+            {"1KB", 1024},
+            {"2M", 2 * 1024 * 1024},
+            {"100MB", 100 * 1024 * 1024},
+            {"9G", 9 * 1024ULL * 1024ULL * 1024ULL},
+            {"44GB", 44 * 1024ULL * 1024ULL * 1024ULL},
+            {"1TB", 1ULL << 40},
+            {"2T", 2ULL << 40},
+            {"1 B", std::nullopt},
+            {nullptr, std::nullopt},
+            {"", std::nullopt},
+            {"foo", std::nullopt}};
+
+        for (const auto& [Input, Expected] : TestCases)
+        {
+            VERIFY_ARE_EQUAL(wsl::shared::string::ParseMemorySize(Input), Expected);
+
+            const auto wideInput = wsl::shared::string::MultiByteToWide(Input);
+            VERIFY_ARE_EQUAL(wsl::shared::string::ParseMemorySize(wideInput.c_str()), Expected);
+        }
+    }
+
+    TEST_METHOD(ParseStorageSize_DockerDecimalUnits)
+    {
+        VerifyDockerStorageUnits(StorageSizeUnit::Decimal, 1000);
+    }
+
+    TEST_METHOD(ParseStorageSize_DockerBinaryUnits)
+    {
+        VerifyDockerStorageUnits(StorageSizeUnit::Binary, 1024);
+    }
+
+    TEST_METHOD(ParseStorageSize_DockerNumericForms)
+    {
+        for (const auto Unit : {StorageSizeUnit::Decimal, StorageSizeUnit::Binary})
+        {
+            VerifyDockerStorageSize("0", Unit, 0);
+            VerifyDockerStorageSize("0b", Unit, 0);
+            VerifyDockerStorageSize("0B", Unit, 0);
+            VerifyDockerStorageSize("0 B", Unit, 0);
+            VerifyDockerStorageSize("32", Unit, 32);
+            VerifyDockerStorageSize("32b", Unit, 32);
+            VerifyDockerStorageSize("32B", Unit, 32);
+            VerifyDockerStorageSize("32.5 B", Unit, 32);
+            VerifyDockerStorageSize("0.", Unit, 0);
+            VerifyDockerStorageSize("0. ", Unit, 0);
+            VerifyDockerStorageSize("0.b", Unit, 0);
+            VerifyDockerStorageSize("0.B", Unit, 0);
+            VerifyDockerStorageSize("-0", Unit, 0);
+            VerifyDockerStorageSize("-0b", Unit, 0);
+            VerifyDockerStorageSize("-0B", Unit, 0);
+            VerifyDockerStorageSize("-0 b", Unit, 0);
+            VerifyDockerStorageSize("-0 B", Unit, 0);
+            VerifyDockerStorageSize("+32K", Unit, 32 * (Unit == StorageSizeUnit::Decimal ? 1000 : 1024));
+            VerifyDockerStorageSize("1e3K", Unit, 1000 * (Unit == StorageSizeUnit::Decimal ? 1000 : 1024));
+            VerifyDockerStorageSize("32.", Unit, 32);
+            VerifyDockerStorageSize("32.b", Unit, 32);
+            VerifyDockerStorageSize("32.B", Unit, 32);
+            VerifyDockerStorageSize("32. b", Unit, 32);
+            VerifyDockerStorageSize("32. B", Unit, 32);
+        }
+
+        VerifyDockerStorageSize("32.5kB", StorageSizeUnit::Decimal, 32'500);
+        VerifyDockerStorageSize("32.5 kB", StorageSizeUnit::Decimal, 32'500);
+        VerifyDockerStorageSize("0.3 K", StorageSizeUnit::Decimal, 300);
+        VerifyDockerStorageSize(".3kB", StorageSizeUnit::Decimal, 300);
+        VerifyDockerStorageSize("32.3 mb", StorageSizeUnit::Binary, 33'869'004);
+        VerifyDockerStorageSize("0.3MB", StorageSizeUnit::Binary, 314'572);
+    }
+
+    TEST_METHOD(ParseStorageSize_DockerInvalidForms)
+    {
+        const std::vector<std::string> InvalidSizes{
+            "",       "hello",
+            ".",      ". ",
+            " ",      "  ",
+            " .",     " . ",
+            " 0",     " 0b",
+            " 0B",    " 0 B",
+            "0b ",    "0B ",
+            "0 B ",   "-32",
+            "-32b",   "-32B",
+            "-32 b",  "-32 B",
+            "32b.",   "32B.",
+            "32 b.",  "32 B.",
+            "32 bb",  "32 BB",
+            "32 b b", "32 B B",
+            "32  b",  "32  B",
+            " 32 ",   "32m b",
+            "32bm",   "1E",
+            "1EB",    "1EiB",
+            "1e309",  "18446744073709551616",
+        };
+
+        for (const auto Unit : {StorageSizeUnit::Decimal, StorageSizeUnit::Binary})
+        {
+            for (const auto& Input : InvalidSizes)
+            {
+                VerifyDockerStorageSize(Input, Unit, std::nullopt);
+            }
+        }
+    }
+
+    TEST_METHOD(FormatStorageSize_UsesRequestedPrecision)
+    {
+        const std::vector<StorageSizeFormatCase> TestCases{
+            {0, StorageSizeUnit::Decimal, 0, false, L"0B"},
+            {999, StorageSizeUnit::Decimal, 2, true, L"999 B"},
+            {1'000, StorageSizeUnit::Decimal, 0, false, L"1KB"},
+            {119'856'765, StorageSizeUnit::Decimal, 0, false, L"120MB"},
+            {119'856'765, StorageSizeUnit::Decimal, 1, false, L"119.9MB"},
+            {119'856'765, StorageSizeUnit::Decimal, 2, false, L"119.86MB"},
+            {1'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00TB"},
+            {1'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00PB"},
+            {1'000'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00EB"},
+            {1'023, StorageSizeUnit::Binary, 2, true, L"1023 B"},
+            {1'024, StorageSizeUnit::Binary, 0, false, L"1KiB"},
+            {1'536, StorageSizeUnit::Binary, 1, false, L"1.5KiB"},
+            {1'610'612'736, StorageSizeUnit::Binary, 0, false, L"2GiB"},
+            {1'610'612'736, StorageSizeUnit::Binary, 1, false, L"1.5GiB"},
+            {1ULL << 40, StorageSizeUnit::Binary, 2, false, L"1.00TiB"},
+            {1ULL << 50, StorageSizeUnit::Binary, 2, false, L"1.00PiB"},
+            {1ULL << 60, StorageSizeUnit::Binary, 2, false, L"1.00EiB"},
+        };
+
+        for (const auto& TestCase : TestCases)
+        {
+            VERIFY_ARE_EQUAL(
+                FormatStorageSize(TestCase.Bytes, TestCase.Unit, TestCase.DecimalPlaces, TestCase.IncludeSpace), TestCase.Expected);
+        }
+
+        VERIFY_ARE_EQUAL(FormatBytes(119'856'765), std::wstring{L"119.86 MB"});
+    }
+
+    TEST_METHOD(StorageSize_BytesToTextRoundTrips)
+    {
+        const auto VerifyRoundTrip = [](uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace = false) {
+            const auto text = FormatStorageSize(Bytes, Unit, DecimalPlaces, IncludeSpace);
+            VERIFY_ARE_EQUAL(ParseStorageSize(text, Unit), std::optional<uint64_t>{Bytes});
+        };
+
+        VerifyRoundTrip(0, StorageSizeUnit::Decimal, 0);
+        VerifyRoundTrip(32, StorageSizeUnit::Decimal, 0, true);
+        VerifyRoundTrip(1'500, StorageSizeUnit::Decimal, 1);
+        VerifyRoundTrip(1'536, StorageSizeUnit::Binary, 1);
+
+        uint64_t decimalFactor = 1'000;
+        uint64_t binaryFactor = 1'024;
+        for (size_t index = 0; index < 5; ++index)
+        {
+            VerifyRoundTrip(32 * decimalFactor, StorageSizeUnit::Decimal, 0);
+            VerifyRoundTrip(32 * binaryFactor, StorageSizeUnit::Binary, 0, true);
+            decimalFactor *= 1'000;
+            binaryFactor *= 1'024;
+        }
+    }
+
+    TEST_METHOD(StorageSize_TextToBytesRoundTrips)
+    {
+        const std::vector<StorageSizeTextRoundTripCase> TestCases{
+            {L"0B", StorageSizeUnit::Decimal, 0, false},
+            {L"32 B", StorageSizeUnit::Decimal, 0, true},
+            {L"32KB", StorageSizeUnit::Decimal, 0, false},
+            {L"32.5MB", StorageSizeUnit::Decimal, 1, false},
+            {L"1GB", StorageSizeUnit::Decimal, 0, false},
+            {L"1.25TB", StorageSizeUnit::Decimal, 2, false},
+            {L"1PB", StorageSizeUnit::Decimal, 0, false},
+            {L"32KiB", StorageSizeUnit::Binary, 0, false},
+            {L"1.5MiB", StorageSizeUnit::Binary, 1, false},
+            {L"1GiB", StorageSizeUnit::Binary, 0, false},
+            {L"1.25 TiB", StorageSizeUnit::Binary, 2, true},
+            {L"1PiB", StorageSizeUnit::Binary, 0, false},
+        };
+
+        for (const auto& TestCase : TestCases)
+        {
+            const auto bytes = ParseStorageSize(TestCase.Text, TestCase.Unit);
+            VERIFY_IS_TRUE(bytes.has_value());
+
+            const auto text = FormatStorageSize(bytes.value(), TestCase.Unit, TestCase.DecimalPlaces, TestCase.IncludeSpace);
+            VERIFY_ARE_EQUAL(text, TestCase.Text);
+            VERIFY_ARE_EQUAL(ParseStorageSize(text, TestCase.Unit), bytes);
+        }
+    }
+};
+} // namespace StringUnitTests

--- a/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
@@ -174,6 +174,8 @@ class WSLCCLIArgumentUnitTests
         VERIFY_ARE_EQUAL(static_cast<int64_t>(1'610'612'736), validation::GetMemorySizeFromString(L"1.5G"));
         VERIFY_ARE_EQUAL(static_cast<int64_t>(314'572), validation::GetMemorySizeFromString(L"0.3MiB"));
         VERIFY_ARE_EQUAL(static_cast<int64_t>(32), validation::GetMemorySizeFromString(L"32.3"));
+        VERIFY_ARE_EQUAL(static_cast<int64_t>(9'007'199'254'740'993), validation::GetMemorySizeFromString(L"9007199254740993"));
+        VERIFY_ARE_EQUAL(std::numeric_limits<int64_t>::max(), validation::GetMemorySizeFromString(L"9223372036854775807"));
         VERIFY_THROWS(validation::GetMemorySizeFromString(L"-1.5G"), ArgumentException);
         VERIFY_THROWS(validation::GetMemorySizeFromString(L"9223372036854775808"), ArgumentException);
 

--- a/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
@@ -170,6 +170,13 @@ class WSLCCLIArgumentUnitTests
         VERIFY_THROWS(validation::GetProgressModeFromString(L"TTY"), ArgumentException); // Case-sensitive: only lowercase accepted
         VERIFY_THROWS(validation::GetProgressModeFromString(L"fancy"), ArgumentException);
 
+        // Verify Docker-style memory size conversion.
+        VERIFY_ARE_EQUAL(static_cast<int64_t>(1'610'612'736), validation::GetMemorySizeFromString(L"1.5G"));
+        VERIFY_ARE_EQUAL(static_cast<int64_t>(314'572), validation::GetMemorySizeFromString(L"0.3MiB"));
+        VERIFY_ARE_EQUAL(static_cast<int64_t>(32), validation::GetMemorySizeFromString(L"32.3"));
+        VERIFY_THROWS(validation::GetMemorySizeFromString(L"-1.5G"), ArgumentException);
+        VERIFY_THROWS(validation::GetMemorySizeFromString(L"9223372036854775808"), ArgumentException);
+
         // Verify GPU device argument
         VERIFY_NO_THROW(validation::ValidateGpus({L"all"}, L"gpusArg"));
         VERIFY_THROWS(validation::ValidateGpus({L"none"}, L"gpusArg"), ArgumentException);
@@ -380,7 +387,7 @@ class WSLCCLIArgumentUnitTests
 
         // string -> int64_t (memory sizes). The cached value matches the converter's result.
         VERIFY_ARE_EQUAL(ValidateAndGetCached<ArgType::Memory>(L"512M"), validation::GetMemorySizeFromString(L"512M"));
-        VERIFY_ARE_EQUAL(ValidateAndGetCached<ArgType::ShmSize>(L"64M"), validation::GetMemorySizeFromString(L"64M"));
+        VERIFY_ARE_EQUAL(ValidateAndGetCached<ArgType::ShmSize>(L"1.5G"), static_cast<int64_t>(1'610'612'736));
 
         // string -> int64_t (durations, in nanoseconds)
         VERIFY_ARE_EQUAL(ValidateAndGetCached<ArgType::HealthInterval>(L"30s"), validation::GetDurationNanosFromString(L"30s"));

--- a/test/windows/wslc/WSLCCLISettingsUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLISettingsUnitTests.cpp
@@ -153,13 +153,13 @@ class WSLCCLISettingsUnitTests
         VERIFY_ARE_EQUAL(static_cast<int>(CredentialStoreType::File), static_cast<int>(s.Get<Setting::CredentialStore>()));
     }
 
-    TEST_METHOD(LoadSettings_DockerStorageSizes_YieldsExpectedValues)
+    TEST_METHOD(LoadSettings_StorageSizeFormats_YieldExpectedValues)
     {
         auto dir = UniqueTempDir();
         WriteFile(
             dir / L"settings.yaml",
             "session:\n"
-            "  memorySize: 1.5GiB\n"
+            "  memorySize: \" 1.5GiB\"\n"
             "  maxStorageSize: 20.5GB\n");
 
         UserSettingsTest s{dir};

--- a/test/windows/wslc/WSLCCLISettingsUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLISettingsUnitTests.cpp
@@ -153,6 +153,22 @@ class WSLCCLISettingsUnitTests
         VERIFY_ARE_EQUAL(static_cast<int>(CredentialStoreType::File), static_cast<int>(s.Get<Setting::CredentialStore>()));
     }
 
+    TEST_METHOD(LoadSettings_DockerStorageSizes_YieldsExpectedValues)
+    {
+        auto dir = UniqueTempDir();
+        WriteFile(
+            dir / L"settings.yaml",
+            "session:\n"
+            "  memorySize: 1.5GiB\n"
+            "  maxStorageSize: 20.5GB\n");
+
+        UserSettingsTest s{dir};
+
+        VERIFY_ARE_EQUAL(0u, s.GetWarnings().size());
+        VERIFY_ARE_EQUAL(1536u, s.Get<Setting::SessionMemoryMb>());
+        VERIFY_ARE_EQUAL(20992u, s.Get<Setting::SessionStorageSizeMb>());
+    }
+
     // An empty settings file is valid YAML (null document) but not a mapping;
     // a structure warning is emitted and all settings use defaults.
     TEST_METHOD(LoadSettings_EmptySettings_WarnsInvalidStructure)
@@ -234,6 +250,39 @@ class WSLCCLISettingsUnitTests
         VERIFY_ARE_EQUAL(
             Loc::WSLCUserSettings_Warning_InvalidValue(L"session.memorySize", s.SettingsFilePath().wstring(), 2),
             s.GetWarnings().front().Message);
+    }
+
+    TEST_METHOD(Validation_MemoryMb_Limits_AreEnforced)
+    {
+        struct TestCase
+        {
+            std::string Value;
+            uint32_t Expected;
+            bool IsValid;
+        };
+
+        const std::vector<TestCase> TestCases{
+            {"0.5MiB", 0, false},
+            {"4294967295MiB", std::numeric_limits<uint32_t>::max(), true},
+            {"4294967296MiB", 0, false},
+        };
+
+        for (const auto& TestCase : TestCases)
+        {
+            auto dir = UniqueTempDir();
+            WriteFile(dir / L"settings.yaml", std::format("session:\n  memorySize: {}\n", TestCase.Value));
+
+            UserSettingsTest s{dir};
+
+            VERIFY_ARE_EQUAL(TestCase.Expected, s.Get<Setting::SessionMemoryMb>());
+            VERIFY_ARE_EQUAL(TestCase.IsValid ? 0u : 1u, s.GetWarnings().size());
+            if (!TestCase.IsValid)
+            {
+                VERIFY_ARE_EQUAL(
+                    Loc::WSLCUserSettings_Warning_InvalidValue(L"session.memorySize", s.SettingsFilePath().wstring(), 2),
+                    s.GetWarnings().front().Message);
+            }
+        }
     }
 
     // maxStorageSize: 0 must be rejected; the default is used.

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -886,12 +886,14 @@ class WSLCE2EContainerCreateTests
     {
         auto cleanup = wil::scope_exit([&] { EnsureContainerDoesNotExist(WslcContainerName); });
 
-        auto result =
-            RunWslc(std::format(L"container create --shm-size 1.5G --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
+        auto result = RunWslc(std::format(
+            L"container create --shm-size 1.5G --name {} {} sh -c \"df -B1 /dev/shm --output=size | sed 1d\"",
+            WslcContainerName,
+            DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        const auto inspect = InspectContainer(WslcContainerName);
-        VERIFY_ARE_EQUAL(static_cast<int64_t>(1'610'612'736), inspect.HostConfig.ShmSize);
+        result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
+        result.Verify({.Stdout = L" 1610612736\n", .Stderr = L"", .ExitCode = 0});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_ShmSize_Invalid)

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -884,13 +884,12 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_ShmSize)
     {
-        auto result = RunWslc(
-            std::format(L"container create --shm-size 128M --name {} {} df -h /dev/shm", WslcContainerName, DebianImage.NameAndTag()));
+        auto result =
+            RunWslc(std::format(L"container create --shm-size 1.5G --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
-        result.Verify({.Stderr = L"", .ExitCode = 0});
-        VERIFY_IS_TRUE(result.Stdout->find(L"128M") != std::wstring::npos);
+        const auto inspect = InspectContainer(WslcContainerName);
+        VERIFY_ARE_EQUAL(static_cast<int64_t>(1'610'612'736), inspect.HostConfig.ShmSize);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_ShmSize_Invalid)

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -884,6 +884,8 @@ class WSLCE2EContainerCreateTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_ShmSize)
     {
+        auto cleanup = wil::scope_exit([&] { EnsureContainerDoesNotExist(WslcContainerName); });
+
         auto result =
             RunWslc(std::format(L"container create --shm-size 1.5G --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -893,7 +893,7 @@ class WSLCE2EContainerCreateTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         result = RunWslc(std::format(L"container start -a {}", WslcContainerName));
-        result.Verify({.Stdout = L" 1610612736\n", .Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = L"1610612736\n", .Stderr = L"", .ExitCode = 0});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_ShmSize_Invalid)

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1184,9 +1184,12 @@ class WSLCE2EContainerRunTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_ShmSize)
     {
-        auto result = RunWslc(std::format(L"container run --rm --shm-size 128M {} df -h /dev/shm", DebianImage.NameAndTag()));
+        auto result =
+            RunWslc(std::format(L"container run --shm-size 1.5G --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});
-        VERIFY_IS_TRUE(result.Stdout->find(L"128M") != std::wstring::npos);
+
+        const auto inspect = InspectContainer(WslcContainerName);
+        VERIFY_ARE_EQUAL(static_cast<int64_t>(1'610'612'736), inspect.HostConfig.ShmSize);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_ShmSize_Invalid)

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1186,7 +1186,7 @@ class WSLCE2EContainerRunTests
     {
         auto result = RunWslc(std::format(
             L"container run --rm --shm-size 1.5G {} sh -c \"df -B1 /dev/shm --output=size | sed 1d\"", DebianImage.NameAndTag()));
-        result.Verify({.Stdout = L" 1610612736\n", .Stderr = L"", .ExitCode = 0});
+        result.Verify({.Stdout = L"1610612736\n", .Stderr = L"", .ExitCode = 0});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_ShmSize_Invalid)

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1184,6 +1184,8 @@ class WSLCE2EContainerRunTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_ShmSize)
     {
+        auto cleanup = wil::scope_exit([&] { EnsureContainerDoesNotExist(WslcContainerName); });
+
         auto result =
             RunWslc(std::format(L"container run --shm-size 1.5G --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
         result.Verify({.Stderr = L"", .ExitCode = 0});

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1184,14 +1184,9 @@ class WSLCE2EContainerRunTests
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_ShmSize)
     {
-        auto cleanup = wil::scope_exit([&] { EnsureContainerDoesNotExist(WslcContainerName); });
-
-        auto result =
-            RunWslc(std::format(L"container run --shm-size 1.5G --name {} {} true", WslcContainerName, DebianImage.NameAndTag()));
-        result.Verify({.Stderr = L"", .ExitCode = 0});
-
-        const auto inspect = InspectContainer(WslcContainerName);
-        VERIFY_ARE_EQUAL(static_cast<int64_t>(1'610'612'736), inspect.HostConfig.ShmSize);
+        auto result = RunWslc(std::format(
+            L"container run --rm --shm-size 1.5G {} sh -c \"df -B1 /dev/shm --output=size | sed 1d\"", DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L" 1610612736\n", .Stderr = L"", .ExitCode = 0});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_ShmSize_Invalid)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds common Windows storage-size parsing and formatting helpers with Docker-compatible decimal and binary unit support.

The converters are used for WSLC memory arguments, WSLC user settings, container statistics, and byte-count output. Fractional sizes such as `1.5G` are now parsed correctly, and formatting supports configurable decimal places and spacing.

This specifically fixes `--shm-size` rejecting fractional Docker-compatible values such as `1.5G`. The value is parsed as 1,610,612,736 bytes and verified against the runtime `/dev/shm` capacity.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Adds `ParseStorageSize()` and `FormatStorageSize()` to the Windows common string helpers.
- Supports Docker-compatible decimal and binary units through `P`, including case-insensitive `K`, `KB`, and `KiB` forms, fractional values, exponent syntax, and optional spacing.
- Uses checked integer arithmetic for integral inputs so byte counts above `2^53` remain exact; floating-point parsing is limited to fractional and exponent forms.
- Supports configurable output precision and decimal or binary unit formatting.
- Uses the common parser for WSLC `--memory`, `--shm-size`, `session.memorySize`, and `session.maxStorageSize` values.
- Preserves support for leading whitespace in existing quoted WSLC settings values.
- Preserves localized CLI errors and signed `int64_t` range validation for memory arguments.
- Replaces duplicated container statistics formatting with the common formatter.
- Moves the Windows-only `FormatBytes()` helper out of the cross-platform shared header.
- Leaves the separate `wsl.exe` and `.wslconfig` legacy size parsers unchanged.
- Adds table-driven parser, formatter, rounding, invalid-input, boundary, and bidirectional round-trip tests.
- Adds 8 `StringUnitTests` with 350 cases covering Docker formats, invalid inputs, rounding, `2^53` and integer boundaries, and bidirectional round trips.
- Adds WSLC settings coverage for fractional and IEC values, leading-whitespace compatibility, sub-MiB rejection, and `uint32_t` MiB limits.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Full x64 Debug build
- Deployed the rebuilt MSI to the host
- `*StringUnitTests*`: 8 passed
- `*WSLCCLIArgumentUnitTests*`: 18 passed
- `*WSLCCLISettingsUnitTests*`: 38 passed
- `*WSLCE2ETests::*ShmSize*`: 4 passed
