### PR TITLE
Add timeout for udp dns requests to avoid resource leak

### DIFF
--- a/src/linux/init/DnsServer.cpp
+++ b/src/linux/init/DnsServer.cpp
@@ -5,7 +5,6 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include "DnsServer.h"
-#include "RuntimeErrorWithSourceLocation.h"
 #include "Syscall.h"
 #include "util.h"
 
@@ -15,6 +14,8 @@ constexpr int c_dnsServerPort = 53;
 constexpr int c_epollWaitMaxEvents = 100;
 // Maximum size of DNS over UDP requests is 4096 bytes (max size is reached for EDNS UDP requests)
 constexpr int c_maxUdpDnsBufferSize = 4096;
+// Maximum time to wait for a tunneled UDP DNS response
+constexpr auto c_udpRequestTimeout = std::chrono::seconds{60};
 // Max number of pending connections in the TCP listen queue
 constexpr int c_maxListenBacklog = 1000;
 
@@ -119,9 +120,12 @@ try
     }
 
     // Stop tracking the request, irrespective of the DNS response being successfully sent
-    const auto removeDnsRequest = wil::scope_exit([&] { m_udpRequests.erase(dnsClientIdentifier.DnsClientId); });
+    const auto removeDnsRequest = wil::scope_exit([&] {
+        m_udpRequestExpirations.erase(it->second.m_expiration);
+        m_udpRequests.erase(it);
+    });
 
-    sockaddr_in& remoteAddr = it->second;
+    sockaddr_in& remoteAddr = it->second.m_remoteAddress;
 
     // Send DNS response buffer back to the Linux DNS client
     int bufferSize = dnsBuffer.size();
@@ -298,6 +302,25 @@ try
 }
 CATCH_LOG()
 
+int DnsServer::ExpireUdpRequestsAndGetTimeout() noexcept
+{
+    std::scoped_lock<std::mutex> lock{m_udpLock};
+    const auto now = std::chrono::steady_clock::now();
+
+    while (!m_udpRequestExpirations.empty() && m_udpRequestExpirations.front().first <= now)
+    {
+        m_udpRequests.erase(m_udpRequestExpirations.front().second);
+        m_udpRequestExpirations.pop_front();
+    }
+
+    if (m_udpRequestExpirations.empty())
+    {
+        return -1;
+    }
+
+    return static_cast<int>(std::chrono::ceil<std::chrono::milliseconds>(m_udpRequestExpirations.front().first - now).count());
+}
+
 void DnsServer::ServerLoop() noexcept
 {
     UtilSetThreadName("DnsServer");
@@ -311,7 +334,8 @@ void DnsServer::ServerLoop() noexcept
         {
             // A fixed number of events is requested from epoll_wait (c_epollWaitMaxEvents). In case the number of ready events is
             // greater than c_epollWaitMaxEvents, epoll will round-robin through the ready events until we get a notification for all of them.
-            size_t numReadyEvents = Syscall(epoll_wait, m_epollFd.get(), events, c_epollWaitMaxEvents, -1);
+            const auto timeout = ExpireUdpRequestsAndGetTimeout();
+            size_t numReadyEvents = Syscall(epoll_wait, m_epollFd.get(), events, c_epollWaitMaxEvents, timeout);
 
             // No event
             if (numReadyEvents == 0)
@@ -388,14 +412,26 @@ try
         udpRequestId = requestId;
 
         // Track the request
-        m_udpRequests.emplace(requestId, remoteAddr);
+        const auto expiration = std::chrono::steady_clock::now() + c_udpRequestTimeout;
+        const auto expirationIt = m_udpRequestExpirations.emplace(m_udpRequestExpirations.end(), expiration, requestId);
+        auto removeExpirationOnError = wil::scope_exit([&] { m_udpRequestExpirations.erase(expirationIt); });
+
+        const auto [_, inserted] = m_udpRequests.emplace(requestId, UdpRequestContext{remoteAddr, expirationIt});
+        THROW_UNEXPECTED_IF(!inserted);
+
+        removeExpirationOnError.release();
     }
 
     if (!dnsRequest.empty())
     {
         auto removeRequestOnError = wil::scope_exit([&] {
             std::scoped_lock<std::mutex> lock{m_udpLock};
-            m_udpRequests.erase(udpRequestId);
+            const auto it = m_udpRequests.find(udpRequestId);
+            if (it != m_udpRequests.end())
+            {
+                m_udpRequestExpirations.erase(it->second.m_expiration);
+                m_udpRequests.erase(it);
+            }
         });
 
         // Tunnel request to Windows

--- a/src/linux/init/DnsServer.cpp
+++ b/src/linux/init/DnsServer.cpp
@@ -4,6 +4,7 @@
 #include <sys/epoll.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include "RuntimeErrorWithSourceLocation.h"
 #include "DnsServer.h"
 #include "Syscall.h"
 #include "util.h"

--- a/src/linux/init/DnsServer.h
+++ b/src/linux/init/DnsServer.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <chrono>
+#include <list>
 #include <map>
 #include "common.h"
 #include "lxinitshared.h"
@@ -68,6 +70,14 @@ private:
         TcpConnectionContext& operator=(TcpConnectionContext&&) = delete;
     };
 
+    using UdpRequestExpirationQueue = std::list<std::pair<std::chrono::steady_clock::time_point, uint32_t>>;
+
+    struct UdpRequestContext
+    {
+        sockaddr_in m_remoteAddress;
+        UdpRequestExpirationQueue::iterator m_expiration;
+    };
+
     void StartUdpDnsServer(const std::string& ipAddress) noexcept;
 
     void StartTcpDnsServer(const std::string& ipAddress) noexcept;
@@ -83,6 +93,8 @@ private:
 
     // Read the next DNS request from the UDP socket.
     void HandleUdpDnsRequest() noexcept;
+
+    int ExpireUdpRequestsAndGetTimeout() noexcept;
 
     void HandleUdpDnsResponse(const gsl::span<gsl::byte> dnsBuffer, const LX_GNS_DNS_CLIENT_IDENTIFIER& dnsClientIdentifier) noexcept;
 
@@ -105,7 +117,10 @@ private:
     // Mapping id of an UDP DNS request to the sockaddr_in struct storing the IP and port used by the Linux DNS client that made
     // the DNS request. Note: Since we only configure an IPv4 DNS server in Linux, we expect all Linux DNS clients to use IPv4
     // addresses. _Guarded_by_(m_udpLock)
-    std::map<uint32_t, sockaddr_in> m_udpRequests;
+    std::map<uint32_t, UdpRequestContext> m_udpRequests;
+
+    // UDP requests ordered by expiration time. _Guarded_by_(m_udpLock)
+    UdpRequestExpirationQueue m_udpRequestExpirations;
 
     wil::unique_fd m_tcpListenSocket;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The tunneled UDP DNS request could leak if the Windows side produces no response. 

This PR adds a 60s timeout for each request to avoid this potential leak.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested manually:
1. Add temporary periodic size logging for m_udpRequests.
2. Enabled DNS tunneling and configured a nonexistent external-interface constraint so Windows returned no responses.
3. Sent 1,000 paced UDP DNS queries.
4. Confirmed the map reached 1,000 entries.

Before the fix: 
5. Waited over 70 seconds and confirmed the map remained above 1,000 and continued growing.

After the fix:
5. Confirmed requests were removed approximately 60 seconds after insertion.