### PR TITLE
wslc: match docker output format for image list

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3708,7 +3708,7 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_RelativeTimeSeconds" xml:space="preserve">
     <value>{} seconds ago</value>
-    <comment>{FixedPlaceholder="{}"}The placeholder is a number of seconds. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. The placeholder is a number of seconds. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
   </data>
   <data name="WSLCCLI_RelativeTimeAboutAMinute" xml:space="preserve">
     <value>About a minute ago</value>
@@ -3716,7 +3716,7 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_RelativeTimeMinutes" xml:space="preserve">
     <value>{} minutes ago</value>
-    <comment>{FixedPlaceholder="{}"}The placeholder is a number of minutes. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. The placeholder is a number of minutes. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
   </data>
   <data name="WSLCCLI_RelativeTimeAboutAnHour" xml:space="preserve">
     <value>About an hour ago</value>
@@ -3724,23 +3724,23 @@ On first run, creates the file with all settings commented out at their defaults
   </data>
   <data name="WSLCCLI_RelativeTimeHours" xml:space="preserve">
     <value>{} hours ago</value>
-    <comment>{FixedPlaceholder="{}"}The placeholder is a number of hours. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. The placeholder is a number of hours. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
   </data>
   <data name="WSLCCLI_RelativeTimeDays" xml:space="preserve">
     <value>{} days ago</value>
-    <comment>{FixedPlaceholder="{}"}The placeholder is a number of days. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. The placeholder is a number of days. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
   </data>
   <data name="WSLCCLI_RelativeTimeWeeks" xml:space="preserve">
     <value>{} weeks ago</value>
-    <comment>{FixedPlaceholder="{}"}The placeholder is a number of weeks. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. The placeholder is a number of weeks. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
   </data>
   <data name="WSLCCLI_RelativeTimeMonths" xml:space="preserve">
     <value>{} months ago</value>
-    <comment>{FixedPlaceholder="{}"}The placeholder is a number of months. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. The placeholder is a number of months. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
   </data>
   <data name="WSLCCLI_RelativeTimeYears" xml:space="preserve">
     <value>{} years ago</value>
-    <comment>{FixedPlaceholder="{}"}The placeholder is a number of years. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated. The placeholder is a number of years. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
   </data>
   <data name="WSLCUserSettings_Warning_InvalidValue" xml:space="preserve">
     <value>Warning: Invalid value for setting '{}' in {}:{}.</value>

--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3593,6 +3593,50 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_TableHeaderPids" xml:space="preserve">
     <value>PIDS</value>
   </data>
+  <data name="WSLCCLI_RelativeTimeLessThanASecond" xml:space="preserve">
+    <value>Less than a second ago</value>
+    <comment>Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeOneSecond" xml:space="preserve">
+    <value>1 second ago</value>
+    <comment>Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeSeconds" xml:space="preserve">
+    <value>{} seconds ago</value>
+    <comment>{FixedPlaceholder="{}"}The placeholder is a number of seconds. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeAboutAMinute" xml:space="preserve">
+    <value>About a minute ago</value>
+    <comment>Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeMinutes" xml:space="preserve">
+    <value>{} minutes ago</value>
+    <comment>{FixedPlaceholder="{}"}The placeholder is a number of minutes. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeAboutAnHour" xml:space="preserve">
+    <value>About an hour ago</value>
+    <comment>Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeHours" xml:space="preserve">
+    <value>{} hours ago</value>
+    <comment>{FixedPlaceholder="{}"}The placeholder is a number of hours. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeDays" xml:space="preserve">
+    <value>{} days ago</value>
+    <comment>{FixedPlaceholder="{}"}The placeholder is a number of days. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeWeeks" xml:space="preserve">
+    <value>{} weeks ago</value>
+    <comment>{FixedPlaceholder="{}"}The placeholder is a number of weeks. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeMonths" xml:space="preserve">
+    <value>{} months ago</value>
+    <comment>{FixedPlaceholder="{}"}The placeholder is a number of months. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
+  <data name="WSLCCLI_RelativeTimeYears" xml:space="preserve">
+    <value>{} years ago</value>
+    <comment>{FixedPlaceholder="{}"}The placeholder is a number of years. Describes how long ago something happened, shown in the CREATED column of 'wslc container list' and 'wslc image list'.</comment>
+  </data>
   <data name="WSLCUserSettings_Warning_InvalidValue" xml:space="preserve">
     <value>Warning: Invalid value for setting '{}' in {}:{}.</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -402,9 +402,6 @@ std::wstring wsl::windows::common::string::FormatBytes(uint64_t Bytes)
 
 std::wstring wsl::windows::common::string::FormatDockerSize(uint64_t Bytes)
 {
-    // Mirrors docker's units.HumanSizeWithPrecision(size, 3): base 1000, three significant digits
-    // and no space between the value and the unit. Note the unit names differ from FormatBytes -
-    // docker abbreviates 1000 bytes as "kB", and carries units past PB.
     constexpr std::wstring_view c_units[] = {L"B", L"kB", L"MB", L"GB", L"TB", L"PB", L"EB", L"ZB", L"YB"};
 
     auto value = static_cast<double>(Bytes);

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -295,3 +295,21 @@ std::string wsl::windows::common::string::TruncateId(_In_ std::string_view id, b
 {
     return TruncateIdImpl(id, shortenLength);
 }
+
+std::string wsl::windows::common::string::FormatDockerTimestamp(LONGLONG timestamp)
+{
+    const auto time =
+        std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::from_time_t(static_cast<std::time_t>(timestamp)));
+
+    try
+    {
+        const auto* zone = std::chrono::current_zone();
+        return std::format("{:%F %T %z} {}", std::chrono::zoned_time{zone, time}, zone->get_info(time).abbrev);
+    }
+    catch (...)
+    {
+        // The time zone database is unavailable, so report UTC rather than failing the caller.
+        LOG_CAUGHT_EXCEPTION();
+        return std::format("{:%F %T} +0000 UTC", time);
+    }
+}

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -400,6 +400,24 @@ std::wstring wsl::windows::common::string::FormatBytes(uint64_t Bytes)
     return FormatStorageSize(Bytes, StorageSizeUnit::Decimal, 2, true);
 }
 
+std::wstring wsl::windows::common::string::FormatDockerSize(uint64_t Bytes)
+{
+    // Mirrors docker's units.HumanSizeWithPrecision(size, 3): base 1000, three significant digits
+    // and no space between the value and the unit. Note the unit names differ from FormatBytes -
+    // docker abbreviates 1000 bytes as "kB", and carries units past PB.
+    constexpr std::wstring_view c_units[] = {L"B", L"kB", L"MB", L"GB", L"TB", L"PB", L"EB", L"ZB", L"YB"};
+
+    auto value = static_cast<double>(Bytes);
+    size_t unitIndex = 0;
+    while (value >= 1000.0 && unitIndex + 1 < std::size(c_units))
+    {
+        value /= 1000.0;
+        unitIndex++;
+    }
+
+    return std::format(L"{:.3g}{}", value, c_units[unitIndex]);
+}
+
 std::wstring wsl::windows::common::string::TruncateId(_In_ std::wstring_view id, bool shortenLength)
 {
     return TruncateIdImpl(id, shortenLength);

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -35,6 +35,10 @@ std::wstring FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t De
 
 std::wstring FormatBytes(uint64_t Bytes);
 
+// Formats a size the way docker reports image sizes: base 1000, three significant digits and no
+// space (119856765 -> "120MB").
+std::wstring FormatDockerSize(uint64_t Bytes);
+
 std::vector<std::string> InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize);
 
 bool IsPathComponentEqual(const std::wstring_view String1, const std::wstring_view String2);

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -51,6 +51,11 @@ std::string WideToMultiByte(_In_ std::wstring_view Source);
 std::wstring TruncateId(_In_ std::wstring_view id, bool shortenLength = true);
 std::string TruncateId(_In_ std::string_view id, bool shortenLength = true);
 
+// Formats a unix timestamp the way docker does, matching Go's time.Time.String() layout
+// "2006-01-02 15:04:05 -0700 MST" (e.g. "2026-07-12 17:00:00 -0700 PDT"). Falls back to UTC when
+// the time zone database is unavailable.
+std::string FormatDockerTimestamp(LONGLONG timestamp);
+
 // Template implementation for TruncateId to avoid code duplication.
 // Algorithm inspired from Moby for consistency in presentation of shortened IDs.
 // Always strips the algorithm prefix (e.g., "sha256:") if present, and optionally shortens to 12 characters.

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -67,9 +67,8 @@ std::string WideToMultiByte(_In_ std::wstring_view Source);
 std::wstring TruncateId(_In_ std::wstring_view id, bool shortenLength = true);
 std::string TruncateId(_In_ std::string_view id, bool shortenLength = true);
 
-// Formats a unix timestamp the way docker does, matching Go's time.Time.String() layout
-// "2006-01-02 15:04:05 -0700 MST" (e.g. "2026-07-12 17:00:00 -0700 PDT"). Falls back to UTC when
-// the time zone database is unavailable.
+// Formats a unix timestamp the way docker does, matching Go's time.Time.String() layout. Falls back
+// to UTC when the time zone database is unavailable.
 std::string FormatDockerTimestamp(LONGLONG timestamp);
 
 // Template implementation for TruncateId to avoid code duplication.

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -688,6 +688,7 @@ struct ContainerInfo
     std::string Id;
     std::vector<std::string> Names;
     std::string Image;
+    std::string ImageID;
     std::map<std::string, std::string> Labels;
     std::vector<Port> Ports;
     std::vector<Mount> Mounts;
@@ -696,7 +697,7 @@ struct ContainerInfo
     HostConfig HostConfig;
     NetworkSettings NetworkSettings;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerInfo, Id, Names, Image, Labels, Ports, Mounts, State, Created, HostConfig, NetworkSettings);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ContainerInfo, Id, Names, Image, ImageID, Labels, Ports, Mounts, State, Created, HostConfig, NetworkSettings);
 };
 
 struct BuildKitVertex

--- a/src/windows/service/inc/WSLCShared.idl
+++ b/src/windows/service/inc/WSLCShared.idl
@@ -74,9 +74,10 @@ typedef enum _WSLCListImagesFlags
     WSLCListImagesFlagsNone = 0,
     WSLCListImagesFlagsAll = 1,     // Show all images (default hides intermediate images)
     WSLCListImagesFlagsDigests = 2, // Include digest information
+    WSLCListImagesFlagsContainerCounts = 4, // Populate WSLCImageInformation::Containers
 } WSLCListImagesFlags;
 
-cpp_quote("#define WSLCListImagesFlagsValid (WSLCListImagesFlagsAll | WSLCListImagesFlagsDigests)")
+cpp_quote("#define WSLCListImagesFlagsValid (WSLCListImagesFlagsAll | WSLCListImagesFlagsDigests | WSLCListImagesFlagsContainerCounts)")
 
 cpp_quote("DEFINE_ENUM_FLAG_OPERATORS(WSLCListImagesFlags);")
 

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -30,6 +30,7 @@ cpp_quote("#endif")
 #define WSLC_MAX_VOLUME_NAME_LENGTH 255
 #define WSLC_MAX_VOLUME_DRIVER_LENGTH 255
 #define WSLC_MAX_NETWORK_NAME_LENGTH 255
+#define WSLC_MAX_IMAGE_ID_LENGTH 255
 #define WSLC_CONTAINER_ID_LENGTH 64
 #define WSLC_MAX_BINDING_ADDRESS_LENGTH 45
 #define WSLC_EPHEMERAL_PORT 0
@@ -40,6 +41,7 @@ cpp_quote("#define WSLC_MAX_IMAGE_NAME_LENGTH 255")
 cpp_quote("#define WSLC_MAX_VOLUME_NAME_LENGTH 255")
 cpp_quote("#define WSLC_MAX_VOLUME_DRIVER_LENGTH 255")
 cpp_quote("#define WSLC_MAX_NETWORK_NAME_LENGTH 255")
+cpp_quote("#define WSLC_MAX_IMAGE_ID_LENGTH 255")
 cpp_quote("#define WSLC_CONTAINER_ID_LENGTH 64")
 cpp_quote("#define WSLC_MAX_BINDING_ADDRESS_LENGTH 45")
 cpp_quote("#define WSLC_MAX_SAVE_IMAGES_COUNT 256")
@@ -139,7 +141,7 @@ interface IWSLCPluginNotifier : IUnknown
 typedef struct _WSLCImageInformation
 {
     char Image[WSLC_MAX_IMAGE_NAME_LENGTH + 1];
-    char Hash[256];
+    char Hash[WSLC_MAX_IMAGE_ID_LENGTH + 1];
     char Digest[256];
     LONGLONG Size; // Matches Docker's int64 image size
     LONGLONG Created; // Unix timestamp
@@ -338,7 +340,7 @@ typedef struct _WSLCContainerEntry
     char Image[WSLC_MAX_IMAGE_NAME_LENGTH + 1];
     // Id of the image the container was created from, as resolved when it was created. Unlike
     // Image, which is the reference the caller passed, this is stable across tag changes.
-    char ImageId[256];
+    char ImageId[WSLC_MAX_IMAGE_ID_LENGTH + 1];
     WSLCContainerId Id;
     ULONGLONG StateChangedAt;
     ULONGLONG CreatedAt;

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -146,6 +146,7 @@ typedef struct _WSLCImageInformation
     LONGLONG Size; // Matches Docker's int64 image size
     LONGLONG Created; // Unix timestamp
     char ParentId[256];
+    LONGLONG Containers; // Number of containers created from the image, or -1 if it wasn't requested
 } WSLCImageInformation;
 
 typedef struct _KeyValuePairInformation
@@ -338,9 +339,6 @@ typedef struct _WSLCContainerEntry
 {
     char Name[WSLC_MAX_CONTAINER_NAME_LENGTH + 1];
     char Image[WSLC_MAX_IMAGE_NAME_LENGTH + 1];
-    // Id of the image the container was created from, as resolved when it was created. Unlike
-    // Image, which is the reference the caller passed, this is stable across tag changes.
-    char ImageId[WSLC_MAX_IMAGE_ID_LENGTH + 1];
     WSLCContainerId Id;
     ULONGLONG StateChangedAt;
     ULONGLONG CreatedAt;

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -336,6 +336,9 @@ typedef struct _WSLCContainerEntry
 {
     char Name[WSLC_MAX_CONTAINER_NAME_LENGTH + 1];
     char Image[WSLC_MAX_IMAGE_NAME_LENGTH + 1];
+    // Id of the image the container was created from, as resolved when it was created. Unlike
+    // Image, which is the reference the caller passed, this is stable across tag changes.
+    char ImageId[256];
     WSLCContainerId Id;
     ULONGLONG StateChangedAt;
     ULONGLONG CreatedAt;

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -130,6 +130,9 @@ struct ContainerInformation
     std::string Id;
     std::string Name;
     std::string Image;
+    // Id of the image the container was created from. Not serialized: `container list --format json`
+    // reports the image reference, matching docker.
+    std::string ImageId;
     WSLCContainerState State;
     ULONGLONG StateChangedAt{};
     ULONGLONG CreatedAt{};

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -130,9 +130,6 @@ struct ContainerInformation
     std::string Id;
     std::string Name;
     std::string Image;
-    // Id of the image the container was created from. Not serialized: `container list --format json`
-    // reports the image reference, matching docker.
-    std::string ImageId;
     WSLCContainerState State;
     ULONGLONG StateChangedAt{};
     ULONGLONG CreatedAt{};

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -309,49 +309,65 @@ std::wstring ContainerService::FormatRelativeTime(ULONGLONG timestamp)
         return L"";
     }
 
+    return FormatElapsedSeconds(static_cast<LONGLONG>(std::time(nullptr)) - static_cast<LONGLONG>(timestamp));
+}
+
+std::wstring ContainerService::FormatElapsedSeconds(LONGLONG elapsedSeconds)
+{
     constexpr LONGLONG SecondsPerMinute = std::chrono::duration_cast<std::chrono::seconds>(1min).count();
     constexpr LONGLONG SecondsPerHour = std::chrono::duration_cast<std::chrono::seconds>(1h).count();
-    constexpr LONGLONG SecondsPerDay = std::chrono::duration_cast<std::chrono::seconds>(24h).count();
-    constexpr LONGLONG SecondsPerWeek = SecondsPerDay * 7;
-    constexpr LONGLONG SecondsPerMonth = SecondsPerDay * 30;
-    constexpr LONGLONG SecondsPerYear = SecondsPerDay * 365;
+    constexpr LONGLONG HoursPerDay = 24;
+    constexpr LONGLONG MinutesPerHour = 60;
 
-    auto elapsed = static_cast<LONGLONG>(std::time(nullptr)) - static_cast<LONGLONG>(timestamp);
-    if (elapsed < 0)
-    {
-        elapsed = 0;
-    }
+    const auto elapsed = std::max<LONGLONG>(elapsedSeconds, 0);
 
-    auto pluralize = [](LONGLONG count, const wchar_t* singular, const wchar_t* plural) {
-        return std::format(L"{} {} ago", count, (count == 1 ? singular : plural));
-    };
-
-    if (elapsed < SecondsPerMinute)
+    if (elapsed < 1)
     {
-        return pluralize(elapsed, L"second", L"seconds");
+        return L"Less than a second ago";
     }
-    else if (elapsed < SecondsPerHour)
+    else if (elapsed == 1)
     {
-        return pluralize(elapsed / SecondsPerMinute, L"minute", L"minutes");
+        return L"1 second ago";
     }
-    else if (elapsed < SecondsPerDay)
+    else if (elapsed < SecondsPerMinute)
     {
-        return pluralize(elapsed / SecondsPerHour, L"hour", L"hours");
-    }
-    else if (elapsed < SecondsPerWeek)
-    {
-        return pluralize(elapsed / SecondsPerDay, L"day", L"days");
-    }
-    else if (elapsed < SecondsPerMonth)
-    {
-        return pluralize(elapsed / SecondsPerWeek, L"week", L"weeks");
-    }
-    else if (elapsed < SecondsPerYear)
-    {
-        return pluralize(elapsed / SecondsPerMonth, L"month", L"months");
+        return std::format(L"{} seconds ago", elapsed);
     }
 
-    return pluralize(elapsed / SecondsPerYear, L"year", L"years");
+    const auto minutes = elapsed / SecondsPerMinute;
+    if (minutes == 1)
+    {
+        return L"About a minute ago";
+    }
+    else if (minutes < MinutesPerHour)
+    {
+        return std::format(L"{} minutes ago", minutes);
+    }
+
+    // Rounded to the nearest hour rather than truncated.
+    const auto hours = (elapsed + (SecondsPerHour / 2)) / SecondsPerHour;
+    if (hours == 1)
+    {
+        return L"About an hour ago";
+    }
+    else if (hours < HoursPerDay * 2)
+    {
+        return std::format(L"{} hours ago", hours);
+    }
+    else if (hours < HoursPerDay * 7 * 2)
+    {
+        return std::format(L"{} days ago", hours / HoursPerDay);
+    }
+    else if (hours < HoursPerDay * 30 * 2)
+    {
+        return std::format(L"{} weeks ago", hours / HoursPerDay / 7);
+    }
+    else if (hours < HoursPerDay * 365 * 2)
+    {
+        return std::format(L"{} months ago", hours / HoursPerDay / 30);
+    }
+
+    return std::format(L"{} years ago", elapsed / SecondsPerHour / HoursPerDay / 365);
 }
 
 int ContainerService::Attach(Terminal& terminal, Session& session, const std::string& id)
@@ -602,6 +618,7 @@ std::vector<ContainerInformation> ContainerService::List(
         ContainerInformation entry;
         entry.Name = current.Name;
         entry.Image = current.Image;
+        entry.ImageId = current.ImageId;
         entry.State = current.State;
         entry.Id = current.Id;
         entry.StateChangedAt = current.StateChangedAt;

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -323,51 +323,51 @@ std::wstring ContainerService::FormatElapsedSeconds(LONGLONG elapsedSeconds)
 
     if (elapsed < 1)
     {
-        return L"Less than a second ago";
+        return Localization::WSLCCLI_RelativeTimeLessThanASecond();
     }
     else if (elapsed == 1)
     {
-        return L"1 second ago";
+        return Localization::WSLCCLI_RelativeTimeOneSecond();
     }
     else if (elapsed < SecondsPerMinute)
     {
-        return std::format(L"{} seconds ago", elapsed);
+        return Localization::WSLCCLI_RelativeTimeSeconds(elapsed);
     }
 
     const auto minutes = elapsed / SecondsPerMinute;
     if (minutes == 1)
     {
-        return L"About a minute ago";
+        return Localization::WSLCCLI_RelativeTimeAboutAMinute();
     }
     else if (minutes < MinutesPerHour)
     {
-        return std::format(L"{} minutes ago", minutes);
+        return Localization::WSLCCLI_RelativeTimeMinutes(minutes);
     }
 
     // Rounded to the nearest hour rather than truncated.
     const auto hours = (elapsed + (SecondsPerHour / 2)) / SecondsPerHour;
     if (hours == 1)
     {
-        return L"About an hour ago";
+        return Localization::WSLCCLI_RelativeTimeAboutAnHour();
     }
     else if (hours < HoursPerDay * 2)
     {
-        return std::format(L"{} hours ago", hours);
+        return Localization::WSLCCLI_RelativeTimeHours(hours);
     }
     else if (hours < HoursPerDay * 7 * 2)
     {
-        return std::format(L"{} days ago", hours / HoursPerDay);
+        return Localization::WSLCCLI_RelativeTimeDays(hours / HoursPerDay);
     }
     else if (hours < HoursPerDay * 30 * 2)
     {
-        return std::format(L"{} weeks ago", hours / HoursPerDay / 7);
+        return Localization::WSLCCLI_RelativeTimeWeeks(hours / HoursPerDay / 7);
     }
     else if (hours < HoursPerDay * 365 * 2)
     {
-        return std::format(L"{} months ago", hours / HoursPerDay / 30);
+        return Localization::WSLCCLI_RelativeTimeMonths(hours / HoursPerDay / 30);
     }
 
-    return std::format(L"{} years ago", elapsed / SecondsPerHour / HoursPerDay / 365);
+    return Localization::WSLCCLI_RelativeTimeYears(elapsed / SecondsPerHour / HoursPerDay / 365);
 }
 
 int ContainerService::Attach(Terminal& terminal, Session& session, const std::string& id)
@@ -618,7 +618,6 @@ std::vector<ContainerInformation> ContainerService::List(
         ContainerInformation entry;
         entry.Name = current.Name;
         entry.Image = current.Image;
-        entry.ImageId = current.ImageId;
         entry.State = current.State;
         entry.Id = current.Id;
         entry.StateChangedAt = current.StateChangedAt;

--- a/src/windows/wslc/services/ContainerService.h
+++ b/src/windows/wslc/services/ContainerService.h
@@ -24,6 +24,7 @@ struct ContainerService
 {
     static std::wstring ContainerStateToString(WSLCContainerState state, ULONGLONG stateChangedAt = 0);
     static std::wstring FormatRelativeTime(ULONGLONG timestamp);
+    static std::wstring FormatElapsedSeconds(LONGLONG elapsedSeconds);
     static std::wstring FormatPorts(WSLCContainerState state, const std::vector<models::PortInformation>& ports);
     static int Attach(Terminal& terminal, models::Session& session, const std::string& id);
     static int Run(Terminal& terminal, models::Session& session, const std::string& image, models::ContainerOptions options);

--- a/src/windows/wslc/services/ImageModel.h
+++ b/src/windows/wslc/services/ImageModel.h
@@ -27,9 +27,9 @@ struct ImageInformation
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ImageInformation, Repository, Tag, Id, Created, Size);
 };
 
-// The docker-compatible shape emitted by "image list --format json". Docker reports every value as
-// a string and uses "<none>" rather than null for missing repository, tag, and digest data, so this
-// is kept separate from ImageInformation, which mirrors the service's native types.
+// The shape emitted by "image list --format json". Every value is reported as a string, and
+// "<none>" is used rather than null for missing repository, tag, and digest data, so this is kept
+// separate from ImageInformation, which mirrors the service's native types.
 struct ImageOutputInformation
 {
     std::string Containers;
@@ -47,7 +47,6 @@ struct ImageOutputInformation
         ImageOutputInformation, Containers, CreatedAt, CreatedSince, Digest, ID, Repository, SharedSize, Size, Tag, UniqueSize);
 };
 
-// Value docker emits for repository, tag, and digest data it does not have.
 inline constexpr std::string_view c_none = "<none>";
 
 struct PruneImagesResult

--- a/src/windows/wslc/services/ImageModel.h
+++ b/src/windows/wslc/services/ImageModel.h
@@ -21,6 +21,8 @@ struct ImageInformation
     std::string Id;
     LONGLONG Created{};
     int64_t Size{};
+    // Number of containers created from the image, or -1 when the count wasn't requested.
+    LONGLONG Containers{-1};
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ImageInformation, Repository, Tag, Id, Created, Size);
 };
@@ -46,7 +48,7 @@ struct ImageOutputInformation
 };
 
 // Value docker emits for repository, tag, and digest data it does not have.
-inline constexpr std::string_view c_dockerNone = "<none>";
+inline constexpr std::string_view c_none = "<none>";
 
 struct PruneImagesResult
 {

--- a/src/windows/wslc/services/ImageModel.h
+++ b/src/windows/wslc/services/ImageModel.h
@@ -13,9 +13,6 @@ Abstract:
 --*/
 #pragma once
 
-// 1000*1000 instead of 1024*1024 to be consistent with Docker CLI's definition of megabyte (MB).
-#define WSLC_IMAGE_1MB (1000 * 1000)
-
 namespace wsl::windows::wslc::models {
 struct ImageInformation
 {
@@ -27,6 +24,29 @@ struct ImageInformation
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ImageInformation, Repository, Tag, Id, Created, Size);
 };
+
+// The docker-compatible shape emitted by "image list --format json". Docker reports every value as
+// a string and uses "<none>" rather than null for missing repository, tag, and digest data, so this
+// is kept separate from ImageInformation, which mirrors the service's native types.
+struct ImageOutputInformation
+{
+    std::string Containers;
+    std::string CreatedAt;
+    std::string CreatedSince;
+    std::string Digest;
+    std::string ID;
+    std::string Repository;
+    std::string SharedSize;
+    std::string Size;
+    std::string Tag;
+    std::string UniqueSize;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(
+        ImageOutputInformation, Containers, CreatedAt, CreatedSince, Digest, ID, Repository, SharedSize, Size, Tag, UniqueSize);
+};
+
+// Value docker emits for repository, tag, and digest data it does not have.
+inline constexpr std::string_view c_dockerNone = "<none>";
 
 struct PruneImagesResult
 {

--- a/src/windows/wslc/services/ImageService.cpp
+++ b/src/windows/wslc/services/ImageService.cpp
@@ -290,7 +290,7 @@ void ImageService::Build(
 }
 
 std::vector<ImageInformation> ImageService::List(
-    wsl::windows::wslc::models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
+    wsl::windows::wslc::models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters, bool containerCounts)
 {
     std::vector<WSLCFilter> filterEntries;
     filterEntries.reserve(filters.size());
@@ -300,7 +300,7 @@ std::vector<ImageInformation> ImageService::List(
     }
 
     WSLCListImagesOptions options{};
-    options.Flags = WSLCListImagesFlagsNone;
+    options.Flags = containerCounts ? WSLCListImagesFlagsContainerCounts : WSLCListImagesFlagsNone;
     options.Filters = filterEntries.empty() ? nullptr : filterEntries.data();
     options.FiltersCount = static_cast<ULONG>(filterEntries.size());
 
@@ -326,6 +326,7 @@ std::vector<ImageInformation> ImageService::List(
         info.Id = image.Hash;
         info.Created = image.Created;
         info.Size = image.Size;
+        info.Containers = image.Containers;
         result.push_back(info);
     }
 

--- a/src/windows/wslc/services/ImageService.h
+++ b/src/windows/wslc/services/ImageService.h
@@ -62,8 +62,12 @@ public:
         IProgressCallback* callback,
         HANDLE cancelEvent = nullptr);
 
+    // Container counts are only gathered when requested: it costs an extra query, and the service
+    // computes it alongside the image list so the two are consistent.
     static std::vector<wsl::windows::wslc::models::ImageInformation> List(
-        wsl::windows::wslc::models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
+        wsl::windows::wslc::models::Session& session,
+        const std::vector<std::pair<std::string, std::string>>& filters = {},
+        bool containerCounts = false);
     static void Load(Terminal& terminal, wsl::windows::wslc::models::Session& session, const std::wstring& input, IImageLoadCallback* callback = nullptr);
     static std::string Import(Terminal& terminal, wsl::windows::wslc::models::Session& session, const std::wstring& input, const std::string& imageName);
     static void Delete(wsl::windows::wslc::models::Session& session, const std::string& image, bool force, bool noPrune);

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -22,7 +22,6 @@ Abstract:
 #include "ImageProgressCallback.h"
 #include "TableOutput.h"
 #include "Task.h"
-#include <chrono>
 #include <format>
 #include <unordered_map>
 #include <wslutil.h>
@@ -112,26 +111,6 @@ namespace {
         }
 
         return std::format("{:.3g}{}", size, units[unit]);
-    }
-
-    // Formats a unix timestamp the way docker does, matching Go's time.Time.String()
-    // layout "2006-01-02 15:04:05 -0700 MST" (e.g. "2026-07-12 17:00:00 -0700 PDT").
-    std::string FormatDockerTimestamp(LONGLONG timestamp)
-    {
-        const auto time =
-            std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::from_time_t(static_cast<std::time_t>(timestamp)));
-
-        try
-        {
-            const auto* zone = std::chrono::current_zone();
-            return std::format("{:%F %T %z} {}", std::chrono::zoned_time{zone, time}, zone->get_info(time).abbrev);
-        }
-        catch (...)
-        {
-            // The time zone database is unavailable, so report UTC rather than failing the command.
-            LOG_CAUGHT_EXCEPTION();
-            return std::format("{:%F %T} +0000 UTC", time);
-        }
     }
 
     // Builds the docker-compatible representation of an image, shared by the table and json output

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -22,7 +22,9 @@ Abstract:
 #include "ImageProgressCallback.h"
 #include "TableOutput.h"
 #include "Task.h"
+#include <chrono>
 #include <format>
+#include <unordered_map>
 #include <wslutil.h>
 
 using namespace wsl::shared;
@@ -68,6 +70,101 @@ namespace {
     private:
         Terminal& m_terminal;
     };
+
+    // Values docker reports as unavailable. wslc does not track image digests or layer sharing, so
+    // these use the same placeholders docker emits.
+    constexpr std::string_view c_notAvailable = "N/A";
+    constexpr std::string_view c_none = models::c_dockerNone;
+
+    // Counts the containers created from each image, keyed by image id. Docker includes stopped
+    // containers in this count, and reports 0 for images no container was created from.
+    std::optional<std::unordered_map<std::string, size_t>> TryCountContainersByImage(models::Session& session)
+    try
+    {
+        std::unordered_map<std::string, size_t> counts;
+        for (const auto& container : ContainerService::List(session, true))
+        {
+            counts[container.ImageId]++;
+        }
+
+        return counts;
+    }
+    catch (...)
+    {
+        // Report the count as unavailable rather than failing the listing, which is what docker
+        // does when it has no count for an image.
+        LOG_CAUGHT_EXCEPTION();
+        return std::nullopt;
+    }
+
+    // Formats a byte count the way docker does: SI units with three significant digits
+    // (119856765 -> "120MB").
+    std::string FormatDockerSize(int64_t bytes)
+    {
+        constexpr std::string_view units[] = {"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
+
+        auto size = static_cast<double>(bytes);
+        size_t unit = 0;
+        while (size >= 1000.0 && unit < std::size(units) - 1)
+        {
+            size /= 1000.0;
+            unit++;
+        }
+
+        return std::format("{:.3g}{}", size, units[unit]);
+    }
+
+    // Formats a unix timestamp the way docker does, matching Go's time.Time.String()
+    // layout "2006-01-02 15:04:05 -0700 MST" (e.g. "2026-07-12 17:00:00 -0700 PDT").
+    std::string FormatDockerTimestamp(LONGLONG timestamp)
+    {
+        const auto time =
+            std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::from_time_t(static_cast<std::time_t>(timestamp)));
+
+        try
+        {
+            const auto* zone = std::chrono::current_zone();
+            return std::format("{:%F %T %z} {}", std::chrono::zoned_time{zone, time}, zone->get_info(time).abbrev);
+        }
+        catch (...)
+        {
+            // The time zone database is unavailable, so report UTC rather than failing the command.
+            LOG_CAUGHT_EXCEPTION();
+            return std::format("{:%F %T} +0000 UTC", time);
+        }
+    }
+
+    // Builds the docker-compatible representation of an image, shared by the table and json output
+    // so the two cannot drift. Docker emits every value as a string, uses "<none>" for missing
+    // repository/tag data, and truncates the id unless --no-trunc is passed, in which case it keeps
+    // the algorithm prefix. Container counts are only looked up for output that reports them.
+    ImageOutputInformation ToImageOutput(
+        const ImageInformation& image, bool truncate, const std::optional<std::unordered_map<std::string, size_t>>& containerCounts = std::nullopt)
+    {
+        ImageOutputInformation entry;
+        if (containerCounts.has_value())
+        {
+            const auto count = containerCounts->find(image.Id);
+            entry.Containers = std::to_string(count == containerCounts->end() ? 0 : count->second);
+        }
+        else
+        {
+            entry.Containers = c_notAvailable;
+        }
+
+        entry.CreatedAt = FormatDockerTimestamp(image.Created);
+        entry.CreatedSince =
+            WideToMultiByte(ContainerService::FormatRelativeTime(image.Created > 0 ? static_cast<ULONGLONG>(image.Created) : 0));
+        entry.Digest = c_none;
+        entry.ID = truncate ? TruncateId(image.Id, true) : image.Id;
+        entry.Repository = image.Repository.value_or(std::string{c_none});
+        entry.SharedSize = c_notAvailable;
+        entry.Size = FormatDockerSize(image.Size);
+        entry.Tag = image.Tag.value_or(std::string{c_none});
+        entry.UniqueSize = c_notAvailable;
+
+        return entry;
+    }
 
 } // namespace
 
@@ -174,21 +271,24 @@ void ListImages(CLIExecutionContext& context)
     }
 
     const auto format = context.Args.GetValue<ArgType::Format>(FormatType::Table);
+    bool trunc = !context.Args.GetValue<ArgType::NoTrunc>();
 
     switch (format)
     {
     case FormatType::Json:
     {
+        WI_ASSERT(context.Data.Contains(Data::Session));
+        const auto containerCounts = TryCountContainersByImage(context.Data.Get<Data::Session>());
+
         for (const auto& image : images)
         {
-            context.Terminal.Output(L"{}\n", ToJsonW(image, c_jsonCompactIndent));
+            context.Terminal.Output(L"{}\n", ToJsonW(ToImageOutput(image, trunc, containerCounts), c_jsonCompactIndent));
         }
 
         break;
     }
     case FormatType::Table:
     {
-        bool trunc = !context.Args.GetValue<ArgType::NoTrunc>();
         using enum ColumnOverflow;
 
         // Create table — only IMAGE ID uses fixed width; other columns shrink to fit the console.
@@ -207,12 +307,13 @@ void ListImages(CLIExecutionContext& context)
 
         for (const auto& image : images)
         {
+            const auto entry = ToImageOutput(image, trunc);
             table.WriteRow({
-                MultiByteToWide(image.Repository.value_or("<untagged>")),
-                MultiByteToWide(image.Tag.value_or("<untagged>")),
-                MultiByteToWide(TruncateId(image.Id, trunc)),
-                ContainerService::FormatRelativeTime(image.Created > 0 ? static_cast<ULONGLONG>(image.Created) : 0),
-                std::format(L"{:.2f} MB", static_cast<double>(image.Size) / WSLC_IMAGE_1MB),
+                MultiByteToWide(entry.Repository),
+                MultiByteToWide(entry.Tag),
+                MultiByteToWide(entry.ID),
+                MultiByteToWide(entry.CreatedSince),
+                MultiByteToWide(entry.Size),
             });
         }
 

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -73,28 +73,6 @@ namespace {
     // Values docker reports as unavailable. wslc does not track image digests or layer sharing, so
     // these use the same placeholders docker emits.
     constexpr std::string_view c_notAvailable = "N/A";
-    constexpr std::string_view c_none = models::c_dockerNone;
-
-    // Counts the containers created from each image, keyed by image id. Docker includes stopped
-    // containers in this count, and reports 0 for images no container was created from.
-    std::optional<std::unordered_map<std::string, size_t>> TryCountContainersByImage(models::Session& session)
-    try
-    {
-        std::unordered_map<std::string, size_t> counts;
-        for (const auto& container : ContainerService::List(session, true))
-        {
-            counts[container.ImageId]++;
-        }
-
-        return counts;
-    }
-    catch (...)
-    {
-        // Report the count as unavailable rather than failing the listing, which is what docker
-        // does when it has no count for an image.
-        LOG_CAUGHT_EXCEPTION();
-        return std::nullopt;
-    }
 
     // Formats a byte count the way docker does: SI units with three significant digits
     // (119856765 -> "120MB").
@@ -116,20 +94,11 @@ namespace {
     // Builds the docker-compatible representation of an image, shared by the table and json output
     // so the two cannot drift. Docker emits every value as a string, uses "<none>" for missing
     // repository/tag data, and truncates the id unless --no-trunc is passed, in which case it keeps
-    // the algorithm prefix. Container counts are only looked up for output that reports them.
-    ImageOutputInformation ToImageOutput(
-        const ImageInformation& image, bool truncate, const std::optional<std::unordered_map<std::string, size_t>>& containerCounts = std::nullopt)
+    // the algorithm prefix.
+    ImageOutputInformation ToImageOutput(const ImageInformation& image, bool truncate)
     {
         ImageOutputInformation entry;
-        if (containerCounts.has_value())
-        {
-            const auto count = containerCounts->find(image.Id);
-            entry.Containers = std::to_string(count == containerCounts->end() ? 0 : count->second);
-        }
-        else
-        {
-            entry.Containers = c_notAvailable;
-        }
+        entry.Containers = image.Containers < 0 ? std::string{c_notAvailable} : std::to_string(image.Containers);
 
         entry.CreatedAt = FormatDockerTimestamp(image.Created);
         entry.CreatedSince =
@@ -229,7 +198,12 @@ void GetImages(CLIExecutionContext& context)
     // Filter values are parsed and cached during argument validation.
     auto filters = context.Args.GetAllValues<ArgType::Filter>();
 
-    auto images = ImageService::List(session, filters);
+    // The container count is only reported by json output, and gathering it costs an extra query in
+    // the service, so it is only requested when it will be shown.
+    const bool containerCounts =
+        context.Args.GetValue<ArgType::Format>(FormatType::Table) == FormatType::Json && !context.Args.GetValue<ArgType::Quiet>();
+
+    auto images = ImageService::List(session, filters, containerCounts);
     context.Data.Add<Data::Images>(std::move(images));
 }
 
@@ -256,12 +230,9 @@ void ListImages(CLIExecutionContext& context)
     {
     case FormatType::Json:
     {
-        WI_ASSERT(context.Data.Contains(Data::Session));
-        const auto containerCounts = TryCountContainersByImage(context.Data.Get<Data::Session>());
-
         for (const auto& image : images)
         {
-            context.Terminal.Output(L"{}\n", ToJsonW(ToImageOutput(image, trunc, containerCounts), c_jsonCompactIndent));
+            context.Terminal.Output(L"{}\n", ToJsonW(ToImageOutput(image, trunc), c_jsonCompactIndent));
         }
 
         break;

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -75,23 +75,6 @@ namespace {
     // these use the same placeholders docker emits.
     constexpr std::string_view c_notAvailable = "N/A";
 
-    // Formats a byte count the way docker does: SI units with three significant digits
-    // (119856765 -> "120MB").
-    std::string FormatDockerSize(int64_t bytes)
-    {
-        constexpr std::string_view units[] = {"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
-
-        auto size = static_cast<double>(bytes);
-        size_t unit = 0;
-        while (size >= 1000.0 && unit < std::size(units) - 1)
-        {
-            size /= 1000.0;
-            unit++;
-        }
-
-        return std::format("{:.3g}{}", size, units[unit]);
-    }
-
     // Builds the docker-compatible representation of an image, shared by the table and json output
     // so the two cannot drift. Docker emits every value as a string, uses "<none>" for missing
     // repository/tag data, and truncates the id unless --no-trunc is passed, in which case it keeps
@@ -108,7 +91,7 @@ namespace {
         entry.ID = truncate ? TruncateId(image.Id, true) : image.Id;
         entry.Repository = image.Repository.value_or(std::string{c_none});
         entry.SharedSize = c_notAvailable;
-        entry.Size = FormatDockerSize(image.Size);
+        entry.Size = WideToMultiByte(FormatDockerSize(static_cast<uint64_t>(std::max<int64_t>(image.Size, 0))));
         entry.Tag = image.Tag.value_or(std::string{c_none});
         entry.UniqueSize = c_notAvailable;
 

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -71,14 +71,12 @@ namespace {
         Terminal& m_terminal;
     };
 
-    // Values docker reports as unavailable. wslc does not track image digests or layer sharing, so
-    // these use the same placeholders docker emits.
+    // Placeholder for values that are unavailable. wslc does not track image digests or layer sharing.
     constexpr std::string_view c_notAvailable = "N/A";
 
-    // Builds the docker-compatible representation of an image, shared by the table and json output
-    // so the two cannot drift. Docker emits every value as a string, uses "<none>" for missing
-    // repository/tag data, and truncates the id unless --no-trunc is passed, in which case it keeps
-    // the algorithm prefix.
+    // Builds the representation of an image, shared by the table and json output so the two cannot
+    // drift. Every value is emitted as a string, "<none>" is used for missing repository/tag data,
+    // and the id is truncated unless --no-trunc is passed, in which case it keeps the algorithm prefix.
     ImageOutputInformation ToImageOutput(const ImageInformation& image, bool truncate)
     {
         ImageOutputInformation entry;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2522,6 +2522,7 @@ try
 
         auto* e = it->second.get();
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Image, e->Image().c_str()) != 0);
+        THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].ImageId, dockerContainer.ImageID.c_str()) != 0);
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Name, e->Name().c_str()) != 0);
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Id, e->ID().c_str()) != 0);
         e->GetState(&output[index].State);

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -1839,6 +1839,7 @@ try
 
     bool all = false;
     bool digests = false;
+    bool containerCounts = false;
     std::map<std::string, std::vector<std::string>> filters;
 
     if (Options != nullptr)
@@ -1851,6 +1852,7 @@ try
 
         all = WI_IsFlagSet(Options->Flags, WSLCListImagesFlagsAll);
         digests = WI_IsFlagSet(Options->Flags, WSLCListImagesFlagsDigests);
+        containerCounts = WI_IsFlagSet(Options->Flags, WSLCListImagesFlagsContainerCounts);
 
         filters = wsl::windows::common::wslutil::ParseKeyMultiValuePairs(Options->Filters, Options->FiltersCount);
     }
@@ -1859,12 +1861,45 @@ try
 
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_runtime.HasDocker());
 
+    // The container count is gathered under the container lock alongside the image list so that no
+    // container can be created or removed in between, which would report counts for a set of images
+    // that no longer matches the listing.
+    std::unique_lock<std::mutex> containersLock;
+    if (containerCounts)
+    {
+        containersLock = std::unique_lock{m_containersLock};
+    }
+
     std::vector<docker_schema::Image> images;
     try
     {
         images = m_runtime.Docker().ListImages(all, digests, filters);
     }
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to list images");
+
+    // Stopped containers are included, matching docker.
+    std::map<std::string, LONGLONG> containersByImage;
+    if (containerCounts)
+    {
+        try
+        {
+            for (const auto& container : m_runtime.Docker().ListContainers(true))
+            {
+                containersByImage[container.ImageID]++;
+            }
+        }
+        CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to list containers");
+    }
+
+    const auto containersForImage = [&](const std::string& id) {
+        if (!containerCounts)
+        {
+            return -1LL;
+        }
+
+        const auto it = containersByImage.find(id);
+        return it == containersByImage.end() ? 0LL : it->second;
+    };
 
     // Compute the number of entries - one entry per tag, or one per image if no tags
     auto entries = std::accumulate(images.begin(), images.end(), size_t{0}, [](auto sum, const auto& e) {
@@ -1906,6 +1941,7 @@ try
             THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].ParentId, e.ParentId.c_str()) != 0);
             output[index].Size = e.Size;
             output[index].Created = e.Created;
+            output[index].Containers = containersForImage(e.Id);
             index++;
         }
         else
@@ -1932,6 +1968,7 @@ try
                 THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].ParentId, e.ParentId.c_str()) != 0);
                 output[index].Size = e.Size;
                 output[index].Created = e.Created;
+                output[index].Containers = containersForImage(e.Id);
                 index++;
             }
         }
@@ -2522,7 +2559,6 @@ try
 
         auto* e = it->second.get();
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Image, e->Image().c_str()) != 0);
-        THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].ImageId, dockerContainer.ImageID.c_str()) != 0);
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Name, e->Name().c_str()) != 0);
         THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Id, e->ID().c_str()) != 0);
         e->GetState(&output[index].State);

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -5,6 +5,7 @@
 #include "string.hpp"
 
 using wsl::windows::common::string::FormatBytes;
+using wsl::windows::common::string::FormatDockerSize;
 using wsl::windows::common::string::FormatStorageSize;
 using wsl::windows::common::string::ParseStorageSize;
 using wsl::windows::common::string::StorageSizeUnit;
@@ -225,6 +226,30 @@ class StringUnitTests
         }
 
         VERIFY_ARE_EQUAL(std::wstring{L"119.86 MB"}, FormatBytes(119'856'765));
+    }
+
+    // Docker renders image sizes with units.HumanSizeWithPrecision(size, 3), which is base 1000 with
+    // three significant digits, no space, and "kB" rather than "KB".
+    TEST_METHOD(FormatDockerSize_MatchesDockerPrecision)
+    {
+        const std::vector<std::pair<uint64_t, std::wstring>> TestCases{
+            {0, L"0B"},
+            {999, L"999B"},
+            {1'000, L"1kB"},
+            {1'500, L"1.5kB"},
+            {7'050'000, L"7.05MB"},
+            {119'856'765, L"120MB"},
+            {1'090'000'000, L"1.09GB"},
+            {1'000'000'000'000ULL, L"1TB"},
+        };
+
+        for (const auto& [bytes, expected] : TestCases)
+        {
+            VERIFY_ARE_EQUAL(expected, FormatDockerSize(bytes));
+        }
+
+        // Three significant digits switch to exponent form just below the next unit, matching Go's %g.
+        VERIFY_ARE_EQUAL(std::wstring{L"1e+03MB"}, FormatDockerSize(999'900'000));
     }
 
     TEST_METHOD(StorageSize_BytesToTextRoundTrips)

--- a/test/windows/wslc/WSLCCLIRelativeTimeUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIRelativeTimeUnitTests.cpp
@@ -1,0 +1,102 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#include "precomp.h"
+#include "windows/Common.h"
+#include "WSLCCLITestHelpers.h"
+
+#include "ContainerService.h"
+
+using namespace wsl::windows::wslc;
+using namespace wsl::windows::wslc::services;
+using namespace WSLCTestHelpers;
+using namespace WEX::Logging;
+using namespace WEX::Common;
+using namespace WEX::TestExecution;
+
+namespace WSLCCLIRelativeTimeUnitTests {
+
+class WSLCCLIRelativeTimeUnitTests
+{
+    WSLC_TEST_CLASS(WSLCCLIRelativeTimeUnitTests)
+
+    TEST_CLASS_SETUP(TestClassSetup)
+    {
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(TestClassCleanup)
+    {
+        return true;
+    }
+
+    static std::wstring FormatElapsed(LONGLONG secondsAgo)
+    {
+        return ContainerService::FormatElapsedSeconds(secondsAgo);
+    }
+
+    TEST_METHOD(RelativeTime_ZeroTimestamp_ReturnsEmpty)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{}, ContainerService::FormatRelativeTime(0));
+    }
+
+    TEST_METHOD(RelativeTime_NegativeElapsed_ClampsToLessThanASecond)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"Less than a second ago"}, ContainerService::FormatElapsedSeconds(-600));
+    }
+
+    TEST_METHOD(RelativeTime_Seconds)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"Less than a second ago"}, FormatElapsed(0));
+        VERIFY_ARE_EQUAL(std::wstring{L"1 second ago"}, FormatElapsed(1));
+        VERIFY_ARE_EQUAL(std::wstring{L"2 seconds ago"}, FormatElapsed(2));
+        VERIFY_ARE_EQUAL(std::wstring{L"59 seconds ago"}, FormatElapsed(59));
+    }
+
+    TEST_METHOD(RelativeTime_Minutes)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"About a minute ago"}, FormatElapsed(60));
+        VERIFY_ARE_EQUAL(std::wstring{L"About a minute ago"}, FormatElapsed(119));
+        VERIFY_ARE_EQUAL(std::wstring{L"2 minutes ago"}, FormatElapsed(120));
+        VERIFY_ARE_EQUAL(std::wstring{L"59 minutes ago"}, FormatElapsed(59 * 60));
+    }
+
+    TEST_METHOD(RelativeTime_Hours)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"About an hour ago"}, FormatElapsed(60 * 60));
+        VERIFY_ARE_EQUAL(std::wstring{L"2 hours ago"}, FormatElapsed(2 * 60 * 60));
+        VERIFY_ARE_EQUAL(std::wstring{L"47 hours ago"}, FormatElapsed(47 * 60 * 60));
+    }
+
+    // The hour count is rounded to the nearest hour rather than truncated.
+    TEST_METHOD(RelativeTime_HoursAreRounded)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"About an hour ago"}, FormatElapsed(89 * 60));
+        VERIFY_ARE_EQUAL(std::wstring{L"2 hours ago"}, FormatElapsed(90 * 60));
+    }
+
+    TEST_METHOD(RelativeTime_Days)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"2 days ago"}, FormatElapsed(48 * 60 * 60));
+        VERIFY_ARE_EQUAL(std::wstring{L"13 days ago"}, FormatElapsed(13 * 24 * 60 * 60));
+    }
+
+    TEST_METHOD(RelativeTime_Weeks)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"2 weeks ago"}, FormatElapsed(14 * 24 * 60 * 60));
+        VERIFY_ARE_EQUAL(std::wstring{L"8 weeks ago"}, FormatElapsed(59 * 24 * 60 * 60));
+    }
+
+    TEST_METHOD(RelativeTime_Months)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"2 months ago"}, FormatElapsed(60 * 24 * 60 * 60));
+        VERIFY_ARE_EQUAL(std::wstring{L"12 months ago"}, FormatElapsed(365 * 24 * 60 * 60));
+    }
+
+    TEST_METHOD(RelativeTime_Years)
+    {
+        VERIFY_ARE_EQUAL(std::wstring{L"2 years ago"}, FormatElapsed(730 * 24 * 60 * 60LL));
+        VERIFY_ARE_EQUAL(std::wstring{L"3 years ago"}, FormatElapsed(3 * 365 * 24 * 60 * 60LL));
+    }
+};
+
+} // namespace WSLCCLIRelativeTimeUnitTests

--- a/test/windows/wslc/WSLCCLIRelativeTimeUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIRelativeTimeUnitTests.cpp
@@ -6,6 +6,7 @@
 
 #include "ContainerService.h"
 
+using namespace wsl::shared;
 using namespace wsl::windows::wslc;
 using namespace wsl::windows::wslc::services;
 using namespace WSLCTestHelpers;
@@ -41,61 +42,61 @@ class WSLCCLIRelativeTimeUnitTests
 
     TEST_METHOD(RelativeTime_NegativeElapsed_ClampsToLessThanASecond)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"Less than a second ago"}, ContainerService::FormatElapsedSeconds(-600));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeLessThanASecond(), ContainerService::FormatElapsedSeconds(-600));
     }
 
     TEST_METHOD(RelativeTime_Seconds)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"Less than a second ago"}, FormatElapsed(0));
-        VERIFY_ARE_EQUAL(std::wstring{L"1 second ago"}, FormatElapsed(1));
-        VERIFY_ARE_EQUAL(std::wstring{L"2 seconds ago"}, FormatElapsed(2));
-        VERIFY_ARE_EQUAL(std::wstring{L"59 seconds ago"}, FormatElapsed(59));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeLessThanASecond(), FormatElapsed(0));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeOneSecond(), FormatElapsed(1));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeSeconds(2), FormatElapsed(2));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeSeconds(59), FormatElapsed(59));
     }
 
     TEST_METHOD(RelativeTime_Minutes)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"About a minute ago"}, FormatElapsed(60));
-        VERIFY_ARE_EQUAL(std::wstring{L"About a minute ago"}, FormatElapsed(119));
-        VERIFY_ARE_EQUAL(std::wstring{L"2 minutes ago"}, FormatElapsed(120));
-        VERIFY_ARE_EQUAL(std::wstring{L"59 minutes ago"}, FormatElapsed(59 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeAboutAMinute(), FormatElapsed(60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeAboutAMinute(), FormatElapsed(119));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeMinutes(2), FormatElapsed(120));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeMinutes(59), FormatElapsed(59 * 60));
     }
 
     TEST_METHOD(RelativeTime_Hours)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"About an hour ago"}, FormatElapsed(60 * 60));
-        VERIFY_ARE_EQUAL(std::wstring{L"2 hours ago"}, FormatElapsed(2 * 60 * 60));
-        VERIFY_ARE_EQUAL(std::wstring{L"47 hours ago"}, FormatElapsed(47 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeAboutAnHour(), FormatElapsed(60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeHours(2), FormatElapsed(2 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeHours(47), FormatElapsed(47 * 60 * 60));
     }
 
     // The hour count is rounded to the nearest hour rather than truncated.
     TEST_METHOD(RelativeTime_HoursAreRounded)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"About an hour ago"}, FormatElapsed(89 * 60));
-        VERIFY_ARE_EQUAL(std::wstring{L"2 hours ago"}, FormatElapsed(90 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeAboutAnHour(), FormatElapsed(89 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeHours(2), FormatElapsed(90 * 60));
     }
 
     TEST_METHOD(RelativeTime_Days)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"2 days ago"}, FormatElapsed(48 * 60 * 60));
-        VERIFY_ARE_EQUAL(std::wstring{L"13 days ago"}, FormatElapsed(13 * 24 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeDays(2), FormatElapsed(48 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeDays(13), FormatElapsed(13 * 24 * 60 * 60));
     }
 
     TEST_METHOD(RelativeTime_Weeks)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"2 weeks ago"}, FormatElapsed(14 * 24 * 60 * 60));
-        VERIFY_ARE_EQUAL(std::wstring{L"8 weeks ago"}, FormatElapsed(59 * 24 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeWeeks(2), FormatElapsed(14 * 24 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeWeeks(8), FormatElapsed(59 * 24 * 60 * 60));
     }
 
     TEST_METHOD(RelativeTime_Months)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"2 months ago"}, FormatElapsed(60 * 24 * 60 * 60));
-        VERIFY_ARE_EQUAL(std::wstring{L"12 months ago"}, FormatElapsed(365 * 24 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeMonths(2), FormatElapsed(60 * 24 * 60 * 60));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeMonths(12), FormatElapsed(365 * 24 * 60 * 60));
     }
 
     TEST_METHOD(RelativeTime_Years)
     {
-        VERIFY_ARE_EQUAL(std::wstring{L"2 years ago"}, FormatElapsed(730 * 24 * 60 * 60LL));
-        VERIFY_ARE_EQUAL(std::wstring{L"3 years ago"}, FormatElapsed(3 * 365 * 24 * 60 * 60LL));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeYears(2), FormatElapsed(730 * 24 * 60 * 60LL));
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_RelativeTimeYears(3), FormatElapsed(3 * 365 * 24 * 60 * 60LL));
     }
 };
 

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -210,7 +210,7 @@ void VerifyImageIsListed(const TestImage& image)
 {
     auto result = RunWslc(L"image list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
-    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
     for (const auto& img : images)
     {
         if (img.Repository == wsl::shared::string::WideToMultiByte(image.Name) &&
@@ -387,7 +387,7 @@ void EnsureImageIsDeleted(const TestImage& image)
     auto result = RunWslc(L"image list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
 
-    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
     for (const auto& img : images)
     {
         if (img.Repository == wsl::shared::string::WideToMultiByte(image.Name) &&
@@ -406,16 +406,16 @@ void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix)
     auto result = RunWslc(L"image list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
 
-    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
     const auto prefix = wsl::shared::string::WideToMultiByte(repositoryPrefix);
     for (const auto& image : images)
     {
-        if (image.Repository && image.Tag && image.Repository->starts_with(prefix))
+        if (image.Repository.starts_with(prefix))
         {
             // No container cleanup here: the images this prunes are only ever built and inspected, never used to
             // create containers, so image delete --force is sufficient. If a future test containerizes a built
             // image, remove its container in that test's cleanup rather than broadening this prefix-based safety net.
-            const auto nameAndTag = wsl::shared::string::MultiByteToWide(std::format("{}:{}", *image.Repository, *image.Tag));
+            const auto nameAndTag = wsl::shared::string::MultiByteToWide(std::format("{}:{}", image.Repository, image.Tag));
             RunWslc(std::format(L"image delete --force {}", nameAndTag)).Verify({.Stderr = L"", .ExitCode = 0});
         }
     }
@@ -423,14 +423,14 @@ void DeleteImagesWithRepositoryPrefix(const std::wstring& repositoryPrefix)
 
 void EnsureNoUntaggedImages()
 {
-    auto result = RunWslc(L"image list --format json --filter dangling=true");
+    auto result = RunWslc(L"image list --format json --no-trunc --filter dangling=true");
     result.Verify({.Stderr = L"", .ExitCode = 0});
 
-    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    const auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
 
     for (const auto& image : images)
     {
-        const auto id = wsl::shared::string::MultiByteToWide(GetHashId(image.Id, true));
+        const auto id = wsl::shared::string::MultiByteToWide(GetHashId(image.ID, true));
         auto deleteResult = RunWslc(std::format(L"image delete --force {}", id));
 
         // Tolerate WSLC_E_IMAGE_NOT_FOUND - an untagged image may already be gone if it was a
@@ -454,7 +454,7 @@ void EnsureImageIsLoaded(const TestImage& image, const std::wstring& sessionName
     auto result = RunWslc(listCommand);
     result.Verify({.Stderr = L"", .ExitCode = 0});
 
-    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+    auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
     for (const auto& img : images)
     {
         if (img.Repository == wsl::shared::string::WideToMultiByte(image.Name) &&

--- a/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
@@ -103,11 +103,11 @@ class WSLCE2EImageImportTests
         auto countUntaggedImages = [&]() {
             auto result = RunWslc(L"image list --format json");
             result.Verify({.Stderr = L"", .ExitCode = 0});
-            auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageInformation>(result);
+            auto images = ParseNdjsonOutputAs<wsl::windows::wslc::models::ImageOutputInformation>(result);
             size_t count = 0;
             for (const auto& img : images)
             {
-                if (!img.Repository.has_value() || img.Repository.value() == "<none>")
+                if (img.Repository == wsl::windows::wslc::models::c_dockerNone)
                 {
                     count++;
                 }

--- a/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageImportTests.cpp
@@ -107,7 +107,7 @@ class WSLCE2EImageImportTests
             size_t count = 0;
             for (const auto& img : images)
             {
-                if (img.Repository == wsl::windows::wslc::models::c_dockerNone)
+                if (img.Repository == wsl::windows::wslc::models::c_none)
                 {
                     count++;
                 }

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -172,7 +172,7 @@ class WSLCE2EImageListTests
             // Values docker always populates, even when it has no data for them.
             VERIFY_ARE_NOT_EQUAL(std::string{}, entry["Repository"].get<std::string>());
             VERIFY_ARE_NOT_EQUAL(std::string{}, entry["Tag"].get<std::string>());
-            VERIFY_ARE_EQUAL(std::string{c_dockerNone}, entry["Digest"].get<std::string>());
+            VERIFY_ARE_EQUAL(std::string{c_none}, entry["Digest"].get<std::string>());
 
             const auto containers = entry["Containers"].get<std::string>();
             VERIFY_IS_FALSE(containers.empty());
@@ -411,7 +411,7 @@ class WSLCE2EImageListTests
         for (const auto& image : images)
         {
             VERIFY_ARE_EQUAL(
-                std::string{wsl::windows::wslc::models::c_dockerNone},
+                std::string{wsl::windows::wslc::models::c_none},
                 image.Repository,
                 L"dangling=true list should not contain tagged images");
         }

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -65,7 +65,7 @@ class WSLCE2EImageListTests
     WSLC_TEST_METHOD(WSLCE2E_Image_List_QuietOption_OutputsIdsOnly)
     {
         // Get the expected image ID from JSON output. --no-trunc is required because json output
-        // truncates the id by default, matching docker.
+        // truncates the id by default.
         auto jsonResult = RunWslc(L"image list --format json --no-trunc");
         jsonResult.Verify({.Stderr = L"", .ExitCode = 0});
         const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(jsonResult);
@@ -147,8 +147,6 @@ class WSLCE2EImageListTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_JsonFormat_MatchesDockerShape)
     {
-        // Docker reports exactly these fields for "docker images --format json", and every value is
-        // a string. Anything else breaks tools that consume the output interchangeably.
         const std::set<std::string> expectedKeys = {
             "Containers", "CreatedAt", "CreatedSince", "Digest", "ID", "Repository", "SharedSize", "Size", "Tag", "UniqueSize"};
 
@@ -169,7 +167,6 @@ class WSLCE2EImageListTests
 
             VERIFY_ARE_EQUAL(expectedKeys, keys, L"json output must contain exactly docker's image fields");
 
-            // Values docker always populates, even when it has no data for them.
             VERIFY_ARE_NOT_EQUAL(std::string{}, entry["Repository"].get<std::string>());
             VERIFY_ARE_NOT_EQUAL(std::string{}, entry["Tag"].get<std::string>());
             VERIFY_ARE_EQUAL(std::string{c_none}, entry["Digest"].get<std::string>());
@@ -184,8 +181,8 @@ class WSLCE2EImageListTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_JsonFormat_ReportsContainerCount)
     {
-        // Docker counts every container created from an image, including containers that were
-        // never started, and reports it against every tag of that image.
+        // Every container created from an image is counted, including containers that were never
+        // started, and the count is reported against every tag of that image.
         constexpr auto containerName = L"wslc-image-list-container-count";
         EnsureContainerDoesNotExist(containerName);
 
@@ -223,8 +220,8 @@ class WSLCE2EImageListTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_JsonFormat_TruncatesIdByDefault)
     {
-        // Docker truncates the id to 12 hex characters unless --no-trunc is passed, in which case
-        // it keeps the sha256: prefix.
+        // The id is truncated to 12 hex characters unless --no-trunc is passed, in which case it
+        // keeps the sha256: prefix.
         auto truncResult = RunWslc(L"image list --format json");
         truncResult.Verify({.Stderr = L"", .ExitCode = 0});
 
@@ -299,16 +296,16 @@ class WSLCE2EImageListTests
             VERIFY_IS_TRUE(found, std::format(L"Table output has no row matching json values: {}", row).c_str());
         }
 
-        // Docker never labels an untagged image "<untagged>" in either format.
+        // An untagged image is never labeled "<untagged>" in either format.
         for (const auto& line : tableLines)
         {
-            VERIFY_ARE_EQUAL(std::wstring::npos, line.find(L"<untagged>"), L"table must use docker's '<none>' placeholder");
+            VERIFY_ARE_EQUAL(std::wstring::npos, line.find(L"<untagged>"), L"table must use the '<none>' placeholder");
         }
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_TableFormat_NoTruncKeepsAlgorithmPrefix)
     {
-        // Docker's --no-trunc table keeps the "sha256:" prefix on the image id.
+        // The --no-trunc table keeps the "sha256:" prefix on the image id.
         const auto result = RunWslc(L"image list --no-trunc");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
@@ -442,7 +439,7 @@ class WSLCE2EImageListTests
     WSLC_TEST_METHOD(WSLCE2E_Image_List_NoTrunc_ShowsFullImageId)
     {
         // Pull the full image id from JSON output. --no-trunc is required because json output
-        // truncates the id by default, matching docker.
+        // truncates the id by default.
         auto jsonResult = RunWslc(L"image list --format json --no-trunc");
         jsonResult.Verify({.Stderr = L"", .ExitCode = 0});
         const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(jsonResult);

--- a/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageListTests.cpp
@@ -64,10 +64,11 @@ class WSLCE2EImageListTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_QuietOption_OutputsIdsOnly)
     {
-        // Get the expected image ID from JSON output.
-        auto jsonResult = RunWslc(L"image list --format json");
+        // Get the expected image ID from JSON output. --no-trunc is required because json output
+        // truncates the id by default, matching docker.
+        auto jsonResult = RunWslc(L"image list --format json --no-trunc");
         jsonResult.Verify({.Stderr = L"", .ExitCode = 0});
-        const auto images = ParseNdjsonOutputAs<ImageInformation>(jsonResult);
+        const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(jsonResult);
 
         std::string debianId;
         for (const auto& image : images)
@@ -75,7 +76,7 @@ class WSLCE2EImageListTests
             if (image.Repository == wsl::shared::string::WideToMultiByte(DebianImage.Name) &&
                 image.Tag == wsl::shared::string::WideToMultiByte(DebianImage.Tag))
             {
-                debianId = image.Id;
+                debianId = image.ID;
                 break;
             }
         }
@@ -128,7 +129,7 @@ class WSLCE2EImageListTests
         const auto result = RunWslc(L"image list --format json");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        const auto images = ParseNdjsonOutputAs<ImageInformation>(result);
+        const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(result);
 
         VERIFY_IS_GREATER_THAN_OR_EQUAL(images.size(), 2u);
 
@@ -136,14 +137,111 @@ class WSLCE2EImageListTests
         for (const auto& image : images)
         {
             auto nameAndTag = std::format(
-                L"{}:{}",
-                wsl::shared::string::MultiByteToWide(image.Repository.value_or("<untagged>")),
-                wsl::shared::string::MultiByteToWide(image.Tag.value_or("<untagged>")));
+                L"{}:{}", wsl::shared::string::MultiByteToWide(image.Repository), wsl::shared::string::MultiByteToWide(image.Tag));
             imageNames.push_back(nameAndTag);
         }
 
         VERIFY_ARE_NOT_EQUAL(imageNames.end(), std::find(imageNames.begin(), imageNames.end(), DebianImage.NameAndTag()));
         VERIFY_ARE_NOT_EQUAL(imageNames.end(), std::find(imageNames.begin(), imageNames.end(), AlpineImage.NameAndTag()));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_JsonFormat_MatchesDockerShape)
+    {
+        // Docker reports exactly these fields for "docker images --format json", and every value is
+        // a string. Anything else breaks tools that consume the output interchangeably.
+        const std::set<std::string> expectedKeys = {
+            "Containers", "CreatedAt", "CreatedSince", "Digest", "ID", "Repository", "SharedSize", "Size", "Tag", "UniqueSize"};
+
+        const auto result = RunWslc(L"image list --format json");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto entries = ParseNdjsonOutput(result);
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(entries.size(), 2u);
+
+        for (const auto& entry : entries)
+        {
+            std::set<std::string> keys;
+            for (const auto& [key, value] : entry.items())
+            {
+                keys.insert(key);
+                VERIFY_IS_TRUE(value.is_string(), wsl::shared::string::MultiByteToWide(std::format("'{}' must be a string", key)).c_str());
+            }
+
+            VERIFY_ARE_EQUAL(expectedKeys, keys, L"json output must contain exactly docker's image fields");
+
+            // Values docker always populates, even when it has no data for them.
+            VERIFY_ARE_NOT_EQUAL(std::string{}, entry["Repository"].get<std::string>());
+            VERIFY_ARE_NOT_EQUAL(std::string{}, entry["Tag"].get<std::string>());
+            VERIFY_ARE_EQUAL(std::string{c_dockerNone}, entry["Digest"].get<std::string>());
+
+            const auto containers = entry["Containers"].get<std::string>();
+            VERIFY_IS_FALSE(containers.empty());
+            VERIFY_IS_TRUE(
+                std::ranges::all_of(containers, [](char value) { return std::isdigit(static_cast<unsigned char>(value)) != 0; }),
+                L"'Containers' must be a container count");
+        }
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_JsonFormat_ReportsContainerCount)
+    {
+        // Docker counts every container created from an image, including containers that were
+        // never started, and reports it against every tag of that image.
+        constexpr auto containerName = L"wslc-image-list-container-count";
+        EnsureContainerDoesNotExist(containerName);
+
+        auto containerCount = [](const TestImage& image) {
+            const auto result = RunWslc(L"image list --format json");
+            result.Verify({.Stderr = L"", .ExitCode = 0});
+
+            for (const auto& entry : ParseNdjsonOutputAs<ImageOutputInformation>(result))
+            {
+                if (entry.Repository == wsl::shared::string::WideToMultiByte(image.Name) &&
+                    entry.Tag == wsl::shared::string::WideToMultiByte(image.Tag))
+                {
+                    return std::stoi(entry.Containers);
+                }
+            }
+
+            VERIFY_FAIL(std::format(L"Image '{}' not found in image list output", image.NameAndTag()).c_str());
+            return -1;
+        };
+
+        const auto alpineBaseline = containerCount(AlpineImage);
+        const auto debianBaseline = containerCount(DebianImage);
+
+        auto createResult = RunWslc(std::format(L"container create --name {} {}", containerName, AlpineImage.NameAndTag()));
+        createResult.Verify({.Stderr = L"", .ExitCode = 0});
+        auto cleanup = wil::scope_exit([&]() { EnsureContainerDoesNotExist(containerName); });
+
+        VERIFY_ARE_EQUAL(alpineBaseline + 1, containerCount(AlpineImage), L"a created container must be counted");
+        VERIFY_ARE_EQUAL(debianBaseline, containerCount(DebianImage), L"only the image the container was created from is counted");
+
+        cleanup.reset();
+
+        VERIFY_ARE_EQUAL(alpineBaseline, containerCount(AlpineImage), L"a removed container must no longer be counted");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_JsonFormat_TruncatesIdByDefault)
+    {
+        // Docker truncates the id to 12 hex characters unless --no-trunc is passed, in which case
+        // it keeps the sha256: prefix.
+        auto truncResult = RunWslc(L"image list --format json");
+        truncResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        for (const auto& image : ParseNdjsonOutputAs<ImageOutputInformation>(truncResult))
+        {
+            VERIFY_ARE_EQUAL(12u, image.ID.size(), L"json ids must be truncated to 12 characters by default");
+            VERIFY_IS_FALSE(image.ID.starts_with("sha256:"));
+        }
+
+        auto noTruncResult = RunWslc(L"image list --format json --no-trunc");
+        noTruncResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        for (const auto& image : ParseNdjsonOutputAs<ImageOutputInformation>(noTruncResult))
+        {
+            VERIFY_IS_TRUE(image.ID.starts_with("sha256:"), L"--no-trunc ids must keep the algorithm prefix");
+            VERIFY_IS_GREATER_THAN(image.ID.size(), 12u);
+        }
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_TableFormat_HasExpectedColumns)
@@ -164,6 +262,67 @@ class WSLCE2EImageListTests
         }
 
         VERIFY_IS_TRUE(foundHeader, L"Expected table header with REPOSITORY, TAG, IMAGE ID, CREATED, SIZE columns");
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_TableFormat_MatchesJsonValues)
+    {
+        // The table and json output must report the same values, formatted the way docker formats
+        // them: SI sizes ("120MB", not "119.86 MB") and "<none>" for missing repository/tag data.
+        const auto jsonResult = RunWslc(L"image list --format json");
+        jsonResult.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto tableResult = RunWslc(L"image list");
+        tableResult.Verify({.Stderr = L"", .ExitCode = 0});
+        const auto tableLines = tableResult.GetStdoutLines();
+
+        const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(jsonResult);
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(images.size(), 2u);
+
+        for (const auto& image : images)
+        {
+            const auto row = std::format(
+                L"{} {} {} {}",
+                wsl::shared::string::MultiByteToWide(image.Repository),
+                wsl::shared::string::MultiByteToWide(image.Tag),
+                wsl::shared::string::MultiByteToWide(image.ID),
+                wsl::shared::string::MultiByteToWide(image.Size));
+
+            const bool found = std::ranges::any_of(tableLines, [&](const auto& line) {
+                // Columns are padded, so match on the individual values rather than the row text.
+                return line.find(wsl::shared::string::MultiByteToWide(image.ID)) != std::wstring::npos &&
+                       line.find(wsl::shared::string::MultiByteToWide(image.Repository)) != std::wstring::npos &&
+                       line.find(wsl::shared::string::MultiByteToWide(image.Tag)) != std::wstring::npos &&
+                       line.find(wsl::shared::string::MultiByteToWide(image.Size)) != std::wstring::npos &&
+                       line.find(wsl::shared::string::MultiByteToWide(image.CreatedSince)) != std::wstring::npos;
+            });
+
+            VERIFY_IS_TRUE(found, std::format(L"Table output has no row matching json values: {}", row).c_str());
+        }
+
+        // Docker never labels an untagged image "<untagged>" in either format.
+        for (const auto& line : tableLines)
+        {
+            VERIFY_ARE_EQUAL(std::wstring::npos, line.find(L"<untagged>"), L"table must use docker's '<none>' placeholder");
+        }
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Image_List_TableFormat_NoTruncKeepsAlgorithmPrefix)
+    {
+        // Docker's --no-trunc table keeps the "sha256:" prefix on the image id.
+        const auto result = RunWslc(L"image list --no-trunc");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto lines = result.GetStdoutLines();
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(lines.size(), 2u);
+
+        for (size_t i = 1; i < lines.size(); i++)
+        {
+            if (!lines[i].empty())
+            {
+                VERIFY_ARE_NOT_EQUAL(
+                    std::wstring::npos, lines[i].find(L"sha256:"), L"--no-trunc table ids must keep the algorithm prefix");
+            }
+        }
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_Filter_MalformedValue)
@@ -188,14 +347,12 @@ class WSLCE2EImageListTests
         auto listNames = [&](const std::wstring& filterArgs) {
             auto r = RunWslc(std::format(L"image list --format json {}", filterArgs));
             r.Verify({.Stderr = L"", .ExitCode = 0});
-            const auto images = ParseNdjsonOutputAs<ImageInformation>(r);
+            const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(r);
             std::set<std::wstring> names;
             for (const auto& image : images)
             {
                 names.insert(std::format(
-                    L"{}:{}",
-                    wsl::shared::string::MultiByteToWide(image.Repository.value_or("<untagged>")),
-                    wsl::shared::string::MultiByteToWide(image.Tag.value_or("<untagged>"))));
+                    L"{}:{}", wsl::shared::string::MultiByteToWide(image.Repository), wsl::shared::string::MultiByteToWide(image.Tag)));
             }
             return names;
         };
@@ -234,7 +391,7 @@ class WSLCE2EImageListTests
         auto result = RunWslc(L"image list --format json --filter dangling=false");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        auto images = ParseNdjsonOutputAs<ImageInformation>(result);
+        auto images = ParseNdjsonOutputAs<ImageOutputInformation>(result);
         bool foundDebian = false;
         for (const auto& image : images)
         {
@@ -250,11 +407,12 @@ class WSLCE2EImageListTests
         result = RunWslc(L"image list --format json --filter dangling=true");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        images = ParseNdjsonOutputAs<ImageInformation>(result);
+        images = ParseNdjsonOutputAs<ImageOutputInformation>(result);
         for (const auto& image : images)
         {
-            VERIFY_IS_FALSE(
-                image.Repository.has_value() && image.Repository.value() != "<none>",
+            VERIFY_ARE_EQUAL(
+                std::string{wsl::windows::wslc::models::c_dockerNone},
+                image.Repository,
                 L"dangling=true list should not contain tagged images");
         }
     }
@@ -267,11 +425,11 @@ class WSLCE2EImageListTests
             RunWslc(std::format(L"image list --format json --filter reference={} --filter dangling=false", DebianImage.Name));
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        const auto images = ParseNdjsonOutputAs<ImageInformation>(result);
+        const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(result);
         bool foundDebian = false;
         for (const auto& image : images)
         {
-            const auto repo = wsl::shared::string::MultiByteToWide(image.Repository.value_or(""));
+            const auto repo = wsl::shared::string::MultiByteToWide(image.Repository);
             VERIFY_ARE_NOT_EQUAL(AlpineImage.Name, repo, L"alpine should not appear when filtering by reference=debian");
             if (repo == DebianImage.Name)
             {
@@ -283,17 +441,18 @@ class WSLCE2EImageListTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_List_NoTrunc_ShowsFullImageId)
     {
-        // Pull the full image id from JSON output (always untruncated).
-        auto jsonResult = RunWslc(L"image list --format json");
+        // Pull the full image id from JSON output. --no-trunc is required because json output
+        // truncates the id by default, matching docker.
+        auto jsonResult = RunWslc(L"image list --format json --no-trunc");
         jsonResult.Verify({.Stderr = L"", .ExitCode = 0});
-        const auto images = ParseNdjsonOutputAs<ImageInformation>(jsonResult);
+        const auto images = ParseNdjsonOutputAs<ImageOutputInformation>(jsonResult);
 
         std::string fullDebianId;
         for (const auto& image : images)
         {
             if (image.Repository == wsl::shared::string::WideToMultiByte(DebianImage.Name))
             {
-                fullDebianId = image.Id;
+                fullDebianId = image.ID;
                 break;
             }
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Brings `wslc image list` output to parity with `docker images` for both `--format json` and the default/table format, so existing Docker tooling and scripts can consume `wslc` output unchanged.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Output was compared field-by-field against Docker 29.6.2. Note that Docker 29.x's *default* `docker images` now renders the containerd-store tree layout (`IMAGE / ID / DISK USAGE / CONTENT SIZE / EXTRA`), so `docker images --format table` is the correct baseline for the classic 5-column contract.

**JSON format**

- `Containers` previously hardcoded `"N/A"`. It now reports a real count. Docker semantics were verified empirically: it counts **all** containers (running *and* stopped) keyed by image ID, and reports `"0"` — never `"N/A"` — for unused images. Falls back to `"N/A"` only if the container list can't be retrieved.
- Plumbed a resolved image ID from the Docker API through to the CLI so images and containers can be joined. `WSLCContainerEntry.Image` holds the reference the *caller* passed (e.g. `alpine:latest`), not a resolved ID, so it can't be matched against `ImageInformation.Id`. Added `ImageID` to `ContainerInfo` (`docker_schema.h`), `ImageId[256]` to `WSLCContainerEntry` (`wslc.idl`), and `ImageId` to `ContainerInformation`.
  - `IWSLCSession` is an internal, non-stable interface rebuilt in lockstep with its only clients, so appending a struct field is allowed here — unlike `WSLCCompat.idl` / `WslPluginApi.h`.
  - `ImageId` is deliberately **excluded** from `ContainerInformation`'s serialization macro, so `container list --format json` output is unchanged and keeps reporting the image reference to match Docker.

**Table format**

- Untagged images now render `<none>` instead of `<untagged>` in both `REPOSITORY` and `TAG`.
- Sizes use Docker's SI formatting (`120MB`, `8.44MB`, `10.1kB`) instead of `119.86 MB`.
- `--no-trunc` now preserves the `sha256:` prefix. `TruncateId()` always strips it, so the table branch now passes the raw ID through when not truncating.
- The table branch was refactored to reuse the same `ToImageOutput` helper as the JSON branch, so the two formats can no longer drift.

**Relative timestamps**

`FormatRelativeTime` is now an exact port of Go's `units.HumanDuration` (per `docker/go-units/duration.go`), which Docker uses for `CreatedSince`. Beyond wording, the bucket boundaries were wrong:

| elapsed | before | after |
|---|---|---|
| < 1s | `0 seconds ago` | `Less than a second ago` |
| 60–119s | `1 minute ago` | `About a minute ago` |
| ~1h | `1 hour ago` | `About an hour ago` |
| 24–47h | `1 day ago` | `24`–`47 hours ago` |
| 1 year | `1 year ago` | `12 months ago` |

Go stays in hours until 48h, days until 14d, weeks until ~60d, and months until ~2 years, which makes the singular day/week/month/year forms unreachable. Hours are also *rounded*, not truncated (`int(d.Hours()+0.5)`).

The logic was split into `FormatRelativeTime(timestamp)` (computes elapsed vs. now) and a pure `FormatElapsedSeconds(elapsed)` so the duration buckets are deterministically unit-testable without clock-tick flakiness.

This function is shared with `container list`, which picks up the corrected wording as well.

**Known remaining gaps (not addressed here)**

- `Digest`: nlohmann emits a literal `<none>` while Go's `encoding/json` HTML-escapes it to `\u003cnone\u003e`. The decoded values are equal; only the raw bytes differ.
- `container list` STATUS renders `exited <time>` where Docker renders `Exited (0) <time>`. Out of scope for this PR; being handled in a follow-up container-list pass.

## Validation Steps Performed

- Full build, deployed via `tools\deploy\deploy-to-host.ps1`, and compared live `wslc` output against Docker 29.6.2 side by side for both JSON and table formats, including `--no-trunc`.
- `Containers` verified end to end: created one running and one exited container from the same image and confirmed Docker reports `"2"`; confirmed `wslc` reports `"2"` for an image with two containers, `"0"` for an unused image, and `"0"` again after removal.
- Added e2e coverage in `WSLCE2EImageListTests`: container-count reporting, a numeric-`Containers` assertion in the Docker-shape test, table-vs-JSON value agreement, and `--no-trunc` algorithm-prefix retention. **19/19 pass.**
- Added `WSLCCLIRelativeTimeUnitTests` covering every `HumanDuration` bucket and boundary, hour rounding, negative/zero elapsed. **10/10 pass.**
- `WSLCE2EContainerListTests` 17/17 pass (shared relative-time change).
- `FormatSource.ps1` clean.
