### PR TITLE
Propagate LaunchInit error code

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1474,7 +1474,6 @@ Return Value:
 
 --*/
 
-try
 {
     std::vector<std::string> Variables;
     auto AddEnvironmentVariable = [&Variables](const char* Name, const char* Value) {
@@ -1500,7 +1499,7 @@ try
     {
         THROW_LAST_ERROR_IF(TEMP_FAILURE_RETRY(dup2(SocketFd, LX_INIT_UTILITY_VM_INIT_SOCKET_FD)) < 0);
 
-        close(SocketFd);
+        THROW_LAST_ERROR_IF(SetCloseOnExec(SocketFd, true));
         SocketFd = LX_INIT_UTILITY_VM_INIT_SOCKET_FD;
     }
     else
@@ -1659,11 +1658,6 @@ try
 
     execle(LX_INIT_PATH, LX_INIT_PATH, nullptr, Environment.data());
     LOG_ERROR("execle({}) failed {}", LX_INIT_PATH, errno);
-    _exit(1);
-}
-catch (...)
-{
-    LOG_CAUGHT_EXCEPTION();
     _exit(1);
 }
 

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1518,7 +1518,6 @@ Return Value:
     //
 
     bool readOnly = false;
-
     try
     {
         AddTemporaryMount(LX_WSL2_CROSS_DISTRO_ENV, CROSS_DISTRO_SHARE_PATH, (MS_MOVE | MS_REC));

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -2375,6 +2375,7 @@ void ProcessLaunchInitMessage(
     }
     catch (...)
     {
+        LOG_CAUGHT_EXCEPTION();
         ReportStatus(wil::ResultFromCaughtException());
         _exit(1);
     }

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1518,6 +1518,7 @@ Return Value:
     //
 
     bool readOnly = false;
+
     try
     {
         AddTemporaryMount(LX_WSL2_CROSS_DISTRO_ENV, CROSS_DISTRO_SHARE_PATH, (MS_MOVE | MS_REC));

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1512,7 +1512,6 @@ Return Value:
         THROW_LAST_ERROR_IF(SetCloseOnExec(SocketFd, false));
     }
 
-    
     //
     // Move the cross-distro shared mount to a temporary location. This mount
     // will be moved by the distro init.

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1501,6 +1501,7 @@ Return Value:
 
         THROW_LAST_ERROR_IF(SetCloseOnExec(SocketFd, true));
         SocketFd = LX_INIT_UTILITY_VM_INIT_SOCKET_FD;
+
     }
     else
     {

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1501,7 +1501,6 @@ Return Value:
 
         THROW_LAST_ERROR_IF(SetCloseOnExec(SocketFd, true));
         SocketFd = LX_INIT_UTILITY_VM_INIT_SOCKET_FD;
-
     }
     else
     {

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -1512,6 +1512,7 @@ Return Value:
         THROW_LAST_ERROR_IF(SetCloseOnExec(SocketFd, false));
     }
 
+    
     //
     // Move the cross-distro shared mount to a temporary location. This mount
     // will be moved by the distro init.

--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -66,7 +66,9 @@ WslCoreInstance::WslCoreInstance(
     if (result.Result != 0)
     {
         // N.B. EFSBADCRC (74) or EFSCORRUPTED (117) can be returned if the disk's journal is corrupted.
-        if ((result.Result == EINVAL || result.Result == 74 || result.Result == 117) && result.FailureStep == LxInitCreateInstanceStepMountDisk)
+        // EIO (5) can be returned during LaunchInit if corruption is detected after the initial mount succeeds.
+        if (((result.Result == EINVAL || result.Result == 74 || result.Result == 117) && result.FailureStep == LxInitCreateInstanceStepMountDisk) ||
+            (result.Result == 5 && result.FailureStep == LxInitCreateInstanceStepLaunchInit))
         {
             THROW_HR(WSL_E_DISK_CORRUPTED);
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

LaunchInit currently try catch _exit(1) all exceptions. This could cause a files system failure being reported to the user as E_UNEXPECTED instead. For example: #13028 and #13237. Where the original EIO at step 3 were collapsed to E_UNEXPECTED.

This PR propagates the error out by removing LaunchInit's own try catch and rely on the caller's try catch logic. And also delays the closure of the original socket fd by setting it to CLOEXEC instead of manually close. So, the caller can still use it in catch.
This PR also adds EIO (5) at step 3 to the treated as disk corruption list.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #13028, #13237, #13572. This PR helps with the error code but does not fix the original file system corruption issue.
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested by manually injecting an error in LaunchInit:
```
The distribution failed to start because its virtual disk is corrupted.
Error code: Wsl/Service/CreateInstance/WSL_E_DISK_CORRUPTED
```