### PR TITLE
Bound WslCoreInstance init transactions

### DIFF
--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -225,7 +225,7 @@ void WslCoreInstance::CreateLxProcess(
     ULONG port;
     {
         auto sessionLock = sessionLeader->Lock();
-        port = sessionLeader->GetChannel().Transaction<LX_INIT_CREATE_PROCESS_UTILITY_VM>(messageSpan).Result;
+        port = sessionLeader->GetChannel().Transaction<LX_INIT_CREATE_PROCESS_UTILITY_VM>(messageSpan, nullptr, m_socketTimeout).Result;
     }
 
     // Connect to the port specified by the session leader.
@@ -354,7 +354,7 @@ void WslCoreInstance::UpdateTimezone()
         wsl::windows::common::helpers::GenerateTimezoneUpdateMessage(wsl::windows::common::helpers::GetLinuxTimezone(m_userToken.get()));
 
     auto lock = m_initChannel->Lock();
-    auto transaction = m_initChannel->GetChannel().StartTransaction();
+    auto transaction = m_initChannel->GetChannel().StartTransaction(m_socketTimeout);
     transaction.Send<LX_INIT_TIMEZONE_INFORMATION>(gsl::make_span(message));
 }
 
@@ -401,7 +401,7 @@ void WslCoreInstance::Initialize()
     auto config = wsl::windows::common::helpers::GenerateConfigurationMessage(
         m_configuration.Name, fixedDrives, m_defaultUid, timezone, {}, m_featureFlags, drvfsMount);
 
-    auto transaction = m_initChannel->GetChannel().StartTransaction();
+    auto transaction = m_initChannel->GetChannel().StartTransaction(m_socketTimeout);
     transaction.Send<LX_INIT_CONFIGURATION_INFORMATION>(gsl::span(config));
 
     // Init replies with information about the distribution.

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -7711,60 +7711,6 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             const auto hr = wil::ResultFromException([&]() { channel.ReceiveMessage<RESULT_MESSAGE<int32_t>>(nullptr, 100); });
             VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_TIMEOUT));
         }
-
-        {
-            constexpr DWORD transactionTimeout = 200;
-            constexpr LONGLONG schedulingTolerance = 50;
-            constexpr LONGLONG maximumWait = 5000;
-            auto [client, server] = MakeSocketPair();
-            wsl::shared::SocketChannel channel{std::move(client), "client"};
-            auto transaction = channel.StartTransaction(transactionTimeout);
-
-            RESULT_MESSAGE<int32_t> request{};
-            request.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
-            request.Header.MessageSize = sizeof(request);
-            transaction.Send(request);
-
-            RESULT_MESSAGE<int32_t> receivedRequest{};
-            recvAll(server.get(), &receivedRequest, sizeof(receivedRequest));
-            VERIFY_ARE_EQUAL(receivedRequest.Header.TransactionStep, static_cast<unsigned int>(TRANSACTION_STEP::REQUEST));
-
-            const auto start = std::chrono::steady_clock::now();
-            const auto hr = wil::ResultFromException([&]() { transaction.Receive<RESULT_MESSAGE<int32_t>>(); });
-            const auto elapsed =
-                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
-
-            VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_TIMEOUT));
-            VERIFY_IS_GREATER_THAN_OR_EQUAL(elapsed, static_cast<LONGLONG>(transactionTimeout) - schedulingTolerance);
-            VERIFY_IS_LESS_THAN(elapsed, maximumWait);
-        }
-
-        {
-            constexpr DWORD transactionTimeout = 1000;
-            constexpr int32_t expectedResult = 42;
-            auto [client, server] = MakeSocketPair();
-            wsl::shared::SocketChannel channel{std::move(client), "client"};
-            auto transaction = channel.StartTransaction(transactionTimeout);
-
-            RESULT_MESSAGE<int32_t> request{};
-            request.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
-            request.Header.MessageSize = sizeof(request);
-            transaction.Send(request);
-
-            RESULT_MESSAGE<int32_t> receivedRequest{};
-            recvAll(server.get(), &receivedRequest, sizeof(receivedRequest));
-
-            RESULT_MESSAGE<int32_t> response{};
-            response.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
-            response.Header.MessageSize = sizeof(response);
-            response.Header.TransactionId = receivedRequest.Header.TransactionId;
-            response.Header.TransactionStep = static_cast<unsigned int>(TRANSACTION_STEP::FIRST_REPLY);
-            response.Result = expectedResult;
-            WriteSocket(server.get(), &response, sizeof(response));
-
-            const auto& receivedResponse = transaction.Receive<RESULT_MESSAGE<int32_t>>();
-            VERIFY_ARE_EQUAL(receivedResponse.Result, expectedResult);
-        }
     }
 
     TEST_METHOD(DownloadToHiddenSystemTempFolder)

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -7713,9 +7713,12 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         }
 
         {
+            constexpr DWORD transactionTimeout = 200;
+            constexpr LONGLONG schedulingTolerance = 50;
+            constexpr LONGLONG maximumWait = 5000;
             auto [client, server] = MakeSocketPair();
             wsl::shared::SocketChannel channel{std::move(client), "client"};
-            auto transaction = channel.StartTransaction(200);
+            auto transaction = channel.StartTransaction(transactionTimeout);
 
             RESULT_MESSAGE<int32_t> request{};
             request.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
@@ -7732,14 +7735,16 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
                 std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
 
             VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_TIMEOUT));
-            VERIFY_IS_GREATER_THAN_OR_EQUAL(elapsed, 100LL);
-            VERIFY_IS_LESS_THAN(elapsed, 5000LL);
+            VERIFY_IS_GREATER_THAN_OR_EQUAL(elapsed, static_cast<LONGLONG>(transactionTimeout) - schedulingTolerance);
+            VERIFY_IS_LESS_THAN(elapsed, maximumWait);
         }
 
         {
+            constexpr DWORD transactionTimeout = 1000;
+            constexpr int32_t expectedResult = 42;
             auto [client, server] = MakeSocketPair();
             wsl::shared::SocketChannel channel{std::move(client), "client"};
-            auto transaction = channel.StartTransaction(1000);
+            auto transaction = channel.StartTransaction(transactionTimeout);
 
             RESULT_MESSAGE<int32_t> request{};
             request.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
@@ -7754,11 +7759,11 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             response.Header.MessageSize = sizeof(response);
             response.Header.TransactionId = receivedRequest.Header.TransactionId;
             response.Header.TransactionStep = static_cast<unsigned int>(TRANSACTION_STEP::FIRST_REPLY);
-            response.Result = 42;
+            response.Result = expectedResult;
             WriteSocket(server.get(), &response, sizeof(response));
 
             const auto& receivedResponse = transaction.Receive<RESULT_MESSAGE<int32_t>>();
-            VERIFY_ARE_EQUAL(receivedResponse.Result, 42);
+            VERIFY_ARE_EQUAL(receivedResponse.Result, expectedResult);
         }
     }
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -7711,6 +7711,55 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
             const auto hr = wil::ResultFromException([&]() { channel.ReceiveMessage<RESULT_MESSAGE<int32_t>>(nullptr, 100); });
             VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_TIMEOUT));
         }
+
+        {
+            auto [client, server] = MakeSocketPair();
+            wsl::shared::SocketChannel channel{std::move(client), "client"};
+            auto transaction = channel.StartTransaction(200);
+
+            RESULT_MESSAGE<int32_t> request{};
+            request.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
+            request.Header.MessageSize = sizeof(request);
+            transaction.Send(request);
+
+            RESULT_MESSAGE<int32_t> receivedRequest{};
+            recvAll(server.get(), &receivedRequest, sizeof(receivedRequest));
+            VERIFY_ARE_EQUAL(receivedRequest.Header.TransactionStep, static_cast<unsigned int>(TRANSACTION_STEP::REQUEST));
+
+            const auto start = std::chrono::steady_clock::now();
+            const auto hr = wil::ResultFromException([&]() { transaction.Receive<RESULT_MESSAGE<int32_t>>(); });
+            const auto elapsed =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+
+            VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_TIMEOUT));
+            VERIFY_IS_GREATER_THAN_OR_EQUAL(elapsed, 100LL);
+            VERIFY_IS_LESS_THAN(elapsed, 5000LL);
+        }
+
+        {
+            auto [client, server] = MakeSocketPair();
+            wsl::shared::SocketChannel channel{std::move(client), "client"};
+            auto transaction = channel.StartTransaction(1000);
+
+            RESULT_MESSAGE<int32_t> request{};
+            request.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
+            request.Header.MessageSize = sizeof(request);
+            transaction.Send(request);
+
+            RESULT_MESSAGE<int32_t> receivedRequest{};
+            recvAll(server.get(), &receivedRequest, sizeof(receivedRequest));
+
+            RESULT_MESSAGE<int32_t> response{};
+            response.Header.MessageType = RESULT_MESSAGE<int32_t>::Type;
+            response.Header.MessageSize = sizeof(response);
+            response.Header.TransactionId = receivedRequest.Header.TransactionId;
+            response.Header.TransactionStep = static_cast<unsigned int>(TRANSACTION_STEP::FIRST_REPLY);
+            response.Result = 42;
+            WriteSocket(server.get(), &response, sizeof(response));
+
+            const auto& receivedResponse = transaction.Receive<RESULT_MESSAGE<int32_t>>();
+            VERIFY_ARE_EQUAL(receivedResponse.Result, 42);
+        }
     }
 
     TEST_METHOD(DownloadToHiddenSystemTempFolder)


### PR DESCRIPTION
## Summary of the Pull Request

`SocketChannel` defaults to an infinite timeout when none is supplied. Three `WslCoreInstance` operations rely on that default while holding locks needed by shutdown or other session operations. If the guest stays connected but stops responding, those operations can wait indefinitely and prevent `WslService` from making progress.

This passes the instance's existing `m_socketTimeout` to all three operations.

## PR Checklist

- [x] **Closes:** Closes #41384
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized — no user-facing strings were changed
- [x] **Dev docs:** Added/updated if needed — no developer documentation changes are required
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

On Windows, `DefaultSocketTimeout` is `INFINITE`, so a `SocketChannel` transaction that does not receive an explicit timeout can wait without bound.

`WslCoreInstance` already owns the applicable timeout value: `m_socketTimeout`, sourced from `DistributionStartTimeout`, which defaults to 60 seconds and is configurable through `.wslconfig` as `wsl2.distributionStartTimeout`.

The class already applies this timeout to comparable operations:

| Operation | Bounded call |
|---|---|
| Instance creation result | `ReceiveMessage(..., m_socketTimeout)` |
| DrvFs mounting | `Transaction(..., m_socketTimeout)` |
| Instance termination | `StartTransaction(m_socketTimeout)` |
| Linux process creation | `CreateLinuxProcess(..., m_socketTimeout)` |
| Session creation | `Transaction(..., m_socketTimeout)` |

The timeout was omitted from three operations:

| Function | Lock held |
|---|---|
| `CreateLxProcess()` | `WslCoreInstance::m_lock` and the session-leader channel lock |
| `Initialize()` | `WslCoreInstance::m_lock`; its caller holds `LxssUserSessionImpl::m_instanceLock` |
| `UpdateTimezone()` | The init-channel lock; its caller holds `m_instanceLock` |

A process-creation transaction can therefore hold `WslCoreInstance::m_lock` indefinitely. `RequestStop()` and `Stop()` require the same lock, while their callers hold `LxssUserSessionImpl::m_instanceLock`. This can prevent shutdown and other session operations from progressing.

If service or session teardown subsequently enters `ClearSessionsAndBlockNewInstancesLockHeld()`, it holds `g_sessionTerminationLock` while waiting for shutdown. New COM session activation can then also stop progressing.

This change passes `m_socketTimeout` to the three omitted operations. When the timeout expires, the affected operation fails, unwinds, and releases its locks. It does not change the timeout value or introduce a new policy.

This removes three unbounded waits. It does not address other independent causes of guest or service instability. Other unbounded `m_miniInitChannel` operations in `WslCoreVm` are intentionally left out because each requires a separate timeout and cancellation analysis.

## Validation Steps Performed

Extended `UnitTests::SocketChannel` with two cases:

- A connected peer that remains open without replying makes the transaction fail with `HRESULT_FROM_WIN32(ERROR_TIMEOUT)`. The elapsed time is checked to verify that the configured deadline was honored rather than the operation returning immediately.
- A peer that replies before the deadline completes normally and returns the expected payload.

Static inspection confirmed that the test helpers and assertions are available in the existing test scope.

The Windows build and tests were not run locally. Build, `clang-format`, and test validation are pending repository CI.
