### PR TITLE
Avoid holding the instance lock while waiting for OOBE

### DIFF
--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -180,10 +180,8 @@ void WslCoreInstance::CreateLxProcess(
     {
         EMIT_USER_WARNING(wsl::shared::Localization::MessageWaitingForOobe(m_configuration.Name.c_str()));
 
-        const wil::unique_handle oobeCompleteEvent{
-            wsl::windows::common::wslutil::DuplicateHandle(m_oobeCompleteEvent.get(), SYNCHRONIZE)};
-        const wil::unique_handle destroyingEvent{
-            wsl::windows::common::wslutil::DuplicateHandle(m_destroyingEvent.get(), SYNCHRONIZE)};
+        const auto oobeCompleteEvent = m_oobeCompleteEvent;
+        const auto destroyingEvent = m_destroyingEvent;
         const HANDLE waitHandles[] = {oobeCompleteEvent.get(), destroyingEvent.get()};
         lock.unlock();
         const DWORD waitResult = WaitForMultipleObjects(RTL_NUMBER_OF(waitHandles), waitHandles, FALSE, INFINITE);

--- a/src/windows/service/exe/WslCoreInstance.cpp
+++ b/src/windows/service/exe/WslCoreInstance.cpp
@@ -173,13 +173,24 @@ void WslCoreInstance::CreateLxProcess(
 
     // Ensure the instance is still running.
 
-    std::lock_guard lock(m_lock);
+    std::unique_lock lock(m_lock);
     THROW_HR_IF(HCS_E_TERMINATED, (!m_initChannel || !m_consoleManager));
 
     if (m_oobeCompleteEvent && !m_oobeCompleteEvent.is_signaled())
     {
         EMIT_USER_WARNING(wsl::shared::Localization::MessageWaitingForOobe(m_configuration.Name.c_str()));
-        m_oobeCompleteEvent.wait();
+
+        const wil::unique_handle oobeCompleteEvent{
+            wsl::windows::common::wslutil::DuplicateHandle(m_oobeCompleteEvent.get(), SYNCHRONIZE)};
+        const wil::unique_handle destroyingEvent{
+            wsl::windows::common::wslutil::DuplicateHandle(m_destroyingEvent.get(), SYNCHRONIZE)};
+        const HANDLE waitHandles[] = {oobeCompleteEvent.get(), destroyingEvent.get()};
+        lock.unlock();
+        const DWORD waitResult = WaitForMultipleObjects(RTL_NUMBER_OF(waitHandles), waitHandles, FALSE, INFINITE);
+        THROW_LAST_ERROR_IF(waitResult == WAIT_FAILED);
+        lock.lock();
+        THROW_HR_IF(HCS_E_TERMINATED, waitResult == WAIT_OBJECT_0 + 1 || !m_initChannel || !m_consoleManager);
+        THROW_HR_IF(E_UNEXPECTED, waitResult != WAIT_OBJECT_0);
     }
 
     // Initialize the create process message.

--- a/src/windows/service/exe/WslCoreInstance.h
+++ b/src/windows/service/exe/WslCoreInstance.h
@@ -139,6 +139,6 @@ private:
     DWORD m_socketTimeout{};
     HANDLE m_jobObject{};
     std::thread m_oobeThread;
-    wil::unique_event m_destroyingEvent{wil::EventOptions::ManualReset};
-    wil::unique_event m_oobeCompleteEvent;
+    wil::shared_event m_destroyingEvent{wil::EventOptions::ManualReset};
+    wil::shared_event m_oobeCompleteEvent;
 };

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -4747,6 +4747,57 @@ VERSION_ID="Invalid|Format"
         TerminateDistribution();
     }
 
+    WSL2_TEST_METHOD(ModernOOBETermination)
+    {
+        constexpr DWORD oobeDurationSeconds = 30;
+        constexpr DWORD waiterObservationTimeout = 1000;
+        constexpr DWORD terminationTimeout = 10000;
+        constexpr DWORD cleanupTimeout = 45000;
+
+        const auto lxssKey = wsl::windows::common::registry::OpenLxssUserKey();
+        const auto testDistroId = GetDistributionId(LXSS_DISTRO_NAME_TEST_L);
+        VERIFY_IS_TRUE(testDistroId.has_value());
+        const auto testDistroIdString = wsl::shared::string::GuidToString<wchar_t>(testDistroId.value());
+
+        DistroFileChange distributionconf(L"/etc/wsl-distribution.conf", false);
+        distributionconf.SetContent(
+            std::format(L"[oobe]\ncommand = /bin/bash -c 'echo OOBE_STARTED; sleep {}'\n", oobeDurationSeconds).c_str());
+
+        RegistryKeyChange<DWORD> runOOBE(lxssKey.get(), testDistroIdString.c_str(), L"RunOOBE", 1);
+        TerminateDistribution();
+
+        auto [oobeOutputRead, oobeOutputWrite] = CreateSubprocessPipe(false, true);
+        wsl::windows::common::SubProcess oobeProcessBuilder(
+            nullptr, LxssGenerateWslCommandLine(L"-d " LXSS_DISTRO_NAME_TEST_L).c_str());
+        oobeProcessBuilder.SetStdHandles(nullptr, oobeOutputWrite.get(), oobeOutputWrite.get());
+        const auto oobeProcess = oobeProcessBuilder.Start();
+        oobeOutputWrite.reset();
+
+        PartialHandleRead oobeOutput(oobeOutputRead.get());
+        oobeOutput.Expect("OOBE_STARTED\n");
+
+        wsl::windows::common::SubProcess waitingProcessBuilder(
+            nullptr, LxssGenerateWslCommandLine(L"-d " LXSS_DISTRO_NAME_TEST_L L" true").c_str());
+        const auto waitingProcess = waitingProcessBuilder.Start();
+        const DWORD waitingResult = WaitForSingleObject(waitingProcess.get(), waiterObservationTimeout);
+
+        wsl::windows::common::SubProcess terminationProcessBuilder(
+            nullptr, LxssGenerateWslCommandLine(L"--terminate " LXSS_DISTRO_NAME_TEST_L).c_str());
+        const auto terminationProcess = terminationProcessBuilder.Start();
+        const DWORD terminationResult = WaitForSingleObject(terminationProcess.get(), terminationTimeout);
+
+        if (terminationResult == WAIT_TIMEOUT)
+        {
+            VERIFY_ARE_EQUAL(WaitForSingleObject(terminationProcess.get(), cleanupTimeout), WAIT_OBJECT_0);
+        }
+
+        VERIFY_ARE_EQUAL(waitingResult, WAIT_TIMEOUT);
+        VERIFY_ARE_EQUAL(terminationResult, WAIT_OBJECT_0);
+        VERIFY_ARE_EQUAL(wsl::windows::common::SubProcess::GetExitCode(terminationProcess.get(), 0), 0u);
+        VERIFY_ARE_EQUAL(WaitForSingleObject(waitingProcess.get(), cleanupTimeout), WAIT_OBJECT_0);
+        VERIFY_ARE_EQUAL(WaitForSingleObject(oobeProcess.get(), cleanupTimeout), WAIT_OBJECT_0);
+    }
+
     static void ValidateDistributionStarts(LPCWSTR Name)
     {
         auto [out, _] = LxsstuLaunchWslAndCaptureOutput(std::format(L"-d {} echo -n OK", Name));

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -4783,17 +4783,9 @@ VERSION_ID="Invalid|Format"
 
         wsl::windows::common::SubProcess terminationProcessBuilder(
             nullptr, LxssGenerateWslCommandLine(L"--terminate " LXSS_DISTRO_NAME_TEST_L).c_str());
-        const auto terminationProcess = terminationProcessBuilder.Start();
-        const DWORD terminationResult = WaitForSingleObject(terminationProcess.get(), terminationTimeout);
-
-        if (terminationResult == WAIT_TIMEOUT)
-        {
-            VERIFY_ARE_EQUAL(WaitForSingleObject(terminationProcess.get(), cleanupTimeout), WAIT_OBJECT_0);
-        }
+        VERIFY_ARE_EQUAL(terminationProcessBuilder.Run(terminationTimeout), 0u);
 
         VERIFY_ARE_EQUAL(waitingResult, WAIT_TIMEOUT);
-        VERIFY_ARE_EQUAL(terminationResult, WAIT_OBJECT_0);
-        VERIFY_ARE_EQUAL(wsl::windows::common::SubProcess::GetExitCode(terminationProcess.get(), 0), 0u);
         VERIFY_ARE_EQUAL(WaitForSingleObject(waitingProcess.get(), cleanupTimeout), WAIT_OBJECT_0);
         VERIFY_ARE_EQUAL(WaitForSingleObject(oobeProcess.get(), cleanupTimeout), WAIT_OBJECT_0);
     }


### PR DESCRIPTION
## Summary of the Pull Request

Process creation can wait for a distribution's OOBE to complete while holding
`WslCoreInstance::m_lock`. Because `Stop()` requires the same lock before it can
signal `m_destroyingEvent`, terminating the distribution can deadlock until the
OOBE exits on its own.

This change releases the instance lock while waiting and waits for either OOBE
completion or instance destruction. After reacquiring the lock, it validates
that the instance is still running before continuing.

## PR Checklist

- [x] **Closes:** Closes #41386
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

`WslCoreInstance::CreateLxProcess()` currently acquires `m_lock` before checking
whether OOBE is still running. If it is, the function waits indefinitely on
`m_oobeCompleteEvent` without releasing the lock.

`WslCoreInstance::Stop()` acquires `m_lock` before setting
`m_destroyingEvent`. This creates the following cycle:

1. Process creation holds `m_lock` and waits for OOBE completion.
2. Distribution termination waits for `m_lock` in `Stop()`.
3. `Stop()` cannot signal `m_destroyingEvent` while process creation holds the lock.

The wait now uses duplicated event handles captured while the instance state is
protected, releases `m_lock`, and waits for either OOBE completion or instance
destruction. It then reacquires the lock and revalidates `m_initChannel` and
`m_consoleManager` before using them.

## Validation Steps Performed

Added `ModernOOBETermination`, a WSL2 regression test that:

1. Starts an OOBE command that signals readiness and remains active.
2. Starts a second process that waits for OOBE completion.
3. Terminates the distribution while that process is waiting.
4. Verifies termination completes before the OOBE command's natural exit.
5. Verifies both waiting processes exit during cleanup.

Static inspection was performed locally. The Windows build, formatting check,
and test execution are left to repository CI because the integration tests
affect machine-wide WSL state.
