### PR TITLE
Match docker's network list, inspect and prune output in wslc

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3538,9 +3538,8 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_NetworkPruneLongDesc" xml:space="preserve">
     <value>Removes all unused networks. A network is considered unused when it is not referenced by any container.</value>
   </data>
-  <data name="WSLCCLI_NetworkPruneDeleted" xml:space="preserve">
-    <value>Deleted: {}</value>
-    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  <data name="WSLCCLI_NetworkPruneDeletedHeader" xml:space="preserve">
+    <value>Deleted Networks:</value>
   </data>
   <data name="WSLCCLI_NetworkConnectDesc" xml:space="preserve">
     <value>Connect a container to a network.</value>

--- a/src/shared/inc/JsonUtils.h
+++ b/src/shared/inc/JsonUtils.h
@@ -203,26 +203,6 @@ struct adl_serializer<WSLCVolumeInformation>
         strncpy_s(volume.Driver, sizeof(volume.Driver), driver.c_str(), _TRUNCATE);
     }
 };
-
-template <>
-struct adl_serializer<WSLCNetworkInformation>
-{
-    static void to_json(json& j, const WSLCNetworkInformation& network)
-    {
-        j = json{{"Name", std::string(network.Name)}, {"ID", std::string(network.Id)}, {"Driver", std::string(network.Driver)}};
-    }
-
-    static void from_json(const json& j, WSLCNetworkInformation& network)
-    {
-        std::string name = j.at("Name").get<std::string>();
-        std::string id = j.at("ID").get<std::string>();
-        std::string driver = j.at("Driver").get<std::string>();
-
-        strncpy_s(network.Name, sizeof(network.Name), name.c_str(), _TRUNCATE);
-        strncpy_s(network.Id, sizeof(network.Id), id.c_str(), _TRUNCATE);
-        strncpy_s(network.Driver, sizeof(network.Driver), driver.c_str(), _TRUNCATE);
-    }
-};
 #endif
 
 } // namespace nlohmann

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -426,7 +426,17 @@ std::string wsl::windows::common::string::TruncateId(_In_ std::string_view id, b
     return TruncateIdImpl(id, shortenLength);
 }
 
-std::string wsl::windows::common::string::FormatDockerTimestamp(LONGLONG timestamp)
+std::uint64_t wsl::windows::common::string::Rfc3339ToEpoch(const std::string& timestamp)
+{
+    std::chrono::sys_seconds utcSeconds;
+    std::istringstream stream(timestamp);
+    stream >> std::chrono::parse("%FT%H:%M:%S%Z", utcSeconds);
+    THROW_HR_IF_MSG(E_INVALIDARG, stream.fail(), "Failed to parse timestamp '%hs'", timestamp.c_str());
+
+    return static_cast<std::uint64_t>(utcSeconds.time_since_epoch().count());
+}
+
+std::string wsl::windows::common::string::EpochToLocalDisplayTime(LONGLONG timestamp)
 {
     const auto time =
         std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::from_time_t(static_cast<std::time_t>(timestamp)));
@@ -444,7 +454,7 @@ std::string wsl::windows::common::string::FormatDockerTimestamp(LONGLONG timesta
     }
 }
 
-std::string wsl::windows::common::string::FormatDockerTimestamp(std::string_view timestamp)
+std::string wsl::windows::common::string::Rfc3339ToUtcDisplayTime(std::string_view timestamp)
 {
     if (timestamp.empty())
     {

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -16,6 +16,7 @@ Abstract:
 #include <charconv>
 #include <cmath>
 #include <limits>
+#include <sstream>
 
 std::vector<std::string> wsl::windows::common::string::InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize)
 {
@@ -441,4 +442,40 @@ std::string wsl::windows::common::string::FormatDockerTimestamp(LONGLONG timesta
         LOG_CAUGHT_EXCEPTION();
         return std::format("{:%F %T} +0000 UTC", time);
     }
+}
+
+std::string wsl::windows::common::string::FormatDockerTimestamp(std::string_view timestamp)
+{
+    if (timestamp.empty())
+    {
+        return {};
+    }
+
+    // The number of fractional digits varies per timestamp, so they are captured verbatim and
+    // re-inserted after formatting instead of being parsed.
+    std::string parsable{timestamp};
+    std::string fraction;
+    const auto separator = parsable.find('.');
+    if (separator != std::string::npos)
+    {
+        auto end = separator + 1;
+        while (end < parsable.size() && (std::isdigit(static_cast<unsigned char>(parsable[end])) != 0))
+        {
+            end++;
+        }
+
+        fraction = parsable.substr(separator, end - separator);
+        parsable.erase(separator, end - separator);
+    }
+
+    std::chrono::sys_seconds parsed{};
+    std::istringstream stream(parsable);
+    stream >> std::chrono::parse("%FT%H:%M:%S%Z", parsed);
+    if (stream.fail())
+    {
+        return std::string{timestamp};
+    }
+
+    // Docker reports network timestamps in UTC rather than converting them to the local time zone.
+    return std::format("{:%F %T}{} +0000 UTC", parsed, fraction);
 }

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -451,8 +451,7 @@ std::string wsl::windows::common::string::FormatDockerTimestamp(std::string_view
         return {};
     }
 
-    // The number of fractional digits varies per timestamp, so they are captured verbatim and
-    // re-inserted after formatting instead of being parsed.
+    // Fractional digits vary in length, so they are captured verbatim and re-inserted after formatting.
     std::string parsable{timestamp};
     std::string fraction;
     const auto separator = parsable.find('.');
@@ -476,6 +475,6 @@ std::string wsl::windows::common::string::FormatDockerTimestamp(std::string_view
         return std::string{timestamp};
     }
 
-    // Docker reports network timestamps in UTC rather than converting them to the local time zone.
+    // Network timestamps are reported in UTC rather than the local time zone.
     return std::format("{:%F %T}{} +0000 UTC", parsed, fraction);
 }

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -71,9 +71,8 @@ std::string TruncateId(_In_ std::string_view id, bool shortenLength = true);
 // to UTC when the time zone database is unavailable.
 std::string FormatDockerTimestamp(LONGLONG timestamp);
 
-// Formats an RFC 3339 timestamp reported by the docker API, e.g. "2026-03-05T10:30:00.123456789Z",
-// the way docker formats network timestamps: UTC, with the fractional seconds preserved exactly as
-// the daemon reported them. The input is returned unchanged when it cannot be parsed.
+// Formats an RFC 3339 timestamp, e.g. "2026-03-05T10:30:00.123456789Z", as UTC with its fractional
+// seconds preserved. The input is returned unchanged when it cannot be parsed.
 std::string FormatDockerTimestamp(std::string_view timestamp);
 
 // Template implementation for TruncateId to avoid code duplication.

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -71,6 +71,11 @@ std::string TruncateId(_In_ std::string_view id, bool shortenLength = true);
 // to UTC when the time zone database is unavailable.
 std::string FormatDockerTimestamp(LONGLONG timestamp);
 
+// Formats an RFC 3339 timestamp reported by the docker API, e.g. "2026-03-05T10:30:00.123456789Z",
+// the way docker formats network timestamps: UTC, with the fractional seconds preserved exactly as
+// the daemon reported them. The input is returned unchanged when it cannot be parsed.
+std::string FormatDockerTimestamp(std::string_view timestamp);
+
 // Template implementation for TruncateId to avoid code duplication.
 // Algorithm inspired from Moby for consistency in presentation of shortened IDs.
 // Always strips the algorithm prefix (e.g., "sha256:") if present, and optionally shortens to 12 characters.

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -67,13 +67,17 @@ std::string WideToMultiByte(_In_ std::wstring_view Source);
 std::wstring TruncateId(_In_ std::wstring_view id, bool shortenLength = true);
 std::string TruncateId(_In_ std::string_view id, bool shortenLength = true);
 
-// Formats a unix timestamp the way docker does, matching Go's time.Time.String() layout. Falls back
-// to UTC when the time zone database is unavailable.
-std::string FormatDockerTimestamp(LONGLONG timestamp);
+// Converts an RFC 3339 timestamp to seconds since the unix epoch. Only the 'Z' zone designator is
+// accepted; numeric offsets are not.
+std::uint64_t Rfc3339ToEpoch(const std::string& timestamp);
 
-// Formats an RFC 3339 timestamp, e.g. "2026-03-05T10:30:00.123456789Z", as UTC with its fractional
-// seconds preserved. The input is returned unchanged when it cannot be parsed.
-std::string FormatDockerTimestamp(std::string_view timestamp);
+// Renders seconds since the unix epoch in the local time zone, using the layout
+// "2006-01-02 15:04:05 -0700 MST". Falls back to UTC when the time zone database is unavailable.
+std::string EpochToLocalDisplayTime(LONGLONG timestamp);
+
+// Renders an RFC 3339 timestamp in the same layout, but as UTC and with its fractional seconds
+// preserved. The input is returned unchanged when it cannot be parsed.
+std::string Rfc3339ToUtcDisplayTime(std::string_view timestamp);
 
 // Template implementation for TruncateId to avoid code duplication.
 // Algorithm inspired from Moby for consistency in presentation of shortened IDs.

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -17,10 +17,38 @@ Abstract:
 #pragma once
 
 #include "JsonUtils.h"
+#include <chrono>
+#include <sstream>
 
 namespace wsl::windows::common::docker_schema {
 
 using wsl::shared::EmptyObject;
+
+// Reads a value from a docker response, treating both a missing key and an explicit null as absent.
+// Docker reports several empty maps and objects as null, which the default deserializer rejects.
+template <typename T>
+T ValueOrNull(const nlohmann::json& json, const char* key, T defaultValue = T{})
+{
+    const auto entry = json.find(key);
+    if (entry == json.end() || entry->is_null())
+    {
+        return defaultValue;
+    }
+
+    return entry->get<T>();
+}
+
+// Converts a docker UTC ISO 8601 timestamp, e.g. "2026-03-05T10:30:00.123456789Z", to seconds since
+// the unix epoch.
+inline std::uint64_t ParseTimestamp(const std::string& timestamp)
+{
+    std::chrono::sys_seconds utcSeconds;
+    std::istringstream stream(timestamp);
+    stream >> std::chrono::parse("%FT%H:%M:%S%Z", utcSeconds);
+    THROW_HR_IF_MSG(E_INVALIDARG, stream.fail(), "Failed to parse timestamp '%hs'", timestamp.c_str());
+
+    return static_cast<std::uint64_t>(utcSeconds.time_since_epoch().count());
+}
 
 struct CreatedContainer
 {
@@ -127,8 +155,37 @@ struct IPAM
 {
     std::string Driver;
     std::optional<std::vector<IPAMConfig>> Config;
+    std::map<std::string, std::string> Options;
+};
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAM, Driver, Config);
+inline void to_json(nlohmann::json& j, const IPAM& ipam)
+{
+    j = nlohmann::json{{"Driver", ipam.Driver}, {"Config", ipam.Config}, {"Options", ipam.Options}};
+}
+
+inline void from_json(const nlohmann::json& j, IPAM& ipam)
+{
+    ipam.Driver = ValueOrNull<std::string>(j, "Driver");
+    ipam.Config = ValueOrNull<std::optional<std::vector<IPAMConfig>>>(j, "Config");
+    ipam.Options = ValueOrNull<std::map<std::string, std::string>>(j, "Options");
+}
+
+struct NetworkConfigFrom
+{
+    std::string Network;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkConfigFrom, Network);
+};
+
+struct NetworkContainer
+{
+    std::string Name;
+    std::string EndpointID;
+    std::string MacAddress;
+    std::string IPv4Address;
+    std::string IPv6Address;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkContainer, Name, EndpointID, MacAddress, IPv4Address, IPv6Address);
 };
 
 struct CreateNetworkResponse
@@ -157,15 +214,45 @@ struct Network
 {
     std::string Id;
     std::string Name;
+    std::string Created;
     std::string Driver;
     std::string Scope;
+    bool EnableIPv4{true};
+    bool EnableIPv6{};
     bool Internal{};
+    bool Attachable{};
+    bool Ingress{};
+    bool ConfigOnly{};
+    NetworkConfigFrom ConfigFrom;
     IPAM IPAM;
-    std::optional<std::map<std::string, std::string>> Options;
+    std::map<std::string, std::string> Options;
     std::map<std::string, std::string> Labels;
-
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Network, Id, Name, Driver, Scope, Internal, IPAM, Options, Labels);
+    std::map<std::string, NetworkContainer> Containers;
+    nlohmann::json Status = nlohmann::json::object();
 };
+
+inline void from_json(const nlohmann::json& j, Network& network)
+{
+    const Network defaults{};
+
+    network.Id = ValueOrNull<std::string>(j, "Id");
+    network.Name = ValueOrNull<std::string>(j, "Name");
+    network.Created = ValueOrNull<std::string>(j, "Created");
+    network.Driver = ValueOrNull<std::string>(j, "Driver");
+    network.Scope = ValueOrNull<std::string>(j, "Scope");
+    network.EnableIPv4 = ValueOrNull<bool>(j, "EnableIPv4", defaults.EnableIPv4);
+    network.EnableIPv6 = ValueOrNull<bool>(j, "EnableIPv6");
+    network.Internal = ValueOrNull<bool>(j, "Internal");
+    network.Attachable = ValueOrNull<bool>(j, "Attachable");
+    network.Ingress = ValueOrNull<bool>(j, "Ingress");
+    network.ConfigOnly = ValueOrNull<bool>(j, "ConfigOnly");
+    network.ConfigFrom = ValueOrNull<NetworkConfigFrom>(j, "ConfigFrom");
+    network.IPAM = ValueOrNull<docker_schema::IPAM>(j, "IPAM");
+    network.Options = ValueOrNull<std::map<std::string, std::string>>(j, "Options");
+    network.Labels = ValueOrNull<std::map<std::string, std::string>>(j, "Labels");
+    network.Containers = ValueOrNull<std::map<std::string, NetworkContainer>>(j, "Containers");
+    network.Status = ValueOrNull<nlohmann::json>(j, "Status", defaults.Status);
+}
 
 struct EndpointIPAMConfig
 {

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -24,8 +24,8 @@ namespace wsl::windows::common::docker_schema {
 
 using wsl::shared::EmptyObject;
 
-// Reads a value from a docker response, treating both a missing key and an explicit null as absent.
-// Docker reports several empty maps and objects as null, which the default deserializer rejects.
+// Reads a value, treating both a missing key and an explicit null as absent. The daemon reports some
+// empty maps and objects as null, which the default deserializer rejects.
 template <typename T>
 T ValueOrNull(const nlohmann::json& json, const char* key, T defaultValue = T{})
 {
@@ -38,8 +38,7 @@ T ValueOrNull(const nlohmann::json& json, const char* key, T defaultValue = T{})
     return entry->get<T>();
 }
 
-// Converts a docker UTC ISO 8601 timestamp, e.g. "2026-03-05T10:30:00.123456789Z", to seconds since
-// the unix epoch.
+// Converts a UTC ISO 8601 timestamp, e.g. "2026-03-05T10:30:00.123456789Z", to seconds since the unix epoch.
 inline std::uint64_t ParseTimestamp(const std::string& timestamp)
 {
     std::chrono::sys_seconds utcSeconds;

--- a/src/windows/inc/docker_schema.h
+++ b/src/windows/inc/docker_schema.h
@@ -17,8 +17,6 @@ Abstract:
 #pragma once
 
 #include "JsonUtils.h"
-#include <chrono>
-#include <sstream>
 
 namespace wsl::windows::common::docker_schema {
 
@@ -36,17 +34,6 @@ T ValueOrNull(const nlohmann::json& json, const char* key, T defaultValue = T{})
     }
 
     return entry->get<T>();
-}
-
-// Converts a UTC ISO 8601 timestamp, e.g. "2026-03-05T10:30:00.123456789Z", to seconds since the unix epoch.
-inline std::uint64_t ParseTimestamp(const std::string& timestamp)
-{
-    std::chrono::sys_seconds utcSeconds;
-    std::istringstream stream(timestamp);
-    stream >> std::chrono::parse("%FT%H:%M:%S%Z", utcSeconds);
-    THROW_HR_IF_MSG(E_INVALIDARG, stream.fail(), "Failed to parse timestamp '%hs'", timestamp.c_str());
-
-    return static_cast<std::uint64_t>(utcSeconds.time_since_epoch().count());
 }
 
 struct CreatedContainer

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -223,8 +223,7 @@ struct IPAMConfig
     std::string IPRange;
 };
 
-// Docker omits the gateway and ip range when they were never configured, so they are only emitted
-// when set rather than as empty strings.
+// The gateway and ip range are omitted when unset rather than emitted as empty strings.
 inline void to_json(nlohmann::json& j, const IPAMConfig& config)
 {
     j = nlohmann::json::object();
@@ -295,7 +294,7 @@ struct Network
 };
 
 // The network properties carried from the session to the CLI for "network list". Values keep their
-// native types; the CLI turns them into docker's all-string list output.
+// native types; the CLI renders the string output.
 struct NetworkListEntry
 {
     std::string Id;

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -221,30 +221,94 @@ struct IPAMConfig
     std::string Subnet;
     std::string Gateway;
     std::string IPRange;
-
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAMConfig, Subnet, Gateway, IPRange);
 };
+
+// Docker omits the gateway and ip range when they were never configured, so they are only emitted
+// when set rather than as empty strings.
+inline void to_json(nlohmann::json& j, const IPAMConfig& config)
+{
+    j = nlohmann::json::object();
+    j["Subnet"] = config.Subnet;
+
+    if (!config.Gateway.empty())
+    {
+        j["Gateway"] = config.Gateway;
+    }
+
+    if (!config.IPRange.empty())
+    {
+        j["IPRange"] = config.IPRange;
+    }
+}
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT_FROM_ONLY(IPAMConfig, Subnet, Gateway, IPRange);
 
 struct IPAM
 {
     std::string Driver;
     std::optional<std::vector<IPAMConfig>> Config;
+    std::map<std::string, std::string> Options;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAM, Driver, Config);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(IPAM, Driver, Config, Options);
+};
+
+struct NetworkConfigFrom
+{
+    std::string Network;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkConfigFrom, Network);
+};
+
+struct NetworkContainer
+{
+    std::string Name;
+    std::string EndpointID;
+    std::string MacAddress;
+    std::string IPv4Address;
+    std::string IPv6Address;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkContainer, Name, EndpointID, MacAddress, IPv4Address, IPv6Address);
 };
 
 struct Network
 {
     std::string Id;
     std::string Name;
+    std::string Created;
     std::string Driver;
     std::string Scope;
+    bool EnableIPv4{true};
+    bool EnableIPv6{};
     bool Internal{};
+    bool Attachable{};
+    bool Ingress{};
+    bool ConfigOnly{};
+    NetworkConfigFrom ConfigFrom;
     IPAM IPAM;
-    std::optional<std::map<std::string, std::string>> Options;
+    std::map<std::string, std::string> Options;
+    std::map<std::string, std::string> Labels;
+    std::map<std::string, NetworkContainer> Containers;
+    nlohmann::json Status = nlohmann::json::object();
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(
+        Network, Id, Name, Created, Driver, Scope, EnableIPv4, EnableIPv6, Internal, Attachable, Ingress, ConfigOnly, ConfigFrom, IPAM, Options, Labels, Containers, Status);
+};
+
+// The network properties carried from the session to the CLI for "network list". Values keep their
+// native types; the CLI turns them into docker's all-string list output.
+struct NetworkListEntry
+{
+    std::string Id;
+    std::string Name;
+    std::string Driver;
+    std::string Scope;
+    std::string Created;
+    bool EnableIPv4{true};
+    bool EnableIPv6{};
+    bool Internal{};
     std::map<std::string, std::string> Labels;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Network, Id, Name, Driver, Scope, Internal, IPAM, Options, Labels);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkListEntry, Id, Name, Driver, Scope, Created, EnableIPv4, EnableIPv6, Internal, Labels);
 };
 
 } // namespace wsl::windows::common::wslc_schema

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -648,13 +648,6 @@ typedef struct _WSLCNetworkOptions
 
 typedef char WSLCNetworkName[WSLC_MAX_NETWORK_NAME_LENGTH + 1];
 
-typedef struct _WSLCNetworkInformation
-{
-    char Name[WSLC_MAX_NETWORK_NAME_LENGTH + 1];
-    char Id[WSLC_CONTAINER_ID_LENGTH + 1];
-    char Driver[64];
-} WSLCNetworkInformation;
-
 typedef struct _WSLCPruneContainersResults
 {
     [unique, size_is(ContainersCount)] WSLCContainerId* Containers;
@@ -775,7 +768,8 @@ interface IWSLCSession : IUnknown
     // Network management.
     HRESULT CreateNetwork([in] const WSLCNetworkOptions* Options, [in, unique] IWarningCallback* WarningCallback);
     HRESULT DeleteNetwork([in] LPCSTR Name);
-    HRESULT ListNetworks([in, unique, size_is(FiltersCount)] const WSLCFilter* Filters, [in] ULONG FiltersCount, [out, size_is(, *Count)] WSLCNetworkInformation** Networks, [out] ULONG* Count);
+    // Returns a JSON array of the session's networks, matching the shape docker's network list reports.
+    HRESULT ListNetworks([in, unique, size_is(FiltersCount)] const WSLCFilter* Filters, [in] ULONG FiltersCount, [out] LPSTR* Output);
     HRESULT InspectNetwork([in] LPCSTR Name, [out] LPSTR* Output);
     HRESULT PruneNetworks([in, unique, size_is(FiltersCount)] const WSLCFilter* Filters, [in] ULONG FiltersCount, [out, size_is(, *NetworksCount)] WSLCNetworkName** Networks, [out] ULONG* NetworksCount);
 

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -768,7 +768,7 @@ interface IWSLCSession : IUnknown
     // Network management.
     HRESULT CreateNetwork([in] const WSLCNetworkOptions* Options, [in, unique] IWarningCallback* WarningCallback);
     HRESULT DeleteNetwork([in] LPCSTR Name);
-    // Returns a JSON array of the session's networks, matching the shape docker's network list reports.
+    // Returns a JSON array of wslc_schema::NetworkListEntry objects describing the session's networks.
     HRESULT ListNetworks([in, unique, size_is(FiltersCount)] const WSLCFilter* Filters, [in] ULONG FiltersCount, [out] LPSTR* Output);
     HRESULT InspectNetwork([in] LPCSTR Name, [out] LPSTR* Output);
     HRESULT PruneNetworks([in, unique, size_is(FiltersCount)] const WSLCFilter* Filters, [in] ULONG FiltersCount, [out, size_is(, *NetworksCount)] WSLCNetworkName** Networks, [out] ULONG* NetworksCount);

--- a/src/windows/wslc/core/ExecutionContextData.h
+++ b/src/windows/wslc/core/ExecutionContextData.h
@@ -18,6 +18,7 @@ Abstract:
 #include "NetworkModel.h"
 #include "SessionModel.h"
 #include "wslc.h"
+#include <wslc_schema.h>
 
 #include <string>
 
@@ -56,7 +57,7 @@ namespace details {
     DEFINE_DATA_MAPPING(ContainerOptions, wsl::windows::wslc::models::ContainerOptions);
     DEFINE_DATA_MAPPING(Images, std::vector<wsl::windows::wslc::models::ImageInformation>);
     DEFINE_DATA_MAPPING(Volumes, std::vector<WSLCVolumeInformation>);
-    DEFINE_DATA_MAPPING(Networks, std::vector<WSLCNetworkInformation>);
+    DEFINE_DATA_MAPPING(Networks, std::vector<wsl::windows::common::wslc_schema::NetworkListEntry>);
     DEFINE_DATA_MAPPING(NetworkEndpointOptions, wsl::windows::wslc::models::NetworkEndpointOptions);
 } // namespace details
 

--- a/src/windows/wslc/services/NetworkModel.h
+++ b/src/windows/wslc/services/NetworkModel.h
@@ -56,4 +56,21 @@ struct PruneNetworksResult
     std::vector<std::string> PrunedNetworks;
 };
 
+// The shape emitted by "network list --format json". Every value is reported as a string, so this is
+// kept separate from the schema type, which mirrors the service's native types.
+struct NetworkOutputInformation
+{
+    std::string CreatedAt;
+    std::string Driver;
+    std::string ID;
+    std::string IPv4;
+    std::string IPv6;
+    std::string Internal;
+    std::string Labels;
+    std::string Name;
+    std::string Scope;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkOutputInformation, CreatedAt, Driver, ID, IPv4, IPv6, Internal, Labels, Name, Scope);
+};
+
 } // namespace wsl::windows::wslc::models

--- a/src/windows/wslc/services/NetworkModel.h
+++ b/src/windows/wslc/services/NetworkModel.h
@@ -56,8 +56,7 @@ struct PruneNetworksResult
     std::vector<std::string> PrunedNetworks;
 };
 
-// The shape emitted by "network list --format json". Every value is reported as a string, so this is
-// kept separate from the schema type, which mirrors the service's native types.
+// The shape emitted by "network list --format json"; every value is reported as a string.
 struct NetworkOutputInformation
 {
     std::string CreatedAt;

--- a/src/windows/wslc/services/NetworkService.cpp
+++ b/src/windows/wslc/services/NetworkService.cpp
@@ -75,7 +75,8 @@ void NetworkService::Delete(models::Session& session, const std::string& name)
     THROW_IF_FAILED(session.Get()->DeleteNetwork(name.c_str()));
 }
 
-std::vector<WSLCNetworkInformation> NetworkService::List(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
+std::vector<wsl::windows::common::wslc_schema::NetworkListEntry> NetworkService::List(
+    models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
 {
     std::vector<WSLCFilter> filterEntries;
     filterEntries.reserve(filters.size());
@@ -84,19 +85,11 @@ std::vector<WSLCNetworkInformation> NetworkService::List(models::Session& sessio
         filterEntries.push_back({.Key = key.c_str(), .Value = value.c_str()});
     }
 
-    wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> rawNetworks;
-    ULONG count = 0;
+    wil::unique_cotaskmem_ansistring output;
     THROW_IF_FAILED(session.Get()->ListNetworks(
-        filterEntries.empty() ? nullptr : filterEntries.data(), static_cast<ULONG>(filterEntries.size()), &rawNetworks, &count));
+        filterEntries.empty() ? nullptr : filterEntries.data(), static_cast<ULONG>(filterEntries.size()), &output));
 
-    std::vector<WSLCNetworkInformation> networks;
-    networks.reserve(count);
-    for (auto ptr = rawNetworks.get(), end = rawNetworks.get() + count; ptr != end; ++ptr)
-    {
-        networks.push_back(*ptr);
-    }
-
-    return networks;
+    return FromJson<std::vector<wsl::windows::common::wslc_schema::NetworkListEntry>>(output.get());
 }
 
 wsl::windows::common::wslc_schema::Network NetworkService::Inspect(models::Session& session, const std::string& name)

--- a/src/windows/wslc/services/NetworkService.h
+++ b/src/windows/wslc/services/NetworkService.h
@@ -24,7 +24,8 @@ struct NetworkService
 {
     static void Create(Terminal& terminal, models::Session& session, const models::CreateNetworkOptions& createOptions);
     static void Delete(models::Session& session, const std::string& name);
-    static std::vector<WSLCNetworkInformation> List(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
+    static std::vector<wsl::windows::common::wslc_schema::NetworkListEntry> List(
+        models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
     static wsl::windows::common::wslc_schema::Network Inspect(models::Session& session, const std::string& name);
     static models::PruneNetworksResult Prune(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
     static void Connect(models::Session& session, const models::ConnectNetworkOptions& connectOptions);

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -82,7 +82,7 @@ namespace {
         ImageOutputInformation entry;
         entry.Containers = image.Containers < 0 ? std::string{c_notAvailable} : std::to_string(image.Containers);
 
-        entry.CreatedAt = FormatDockerTimestamp(image.Created);
+        entry.CreatedAt = EpochToLocalDisplayTime(image.Created);
         entry.CreatedSince =
             WideToMultiByte(ContainerService::FormatRelativeTime(image.Created > 0 ? static_cast<ULONGLONG>(image.Created) : 0));
         entry.Digest = c_none;

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -36,7 +36,7 @@ namespace {
     NetworkOutputInformation ToNetworkOutput(const wslc_schema::NetworkListEntry& network, bool truncate)
     {
         NetworkOutputInformation entry;
-        entry.CreatedAt = FormatDockerTimestamp(network.Created);
+        entry.CreatedAt = Rfc3339ToUtcDisplayTime(network.Created);
         entry.Driver = network.Driver;
         entry.ID = TruncateId(network.Id, truncate);
         entry.IPv4 = network.EnableIPv4 ? "true" : "false";

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -30,6 +30,37 @@ using namespace wsl::windows::wslc::services;
 
 namespace wsl::windows::wslc::task {
 
+namespace {
+
+    // Builds the representation of a network, shared by the table and json output so the two cannot
+    // drift. Every value is emitted as a string and the id is truncated unless --no-trunc is passed.
+    NetworkOutputInformation ToNetworkOutput(const wslc_schema::NetworkListEntry& network, bool truncate)
+    {
+        NetworkOutputInformation entry;
+        entry.CreatedAt = FormatDockerTimestamp(network.Created);
+        entry.Driver = network.Driver;
+        entry.ID = TruncateId(network.Id, truncate);
+        entry.IPv4 = network.EnableIPv4 ? "true" : "false";
+        entry.IPv6 = network.EnableIPv6 ? "true" : "false";
+        entry.Internal = network.Internal ? "true" : "false";
+        entry.Name = network.Name;
+        entry.Scope = network.Scope;
+
+        for (const auto& [key, value] : network.Labels)
+        {
+            if (!entry.Labels.empty())
+            {
+                entry.Labels += ",";
+            }
+
+            entry.Labels += value.empty() ? key : std::format("{}={}", key, value);
+        }
+
+        return entry;
+    }
+
+} // namespace
+
 static bool TryInspectNetwork(Terminal& terminal, Session& session, const std::string& networkName, std::optional<wslc_schema::Network>& inspectData)
 {
     try
@@ -172,6 +203,9 @@ void ListNetworks(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Networks));
     auto& networks = context.Data.Get<Data::Networks>();
 
+    // Docker reports networks in name order regardless of how the daemon returns them.
+    std::ranges::sort(networks, {}, &wslc_schema::NetworkListEntry::Name);
+
     const auto format = context.Args.GetValue<ArgType::Format>(FormatType::Table);
     const bool quiet = context.Args.GetValue<ArgType::Quiet>();
     const bool trunc = !context.Args.GetValue<ArgType::NoTrunc>();
@@ -191,22 +225,31 @@ void ListNetworks(CLIExecutionContext& context)
     {
         for (const auto& network : networks)
         {
-            auto json = nlohmann::json(network);
-            json["ID"] = TruncateId(network.Id, trunc);
-            context.Terminal.Output(L"{}\n", ToJsonW(json, c_jsonCompactIndent));
+            context.Terminal.Output(L"{}\n", ToJsonW(ToNetworkOutput(network, trunc), c_jsonCompactIndent));
         }
 
         break;
     }
     case FormatType::Table:
     {
-        auto table = wsl::windows::wslc::TableOutput<3>(context.Terminal, {L"NETWORK ID", L"NAME", L"DRIVER"});
+        // Docker's table writer gives every column a minimum total width of ten characters,
+        // including the padding that follows it.
+        constexpr size_t c_dockerMinimumColumnWidth = 7;
+        auto table = wsl::windows::wslc::TableOutput<4>(
+            context.Terminal,
+            {L"NETWORK ID", L"NAME", L"DRIVER", L"SCOPE"},
+            {ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth},
+             ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth},
+             ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth},
+             ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth}});
         for (const auto& network : networks)
         {
+            const auto entry = ToNetworkOutput(network, trunc);
             table.WriteRow({
-                MultiByteToWide(TruncateId(network.Id, trunc)),
-                MultiByteToWide(network.Name),
-                MultiByteToWide(network.Driver),
+                MultiByteToWide(entry.ID),
+                MultiByteToWide(entry.Name),
+                MultiByteToWide(entry.Driver),
+                MultiByteToWide(entry.Scope),
             });
         }
 
@@ -228,10 +271,18 @@ void PruneNetworks(CLIExecutionContext& context)
 
     auto result = NetworkService::Prune(session, filters);
 
+    if (result.PrunedNetworks.empty())
+    {
+        return;
+    }
+
+    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_NetworkPruneDeletedHeader());
     for (const auto& networkName : result.PrunedNetworks)
     {
-        context.Terminal.Output(L"{}\n", Localization::WSLCCLI_NetworkPruneDeleted(MultiByteToWide(networkName)));
+        context.Terminal.Output(L"{}\n", MultiByteToWide(networkName));
     }
+
+    context.Terminal.Output(L"\n");
 }
 
 void ConnectNetwork(CLIExecutionContext& context)

--- a/src/windows/wslc/tasks/NetworkTasks.cpp
+++ b/src/windows/wslc/tasks/NetworkTasks.cpp
@@ -32,8 +32,7 @@ namespace wsl::windows::wslc::task {
 
 namespace {
 
-    // Builds the representation of a network, shared by the table and json output so the two cannot
-    // drift. Every value is emitted as a string and the id is truncated unless --no-trunc is passed.
+    // Shared by the table and json output so the two cannot drift. The id is truncated unless --no-trunc is passed.
     NetworkOutputInformation ToNetworkOutput(const wslc_schema::NetworkListEntry& network, bool truncate)
     {
         NetworkOutputInformation entry;
@@ -203,7 +202,7 @@ void ListNetworks(CLIExecutionContext& context)
     WI_ASSERT(context.Data.Contains(Data::Networks));
     auto& networks = context.Data.Get<Data::Networks>();
 
-    // Docker reports networks in name order regardless of how the daemon returns them.
+    // Networks are reported in name order regardless of how the daemon returns them.
     std::ranges::sort(networks, {}, &wslc_schema::NetworkListEntry::Name);
 
     const auto format = context.Args.GetValue<ArgType::Format>(FormatType::Table);
@@ -232,16 +231,15 @@ void ListNetworks(CLIExecutionContext& context)
     }
     case FormatType::Table:
     {
-        // Docker's table writer gives every column a minimum total width of ten characters,
-        // including the padding that follows it.
-        constexpr size_t c_dockerMinimumColumnWidth = 7;
+        // Every column has a minimum total width of ten characters, including the padding that follows it.
+        constexpr size_t c_minimumColumnWidth = 7;
         auto table = wsl::windows::wslc::TableOutput<4>(
             context.Terminal,
             {L"NETWORK ID", L"NAME", L"DRIVER", L"SCOPE"},
-            {ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth},
-             ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth},
-             ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth},
-             ColumnWidthConfig{.MinWidth = c_dockerMinimumColumnWidth}});
+            {ColumnWidthConfig{.MinWidth = c_minimumColumnWidth},
+             ColumnWidthConfig{.MinWidth = c_minimumColumnWidth},
+             ColumnWidthConfig{.MinWidth = c_minimumColumnWidth},
+             ColumnWidthConfig{.MinWidth = c_minimumColumnWidth}});
         for (const auto& network : networks)
         {
             const auto entry = ToNetworkOutput(network, trunc);

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -488,17 +488,6 @@ WSLCContainerState DockerStateToWSLCState(ContainerState state)
     }
 }
 
-std::uint64_t ParseDockerTimestamp(const std::string& timestamp)
-{
-    // Docker timestamps are UTC ISO 8601, e.g. "2026-03-05T10:30:00.123456789Z".
-    std::chrono::sys_seconds utcSeconds;
-    std::istringstream stream(timestamp);
-    stream >> std::chrono::parse("%FT%H:%M:%S%Z", utcSeconds);
-    THROW_HR_IF_MSG(E_INVALIDARG, stream.fail(), "Failed to parse timestamp '%hs'", timestamp.c_str());
-
-    return static_cast<std::uint64_t>(utcSeconds.time_since_epoch().count());
-}
-
 std::string CleanContainerName(const std::string& name)
 {
     // Docker container names have a leading '/', strip it.
@@ -2432,7 +2421,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         std::move(mergedLabels),
         std::move(OnDeleted),
         WslcContainerStateCreated,
-        ParseDockerTimestamp(inspectData.Created),
+        ParseTimestamp(inspectData.Created),
         containerOptions.InitProcessOptions.Flags,
         containerOptions.Flags);
 
@@ -2544,7 +2533,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
 
             if (!timestamp.empty())
             {
-                container->m_stateChangedAt = ParseDockerTimestamp(timestamp);
+                container->m_stateChangedAt = ParseTimestamp(timestamp);
             }
         }
     }

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -2421,7 +2421,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
         std::move(mergedLabels),
         std::move(OnDeleted),
         WslcContainerStateCreated,
-        ParseTimestamp(inspectData.Created),
+        wsl::windows::common::string::Rfc3339ToEpoch(inspectData.Created),
         containerOptions.InitProcessOptions.Flags,
         containerOptions.Flags);
 
@@ -2533,7 +2533,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Open(
 
             if (!timestamp.empty())
             {
-                container->m_stateChangedAt = ParseTimestamp(timestamp);
+                container->m_stateChangedAt = wsl::windows::common::string::Rfc3339ToEpoch(timestamp);
             }
         }
     }

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2983,10 +2983,7 @@ try
     entry.Scope = full.Scope;
     entry.Internal = full.Internal;
     entry.Labels = full.Labels;
-    if (full.Options)
-    {
-        entry.Options = *full.Options;
-    }
+    entry.Options = full.Options;
     entry.IPAM.Driver = full.IPAM.Driver;
     if (full.IPAM.Config)
     {
@@ -3046,63 +3043,49 @@ try
 }
 CATCH_RETURN();
 
-HRESULT WSLCSession::ListNetworks(const WSLCFilter* Filters, ULONG FiltersCount, WSLCNetworkInformation** Networks, ULONG* Count)
+HRESULT WSLCSession::ListNetworks(const WSLCFilter* Filters, ULONG FiltersCount, LPSTR* Output)
 try
 {
     WSLCExecutionContext context(this);
 
-    RETURN_HR_IF_NULL(E_POINTER, Networks);
-    RETURN_HR_IF_NULL(E_POINTER, Count);
+    RETURN_HR_IF_NULL(E_POINTER, Output);
 
-    *Networks = nullptr;
-    *Count = 0;
+    *Output = nullptr;
 
     auto filters = wsl::windows::common::wslutil::ParseKeyMultiValuePairs(Filters, FiltersCount);
-    const bool filtered = !filters.empty();
-
-    if (filtered)
-    {
-        // Scope the filtered query to WSLC-managed networks.
-        filters["label"].push_back(WSLCNetworkManagedLabel);
-    }
 
     auto lock = AcquireLease();
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_runtime.HasDocker());
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_runtime.HasVm());
 
     std::vector<docker_schema::Network> dockerNetworks;
-    if (filtered)
+    try
     {
-        try
-        {
-            dockerNetworks = m_runtime.Docker().ListNetworks(filters);
-        }
-        CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to list networks");
+        dockerNetworks = m_runtime.Docker().ListNetworks(filters);
+    }
+    CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to list networks");
+
+    std::vector<wslc_schema::NetworkListEntry> networks;
+    networks.reserve(dockerNetworks.size());
+    for (const auto& network : dockerNetworks)
+    {
+        wslc_schema::NetworkListEntry entry;
+        entry.Id = network.Id;
+        entry.Name = network.Name;
+        entry.Driver = network.Driver;
+        entry.Scope = network.Scope;
+        entry.Created = network.Created;
+        entry.EnableIPv4 = network.EnableIPv4;
+        entry.EnableIPv6 = network.EnableIPv6;
+        entry.Internal = network.Internal;
+        entry.Labels = network.Labels;
+        entry.Labels.erase(WSLCNetworkManagedLabel);
+
+        networks.push_back(std::move(entry));
     }
 
-    std::lock_guard networksLock(m_networksLock);
-
-    auto output = wil::make_unique_cotaskmem<WSLCNetworkInformation[]>(m_networks.size());
-
-    ULONG index = 0;
-    for (const auto& [name, entry] : m_networks)
-    {
-        if (filtered && std::ranges::find_if(dockerNetworks, [&](const auto& n) { return n.Name == name; }) == dockerNetworks.end())
-        {
-            continue;
-        }
-
-        THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Name, name.c_str()) != 0);
-        THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Id, entry.Id.c_str()) != 0);
-        THROW_HR_IF(E_UNEXPECTED, strcpy_s(output[index].Driver, entry.Driver.c_str()) != 0);
-        index++;
-    }
-
-    if (index == 0)
-    {
-        return S_OK;
-    }
-
-    *Networks = output.release();
-    *Count = index;
+    std::string json = wsl::shared::ToJson(networks);
+    *Output = wil::make_unique_ansistring<wil::unique_cotaskmem_ansistring>(json.c_str()).release();
 
     return S_OK;
 }
@@ -3122,30 +3105,44 @@ try
     ValidateName(name.c_str(), WSLC_MAX_NETWORK_NAME_LENGTH);
 
     auto lock = AcquireLease();
-    std::lock_guard networksLock(m_networksLock);
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_runtime.HasDocker());
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_runtime.HasVm());
 
-    auto it = m_networks.find(name);
-    THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), it == m_networks.end());
-
-    const auto& entry = it->second;
-
-    wslc_schema::Network result;
-    result.Id = entry.Id;
-    result.Name = name;
-    result.Driver = entry.Driver;
-    result.Scope = entry.Scope;
-    result.Internal = entry.Internal;
-    result.Labels = entry.Labels;
-    if (!entry.Options.empty())
+    docker_schema::Network network;
+    try
     {
-        result.Options = entry.Options;
+        network = m_runtime.Docker().InspectNetwork(name);
+    }
+    catch (const DockerHTTPException& e)
+    {
+        THROW_HR_WITH_USER_ERROR_IF(WSLC_E_NETWORK_NOT_FOUND, Localization::MessageWslcNetworkNotFound(name), e.StatusCode() == 404);
+        THROW_DOCKER_USER_ERROR_MSG(e, "Failed to inspect network '%hs'", name.c_str());
     }
 
-    result.IPAM.Driver = entry.IPAM.Driver;
-    if (entry.IPAM.Config)
+    wslc_schema::Network result;
+    result.Id = network.Id;
+    result.Name = network.Name;
+    result.Created = network.Created;
+    result.Driver = network.Driver;
+    result.Scope = network.Scope;
+    result.EnableIPv4 = network.EnableIPv4;
+    result.EnableIPv6 = network.EnableIPv6;
+    result.Internal = network.Internal;
+    result.Attachable = network.Attachable;
+    result.Ingress = network.Ingress;
+    result.ConfigOnly = network.ConfigOnly;
+    result.ConfigFrom.Network = network.ConfigFrom.Network;
+    result.Options = network.Options;
+    result.Labels = network.Labels;
+    result.Labels.erase(WSLCNetworkManagedLabel);
+    result.Status = network.Status;
+
+    result.IPAM.Driver = network.IPAM.Driver;
+    result.IPAM.Options = network.IPAM.Options;
+    if (network.IPAM.Config)
     {
         auto& configs = result.IPAM.Config.emplace();
-        for (const auto& cfg : *entry.IPAM.Config)
+        for (const auto& cfg : *network.IPAM.Config)
         {
             wslc_schema::IPAMConfig inspectCfg;
             inspectCfg.Subnet = cfg.Subnet;
@@ -3153,6 +3150,17 @@ try
             inspectCfg.IPRange = cfg.IPRange;
             configs.push_back(std::move(inspectCfg));
         }
+    }
+
+    for (const auto& [id, container] : network.Containers)
+    {
+        wslc_schema::NetworkContainer inspectContainer;
+        inspectContainer.Name = container.Name;
+        inspectContainer.EndpointID = container.EndpointID;
+        inspectContainer.MacAddress = container.MacAddress;
+        inspectContainer.IPv4Address = container.IPv4Address;
+        inspectContainer.IPv6Address = container.IPv6Address;
+        result.Containers.emplace(id, std::move(inspectContainer));
     }
 
     std::string json = wsl::shared::ToJson(result);
@@ -3931,10 +3939,7 @@ void WSLCSession::RecoverExistingNetworks()
             entry.Scope = network.Scope;
             entry.Internal = network.Internal;
             entry.Labels = network.Labels;
-            if (network.Options)
-            {
-                entry.Options = *network.Options;
-            }
+            entry.Options = network.Options;
             entry.IPAM.Driver = network.IPAM.Driver;
             if (network.IPAM.Config)
             {

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -195,8 +195,7 @@ public:
     IFACEMETHOD(CreateNetwork)(_In_ const WSLCNetworkOptions* Options, _In_opt_ IWarningCallback* WarningCallback) override;
     IFACEMETHOD(DeleteNetwork)(_In_ LPCSTR Name) override;
     IFACEMETHOD(ListNetworks)
-    (_In_reads_opt_(FiltersCount) const WSLCFilter* Filters, _In_ ULONG FiltersCount, _Out_ WSLCNetworkInformation** Networks, _Out_ ULONG* Count)
-        override;
+    (_In_reads_opt_(FiltersCount) const WSLCFilter* Filters, _In_ ULONG FiltersCount, _Out_ LPSTR* Output) override;
     IFACEMETHOD(InspectNetwork)(_In_ LPCSTR Name, _Out_ LPSTR* Output) override;
     IFACEMETHOD(PruneNetworks)
     (_In_reads_opt_(FiltersCount) const WSLCFilter* Filters, _In_ ULONG FiltersCount, _Out_ WSLCNetworkName** Networks, _Out_ ULONG* NetworksCount)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5422,7 +5422,7 @@ class WSLCTests
 
         LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
 
-        // The network must not exist yet. Docker's predefined networks are always listed.
+        // The network must not exist yet. The predefined networks are always listed.
         VERIFY_IS_FALSE(NetworkIsListed(networkName));
 
         WSLCNetworkOptions options{};

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5422,10 +5422,8 @@ class WSLCTests
 
         LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str()));
 
-        // List should start empty.
-        wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(0u, networks.size());
+        // The network must not exist yet. Docker's predefined networks are always listed.
+        VERIFY_IS_FALSE(NetworkIsListed(networkName));
 
         WSLCNetworkOptions options{};
         options.Name = networkName.c_str();
@@ -5437,11 +5435,16 @@ class WSLCTests
         auto cleanup = wil::scope_exit([&]() { LOG_IF_FAILED(m_defaultSession->DeleteNetwork(networkName.c_str())); });
 
         // Verify it appears in the list with correct fields.
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(1u, networks.size());
-        VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
-        VERIFY_ARE_EQUAL(std::string("bridge"), std::string(networks[0].Driver));
-        VERIFY_IS_TRUE(strlen(networks[0].Id) > 0);
+        auto networks = ListNetworks();
+        const auto created = std::ranges::find_if(networks, [&](const auto& network) { return network.Name == networkName; });
+        VERIFY_ARE_NOT_EQUAL(networks.end(), created);
+        VERIFY_ARE_EQUAL(std::string("bridge"), created->Driver);
+        VERIFY_ARE_EQUAL(std::string("local"), created->Scope);
+        VERIFY_IS_FALSE(created->Id.empty());
+        VERIFY_IS_FALSE(created->Created.empty());
+
+        // The label used to track wslc managed networks is an implementation detail and must not surface.
+        VERIFY_IS_FALSE(created->Labels.contains("com.microsoft.wsl.network.managed"));
 
         // Duplicate name should fail.
         VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS), m_defaultSession->CreateNetwork(&options, nullptr));
@@ -5449,12 +5452,24 @@ class WSLCTests
         cleanup.release();
         VERIFY_SUCCEEDED(m_defaultSession->DeleteNetwork(networkName.c_str()));
 
-        // List should be empty again.
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(0u, networks.size());
+        VERIFY_IS_FALSE(NetworkIsListed(networkName));
 
         // Delete non-existent should fail.
         VERIFY_ARE_EQUAL(WSLC_E_NETWORK_NOT_FOUND, m_defaultSession->DeleteNetwork(networkName.c_str()));
+    }
+
+    std::vector<wsl::windows::common::wslc_schema::NetworkListEntry> ListNetworks(const std::vector<WSLCFilter>& Filters = {})
+    {
+        wil::unique_cotaskmem_ansistring output;
+        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(Filters.empty() ? nullptr : Filters.data(), static_cast<ULONG>(Filters.size()), &output));
+
+        return wsl::shared::FromJson<std::vector<wsl::windows::common::wslc_schema::NetworkListEntry>>(output.get());
+    }
+
+    bool NetworkIsListed(const std::string& Name)
+    {
+        const auto networks = ListNetworks();
+        return std::ranges::any_of(networks, [&](const auto& network) { return network.Name == Name; });
     }
 
     void CreateNamedNetwork(const std::string& Name, const std::vector<WSLCLabel>& Labels = {})
@@ -5493,26 +5508,19 @@ class WSLCTests
             const WSLCFilter* filtersPtr = filters.empty() ? nullptr : filters.data();
             const ULONG filtersCount = static_cast<ULONG>(filters.size());
 
-            wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-            VERIFY_ARE_EQUAL(
-                expected, m_defaultSession->ListNetworks(filtersPtr, filtersCount, networks.addressof(), networks.size_address<ULONG>()));
+            wil::unique_cotaskmem_ansistring output;
+            VERIFY_ARE_EQUAL(expected, m_defaultSession->ListNetworks(filtersPtr, filtersCount, &output));
         };
 
         auto expectList = [&](const std::vector<std::string>& expected,
                               const std::vector<WSLCFilter>& filters,
                               const std::source_location& source = std::source_location::current()) {
-            const WSLCFilter* filtersPtr = filters.empty() ? nullptr : filters.data();
-            const ULONG filtersCount = static_cast<ULONG>(filters.size());
-
-            wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-            VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(filtersPtr, filtersCount, networks.addressof(), networks.size_address<ULONG>()));
-
             std::vector<std::string> names;
-            for (const auto& n : networks)
+            for (const auto& n : ListNetworks(filters))
             {
                 names.emplace_back(n.Name);
-                VERIFY_IS_TRUE(strlen(n.Id) > 0);
-                VERIFY_ARE_EQUAL(std::string("bridge"), std::string(n.Driver));
+                VERIFY_IS_FALSE(n.Id.empty());
+                VERIFY_ARE_EQUAL(std::string("bridge"), n.Driver);
             }
 
             VerifyAreEqualUnordered(expected, names, source);
@@ -5536,8 +5544,23 @@ class WSLCTests
         expectList(all, {{"label", testLabelKV.c_str()}, {"driver", "bridge"}});
         expectList({}, {{"label", testLabelKV.c_str()}, {"driver", "nonexistent"}});
 
-        // Explicit managed-label filter is idempotent with the auto-injected one.
+        // Networks created by wslc carry the managed label, which can still be filtered on explicitly.
         expectList(all, {{"label", testLabelKV.c_str()}, {"label", managedLabel.c_str()}});
+
+        // Predefined networks are not managed by wslc but are still listed.
+        {
+            const auto networks = ListNetworks();
+            std::vector<std::string> names;
+            for (const auto& n : networks)
+            {
+                names.emplace_back(n.Name);
+            }
+
+            for (const auto& predefined : {"bridge", "host", "none"})
+            {
+                VERIFY_ARE_NOT_EQUAL(names.end(), std::ranges::find(names, predefined));
+            }
+        }
 
         // Null filter key/value is rejected.
         expectListFails(E_POINTER, {{nullptr, "anything"}});
@@ -5582,13 +5605,8 @@ class WSLCTests
 
             expectPrune({a, b});
 
-            wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-            VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-            for (const auto& n : networks)
-            {
-                VERIFY_ARE_NOT_EQUAL(a, std::string(n.Name));
-                VERIFY_ARE_NOT_EQUAL(b, std::string(n.Name));
-            }
+            VERIFY_IS_FALSE(NetworkIsListed(a));
+            VERIFY_IS_FALSE(NetworkIsListed(b));
 
             cleanup.release();
         }
@@ -5723,10 +5741,8 @@ class WSLCTests
 
         VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options, nullptr));
 
-        wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(1u, networks.size());
-        VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
+        const auto networks = ListNetworks();
+        VERIFY_IS_TRUE(std::ranges::any_of(networks, [&](const auto& network) { return network.Name == networkName; }));
     }
 
     WSLC_TEST_METHOD(NetworkCreateInvalidDriverAndOptionTest)
@@ -5786,11 +5802,10 @@ class WSLCTests
 
         VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&options, nullptr));
 
-        wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(1u, networks.size());
-        VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
-        VERIFY_ARE_EQUAL(std::string("bridge"), std::string(networks[0].Driver));
+        const auto networks = ListNetworks();
+        const auto created = std::ranges::find_if(networks, [&](const auto& network) { return network.Name == networkName; });
+        VERIFY_ARE_NOT_EQUAL(networks.end(), created);
+        VERIFY_ARE_EQUAL(std::string("bridge"), created->Driver);
     }
 
     WSLC_TEST_METHOD(NetworkCreateReservedNameTest)
@@ -5997,11 +6012,10 @@ class WSLCTests
         VERIFY_IS_NOT_NULL(output.get());
 
         auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
-        VERIFY_IS_TRUE(inspect.Options.has_value());
-        VERIFY_IS_TRUE(inspect.Options->contains("my.abc.key"));
-        VERIFY_IS_TRUE(inspect.Options->contains("com.example.flag"));
-        VERIFY_ARE_EQUAL(std::string("mygod"), inspect.Options->at("my.abc.key"));
-        VERIFY_ARE_EQUAL(std::string("1"), inspect.Options->at("com.example.flag"));
+        VERIFY_IS_TRUE(inspect.Options.contains("my.abc.key"));
+        VERIFY_IS_TRUE(inspect.Options.contains("com.example.flag"));
+        VERIFY_ARE_EQUAL(std::string("mygod"), inspect.Options.at("my.abc.key"));
+        VERIFY_ARE_EQUAL(std::string("1"), inspect.Options.at("com.example.flag"));
     }
 
     WSLC_TEST_METHOD(NetworkSessionRecoveryTest)
@@ -6024,12 +6038,11 @@ class WSLCTests
         // Reset the session (simulates session restart).
         ResetTestSession();
 
-        wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(1u, networks.size());
-        VERIFY_ARE_EQUAL(networkName, std::string(networks[0].Name));
-        VERIFY_ARE_EQUAL(std::string("bridge"), std::string(networks[0].Driver));
-        VERIFY_IS_TRUE(strlen(networks[0].Id) > 0);
+        const auto networks = ListNetworks();
+        const auto recovered = std::ranges::find_if(networks, [&](const auto& network) { return network.Name == networkName; });
+        VERIFY_ARE_NOT_EQUAL(networks.end(), recovered);
+        VERIFY_ARE_EQUAL(std::string("bridge"), recovered->Driver);
+        VERIFY_IS_FALSE(recovered->Id.empty());
 
         // Verify arbitrary driver options survive session recovery.
         wil::unique_cotaskmem_ansistring output;
@@ -6037,9 +6050,8 @@ class WSLCTests
         VERIFY_IS_NOT_NULL(output.get());
 
         auto inspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::Network>(output.get());
-        VERIFY_IS_TRUE(inspect.Options.has_value());
-        VERIFY_IS_TRUE(inspect.Options->contains("recovery.test.key"));
-        VERIFY_ARE_EQUAL(std::string("preserved"), inspect.Options->at("recovery.test.key"));
+        VERIFY_IS_TRUE(inspect.Options.contains("recovery.test.key"));
+        VERIFY_ARE_EQUAL(std::string("preserved"), inspect.Options.at("recovery.test.key"));
     }
 
     WSLC_TEST_METHOD(NetworkMultipleCreateListDeleteTest)
@@ -6077,13 +6089,27 @@ class WSLCTests
         optionsC.Internal = TRUE;
         VERIFY_SUCCEEDED(m_defaultSession->CreateNetwork(&optionsC, nullptr));
 
-        wil::unique_cotaskmem_array_ptr<WSLCNetworkInformation> networks;
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(3u, networks.size());
+        auto listedNames = [&]() {
+            std::vector<std::string> names;
+            for (const auto& network : ListNetworks())
+            {
+                names.push_back(network.Name);
+            }
+
+            return names;
+        };
+
+        auto names = listedNames();
+        VERIFY_ARE_NOT_EQUAL(names.end(), std::ranges::find(names, networkNameA));
+        VERIFY_ARE_NOT_EQUAL(names.end(), std::ranges::find(names, networkNameB));
+        VERIFY_ARE_NOT_EQUAL(names.end(), std::ranges::find(names, networkNameC));
 
         VERIFY_SUCCEEDED(m_defaultSession->DeleteNetwork(networkNameB.c_str()));
-        VERIFY_SUCCEEDED(m_defaultSession->ListNetworks(nullptr, 0, networks.addressof(), networks.size_address<ULONG>()));
-        VERIFY_ARE_EQUAL(2u, networks.size());
+
+        names = listedNames();
+        VERIFY_ARE_NOT_EQUAL(names.end(), std::ranges::find(names, networkNameA));
+        VERIFY_ARE_EQUAL(names.end(), std::ranges::find(names, networkNameB));
+        VERIFY_ARE_NOT_EQUAL(names.end(), std::ranges::find(names, networkNameC));
     }
 
     WSLC_TEST_METHOD(NetworkInspectTest)

--- a/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
@@ -150,7 +150,7 @@ class WSLCCLIExecutionUnitTests
             }
             else if (dataType == Data::Networks)
             {
-                std::vector<WSLCNetworkInformation> networks;
+                std::vector<wsl::windows::common::wslc_schema::NetworkListEntry> networks;
                 dataMap.Add<Data::Networks>(std::move(networks));
                 handled = true;
             }

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -257,7 +257,7 @@ void VerifyNetworkIsListed(const std::wstring& networkName)
 {
     auto result = RunWslc(L"network list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
-    auto networks = ParseNdjsonOutputAs<WSLCNetworkInformation>(result);
+    auto networks = ParseNdjsonOutputAs<NetworkListOutput>(result);
     for (const auto& net : networks)
     {
         if (net.Name == wsl::shared::string::WideToMultiByte(networkName))
@@ -273,7 +273,7 @@ void VerifyNetworkIsNotListed(const std::wstring& networkName)
 {
     auto result = RunWslc(L"network list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
-    auto networks = ParseNdjsonOutputAs<WSLCNetworkInformation>(result);
+    auto networks = ParseNdjsonOutputAs<NetworkListOutput>(result);
     for (const auto& net : networks)
     {
         if (net.Name == wsl::shared::string::WideToMultiByte(networkName))
@@ -526,7 +526,7 @@ void EnsureNetworkDoesNotExist(const std::wstring& networkName)
 {
     auto result = RunWslc(L"network list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
-    auto networks = ParseNdjsonOutputAs<WSLCNetworkInformation>(result);
+    auto networks = ParseNdjsonOutputAs<NetworkListOutput>(result);
     for (const auto& net : networks)
     {
         if (net.Name == wsl::shared::string::WideToMultiByte(networkName))

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -62,6 +62,22 @@ namespace VT {
     }
 } // namespace VT
 
+// The shape emitted by "network list --format json"; every value is reported as a string.
+struct NetworkListOutput
+{
+    std::string CreatedAt;
+    std::string Driver;
+    std::string ID;
+    std::string IPv4;
+    std::string IPv6;
+    std::string Internal;
+    std::string Labels;
+    std::string Name;
+    std::string Scope;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkListOutput, CreatedAt, Driver, ID, IPv4, IPv6, Internal, Labels, Name, Scope);
+};
+
 struct TestImage
 {
     std::wstring Name;

--- a/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkCreateTests.cpp
@@ -206,9 +206,8 @@ class WSLCE2ENetworkCreateTests
         VerifyNetworkIsListed(TestNetworkName);
         auto inspect = InspectNetwork(TestNetworkName);
         VERIFY_ARE_EQUAL("bridge", inspect.Driver);
-        VERIFY_IS_TRUE(inspect.Options.has_value());
-        VERIFY_ARE_EQUAL("true", (*inspect.Options)["com.docker.network.bridge.enable_icc"]);
-        VERIFY_ARE_EQUAL("1450", (*inspect.Options)["com.docker.network.driver.mtu"]);
+        VERIFY_ARE_EQUAL("true", inspect.Options["com.docker.network.bridge.enable_icc"]);
+        VERIFY_ARE_EQUAL("1450", inspect.Options["com.docker.network.driver.mtu"]);
     }
 
 private:

--- a/test/windows/wslc/e2e/WSLCE2ENetworkInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkInspectTests.cpp
@@ -66,6 +66,26 @@ class WSLCE2ENetworkInspectTests
 
         VERIFY_ARE_EQUAL(WideToMultiByte(TestNetworkName1), inspect.Name);
         VERIFY_ARE_EQUAL("bridge", inspect.Driver);
+        VERIFY_ARE_EQUAL("local", inspect.Scope);
+        VERIFY_IS_FALSE(inspect.Created.empty());
+        VERIFY_IS_TRUE(inspect.EnableIPv4);
+        VERIFY_IS_FALSE(inspect.ConfigOnly);
+        VERIFY_IS_TRUE(inspect.Containers.empty());
+
+        // The label used to track wslc managed networks is an implementation detail and must not surface.
+        VERIFY_IS_FALSE(inspect.Labels.contains("com.microsoft.wsl.network.managed"));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_Inspect_PredefinedNetwork)
+    {
+        // Docker's predefined networks are not created by wslc but must still be inspectable.
+        auto result = RunWslc(L"network inspect bridge");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        auto inspectData = wsl::shared::FromJson<std::vector<wsl::windows::common::wslc_schema::Network>>(result.Stdout.value().c_str());
+        VERIFY_ARE_EQUAL(1u, inspectData.size());
+        VERIFY_ARE_EQUAL("bridge", inspectData[0].Name);
+        VERIFY_ARE_EQUAL("bridge", inspectData[0].Driver);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Network_Inspect_FormatJson_IsSingleLine)

--- a/test/windows/wslc/e2e/WSLCE2ENetworkInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkInspectTests.cpp
@@ -78,7 +78,7 @@ class WSLCE2ENetworkInspectTests
 
     WSLC_TEST_METHOD(WSLCE2E_Network_Inspect_PredefinedNetwork)
     {
-        // Docker's predefined networks are not created by wslc but must still be inspectable.
+        // The predefined networks are not created by wslc but must still be inspectable.
         auto result = RunWslc(L"network inspect bridge");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 

--- a/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
@@ -172,7 +172,7 @@ class WSLCE2ENetworkListTests
 
     WSLC_TEST_METHOD(WSLCE2E_Network_List_IncludesPredefinedNetworks)
     {
-        // Docker's predefined networks are not created by wslc but are still reported by list.
+        // The predefined networks are not created by wslc but are still reported by list.
         auto result = RunWslc(L"network list --format json");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 

--- a/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkListTests.cpp
@@ -127,11 +127,18 @@ class WSLCE2ENetworkListTests
         names.reserve(networks.size());
         for (const auto& network : networks)
         {
-            VERIFY_ARE_EQUAL(3u, network.size());
+            VERIFY_ARE_EQUAL(9u, network.size());
             VERIFY_IS_TRUE(network.contains("ID"));
             VERIFY_IS_FALSE(network.contains("Id"));
             VERIFY_IS_TRUE(network.contains("Name"));
             VERIFY_IS_TRUE(network.contains("Driver"));
+            VERIFY_IS_TRUE(network.contains("Scope"));
+            VERIFY_IS_TRUE(network.contains("CreatedAt"));
+            VERIFY_IS_TRUE(network.contains("IPv4"));
+            VERIFY_IS_TRUE(network.contains("IPv6"));
+            VERIFY_IS_TRUE(network.contains("Internal"));
+            VERIFY_IS_TRUE(network.contains("Labels"));
+            VERIFY_IS_TRUE(network.at("CreatedAt").get<std::string>().ends_with(" +0000 UTC"));
             VerifyIdOutput(MultiByteToWide(network.at("ID").get<std::string>()), true);
             names.push_back(network.at("Name").get<std::string>());
         }
@@ -161,6 +168,28 @@ class WSLCE2ENetworkListTests
             const auto id = MultiByteToWide(network.at("ID").get<std::string>());
             VERIFY_IS_TRUE(fullTableResult.StdoutContainsSubstring(id));
         }
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Network_List_IncludesPredefinedNetworks)
+    {
+        // Docker's predefined networks are not created by wslc but are still reported by list.
+        auto result = RunWslc(L"network list --format json");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        std::set<std::string> names;
+        for (const auto& network : ParseNdjsonOutputAs<NetworkListOutput>(result))
+        {
+            names.insert(network.Name);
+        }
+
+        VERIFY_IS_TRUE(names.contains("bridge"));
+        VERIFY_IS_TRUE(names.contains("host"));
+        VERIFY_IS_TRUE(names.contains("none"));
+
+        result = RunWslc(L"network list");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"NETWORK ID"));
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"SCOPE"));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Network_List_Filter_MalformedValue)
@@ -197,7 +226,7 @@ class WSLCE2ENetworkListTests
         auto listNames = [&](const std::wstring& filterArgs) {
             auto r = RunWslc(std::format(L"network list --format json {}", filterArgs));
             r.Verify({.Stderr = L"", .ExitCode = 0});
-            const auto networks = ParseNdjsonOutputAs<WSLCNetworkInformation>(r);
+            const auto networks = ParseNdjsonOutputAs<NetworkListOutput>(r);
             std::set<std::string> names;
             for (const auto& n : networks)
             {
@@ -243,7 +272,7 @@ class WSLCE2ENetworkListTests
         auto listNames = [&](const std::wstring& filterArgs) {
             auto r = RunWslc(std::format(L"network list --format json {}", filterArgs));
             r.Verify({.Stderr = L"", .ExitCode = 0});
-            const auto networks = ParseNdjsonOutputAs<WSLCNetworkInformation>(r);
+            const auto networks = ParseNdjsonOutputAs<NetworkListOutput>(r);
             std::set<std::string> names;
             for (const auto& n : networks)
             {
@@ -304,7 +333,7 @@ class WSLCE2ENetworkListTests
         auto listNames = [&](const std::wstring& filterArgs) {
             auto r = RunWslc(std::format(L"network list --format json {}", filterArgs));
             r.Verify({.Stderr = L"", .ExitCode = 0});
-            const auto networks = ParseNdjsonOutputAs<WSLCNetworkInformation>(r);
+            const auto networks = ParseNdjsonOutputAs<NetworkListOutput>(r);
             std::set<std::string> names;
             for (const auto& n : networks)
             {

--- a/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2ENetworkPruneTests.cpp
@@ -56,8 +56,8 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_FALSE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
-        VERIFY_IS_FALSE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)));
+        VERIFY_IS_FALSE(result.StdoutContainsLine(TestNetworkName));
+        VERIFY_IS_FALSE(result.StdoutContainsLine(TestNetworkName2));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Network_Prune_RemovesUnusedNetwork)
@@ -71,8 +71,10 @@ class WSLCE2ENetworkPruneTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         auto output = result.GetStdoutLines();
-        VERIFY_ARE_EQUAL(1u, output.size());
-        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, output[0].find(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
+        VERIFY_ARE_EQUAL(3u, output.size());
+        VERIFY_ARE_EQUAL(Localization::WSLCCLI_NetworkPruneDeletedHeader(), output[0]);
+        VERIFY_ARE_EQUAL(TestNetworkName, output[1]);
+        VERIFY_ARE_EQUAL(std::wstring{}, output[2]);
 
         VerifyNetworkIsNotListed(TestNetworkName);
     }
@@ -92,8 +94,8 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
-        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestNetworkName));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestNetworkName2));
 
         VerifyNetworkIsNotListed(TestNetworkName);
         VerifyNetworkIsNotListed(TestNetworkName2);
@@ -117,9 +119,7 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_FALSE(
-            result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)),
-            L"Network in use by a running container must not be pruned");
+        VERIFY_IS_FALSE(result.StdoutContainsLine(TestNetworkName), L"Network in use by a running container must not be pruned");
 
         VerifyNetworkIsListed(TestNetworkName);
     }
@@ -135,15 +135,14 @@ class WSLCE2ENetworkPruneTests
         const auto filteredPrune = RunWslc(L"network prune --filter label=wslc.test.never=present");
         filteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
         VERIFY_IS_FALSE(
-            filteredPrune.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)),
-            L"Filtered prune should not have deleted the non-matching network");
+            filteredPrune.StdoutContainsLine(TestNetworkName), L"Filtered prune should not have deleted the non-matching network");
         VerifyNetworkIsListed(TestNetworkName);
 
         // A subsequent unfiltered prune should still remove it, proving the filter
         // was the reason it survived.
         const auto unfilteredPrune = RunWslc(L"network prune");
         unfilteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
-        VERIFY_IS_TRUE(unfilteredPrune.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
+        VERIFY_IS_TRUE(unfilteredPrune.StdoutContainsLine(TestNetworkName));
         VerifyNetworkIsNotListed(TestNetworkName);
     }
 
@@ -162,10 +161,8 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune --filter label=wslc.test.prune=keep");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)));
-        VERIFY_IS_FALSE(
-            result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)),
-            L"Network without the matching label must not be deleted");
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestNetworkName));
+        VERIFY_IS_FALSE(result.StdoutContainsLine(TestNetworkName2), L"Network without the matching label must not be deleted");
 
         VerifyNetworkIsNotListed(TestNetworkName);
         VerifyNetworkIsListed(TestNetworkName2);
@@ -186,10 +183,9 @@ class WSLCE2ENetworkPruneTests
         const auto result = RunWslc(L"network prune --filter label!=wslc.test.keep");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName2)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestNetworkName2));
         VERIFY_IS_FALSE(
-            result.StdoutContainsLine(Localization::WSLCCLI_NetworkPruneDeleted(TestNetworkName)),
-            L"Labeled network must be preserved when prune negates that label");
+            result.StdoutContainsLine(TestNetworkName), L"Labeled network must be preserved when prune negates that label");
 
         VerifyNetworkIsListed(TestNetworkName);
         VerifyNetworkIsNotListed(TestNetworkName2);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Brings `wslc network list`, `wslc network inspect` and `wslc network prune` output in line with docker. A side-by-side parity harness run against docker showed eleven divergences in the network command; this change addresses all of them except error message wording, which is tracked separately.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

**`network list`**

- Docker's predefined `bridge`, `host` and `none` networks are now listed. `ListNetworks` queries the daemon directly instead of returning only the session's managed-network map.
- Added the `SCOPE` column, and networks are ordered by name, matching docker.
- Table columns use docker's minimum column width so spacing is identical.
- `--format json` now emits docker's nine all-string keys (`CreatedAt`, `Driver`, `ID`, `IPv4`, `IPv6`, `Internal`, `Labels`, `Name`, `Scope`) via a dedicated `NetworkOutputInformation` model, following the same pattern already used for image list output.
- `CreatedAt` is rendered the way docker renders network timestamps: UTC, with the daemon's fractional-second digits preserved verbatim (`2026-08-18 23:35:57.900958925 +0000 UTC`). This is a new `FormatDockerTimestamp(std::string_view)` overload; the existing `LONGLONG` overload, which converts to local time for image and container output, is unchanged.

**`network inspect`**

- Now a live passthrough of the daemon's inspect response instead of being reconstructed from cached session state, so predefined networks are inspectable and values cannot drift.
- Emits docker's full field set: `Created`, `EnableIPv4`, `EnableIPv6`, `Attachable`, `Ingress`, `ConfigOnly`, `ConfigFrom`, `Containers`, `Status` and `IPAM.Options`.
- `Options` is emitted as an object rather than `null`, and empty `Gateway`/`IPRange` entries are omitted, both matching docker.

**`network prune`**

- Prints docker's `Deleted Networks:` header followed by bare network names and a trailing blank line, and prints nothing when no networks were removed.

**Supporting changes**

- The internal `IWSLCSession::ListNetworks` now returns JSON instead of a fixed-size struct array. The list shape includes variable-length labels, which cannot be marshaled safely inside an out-array of structs. `WSLCNetworkInformation` and its serializer are removed. This interface is internal and ships in lockstep with its only clients; the SDK-facing `WSLCCompat.idl` and the plugin API are untouched.
- `docker_schema::Network` and `docker_schema::IPAM` use hand-written deserializers that tolerate `null`, because the daemon reports some empty maps as `null` on predefined networks and the default deserializer rejects that.
- The internal `com.microsoft.wsl.network.managed` label is stripped from both list and inspect output.
- `ParseDockerTimestamp` moved out of `WSLCContainer.cpp` into `docker_schema::ParseTimestamp` and is now shared.

Deliberately out of scope: error message wording, the global JSON indent width and key ordering (shared by container, image and volume inspect), and `network prune --force` (`-f` is already the `--filter` alias and no wslc prune command prompts).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Full x64 Debug build clean; clang-format 19.1.5 clean.
- Deployed to the host and re-ran the wslc-vs-docker parity harness (81 command pairs). All network cases now match docker: `network list` (table, `--format json`, `-q`, `--no-trunc`, `-f driver=bridge`) is byte-identical apart from the daemon-assigned IDs, `network inspect` matches field for field, and `network prune` matches exactly.
- Remaining inspect differences are daemon-version artifacts, not CLI behavior: the host daemon populates `Status.IPAM` and `com.docker.network.enable_ipv4/6` options that the daemon in the WSL VM does not report. Both are passed through unchanged.
- Tests updated and added: service-level list tests reworked for the JSON API and predefined networks; new E2E coverage for predefined networks in list and inspect, the nine-key JSON shape, the UTC timestamp suffix, the new inspect fields, and the prune output format.