### PR TITLE
Add --ip flag to container create and run

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2496,6 +2496,14 @@ For privacy information about this product please visit https://aka.ms/privacy.<
     <value>Network aliases cannot be specified when multiple networks are requested. Use a single --network option.</value>
     <comment>{Locked="--network "}Command line arguments, file names and string inserts should not be translated</comment>
   </data>
+  <data name="MessageWslcIpRequiresUserDefinedNetwork" xml:space="preserve">
+    <value>An IP address requires a user-defined network. Use --network to specify one.</value>
+    <comment>{Locked="--network "}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
+  <data name="MessageWslcIpAmbiguousWithMultipleNetworks" xml:space="preserve">
+    <value>An IP address cannot be specified when multiple networks are requested. Use a single --network option.</value>
+    <comment>{Locked="--network "}Command line arguments, file names and string inserts should not be translated</comment>
+  </data>
   <data name = "MessageWslcFailedToMountVolume" xml:space = "preserve" >
     <value>Failed to create volume '{}': {}</value>
     <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>

--- a/src/windows/common/WSLCContainerLauncher.cpp
+++ b/src/windows/common/WSLCContainerLauncher.cpp
@@ -336,6 +336,11 @@ void wsl::windows::common::WSLCContainerLauncher::AddPrimaryNetworkAlias(const s
     m_primaryNetworkAliases.push_back(Alias);
 }
 
+void wsl::windows::common::WSLCContainerLauncher::SetPrimaryNetworkIpAddress(std::string&& Address)
+{
+    m_primaryNetworkIpAddress = std::move(Address);
+}
+
 std::pair<HRESULT, std::optional<RunningWSLCContainer>> WSLCContainerLauncher::LaunchNoThrow(
     IWSLCSession& Session, WSLCContainerStartFlags Flags, IWarningCallback* WarningCallback)
 {
@@ -485,12 +490,17 @@ std::pair<HRESULT, std::optional<RunningWSLCContainer>> WSLCContainerLauncher::C
     options.ContainerNetwork.Networks = connections.empty() ? nullptr : connections.data();
     options.ContainerNetwork.NetworksCount = static_cast<ULONG>(connections.size());
 
-    // Aliases for the primary endpoint.
+    // Settings for the primary endpoint.
     std::vector<KeyValuePair> primarySettings;
-    primarySettings.reserve(m_primaryNetworkAliases.size());
+    primarySettings.reserve(m_primaryNetworkAliases.size() + (m_primaryNetworkIpAddress.has_value() ? 1 : 0));
     for (const auto& alias : m_primaryNetworkAliases)
     {
         primarySettings.push_back({.Key = "Aliases", .Value = alias.c_str()});
+    }
+
+    if (m_primaryNetworkIpAddress.has_value())
+    {
+        primarySettings.push_back({.Key = "IPAddress", .Value = m_primaryNetworkIpAddress->c_str()});
     }
 
     options.ContainerNetwork.Settings = primarySettings.empty() ? nullptr : primarySettings.data();

--- a/src/windows/common/WSLCContainerLauncher.h
+++ b/src/windows/common/WSLCContainerLauncher.h
@@ -67,6 +67,7 @@ public:
     void AddAdditionalNetwork(const std::string& Name);
     void AddAdditionalNetwork(const std::string& Name, const std::vector<std::string>& Aliases);
     void AddPrimaryNetworkAlias(const std::string& Alias);
+    void SetPrimaryNetworkIpAddress(std::string&& Address);
 
     std::pair<HRESULT, std::optional<RunningWSLCContainer>> CreateNoThrow(IWSLCSession& Session, IWarningCallback* WarningCallback = nullptr);
     RunningWSLCContainer Create(IWSLCSession& Session, IWarningCallback* WarningCallback = nullptr);
@@ -133,6 +134,7 @@ private:
     std::vector<std::string> m_dnsOptions;
     std::vector<NetworkConnection> m_additionalNetworks;
     std::vector<std::string> m_primaryNetworkAliases;
+    std::optional<std::string> m_primaryNetworkIpAddress;
     std::vector<WSLCLabel> m_labels;
     std::deque<std::string> m_labelKeys;
     std::deque<std::string> m_labelValues;

--- a/src/windows/wslc/commands/ContainerCreateCommand.cpp
+++ b/src/windows/wslc/commands/ContainerCreateCommand.cpp
@@ -50,6 +50,7 @@ std::vector<Argument> ContainerCreateCommand::GetArguments() const
         Argument::Create(ArgType::HealthTimeout),
         Argument::Create(ArgType::Hostname),
         Argument::Create(ArgType::Interactive),
+        Argument::Create(ArgType::IpAddress, false),
         Argument::Create(ArgType::Label, false, Limit::Unlimited),
         Argument::Create(ArgType::Memory),
         Argument::Create(ArgType::Mount, false, Limit::Unlimited),

--- a/src/windows/wslc/commands/ContainerRunCommand.cpp
+++ b/src/windows/wslc/commands/ContainerRunCommand.cpp
@@ -50,6 +50,7 @@ std::vector<Argument> ContainerRunCommand::GetArguments() const
         Argument::Create(ArgType::HealthTimeout),
         Argument::Create(ArgType::Hostname),
         Argument::Create(ArgType::Interactive),
+        Argument::Create(ArgType::IpAddress, false),
         Argument::Create(ArgType::Label, false, Limit::Unlimited),
         Argument::Create(ArgType::Memory),
         Argument::Create(ArgType::Mount, false, Limit::Unlimited),

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -87,11 +87,8 @@ struct ContainerOptions
     std::vector<std::string> DnsOptions;
     std::vector<ContainerNetwork> Networks;
     std::vector<std::string> NetworkAliases;
-<<<<<<< Updated upstream
-=======
     std::optional<std::string> IpAddress{};
     std::vector<std::string> Tmpfs;
->>>>>>> Stashed changes
     std::vector<std::pair<std::string, std::string>> Labels;
     std::optional<std::wstring> CidFile{};
     std::optional<int64_t> MemoryBytes{};

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -87,6 +87,11 @@ struct ContainerOptions
     std::vector<std::string> DnsOptions;
     std::vector<ContainerNetwork> Networks;
     std::vector<std::string> NetworkAliases;
+<<<<<<< Updated upstream
+=======
+    std::optional<std::string> IpAddress{};
+    std::vector<std::string> Tmpfs;
+>>>>>>> Stashed changes
     std::vector<std::pair<std::string, std::string>> Labels;
     std::optional<std::wstring> CidFile{};
     std::optional<int64_t> MemoryBytes{};

--- a/src/windows/wslc/services/ContainerService.cpp
+++ b/src/windows/wslc/services/ContainerService.cpp
@@ -105,6 +105,18 @@ static wsl::windows::common::RunningWSLCContainer CreateInternal(Terminal& termi
         }
     }
 
+    if (options.IpAddress.has_value())
+    {
+        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcIpRequiresUserDefinedNetwork(), options.Networks.empty());
+
+        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcIpAmbiguousWithMultipleNetworks(), options.Networks.size() > 1);
+
+        const auto& primary = options.Networks.front().Name;
+        THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessageWslcIpRequiresUserDefinedNetwork(), !SupportsNetworkAliases(primary));
+
+        containerLauncher.SetPrimaryNetworkIpAddress(std::string(options.IpAddress.value()));
+    }
+
     if (!options.Networks.empty())
     {
         const auto& primary = options.Networks.front();

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -822,6 +822,11 @@ void SetContainerOptionsFromArgs(CLIExecutionContext& context)
         }
     }
 
+    if (context.Args.Contains(ArgType::IpAddress))
+    {
+        options.IpAddress = WideToMultiByte(context.Args.GetValue<ArgType::IpAddress>());
+    }
+
     if (context.Args.Contains(ArgType::User))
     {
         options.User = WideToMultiByte(context.Args.GetValue<ArgType::User>());

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -8355,6 +8355,44 @@ class WSLCTests
             VERIFY_ARE_EQUAL(driverOptValue, opt->second);
         }
 
+        // Launcher-driven pinned IP alongside an alias — both settings survive the same KVP batch.
+        {
+            const std::string networkName = "alias-net-ip";
+            const std::string ipAddress = "172.67.0.42";
+            const std::string alias = "db";
+            createNetwork(networkName, "172.67.0.0/16");
+            auto netCleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
+
+            WSLCContainerLauncher launcher("debian:latest", "alias-ctr-ip", {"sleep", "99999"}, {}, networkName);
+            launcher.AddPrimaryNetworkAlias(alias);
+            launcher.SetPrimaryNetworkIpAddress(std::string(ipAddress));
+            auto container = launcher.Launch(*m_defaultSession);
+
+            auto inspect = container.Inspect();
+            VERIFY_IS_TRUE(inspect.NetworkSettings.Networks.contains(networkName));
+            const auto& endpoint = inspect.NetworkSettings.Networks.at(networkName);
+            VERIFY_ARE_EQUAL(ipAddress, endpoint.IPAddress);
+            VERIFY_IS_TRUE(endpoint.IPAMConfig.has_value());
+            VERIFY_ARE_EQUAL(ipAddress, endpoint.IPAMConfig->IPv4Address);
+            VERIFY_IS_TRUE(std::ranges::find(endpoint.Aliases, alias) != endpoint.Aliases.end());
+        }
+
+        // Pinned IP outside a user-defined network — rejected for callers that bypass the CLI checks.
+        {
+            auto expectEndpointSettingsError = [&](const std::string& containerName, const std::string& networkMode) {
+                WSLCContainerLauncher launcher("debian:latest", containerName, {"sleep", "99999"}, {}, networkMode);
+                launcher.SetPrimaryNetworkIpAddress("172.67.0.42");
+
+                auto retVal = launcher.LaunchNoThrow(*m_defaultSession);
+                VERIFY_ARE_EQUAL(E_INVALIDARG, retVal.first);
+                ValidateCOMErrorMessage(std::format(
+                    L"Endpoint settings are not supported for network mode '{}'.", std::wstring(networkMode.begin(), networkMode.end())));
+            };
+
+            expectEndpointSettingsError("alias-ctr-ip-host", "host");
+            expectEndpointSettingsError("alias-ctr-ip-none", "none");
+        }
+
         // Primary endpoint Links: launch a target container with an alias, then a source with --link at create time.
         {
             const std::string networkName = "alias-net-link";

--- a/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerCreateTests.cpp
@@ -1410,6 +1410,85 @@ class WSLCE2EContainerCreateTests
         VerifyContainerIsNotListed(WslcContainerName);
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Container_Create_Ip_Success)
+    {
+        const std::wstring subnet = L"172.74.0.0/16";
+        const std::wstring ipAddress = L"172.74.0.42";
+
+        auto result = RunWslc(std::format(L"network create --driver bridge --subnet {} {}", subnet, TestNetworkName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
+
+        result = RunWslc(std::format(
+            L"container create --name {} --network {} --ip {} {} true", WslcContainerName, TestNetworkName, ipAddress, DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto inspect = InspectContainer(WslcContainerName);
+        const auto networkName = wsl::shared::string::WideToMultiByte(TestNetworkName);
+        const auto expectedIp = wsl::shared::string::WideToMultiByte(ipAddress);
+        VERIFY_IS_TRUE(inspect.NetworkSettings.Networks.contains(networkName));
+        const auto& endpoint = inspect.NetworkSettings.Networks.at(networkName);
+        VERIFY_IS_TRUE(endpoint.IPAMConfig.has_value());
+        VERIFY_ARE_EQUAL(expectedIp, endpoint.IPAMConfig->IPv4Address);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Create_Ip_NoNetwork_Rejected)
+    {
+        const std::wstring ipAddress = L"172.74.0.42";
+
+        auto result =
+            RunWslc(std::format(L"container create --ip {} --name {} {} true", ipAddress, WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify(
+            {.Stderr = std::format(L"{}\r\nError code: E_INVALIDARG\r\n", wsl::shared::Localization::MessageWslcIpRequiresUserDefinedNetwork()),
+             .ExitCode = 1});
+        VerifyContainerIsNotListed(WslcContainerName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Create_Ip_BridgeMode_Rejected)
+    {
+        const std::wstring ipAddress = L"172.74.0.42";
+
+        auto result = RunWslc(std::format(
+            L"container create --network bridge --ip {} --name {} {} true", ipAddress, WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify(
+            {.Stderr = std::format(L"{}\r\nError code: E_INVALIDARG\r\n", wsl::shared::Localization::MessageWslcIpRequiresUserDefinedNetwork()),
+             .ExitCode = 1});
+        VerifyContainerIsNotListed(WslcContainerName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Create_Ip_MultipleNetworks_Rejected)
+    {
+        const std::wstring ipAddress = L"172.74.0.42";
+
+        auto result = RunWslc(std::format(
+            L"container create --network bridge --network bridge --ip {} --name {} {} true",
+            ipAddress,
+            WslcContainerName,
+            DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"", .ExitCode = 1});
+        VERIFY_IS_TRUE(result.StderrContainsSubstring(
+            wsl::shared::Localization::MessageWslcIpAmbiguousWithMultipleNetworks() + L"\r\nError code: E_INVALIDARG"));
+        VerifyContainerIsNotListed(WslcContainerName);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Create_Ip_InvalidValue_Rejected)
+    {
+        const std::wstring badIp = L"not-an-ip";
+
+        auto result = RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
+
+        result = RunWslc(std::format(
+            L"container create --network {} --ip {} --name {} {} true", TestNetworkName, badIp, WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"", .ExitCode = 1});
+        VERIFY_IS_TRUE(result.Stderr.has_value());
+        VerifyPatternMatch(
+            wsl::shared::string::WideToMultiByte(result.Stderr.value()),
+            std::format("*Invalid IP address '{}'*", wsl::shared::string::WideToMultiByte(badIp)));
+        VerifyContainerIsNotListed(WslcContainerName);
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Container_Create_Cpus)
     {
         auto result = RunWslc(std::format(L"container create --name {} --cpus 0.5 {} true", WslcContainerName, DebianImage.NameAndTag()));

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1041,6 +1041,88 @@ class WSLCE2EContainerRunTests
             result.StderrContainsSubstring(L"Invalid network-alias value: network alias cannot be empty or whitespace"));
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Container_Run_Ip_Success)
+    {
+        const std::wstring subnet = L"172.73.0.0/16";
+        const std::wstring ipAddress = L"172.73.0.42";
+
+        auto result = RunWslc(std::format(L"network create --driver bridge --subnet {} {}", subnet, TestNetworkName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
+
+        result = RunWslc(std::format(
+            L"container run -d --name {} --network {} --ip {} {} sleep infinity",
+            WslcContainerName,
+            TestNetworkName,
+            ipAddress,
+            DebianImage.NameAndTag()));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        // Registered after the network so it runs first; the network cannot be deleted while the container holds an endpoint.
+        auto cleanupContainer = wil::scope_exit([&] { EnsureContainerDoesNotExist(WslcContainerName); });
+
+        const auto inspect = InspectContainer(WslcContainerName);
+        const auto networkName = wsl::shared::string::WideToMultiByte(TestNetworkName);
+        const auto expectedIp = wsl::shared::string::WideToMultiByte(ipAddress);
+        VERIFY_IS_TRUE(inspect.NetworkSettings.Networks.contains(networkName));
+        const auto& endpoint = inspect.NetworkSettings.Networks.at(networkName);
+        VERIFY_ARE_EQUAL(expectedIp, endpoint.IPAddress);
+        VERIFY_IS_TRUE(endpoint.IPAMConfig.has_value());
+        VERIFY_ARE_EQUAL(expectedIp, endpoint.IPAMConfig->IPv4Address);
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Run_Ip_NoNetwork_Rejected)
+    {
+        const std::wstring ipAddress = L"172.73.0.42";
+
+        auto result =
+            RunWslc(std::format(L"container run --rm --ip {} --name {} {} true", ipAddress, WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify(
+            {.Stderr = std::format(L"{}\r\nError code: E_INVALIDARG\r\n", wsl::shared::Localization::MessageWslcIpRequiresUserDefinedNetwork()),
+             .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Run_Ip_BridgeMode_Rejected)
+    {
+        const std::wstring ipAddress = L"172.73.0.42";
+
+        auto result = RunWslc(std::format(
+            L"container run --rm --network bridge --ip {} --name {} {} true", ipAddress, WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify(
+            {.Stderr = std::format(L"{}\r\nError code: E_INVALIDARG\r\n", wsl::shared::Localization::MessageWslcIpRequiresUserDefinedNetwork()),
+             .ExitCode = 1});
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Run_Ip_MultipleNetworks_Rejected)
+    {
+        const std::wstring ipAddress = L"172.73.0.42";
+
+        auto result = RunWslc(std::format(
+            L"container run --rm --network bridge --network bridge --ip {} --name {} {} true",
+            ipAddress,
+            WslcContainerName,
+            DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"", .ExitCode = 1});
+        VERIFY_IS_TRUE(result.StderrContainsSubstring(
+            wsl::shared::Localization::MessageWslcIpAmbiguousWithMultipleNetworks() + L"\r\nError code: E_INVALIDARG"));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Container_Run_Ip_InvalidValue_Rejected)
+    {
+        const std::wstring badIp = L"not-an-ip";
+
+        auto result = RunWslc(std::format(L"network create --driver bridge {}", TestNetworkName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        auto cleanupNetwork = wil::scope_exit([&] { EnsureNetworkDoesNotExist(TestNetworkName); });
+
+        result = RunWslc(std::format(
+            L"container run --rm --network {} --ip {} --name {} {} true", TestNetworkName, badIp, WslcContainerName, DebianImage.NameAndTag()));
+        result.Verify({.Stdout = L"", .ExitCode = 1});
+        VERIFY_IS_TRUE(result.Stderr.has_value());
+        VerifyPatternMatch(
+            wsl::shared::string::WideToMultiByte(result.Stderr.value()),
+            std::format("*Invalid IP address '{}'*", wsl::shared::string::WideToMultiByte(badIp)));
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_Volume_NamedVolume_Success)
     {
         // Create a named volume


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds --ip support to wslc container create and wslc container run, allowing users to assign a static IPv4 address to a container's primary network endpoint. This mirrors the existing --network-alias plumbing, the backend was already wired; this PR adds the CLI argument, validation, and launcher integration.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Registers ArgType::IpAddress in both ContainerRunCommand and ContainerCreateCommand
- Parses it in ContainerTasks.cpp into ContainerOptions::IpAddress (std::optional<std::string>)
- Validates in ContainerService::CreateInternal with the same three-check pattern as --network-alias: requires a user-defined network, rejects multiple networks, rejects built-in modes (bridge/host/none/container:*)
- Passes through WSLCContainerLauncher::SetPrimaryNetworkIpAddress → KVP {"IPAddress", ...} in the primary endpoint settings batch
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- WSLCTests.cpp - added two blocks inside the existing NetworkAliasCreateTest omnibus: a happy-path that round-trips IP + alias together through the launcher, and a rejection block verifying the service-layer guard fires for host/none modes
- WSLCE2EContainerRunTests.cpp - 5 new tests: success (asserts both endpoint.IPAddress and IPAMConfig->IPv4Address), no-network rejected, bridge-mode rejected, multiple-networks rejected, invalid IP rejecte
- WSLCE2EContainerCreateTests.cpp - same 5 tests mirrored, asserting IPAMConfig->IPv4Address only (container is created, not started, so endpoint.IPAddress is not populated)