### PR TITLE
Handle Linux failures from GNS callbacks

### DIFF
--- a/src/windows/common/WslCoreNetworkingSupport.h
+++ b/src/windows/common/WslCoreNetworkingSupport.h
@@ -136,6 +136,16 @@ inline constexpr auto* c_ipv4TestRequestTargetA = "www.msftconnecttest.com";
 inline constexpr auto* c_ipv6TestRequestTarget = L"ipv6.msftconnecttest.com";
 inline constexpr auto* c_ipv6TestRequestTargetA = "ipv6.msftconnecttest.com";
 
+inline HRESULT GetGnsCallbackResult(LX_MESSAGE_TYPE messageType, HRESULT transportResult, int linuxResultCode) noexcept
+{
+    if (FAILED(transportResult) || messageType == LxGnsMessageConnectTestRequest || linuxResultCode == 0)
+    {
+        return transportResult;
+    }
+
+    return E_UNEXPECTED;
+}
+
 inline constexpr GUID c_wslFirewallVmCreatorId = {0x40E0AC32, 0x46A5, 0x438A, {0xA0, 0xB2, 0x2B, 0x47, 0x9E, 0x8F, 0x2E, 0x90}};
 
 inline constexpr auto c_networkAdapterPrefix = L"VirtualMachine/Devices/NetworkAdapters/";

--- a/src/windows/common/WslCoreNetworkingSupport.h
+++ b/src/windows/common/WslCoreNetworkingSupport.h
@@ -143,7 +143,7 @@ inline HRESULT GetGnsCallbackResult(LX_MESSAGE_TYPE messageType, HRESULT transpo
         return transportResult;
     }
 
-    return E_UNEXPECTED;
+    return E_FAIL;
 }
 
 inline constexpr GUID c_wslFirewallVmCreatorId = {0x40E0AC32, 0x46A5, 0x438A, {0xA0, 0xB2, 0x2B, 0x47, 0x9E, 0x8F, 0x2E, 0x90}};

--- a/src/windows/service/exe/MirroredNetworking.cpp
+++ b/src/windows/service/exe/MirroredNetworking.cpp
@@ -695,11 +695,9 @@ try
                     TraceLoggingValue(retryCount, "retryCount"));
 
                 ++retryCount;
-                THROW_IF_FAILED(hr);
                 return networking::GetGnsCallbackResult(messageType, hr, linuxResultCode);
             };
 
-            // RetryWithTimeout throws if transport fails after the timeout has elapsed.
             return wsl::shared::retry::RetryWithTimeout<HRESULT>(sendMessage, std::chrono::milliseconds(100), std::chrono::seconds(3));
         }
         CATCH_RETURN()

--- a/src/windows/service/exe/MirroredNetworking.cpp
+++ b/src/windows/service/exe/MirroredNetworking.cpp
@@ -667,42 +667,43 @@ try
         WI_ASSERT(WI_IsFlagSet(callbackFlags, wsl::core::networking::GnsCallbackFlags::Wait));
     }
 
-    auto sendGnsMessage =
-        [this, messageType, capturedNotificationString = std::move(notificationString), callbackFlags, returnedValueFromGns]() mutable {
-            try
-            {
-                auto retryCount = 0ul;
-                // RetryWithTimeout throws if fails after the timeout has elapsed - which is caught and returned by m_gnsMessageQueue below
-                return wsl::shared::retry::RetryWithTimeout<HRESULT>(
-                    [&]() {
-                        const auto hr = wil::ResultFromException([&] {
-                            if (returnedValueFromGns && WI_IsFlagSet(callbackFlags, wsl::core::networking::GnsCallbackFlags::Wait))
-                            {
-                                *returnedValueFromGns =
-                                    m_gnsChannel.SendNetworkDeviceMessageReturnResult(messageType, capturedNotificationString.c_str());
-                            }
-                            else
-                            {
-                                m_gnsChannel.SendNetworkDeviceMessage(messageType, capturedNotificationString.c_str());
-                            }
-                        });
-                        WSL_LOG(
-                            "MirroredNetworking::NetworkManagerGnsMessageCallback",
-                            TraceLoggingValue(ToString(messageType), "messageType"),
-                            TraceLoggingValue(capturedNotificationString.c_str(), "notificationString"),
-                            TraceLoggingValue(hr, "hr"),
-                            TraceLoggingValue(returnedValueFromGns ? *returnedValueFromGns : 0xFFFFFFFF, "returnedValueFromGns"),
-                            TraceLoggingValue(retryCount, "retryCount"));
+    auto sendGnsMessage = [this, messageType, capturedNotificationString = std::move(notificationString), callbackFlags, returnedValueFromGns]() mutable {
+        try
+        {
+            auto retryCount = 0ul;
+            auto sendMessage = [&]() {
+                const auto hr = wil::ResultFromException([&] {
+                    if (returnedValueFromGns && WI_IsFlagSet(callbackFlags, wsl::core::networking::GnsCallbackFlags::Wait))
+                    {
+                        *returnedValueFromGns =
+                            m_gnsChannel.SendNetworkDeviceMessageReturnResult(messageType, capturedNotificationString.c_str());
+                    }
+                    else
+                    {
+                        m_gnsChannel.SendNetworkDeviceMessage(messageType, capturedNotificationString.c_str());
+                    }
+                });
+                const bool hasLinuxResult = returnedValueFromGns != nullptr;
+                const int linuxResultCode = hasLinuxResult ? *returnedValueFromGns : 0;
+                WSL_LOG(
+                    "MirroredNetworking::NetworkManagerGnsMessageCallback",
+                    TraceLoggingValue(ToString(messageType), "messageType"),
+                    TraceLoggingValue(capturedNotificationString.c_str(), "notificationString"),
+                    TraceLoggingValue(hr, "hr"),
+                    TraceLoggingValue(hasLinuxResult, "hasLinuxResult"),
+                    TraceLoggingValue(linuxResultCode, "linuxResultCode"),
+                    TraceLoggingValue(retryCount, "retryCount"));
 
-                        ++retryCount;
-                        return THROW_IF_FAILED(
-                            networking::GetGnsCallbackResult(messageType, hr, returnedValueFromGns ? *returnedValueFromGns : 0));
-                    },
-                    std::chrono::milliseconds(100),
-                    std::chrono::seconds(3));
-            }
-            CATCH_RETURN()
-        };
+                ++retryCount;
+                THROW_IF_FAILED(hr);
+                return networking::GetGnsCallbackResult(messageType, hr, linuxResultCode);
+            };
+
+            // RetryWithTimeout throws if transport fails after the timeout has elapsed.
+            return wsl::shared::retry::RetryWithTimeout<HRESULT>(sendMessage, std::chrono::milliseconds(100), std::chrono::seconds(3));
+        }
+        CATCH_RETURN()
+    };
 
     if (WI_IsFlagSet(callbackFlags, wsl::core::networking::GnsCallbackFlags::Wait))
     {

--- a/src/windows/service/exe/MirroredNetworking.cpp
+++ b/src/windows/service/exe/MirroredNetworking.cpp
@@ -695,7 +695,8 @@ try
                             TraceLoggingValue(retryCount, "retryCount"));
 
                         ++retryCount;
-                        return hr;
+                        return networking::GetGnsCallbackResult(
+                            messageType, hr, returnedValueFromGns ? *returnedValueFromGns : 0);
                     },
                     std::chrono::milliseconds(100),
                     std::chrono::seconds(3));

--- a/src/windows/service/exe/MirroredNetworking.cpp
+++ b/src/windows/service/exe/MirroredNetworking.cpp
@@ -695,8 +695,8 @@ try
                             TraceLoggingValue(retryCount, "retryCount"));
 
                         ++retryCount;
-                        return networking::GetGnsCallbackResult(
-                            messageType, hr, returnedValueFromGns ? *returnedValueFromGns : 0);
+                        return THROW_IF_FAILED(
+                            networking::GetGnsCallbackResult(messageType, hr, returnedValueFromGns ? *returnedValueFromGns : 0));
                     },
                     std::chrono::milliseconds(100),
                     std::chrono::seconds(3));

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -3962,13 +3962,12 @@ class GnsCallbackResultTests
 
     TEST_METHOD(GnsCallbackSuccessfulTransportAndLinuxFailureFails)
     {
-        VERIFY_FAILED(wsl::core::networking::GetGnsCallbackResult(LxGnsMessageDeviceSettingRequest, S_OK, -1));
+        VERIFY_ARE_EQUAL(E_FAIL, wsl::core::networking::GetGnsCallbackResult(LxGnsMessageDeviceSettingRequest, S_OK, -1));
     }
 
     TEST_METHOD(GnsCallbackTransportFailureFails)
     {
-        VERIFY_ARE_EQUAL(
-            E_ABORT, wsl::core::networking::GetGnsCallbackResult(LxGnsMessageDeviceSettingRequest, E_ABORT, 0));
+        VERIFY_ARE_EQUAL(E_ABORT, wsl::core::networking::GetGnsCallbackResult(LxGnsMessageDeviceSettingRequest, E_ABORT, 0));
     }
 
     TEST_METHOD(GnsCallbackConnectTestBusinessResultSucceeds)

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -3974,6 +3974,11 @@ class GnsCallbackResultTests
     {
         VERIFY_SUCCEEDED(wsl::core::networking::GetGnsCallbackResult(LxGnsMessageConnectTestRequest, S_OK, -1));
     }
+
+    TEST_METHOD(GnsCallbackConnectTestTransportFailureFails)
+    {
+        VERIFY_ARE_EQUAL(E_ABORT, wsl::core::networking::GetGnsCallbackResult(LxGnsMessageConnectTestRequest, E_ABORT, -1));
+    }
 };
 
 class MirroredTests

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -18,6 +18,7 @@ Abstract:
 #include "wslpolicies.h"
 #include "hns_schema.h"
 #include "WslCoreNetworkEndpointSettings.h"
+#include "WslCoreNetworkingSupport.h"
 
 #include <mstcpip.h>
 #include <winhttp.h>
@@ -3947,6 +3948,32 @@ class NetworkTests
                                            ? expectedErrorCode
                                            : static_cast<int>(wsl::shared::conncheck::ConnCheckStatus::FailureSocketConnect);
         RunGns(ncsiDnsOnlyName, AdapterId, LxGnsMessageConnectTestRequest, testErrorCode);
+    }
+};
+
+class GnsCallbackResultTests
+{
+    WSL_TEST_CLASS(GnsCallbackResultTests)
+
+    TEST_METHOD(GnsCallbackSuccessfulTransportAndLinuxResultSucceeds)
+    {
+        VERIFY_SUCCEEDED(wsl::core::networking::GetGnsCallbackResult(LxGnsMessageDeviceSettingRequest, S_OK, 0));
+    }
+
+    TEST_METHOD(GnsCallbackSuccessfulTransportAndLinuxFailureFails)
+    {
+        VERIFY_FAILED(wsl::core::networking::GetGnsCallbackResult(LxGnsMessageDeviceSettingRequest, S_OK, -1));
+    }
+
+    TEST_METHOD(GnsCallbackTransportFailureFails)
+    {
+        VERIFY_ARE_EQUAL(
+            E_ABORT, wsl::core::networking::GetGnsCallbackResult(LxGnsMessageDeviceSettingRequest, E_ABORT, 0));
+    }
+
+    TEST_METHOD(GnsCallbackConnectTestBusinessResultSucceeds)
+    {
+        VERIFY_SUCCEEDED(wsl::core::networking::GetGnsCallbackResult(LxGnsMessageConnectTestRequest, S_OK, -1));
     }
 };
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Propagates nonzero Linux GNS results as callback failures instead of treating a successful transport as a successful network configuration operation.

The change preserves transport failures and the special `ConnectTest` result semantics, and adds regression tests for all result combinations.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
GNS callbacks provide two independent results:

- a transport `HRESULT`, indicating whether communication with Linux succeeded;
- a Linux result code, indicating whether Linux successfully applied the requested network configuration.

Previously, the callback returned only the transport `HRESULT`. If communication succeeded but Linux failed to apply an address,
route, interface, or DNS update, the operation was reported as successful. This could cause Windows to mark the configuration as
synchronized and stop retrying it.

This change combines the two results for ordinary GNS requests:

- transport failures retain their original `HRESULT`;
- a successful transport with a zero Linux result remains successful;
- a successful transport with a nonzero Linux result returns a failure;
- `ConnectTest` remains exempt because its nonzero result is connectivity status data, not an operation failure.

The result handling is implemented in a shared helper so production code and regression tests use the same logic.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
