### PR TITLE
Add ADMX policy for privileged WSL container support

### DIFF
--- a/intune/WSL.admx
+++ b/intune/WSL.admx
@@ -187,6 +187,17 @@
       </disabledValue>
     </policy>
 
+    <policy name="AllowWSLContainerPrivileged" class="Machine" displayName="$(string.AllowWSLContainerPrivileged)" explainText="$(string.AllowWSLContainerPrivilegedExplain)" key="Software\Policies\WSL" valueName="AllowWSLContainerPrivileged">
+      <parentCategory ref="WSLContainer" />
+      <supportedOn ref="windows:SUPPORTED_Windows10" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
     <policy name="WSLContainerRegistryAllowlist" class="Machine" displayName="$(string.WSLContainerRegistryAllowlist)" explainText="$(string.WSLContainerRegistryAllowlistExplain)" presentation="$(presentation.WSLContainerRegistryAllowlist)" key="Software\Policies\WSL">
       <parentCategory ref="WSLContainer" />
       <supportedOn ref="windows:SUPPORTED_Windows10" />

--- a/intune/cs-CZ/WSL.adml
+++ b/intune/cs-CZ/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Povolit kontejner WSL</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Tato zásada určuje, jestli se na tomto počítači dá používat kontejner WSL. Když je tato zásada povolená nebo není nakonfigurovaná, uživatelé a aplikace pro Windows můžou spouštět kontejnery Linuxu přes WSL. Když je tato zásada zakázaná, kontejner WSL se zablokuje pro všechny uživatele a aplikace pro Windows nemůžou spouštět kontejnery Linuxu. Upozornění: Nastavení na 'Disabled' může narušit aplikace pro Windows, které závisejí na kontejnerech Linuxu.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Seznam povolených registrů pro kontejnery WSL</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Když je tato zásada povolená, kontejner WSL bude moct stahovat image jen z registrů uvedených tady. Ovlivní to rozhraní CLI kontejneru WSL i všechny aplikace používající rozhraní API kontejneru WSL.</string>
     </stringTable>

--- a/intune/da-DK/WSL.adml
+++ b/intune/da-DK/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Tillad WSL-objektbeholder</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Denne politik styrer, om en WSL-objektbeholder kan bruges på denne enhed. Når den er aktiveret eller ikke konfigureret, kan brugere og Windows-programmer køre Linux-containere via WSL. Når den er indstillet til deaktiveret, blokeres WSL-objektbeholderen for alle brugere, og Windows-apps kan ikke køre Linux-objektbeholdere. Advarsel: Hvis du indstiller denne til "Disabled", kan det ødelægge Windows-apps, der er afhængige af Linux-objektbeholdere.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Liste over tilladte registreringsdatabaser for WSL-objektbeholdere</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Når den er aktiveret, har WSL-objektbeholderen kun tilladelse til at hente billeder fra de registreringsdatabaser, der er angivet her. Dette påvirker både WSL-objektbeholderens CLI og alle programmer, der bruger WSL-objektbeholder-API'et.</string>
     </stringTable>

--- a/intune/de-DE/WSL.adml
+++ b/intune/de-DE/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->WSL-Container zulassen</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Diese Richtlinie steuert, ob der WSL-Container auf diesem Computer verwendet werden kann. Wenn diese Option aktiviert oder nicht konfiguriert ist, können Benutzer und Windows-Anwendungen Linux-Container über WSL ausführen. Wenn diese Option auf „Deaktiviert“ festgelegt ist, ist der WSL-Container für alle Benutzer blockiert, und Windows-Apps können keine Linux-Container ausführen. Warnung: Wenn Sie diese Option auf „Disabled“ festlegen, kann dies zu Fehlfunktionen bei Windows-Apps führen, die auf Linux-Containern basieren.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Zulassungsliste für WSL-Containerregistrierungen</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Wenn diese Richtlinie aktiviert ist, darf der WSL-Container nur Bilder aus den hier aufgeführten Registrierungen abrufen. Dies betrifft sowohl die WSL-Container-CLI als auch alle Anwendungen, die die WSL-Container-API verwenden.</string>
     </stringTable>

--- a/intune/en-GB/WSL.adml
+++ b/intune/en-GB/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Allow WSL container</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL container can be used on this machine. When enabled or not configured, users and Windows applications can run Linux containers via WSL. When set to disabled, WSL container is blocked for all users and Windows apps cannot run Linux containers. Warning: Setting this to 'Disabled' can break Windows apps that depend on Linux containers.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Allowlist for WSL container registries</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->When enabled, WSL container will only be allowed to pull images from the registries listed here. This affects both the WSL container CLI and all applications using the WSL container API.</string>
     </stringTable>

--- a/intune/en-US/WSL.adml
+++ b/intune/en-US/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Allow WSL container</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL container can be used on this machine. When enabled or not configured, users and Windows applications can run Linux containers via WSL. When set to disabled, WSL container is blocked for all users and Windows apps cannot run Linux containers. Warning: Setting this to 'Disabled' can break Windows apps that depend on Linux containers.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Allowlist for WSL container registries</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->When enabled, WSL container will only be allowed to pull images from the registries listed here. This affects both the WSL container CLI and all applications using the WSL container API.</string>
     </stringTable>

--- a/intune/es-ES/WSL.adml
+++ b/intune/es-ES/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Permitir contenedor WSL</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Esta directiva controla si se puede usar el contenedor de WSL en esta máquina. Cuando está habilitada o no se configura, los usuarios y las aplicaciones de Windows pueden ejecutar contenedores de Linux a través de WSL. Cuando se configura como deshabilitada, el contenedor de WSL se bloquea para todos los usuarios y las aplicaciones de Windows no pueden ejecutar contenedores de Linux. Advertencia: configurar esta opción como "Disabled" puede interrumpir las aplicaciones de Windows que dependen de contenedores de Linux.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Lista de permitidos para registros de contenedor WSL</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Cuando se habilita, el contenedor WSL solo podrá extraer imágenes de los registros que se enumeran aquí. Esto afecta tanto a la CLI del contenedor WSL como a todas las aplicaciones que usan la API del contenedor WSL.</string>
     </stringTable>

--- a/intune/fi-FI/WSL.adml
+++ b/intune/fi-FI/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Salli WSL-säilö</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Tämä käytäntö määrittää, voiko WSL-säilöä käyttää tässä laitteessa. Kun se on käytössä tai sitä ei ole määritetty, käyttäjät ja Windows-sovellukset voivat suorittaa Linux-säilöjä WSL:n kautta. Kun se on poissa käytöstä, WSL-säilö on estetty kaikilta käyttäjiltä, eivätkä Windows-sovellukset voi suorittaa Linux-säilöjä. Varoitus: Jos asetat käytännön tilaan Disabled, se voi rikkoa Windows-sovelluksia, jotka ovat riippuvaisia Linux-säilöistä.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->WSL-säilörekisterien sallittujen luettelo</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Kun tämä asetus on käytössä, WSL-säilö voi noutaa kuvia vain täällä luetelluista rekistereistä. Tämä vaikuttaa sekä WSL-säilön CLI:hin että kaikkiin sovelluksiin, jotka käyttävät WSL-säilön ohjelmointirajapintaa.</string>
     </stringTable>

--- a/intune/fr-FR/WSL.adml
+++ b/intune/fr-FR/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Autoriser le conteneur WSL</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Cette stratégie contrôle si le conteneur WSL peut être utilisé sur cet appareil. Lorsqu’elle est activée ou non configurée, les utilisateurs et les applications Windows peuvent exécuter des conteneurs Linux via WSL. Lorsqu’elle est désactivée, le conteneur WSL est bloqué pour tous les utilisateurs et les applications Windows ne peuvent pas exécuter de conteneurs Linux. Avertissement : la définition de cette option sur « Disabled » peut rendre inopérantes des applications Windows qui dépendent de conteneurs Linux.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Liste d'autorisation pour les registres de conteneurs WSL</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Lorsqu’il est activé, le conteneur WSL n’est autorisé à extraire des images qu’à partir des registres répertoriés ici. Cela affecte à la fois l’interface CLI du conteneur WSL et toutes les applications utilisant l’API de conteneur WSL.</string>
     </stringTable>

--- a/intune/hu-HU/WSL.adml
+++ b/intune/hu-HU/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->WSL-tároló engedélyezése</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Ez a házirend szabályozza, hogy ezen a gépen használható-e WSL-tároló. Ha engedélyezve van vagy nincs beállítva, a felhasználók és a Windows-alkalmazások WSL-en keresztül futtathatnak Linux-tárolókat. Ha le van tiltva, a WSL-tároló minden felhasználó számára blokkolva van, és a Windows-alkalmazások nem futtathatnak Linux-tárolókat. Figyelmeztetés: Ha ezt „Disabled” értékre állítja, az megszakíthatja azokat a Windows-alkalmazásokat, amelyek Linux-tárolóktól függenek.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->WSL-tárolóregisztrációs adatbázisok engedélyezési listája</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Ha engedélyezve van, a WSL-tároló csak az itt felsorolt tárolókból kérhet le lemezképeket. Ez hatással van a WSL-tároló CLI-re és a WSL-tároló API-t használó összes alkalmazásra is.</string>
     </stringTable>

--- a/intune/it-IT/WSL.adml
+++ b/intune/it-IT/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Consenti contenitore di WSL</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Questo criterio controlla se il contenitore WSL può essere usato in questo computer. Se è abilitato o non configurato, gli utenti e le applicazioni Windows possono eseguire contenitori Linux tramite WSL. Se è impostato su Disabled, il contenitore WSL è bloccato per tutti gli utenti e le app Windows non possono eseguire contenitori Linux. Avviso: impostando questo criterio su "Disabled", si possono interrompere le app Windows che dipendono da contenitori Linux.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Elenco elementi consentiti per i registri del contenitore WSL</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Quando è abilitato, il contenitore WSL può eseguire il pull delle immagini solo dai registri elencati qui. Questo influisce sia sulla CLI del contenitore WSL sia su tutte le applicazioni che usano l'API del contenitore WSL.</string>
     </stringTable>

--- a/intune/ja-JP/WSL.adml
+++ b/intune/ja-JP/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->WSL コンテナーを許可する</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->このポリシーは、このマシンで WSL コンテナーを使用できるかどうかを制御します。有効にするか未構成の場合、ユーザーと Windows アプリケーションは WSL を介して Linux コンテナーを実行できます。無効に設定すると、WSL コンテナーはすべてのユーザーに対してブロックされ、Windows アプリは Linux コンテナーを実行できません。警告: これを 'Disabled' に設定すると、Linux コンテナーに依存する Windows アプリに問題が発生する可能性があります。</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->WSL コンテナー レジストリの許可リスト</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->有効にすると、WSL コンテナーは、ここに一覧表示されているレジストリからのみイメージをプルできます。これは、WSL コンテナー CLI と、WSL コンテナー API を使用するすべてのアプリケーションの両方に影響します。</string>
     </stringTable>

--- a/intune/ko-KR/WSL.adml
+++ b/intune/ko-KR/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->WSL 컨테이너 허용</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->이 정책은 이 컴퓨터에서 WSL 컨테이너를 사용할 수 있는지 여부를 제어합니다. 사용하도록 설정하거나 구성되지 않은 경우 사용자와 Windows 애플리케이션은 WSL을 통해 Linux 컨테이너를 실행할 수 있습니다. 사용 안 함으로 설정하면 모든 사용자에 대해 WSL 컨테이너가 차단되고 Windows 앱은 Linux 컨테이너를 실행할 수 없습니다. 경고: 이 값을 'Disabled'으로 설정하면 Linux 컨테이너에 의존하는 Windows 앱이 중단될 수 있습니다.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->WSL 컨테이너 레지스트리 허용 목록</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->사용하도록 설정할 경우, WSL 컨테이너는 여기 나열된 레지스트리에서만 이미지를 가져올 수 있습니다. 이는 WSL 컨테이너 CLI와 WSL 컨테이너 API를 사용하는 모든 애플리케이션에 영향을 줍니다.</string>
     </stringTable>

--- a/intune/nb-NO/WSL.adml
+++ b/intune/nb-NO/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Tillat WSL-beholder</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Denne policyen styrer om WSL-beholdere kan brukes på denne maskinen. Når den er aktivert eller ikke konfigurert, kan brukere og Windows-programmer kjøre Linux-beholdere via WSL. Når den er deaktivert, blokkeres WSL-beholdere for alle brukere, og Windows-apper kan ikke kjøre Linux-beholdere. Advarsel: Hvis denne settes til 'Disabled', kan Windows-apper som er avhengige av Linux-beholdere, slutte å fungere.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Tillatelsesliste for WSL-beholderregistre</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Når dette er aktivert, har WSL-beholderen bare tillatelse til å hente bilder fra registrene som er oppført her. Dette påvirker både CLI for WSL-beholderen og alle programmer som bruker WSL-beholder-API-et.</string>
     </stringTable>

--- a/intune/nl-NL/WSL.adml
+++ b/intune/nl-NL/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->WSL-container toestaan</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Dit beleid bepaalt of de WSL-container op dit apparaat kan worden gebruikt. Wanneer deze is ingeschakeld of niet is geconfigureerd, kunnen gebruikers en Windows-toepassingen Linux-containers uitvoeren via WSL. Wanneer deze is uitgeschakeld, wordt de WSL-container voor alle gebruikers geblokkeerd en kunnen Windows-apps geen Linux-containers uitvoeren. Waarschuwing: als je dit instelt op 'Disabled', kunnen Windows-apps die afhankelijk zijn van Linux-containers, worden onderbroken.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Acceptatielijst voor WSL-containerregisters</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Als deze optie is ingeschakeld, mag de WSL-container alleen installatiekopieën ophalen uit de registers die hier worden vermeld. Dit is van invloed op zowel de WSL-container-CLI als alle toepassingen die gebruikmaken van de WSL-container-API.</string>
     </stringTable>

--- a/intune/pl-PL/WSL.adml
+++ b/intune/pl-PL/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Zezwalaj na kontener WSL</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Ta zasada kontroluje, czy kontener WSL może być używany na tym urządzeniu. Po włączeniu lub gdy nie jest skonfigurowana, użytkownicy i aplikacje Windows mogą uruchamiać kontenery Linux za pośrednictwem WSL. Po ustawieniu na wyłączoną, kontener WSL jest blokowany dla wszystkich użytkowników, a aplikacje Windows nie mogą uruchamiać kontenerów Linux. Ostrzeżenie: ustawienie tej opcji na „Disabled” może spowodować problemy z aplikacjami Windows, które zależą od kontenerów Linux.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Lista dozwolonych dla rejestrów kontenerów WSL</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Po włączeniu kontener WSL będzie mógł ściągać obrazy tylko z rejestrów wymienionych w tym miejscu. Ma to wpływ zarówno na interfejs wiersza polecenia kontenera WSL, jak i na wszystkie aplikacje korzystające z interfejsu API kontenera WSL.</string>
     </stringTable>

--- a/intune/pt-BR/WSL.adml
+++ b/intune/pt-BR/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Permitir contêiner WSL</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Essa política controla se o contêiner WSL pode ser usado neste computador. Quando habilitados ou não configurados, os usuários e aplicativos do Windows podem executar contêineres do Linux por meio do WSL. Quando definido como desabilitado, o contêiner WSL é bloqueado para todos os usuários e os aplicativos do Windows não podem executar contêineres do Linux. Aviso: definir isso como 'Disabled' pode interromper aplicativos do Windows que dependem de contêineres do Linux.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Lista de permissões para registros de contêiner do WSL</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Quando habilitado, o contêiner WSL só terá permissão para extrair imagens dos registros listados aqui. Isso afeta a CLI do contêiner do WSL e todos os aplicativos que usam a API de contêiner do WSL.</string>
     </stringTable>

--- a/intune/pt-PT/WSL.adml
+++ b/intune/pt-PT/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Permitir o contentor WSL</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Esta política controla se o contentor WSL pode ser utilizado neste computador. Quando ativada ou não configurada, os utilizadores e as aplicações Windows podem executar contentores Linux através do WSL. Quando definida como desativada, o contentor WSL é bloqueado para todos os utilizadores e as aplicações Windows não conseguem executar contentores Linux. Aviso: definir esta política como "Disabled" pode comprometer aplicações Windows que dependem de contentores Linux.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Lista de permissões para registos de contentor WSL</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Quando ativado, o contentor WSL só poderá solicitar imagens dos registos listados aqui. Isto afeta tanto a CLI do contentor WSL como todas as aplicações que utilizam a API do contentor WSL.</string>
     </stringTable>

--- a/intune/ru-RU/WSL.adml
+++ b/intune/ru-RU/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Разрешить WSL-контейнер</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Эта политика определяет, можно ли использовать WSL-контейнер на этом компьютере. Если эта политика включена или не настроена, пользователи и приложения Windows могут запускать контейнеры Linux с помощью WSL. Если задано значение "Disabled", контейнер WSL блокируется для всех пользователей, а приложения Windows не могут запускать контейнеры Linux. Предупреждение. Если задать значение "Отключено", может быть нарушена работа приложений Windows, которые зависят от контейнеров Linux.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Список разрешений для реестров WSL-контейнеров</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Если этот параметр включен, WSL-контейнеру будет разрешено получать образы только из перечисленных здесь реестров. Этот параметр влияет как на интерфейс командной строки WSL-контейнеров, так и на все приложения, использующие API WSL-контейнеров.</string>
     </stringTable>

--- a/intune/sv-SE/WSL.adml
+++ b/intune/sv-SE/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->Tillåt WSL-container</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Den här principen styr om WSL-containern kan användas på den här datorn. När den är aktiverad eller inte konfigurerad kan användare och Windows-program köra Linux-containrar via WSL. När den är inaktiverad blockeras WSL-containern för alla användare och Windows-appar kan inte köra Linux-containrar. Varning! Om du ställer in den här inställningen på "Disabled" kan Windows-appar som är beroende av Linux-containrar sluta fungera.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->Tillåt lista för WSL-containerregister</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->När WSL-containern är aktiverad tillåts den bara att hämta avbildningar från de register som anges här. Detta påverkar både WSL-containerns CLI och alla program som använder WSL-container-API:et.</string>
     </stringTable>

--- a/intune/tr-TR/WSL.adml
+++ b/intune/tr-TR/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->WSL kapsayıcısına izin ver</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->Bu ilke, bu makinede WSL kapsayıcısının kullanılıp kullanılamayacağını denetler. Bu özellik etkinleştirildiğinde veya yapılandırılmadığında, kullanıcılar ve Windows uygulamaları WSL aracılığıyla Linux kapsayıcılarını çalıştırabilir. Devre dışı bırakıldığında, WSL kapsayıcısı tüm kullanıcılar için engellenir ve Windows uygulamaları Linux kapsayıcılarını çalıştıramaz. Uyarı: Bu ayarı 'Disabled' olarak belirlemek, Linux kapsayıcılarına bağlı Windows uygulamalarının çalışmamasına neden olabilir.</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->WSL kapsayıcısı kayıt defterleri için izin listesi</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->Etkinleştirildiğinde, WSL kapsayıcısının yalnızca burada listelenen kayıt defterlerinden görüntü çekmesine izin verilir. Bu, hem WSL kapsayıcı CLI'sini hem de WSL kapsayıcı API'sini kullanan tüm uygulamaları etkiler.</string>
     </stringTable>

--- a/intune/zh-CN/WSL.adml
+++ b/intune/zh-CN/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->允许 WSL 容器</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->此策略控制是否可在此计算机上使用 WSL 容器。如果已启用或未配置，则用户和 Windows 应用程序可以通过 WSL 运行 Linux 容器。如果设置为“Disabled”，则会阻止所有用户使用 WSL 容器，并且 Windows 应用无法运行 Linux 容器。警告: 将此项设置为“Disabled”可能会导致依赖 Linux 容器的 Windows 应用无法正常工作。</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->WSL 容器注册表的允许列表</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->启用后，WSL 容器将仅允许从此处列出的注册表中拉取映像。这会影响 WSL 容器 CLI 和所有使用 WSL 容器 API 的应用程序。</string>
     </stringTable>

--- a/intune/zh-TW/WSL.adml
+++ b/intune/zh-TW/WSL.adml
@@ -55,6 +55,9 @@
         <string id="AllowWSLContainer"><!-- _locComment_text='{Locked="WSL"}' -->允許 WSL 容器</string>
         <string id="AllowWSLContainerExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->此原則會控制是否可在此電腦上使用 WSL 容器。啟用或未設定時，使用者和 Windows 應用程式可以透過 WSL 執行 Linux 容器。設定為停用時，系統會針對所有使用者封鎖 WSL 容器，且 Windows 應用程式無法執行 Linux 容器。警告: 將此設定為「Disabled」可能會中斷依賴 Linux 容器的 Windows 應用程式。</string>
 
+        <string id="AllowWSLContainerPrivileged"><!-- _locComment_text='{Locked="WSL"}' -->Allow privileged WSL containers</string>
+        <string id="AllowWSLContainerPrivilegedExplain"><!-- _locComment_text='{Locked="WSL"}{Locked="Disabled"}' -->This policy controls whether WSL containers can run in privileged mode on this machine. When enabled or not configured, users and Windows applications can start privileged containers. When set to 'Disabled', requests to start a privileged container are refused for all users and Windows apps. Privileged containers run with elevated Linux capabilities and reduced isolation from the container host.</string>
+
         <string id="WSLContainerRegistryAllowlist"><!-- _locComment_text='{Locked="WSL"}' -->WSL 容器登錄的允許清單</string>
         <string id="WSLContainerRegistryAllowlistExplain"><!-- _locComment_text='{Locked="WSL"}' -->啟用時，只允許 WSL 容器從此處列出的登錄提取映像。這會影響 WSL 容器 CLI 以及所有使用 WSL 容器 API 的應用程式。</string>
     </stringTable>

--- a/src/windows/inc/wslpolicies.h
+++ b/src/windows/inc/wslpolicies.h
@@ -34,6 +34,7 @@ inline constexpr auto c_allowCustomNetworkingModeUserSetting = L"AllowNetworking
 inline constexpr auto c_allowCustomFirewallUserSetting = L"AllowFirewallUserSetting";
 inline constexpr auto c_defaultNetworkingMode = L"DefaultNetworkingMode";
 inline constexpr auto c_allowWSLContainer = L"AllowWSLContainer";
+inline constexpr auto c_allowWSLContainerPrivileged = L"AllowWSLContainerPrivileged";
 inline constexpr auto c_wslContainerRegistryAllowlist = L"WSLContainerRegistryAllowlist";
 
 inline std::optional<DWORD> GetPolicyValue(HKEY key, LPCWSTR name)


### PR DESCRIPTION
Reserves a Group Policy value so administrators can control privileged WSL container support if that capability is added.

### What this adds

- `intune/WSL.admx`: new `AllowWSLContainerPrivileged` policy under the existing WSL Container category, backed by `HKLM\Software\Policies\WSL\AllowWSLContainerPrivileged`.
- `intune/<locale>/WSL.adml`: the two new string ids.
- `src/windows/inc/wslpolicies.h`: `c_allowWSLContainerPrivileged` constant.

### Behavior

Nothing reads this value yet, so there is no functional change. The intent is to have the policy surface in place ahead of a possible feature, so managed environments can set it from day one rather than waiting for a later ADMX refresh.

Semantics follow the existing policies and `policies::IsFeatureAllowed`: absent or enabled means allowed, `Disabled` means blocked. Worth a second opinion given privileged containers are a security-relevant capability - if deny-by-default is preferred here, that needs a different helper than `IsFeatureAllowed`.

### Note on the localized ADML files

`tools/devops/validate-localization.py` requires every locale ADML to carry the same string ids as the en-US baseline, so a en-US-only change fails CI. The non-en-US files therefore carry the en-US text as a placeholder for the two new ids; the localization pipeline will replace it. No existing translation was modified.
