### PR TITLE
In mirrored mode, handle route update as add instead of replace

### DIFF
--- a/src/linux/netlinkutil/RoutingTable.cpp
+++ b/src/linux/netlinkutil/RoutingTable.cpp
@@ -96,7 +96,7 @@ void RoutingTable::ModifyRouteImpl(const Route& route, Operation action)
         // (destination prefix, tos, metric) alone - ignoring the next hop / output interface -
         // so replacing a route can silently overwrite a *different* interface's route that happens
         // to share the same key (e.g. two interfaces with a default route at the same metric),
-        // deleting it. An Update is send by the WSL service to mean "ensure this route exists",
+        // deleting it. An Update is sent by the WSL service to mean "ensure this route exists",
         // so a create is sufficient.
         // Note: The EEXIST error is already treated as non-fatal.
         // flags = NLM_F_CREATE;

--- a/src/linux/netlinkutil/RoutingTable.cpp
+++ b/src/linux/netlinkutil/RoutingTable.cpp
@@ -92,7 +92,15 @@ void RoutingTable::ModifyRouteImpl(const Route& route, Operation action)
     int operation = 0;
     if (action == Update)
     {
-        flags = NLM_F_CREATE | NLM_F_REPLACE;
+        // Intentionally omit NLM_F_REPLACE. NLM_F_REPLACE matches an existing route by
+        // (destination prefix, tos, metric) alone - ignoring the next hop / output interface -
+        // so replacing a route can silently overwrite a *different* interface's route that happens
+        // to share the same key (e.g. two interfaces with a default route at the same metric),
+        // deleting it. An Update is send by the WSL service to mean "ensure this route exists",
+        // so a create is sufficient.
+        // Note: The EEXIST error is already treated as non-fatal.
+        // flags = NLM_F_CREATE;
+        flags = NLM_F_CREATE;
         operation = RTM_NEWROUTE;
     }
     else if (action == Create)

--- a/src/linux/netlinkutil/RoutingTable.cpp
+++ b/src/linux/netlinkutil/RoutingTable.cpp
@@ -92,15 +92,12 @@ void RoutingTable::ModifyRouteImpl(const Route& route, Operation action)
     int operation = 0;
     if (action == Update)
     {
-        // Intentionally omit NLM_F_REPLACE. NLM_F_REPLACE matches an existing route by
+        // Note: NLM_F_REPLACE matches an existing route by
         // (destination prefix, tos, metric) alone - ignoring the next hop / output interface -
         // so replacing a route can silently overwrite a *different* interface's route that happens
         // to share the same key (e.g. two interfaces with a default route at the same metric),
-        // deleting it. An Update is sent by the WSL service to mean "ensure this route exists",
-        // so a create is sufficient.
-        // Note: The EEXIST error is already treated as non-fatal.
-        // flags = NLM_F_CREATE;
-        flags = NLM_F_CREATE;
+        // deleting the second route.
+        flags = NLM_F_CREATE | NLM_F_REPLACE;
         operation = RTM_NEWROUTE;
     }
     else if (action == Create)

--- a/src/windows/service/exe/WslMirroredNetworking.cpp
+++ b/src/windows/service/exe/WslMirroredNetworking.cpp
@@ -1396,38 +1396,23 @@ _Check_return_ bool wsl::core::networking::WslMirroredNetworkManager::SyncIpStat
             std::optional<HRESULT> hr{};
             switch (trackedRoute.SyncStatus)
             {
+            // For routes, an Add and an Update resolve to the same guest netlink operation
+            // (RTM_NEWROUTE | NLM_F_CREATE, with EEXIST ignored), so a single Add is sufficient to plumb
+            // a new route or re-assert an existing one.
             case PendingAdd:
+            case PendingUpdate:
                 hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Add);
-                if (FAILED(hr.value()))
-                {
-                    // try to update it instead if it already exists
-                    hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Update);
-                }
                 break;
 
             case Synced:
                 if (refreshAllRoutes)
                 {
-                    hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Update);
-                    if (FAILED(hr.value()))
-                    {
-                        // try to add it
-                        hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Add);
-                    }
+                    hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Add);
                     if (FAILED(hr.value()))
                     {
                         trackedRoute.SyncStatus = PendingUpdate;
                         trackedRoute.SyncRetryCount = TrackedRoute::MaxSyncRetryCount;
                     }
-                }
-                break;
-
-            case PendingUpdate:
-                hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Update);
-                if (FAILED(hr.value()))
-                {
-                    // try to add it
-                    hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Add);
                 }
                 break;
 

--- a/src/windows/service/exe/WslMirroredNetworking.cpp
+++ b/src/windows/service/exe/WslMirroredNetworking.cpp
@@ -1396,10 +1396,17 @@ _Check_return_ bool wsl::core::networking::WslMirroredNetworkManager::SyncIpStat
             std::optional<HRESULT> hr{};
             switch (trackedRoute.SyncStatus)
             {
-            // Use Add rather than Update to (re-)assert routes. An Update replaces by
+            // Use ModifyRequestType::Add rather than ModifyRequestType::Update for PendingUpdate.
+            // An Update in GNS uses NLM_F_REPLACE and replaces by
             // (destination prefix, tos, metric) key alone and would silently overwrite a same-key route
             // belonging to a *different* interface (e.g. another interface's default at the same metric).
-            // A create plumbs a new route or leaves an existing one in place (EEXIST is ignored).
+            // An ModifyRequestType::Add plumbs a new route or leaves an existing one in place (EEXIST is ignored),
+            // which is the desited behavior for PendingUpdate.
+            //
+            // The route synchronization logic never attempts an in-place update of a route. Whenever
+            // a route change occurs on the host (ProcessRouteChange), we mark for removal the routes that are known
+            // to have been synced in Linux but are no longer part of the latest set of host routes, we do not
+            // do a diff of the route properties to determine if an in-place update is needed.
             case PendingAdd:
             case PendingUpdate:
                 hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Add);

--- a/src/windows/service/exe/WslMirroredNetworking.cpp
+++ b/src/windows/service/exe/WslMirroredNetworking.cpp
@@ -1396,9 +1396,10 @@ _Check_return_ bool wsl::core::networking::WslMirroredNetworkManager::SyncIpStat
             std::optional<HRESULT> hr{};
             switch (trackedRoute.SyncStatus)
             {
-            // For routes, an Add and an Update resolve to the same guest netlink operation
-            // (RTM_NEWROUTE | NLM_F_CREATE, with EEXIST ignored), so a single Add is sufficient to plumb
-            // a new route or re-assert an existing one.
+            // Use Add rather than Update to (re-)assert routes. An Update replaces by
+            // (destination prefix, tos, metric) key alone and would silently overwrite a same-key route
+            // belonging to a *different* interface (e.g. another interface's default at the same metric).
+            // A create plumbs a new route or leaves an existing one in place (EEXIST is ignored).
             case PendingAdd:
             case PendingUpdate:
                 hr = SendRouteRequestToGns(endpoint, trackedRoute, hns::ModifyRequestType::Add);

--- a/src/windows/service/exe/WslMirroredNetworking.cpp
+++ b/src/windows/service/exe/WslMirroredNetworking.cpp
@@ -1401,7 +1401,7 @@ _Check_return_ bool wsl::core::networking::WslMirroredNetworkManager::SyncIpStat
             // (destination prefix, tos, metric) key alone and would silently overwrite a same-key route
             // belonging to a *different* interface (e.g. another interface's default at the same metric).
             // An ModifyRequestType::Add plumbs a new route or leaves an existing one in place (EEXIST is ignored),
-            // which is the desited behavior for PendingUpdate.
+            // which is the desired behavior for PendingUpdate.
             //
             // The route synchronization logic never attempts an in-place update of a route. Whenever
             // a route change occurs on the host (ProcessRouteChange), we mark for removal the routes that are known

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -367,6 +367,43 @@ class NetworkTests
         VERIFY_ARE_EQUAL(v6State.DefaultRoute->Device, L"eth0");
     }
 
+    // Adds a dummy interface with a default route over it, then updates the default route on eth0 to have the same metric.
+    // The test verifies that both default routes exist after the update.
+    WSL2_TEST_METHOD(UpdateDefaultRouteKeepsOtherInterfaceRoute)
+    {
+        constexpr auto c_dummyInterface = L"wsldummy0";
+        constexpr auto c_sharedMetric = 100;
+        const std::wstring metricArg = L" metric " + std::to_wstring(c_sharedMetric);
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::wstring(L"ip link add ") + c_dummyInterface + L" type dummy"), (DWORD)0);
+
+        auto removeDummyInterface = wil::scope_exit([&] { LxsstuLaunchWsl(std::wstring(L"ip link del ") + c_dummyInterface); });
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::wstring(L"ip link set ") + c_dummyInterface + L" up"), (DWORD)0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::wstring(L"ip route add default dev ") + c_dummyInterface + metricArg), (DWORD)0);
+
+        const auto defaultRouteExistsOnDevice = [&](const std::wstring& device) {
+            return LxsstuLaunchWsl(
+                       L"ip -4 route show default | grep -w \"dev " + device + L"\" | grep -qw \"metric " +
+                       std::to_wstring(c_sharedMetric) + L"\"") == (DWORD)0;
+        };
+
+        VERIFY_IS_TRUE(defaultRouteExistsOnDevice(c_dummyInterface));
+
+        wsl::shared::hns::Route route;
+        route.NextHop = L"0.0.0.0";
+        route.DestinationPrefix = LX_INIT_DEFAULT_ROUTE_PREFIX;
+        route.Family = AF_INET;
+        route.Metric = c_sharedMetric;
+        SendDeviceSettingsRequest(L"eth0", route, ModifyRequestType::Update, GuestEndpointResourceType::Route);
+
+        VERIFY_IS_TRUE(defaultRouteExistsOnDevice(c_dummyInterface));
+        VERIFY_IS_TRUE(defaultRouteExistsOnDevice(L"eth0"));
+
+        SendDeviceSettingsRequest(L"eth0", route, ModifyRequestType::Remove, GuestEndpointResourceType::Route);
+        VERIFY_IS_FALSE(defaultRouteExistsOnDevice(L"eth0"));
+    }
+
     WSL2_TEST_METHOD(AddDefaultRouteWithOfflinkGateway)
     {
         TestCase({{L"eth0", {{L"100.96.5.160", 32}}, L"100.96.5.161"}});

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -367,43 +367,6 @@ class NetworkTests
         VERIFY_ARE_EQUAL(v6State.DefaultRoute->Device, L"eth0");
     }
 
-    // Adds a dummy interface with a default route over it, then updates the default route on eth0 to have the same metric.
-    // The test verifies that both default routes exist after the update.
-    WSL2_TEST_METHOD(UpdateDefaultRouteKeepsOtherInterfaceRoute)
-    {
-        constexpr auto c_dummyInterface = L"wsldummy0";
-        constexpr auto c_sharedMetric = 100;
-        const std::wstring metricArg = L" metric " + std::to_wstring(c_sharedMetric);
-
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::wstring(L"ip link add ") + c_dummyInterface + L" type dummy"), (DWORD)0);
-
-        auto removeDummyInterface = wil::scope_exit([&] { LxsstuLaunchWsl(std::wstring(L"ip link del ") + c_dummyInterface); });
-
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::wstring(L"ip link set ") + c_dummyInterface + L" up"), (DWORD)0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::wstring(L"ip route add default dev ") + c_dummyInterface + metricArg), (DWORD)0);
-
-        const auto defaultRouteExistsOnDevice = [&](const std::wstring& device) {
-            return LxsstuLaunchWsl(
-                       L"ip -4 route show default | grep -w \"dev " + device + L"\" | grep -qw \"metric " +
-                       std::to_wstring(c_sharedMetric) + L"\"") == (DWORD)0;
-        };
-
-        VERIFY_IS_TRUE(defaultRouteExistsOnDevice(c_dummyInterface));
-
-        wsl::shared::hns::Route route;
-        route.NextHop = L"0.0.0.0";
-        route.DestinationPrefix = LX_INIT_DEFAULT_ROUTE_PREFIX;
-        route.Family = AF_INET;
-        route.Metric = c_sharedMetric;
-        SendDeviceSettingsRequest(L"eth0", route, ModifyRequestType::Update, GuestEndpointResourceType::Route);
-
-        VERIFY_IS_TRUE(defaultRouteExistsOnDevice(c_dummyInterface));
-        VERIFY_IS_TRUE(defaultRouteExistsOnDevice(L"eth0"));
-
-        SendDeviceSettingsRequest(L"eth0", route, ModifyRequestType::Remove, GuestEndpointResourceType::Route);
-        VERIFY_IS_FALSE(defaultRouteExistsOnDevice(L"eth0"));
-    }
-
     WSL2_TEST_METHOD(AddDefaultRouteWithOfflinkGateway)
     {
         TestCase({{L"eth0", {{L"100.96.5.160", 32}}, L"100.96.5.161"}});


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

GNS is handling a route update operation using the NLM_F_REPLACE flag (equivalent to ip route replace), which collapses multiple routes that have the same destination, metric, tos, even if they have different next hops or interfaces. E.g. replacing one of the 2 routes below will collapse them into 1.
default via 10.130.174.1 dev eth1 proto kernel metric 25
default via 10.120.186.1 dev eth0 proto kernel metric 25

This was found when adding and removing and adapter on a test windows host VM - if the new adapter happens to have the same default route with same metric as existing one, after removing the new one connectivity will be lost in WSL as the route of the original one will be deleted if an update happens for the route of the new one.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The mirrored mode route synchronization logic never attempts an in-place update of a route. Whenever a route change occurs on the host (ProcessRouteChange), we mark for removal the routes that are known to have been synced in Linux but are no longer part of the latest set of host routes, we do not do a diff of the route properties to determine if an in-place update is needed.

Handling an update as an Add (ignoring already exists error, which already happens) is the intended behavior for route updates.

Note: NAT and virtio modes already use just add and remove operations for Routes

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Scenario that found the bug: Add-VMNetworkAdapter/Remove-VMNetworkAdapter on a windows host VM and verifying connectivity
Connecting/disconnecting OpenVPN multiple times and verifying connectivity, which leads to routes being added/deleted multiple times
Existing automated NetworkTests + new tests that validate host route updates are correctly mirrored