### PR TITLE
Move Docker call outside network lock

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -3030,8 +3030,6 @@ try
 
     auto lock = AcquireLease();
 
-    std::lock_guard networksLock(m_networksLock);
-
     std::vector<docker_schema::Network> dockerNetworks;
     if (filtered)
     {
@@ -3041,6 +3039,8 @@ try
         }
         CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to list networks");
     }
+
+    std::lock_guard networksLock(m_networksLock);
 
     auto output = wil::make_unique_cotaskmem<WSLCNetworkInformation[]>(m_networks.size());
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
WSLCSession::ListNetworks was holding m_networksLock while making the Docker /networks HTTP call. Since ListNetworks only reads from m_networks, the lock is only needed when accessing the cache, not during the Docker call.
This matches the existing pattern in WSLCVolumes::ListVolumes, which makes the Docker call first and then acquires the cache lock. There is no known user-visible issue; this change just avoids holding the lock during I/O.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
