### PR TITLE
Align wslc volume inspect and prune output with docker

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -3602,9 +3602,8 @@ On first run, creates the file with all settings commented out at their defaults
   <data name="WSLCCLI_VolumePruneAllArgDescription" xml:space="preserve">
     <value>Remove all unused volumes, not just anonymous ones.</value>
   </data>
-  <data name="WSLCCLI_VolumePruneDeleted" xml:space="preserve">
-    <value>Deleted: {}</value>
-    <comment>{FixedPlaceholder="{}"}Command line arguments, file names and string inserts should not be translated</comment>
+  <data name="WSLCCLI_VolumePruneDeletedHeader" xml:space="preserve">
+    <value>Deleted Volumes:</value>
   </data>
   <data name="WSLCCLI_VolumePruneSpaceReclaimed" xml:space="preserve">
     <value>Total reclaimed space: {}</value>

--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -401,7 +401,7 @@ std::wstring wsl::windows::common::string::FormatBytes(uint64_t Bytes)
     return FormatStorageSize(Bytes, StorageSizeUnit::Decimal, 2, true);
 }
 
-std::wstring wsl::windows::common::string::FormatDockerSize(uint64_t Bytes)
+std::wstring wsl::windows::common::string::FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision)
 {
     constexpr std::wstring_view c_units[] = {L"B", L"kB", L"MB", L"GB", L"TB", L"PB", L"EB", L"ZB", L"YB"};
 
@@ -413,7 +413,7 @@ std::wstring wsl::windows::common::string::FormatDockerSize(uint64_t Bytes)
         unitIndex++;
     }
 
-    return std::format(L"{:.3g}{}", value, c_units[unitIndex]);
+    return std::format(L"{:.{}g}{}", value, Precision, c_units[unitIndex]);
 }
 
 std::wstring wsl::windows::common::string::TruncateId(_In_ std::wstring_view id, bool shortenLength)

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -35,9 +35,10 @@ std::wstring FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t De
 
 std::wstring FormatBytes(uint64_t Bytes);
 
-// Formats a size the way docker reports image sizes: base 1000, three significant digits and no
-// space (119856765 -> "120MB").
-std::wstring FormatDockerSize(uint64_t Bytes);
+// Formats a size as base 1000 with no space and the given number of significant digits
+// (119856765 -> "120MB" at precision 3, "119.9MB" at 4). Image sizes use precision 3; the
+// reclaimed space reported by the prune commands uses 4.
+std::wstring FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision = 3);
 
 std::vector<std::string> InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize);
 

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -36,8 +36,7 @@ std::wstring FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t De
 std::wstring FormatBytes(uint64_t Bytes);
 
 // Formats a size as base 1000 with no space and the given number of significant digits
-// (119856765 -> "120MB" at precision 3, "119.9MB" at 4). Image sizes use precision 3; the
-// reclaimed space reported by the prune commands uses 4.
+// (119856765 -> "120MB" at precision 3, "119.9MB" at 4).
 std::wstring FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision = 3);
 
 std::vector<std::string> InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize);

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -204,17 +204,44 @@ struct InspectImage
         InspectImage, Id, RepoTags, RepoDigests, Parent, Comment, Created, Author, Architecture, Os, Size, Metadata, Config, RootFS);
 };
 
+// The volume properties reported by "volume inspect". The driver options are named "Options" when
+// reading a volume and "DriverOpts" when creating one; this is the read shape.
 struct InspectVolume
 {
     std::string Name;
     std::string Driver;
     std::string CreatedAt;
-    std::map<std::string, std::string> DriverOpts;
-    std::map<std::string, std::string> Labels;
+    std::string Mountpoint;
+    std::string Scope;
+    std::optional<std::map<std::string, std::string>> Options;
+    std::optional<std::map<std::string, std::string>> Labels;
     std::optional<std::map<std::string, std::string>> Status;
-
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(InspectVolume, Name, Driver, CreatedAt, DriverOpts, Labels, Status);
 };
+
+// Labels and options are reported as null rather than as empty objects, and the driver-specific
+// status is omitted entirely when the driver reports nothing.
+inline void to_json(nlohmann::json& j, const InspectVolume& volume)
+{
+    const auto mapOrNull = [](const std::optional<std::map<std::string, std::string>>& value) {
+        return value.has_value() && !value->empty() ? nlohmann::json(*value) : nlohmann::json(nullptr);
+    };
+
+    j = nlohmann::json::object();
+    j["CreatedAt"] = volume.CreatedAt;
+    j["Driver"] = volume.Driver;
+    j["Labels"] = mapOrNull(volume.Labels);
+    j["Mountpoint"] = volume.Mountpoint;
+    j["Name"] = volume.Name;
+    j["Options"] = mapOrNull(volume.Options);
+    j["Scope"] = volume.Scope;
+
+    if (volume.Status.has_value() && !volume.Status->empty())
+    {
+        j["Status"] = *volume.Status;
+    }
+}
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT_FROM_ONLY(InspectVolume, Name, Driver, CreatedAt, Mountpoint, Scope, Options, Labels, Status);
 
 struct IPAMConfig
 {

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -204,8 +204,6 @@ struct InspectImage
         InspectImage, Id, RepoTags, RepoDigests, Parent, Comment, Created, Author, Architecture, Os, Size, Metadata, Config, RootFS);
 };
 
-// The volume properties reported by "volume inspect". The driver options are named "Options" when
-// reading a volume and "DriverOpts" when creating one; this is the read shape.
 struct InspectVolume
 {
     std::string Name;

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -89,7 +89,7 @@ namespace {
         entry.ID = truncate ? TruncateId(image.Id, true) : image.Id;
         entry.Repository = image.Repository.value_or(std::string{c_none});
         entry.SharedSize = c_notAvailable;
-        entry.Size = WideToMultiByte(FormatDockerSize(static_cast<uint64_t>(std::max<int64_t>(image.Size, 0))));
+        entry.Size = WideToMultiByte(FormatHumanReadableSize(static_cast<uint64_t>(std::max<int64_t>(image.Size, 0))));
         entry.Tag = image.Tag.value_or(std::string{c_none});
         entry.UniqueSize = c_notAvailable;
 

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -27,9 +27,12 @@ using namespace wsl::windows::common::wslutil;
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::models;
 using namespace wsl::windows::wslc::services;
-using wsl::windows::common::string::FormatBytes;
+using wsl::windows::common::string::FormatHumanReadableSize;
 
 namespace wsl::windows::wslc::task {
+
+// The prune commands report reclaimed space with four significant digits.
+constexpr uint32_t c_reclaimedSpacePrecision = 4;
 
 static bool TryInspectVolume(Terminal& terminal, Session& session, const std::string& volumeName, std::optional<wslc_schema::InspectVolume>& inspectData)
 {
@@ -211,12 +214,18 @@ void PruneVolumes(CLIExecutionContext& context)
 
     auto result = VolumeService::Prune(context.Terminal, session, all, filters);
 
-    for (const auto& volumeName : result.PrunedVolumes)
+    if (!result.PrunedVolumes.empty())
     {
-        context.Terminal.Output(L"{}\n", Localization::WSLCCLI_VolumePruneDeleted(MultiByteToWide(volumeName)));
+        context.Terminal.Output(L"{}\n", Localization::WSLCCLI_VolumePruneDeletedHeader());
+        for (const auto& volumeName : result.PrunedVolumes)
+        {
+            context.Terminal.Output(L"{}\n", MultiByteToWide(volumeName));
+        }
+
+        context.Terminal.Output(L"\n");
     }
 
-    context.Terminal.Output(L"\n");
-    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_VolumePruneSpaceReclaimed(FormatBytes(result.SpaceReclaimed)));
+    context.Terminal.Output(
+        L"{}\n", Localization::WSLCCLI_VolumePruneSpaceReclaimed(FormatHumanReadableSize(result.SpaceReclaimed, c_reclaimedSpacePrecision)));
 }
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -31,7 +31,6 @@ using wsl::windows::common::string::FormatHumanReadableSize;
 
 namespace wsl::windows::wslc::task {
 
-// The prune commands report reclaimed space with four significant digits.
 constexpr uint32_t c_reclaimedSpacePrecision = 4;
 
 static bool TryInspectVolume(Terminal& terminal, Session& session, const std::string& volumeName, std::optional<wslc_schema::InspectVolume>& inspectData)

--- a/src/windows/wslcsession/WSLCGuestVolume.cpp
+++ b/src/windows/wslcsession/WSLCGuestVolume.cpp
@@ -49,10 +49,16 @@ namespace {
 WSLCGuestVolumeImpl::WSLCGuestVolumeImpl(
     std::string&& Name,
     std::string&& CreatedAt,
+    std::string&& Mountpoint,
     std::map<std::string, std::string>&& DriverOpts,
     std::map<std::string, std::string>&& Labels,
     DockerHTTPClient& DockerClient) :
-    m_name(std::move(Name)), m_createdAt(std::move(CreatedAt)), m_driverOpts(std::move(DriverOpts)), m_labels(std::move(Labels)), m_dockerClient(DockerClient)
+    m_name(std::move(Name)),
+    m_createdAt(std::move(CreatedAt)),
+    m_mountpoint(std::move(Mountpoint)),
+    m_driverOpts(std::move(DriverOpts)),
+    m_labels(std::move(Labels)),
+    m_dockerClient(DockerClient)
 {
 }
 
@@ -80,7 +86,12 @@ std::unique_ptr<WSLCGuestVolumeImpl> WSLCGuestVolumeImpl::Create(
         auto createdVolume = DockerClient.CreateVolume(request);
 
         return std::make_unique<WSLCGuestVolumeImpl>(
-            std::move(createdVolume.Name), std::move(createdVolume.CreatedAt), std::move(DriverOpts), std::move(Labels), DockerClient);
+            std::move(createdVolume.Name),
+            std::move(createdVolume.CreatedAt),
+            std::move(createdVolume.Mountpoint),
+            std::move(DriverOpts),
+            std::move(Labels),
+            DockerClient);
     }
     CATCH_AND_THROW_DOCKER_USER_ERROR("Failed to create volume '%hs'", Name != nullptr ? Name : "");
 }
@@ -98,7 +109,7 @@ std::unique_ptr<WSLCGuestVolumeImpl> WSLCGuestVolumeImpl::Open(const wsl::window
     std::map<std::string, std::string> labels = Volume.Labels.value_or(std::map<std::string, std::string>{});
 
     return std::make_unique<WSLCGuestVolumeImpl>(
-        std::string{Volume.Name}, std::string{Volume.CreatedAt}, std::move(driverOpts), std::move(labels), DockerClient);
+        std::string{Volume.Name}, std::string{Volume.CreatedAt}, std::string{Volume.Mountpoint}, std::move(driverOpts), std::move(labels), DockerClient);
 }
 
 void WSLCGuestVolumeImpl::Delete()
@@ -122,7 +133,9 @@ std::string WSLCGuestVolumeImpl::Inspect() const
     inspect.Name = m_name;
     inspect.Driver = WSLCGuestVolumeDriver;
     inspect.CreatedAt = m_createdAt;
-    inspect.DriverOpts = m_driverOpts;
+    inspect.Mountpoint = m_mountpoint;
+    inspect.Scope = WSLCVolumeScope;
+    inspect.Options = m_driverOpts;
     inspect.Labels = m_labels;
 
     return wsl::shared::ToJson(inspect);

--- a/src/windows/wslcsession/WSLCGuestVolume.h
+++ b/src/windows/wslcsession/WSLCGuestVolume.h
@@ -41,6 +41,7 @@ public:
     WSLCGuestVolumeImpl(
         std::string&& Name,
         std::string&& CreatedAt,
+        std::string&& Mountpoint,
         std::map<std::string, std::string>&& DriverOpts,
         std::map<std::string, std::string>&& Labels,
         DockerHTTPClient& DockerClient);
@@ -76,6 +77,7 @@ public:
 private:
     std::string m_name;
     std::string m_createdAt;
+    std::string m_mountpoint;
     std::map<std::string, std::string> m_driverOpts;
     std::map<std::string, std::string> m_labels;
     DockerHTTPClient& m_dockerClient;

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -118,6 +118,7 @@ WSLCVhdVolumeImpl::WSLCVhdVolumeImpl(
     ULONG Lun,
     std::string&& VirtualMachinePath,
     std::string&& CreatedAt,
+    std::string&& Mountpoint,
     std::map<std::string, std::string>&& DriverOpts,
     std::map<std::string, std::string>&& Labels,
     WSLCVirtualMachine& VirtualMachine,
@@ -128,6 +129,7 @@ WSLCVhdVolumeImpl::WSLCVhdVolumeImpl(
     m_hostPath(std::move(HostPath)),
     m_virtualMachinePath(std::move(VirtualMachinePath)),
     m_createdAt(std::move(CreatedAt)),
+    m_mountpoint(std::move(Mountpoint)),
     m_driverOpts(std::move(DriverOpts)),
     m_labels(std::move(Labels)),
     m_sizeBytes(SizeBytes),
@@ -217,6 +219,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
             lun,
             std::move(virtualMachinePath),
             std::move(createdVolume.CreatedAt),
+            std::move(createdVolume.Mountpoint),
             std::move(DriverOpts),
             std::move(Labels),
             VirtualMachine,
@@ -303,6 +306,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Open(
         lun,
         std::move(virtualMachinePath),
         std::string{Volume.CreatedAt},
+        std::string{Volume.Mountpoint},
         std::move(driverOpts),
         std::move(userLabels),
         VirtualMachine,
@@ -334,7 +338,9 @@ std::string WSLCVhdVolumeImpl::Inspect() const
     inspect.Name = m_name;
     inspect.Driver = WSLCVhdVolumeDriver;
     inspect.CreatedAt = m_createdAt;
-    inspect.DriverOpts = m_driverOpts;
+    inspect.Mountpoint = m_mountpoint;
+    inspect.Scope = WSLCVolumeScope;
+    inspect.Options = m_driverOpts;
     inspect.Labels = m_labels;
     inspect.Status = std::map<std::string, std::string>{
         {"HostPath", m_hostPath.string()},

--- a/src/windows/wslcsession/WSLCVhdVolume.h
+++ b/src/windows/wslcsession/WSLCVhdVolume.h
@@ -43,6 +43,7 @@ public:
         ULONG Lun,
         std::string&& VirtualMachinePath,
         std::string&& CreatedAt,
+        std::string&& Mountpoint,
         std::map<std::string, std::string>&& DriverOpts,
         std::map<std::string, std::string>&& Labels,
         WSLCVirtualMachine& VirtualMachine,
@@ -99,6 +100,7 @@ private:
     std::filesystem::path m_hostPath;
     std::string m_virtualMachinePath;
     std::string m_createdAt;
+    std::string m_mountpoint;
     std::map<std::string, std::string> m_driverOpts;
     std::map<std::string, std::string> m_labels;
     ULONGLONG m_sizeBytes{};

--- a/src/windows/wslcsession/WSLCVolumeMetadata.h
+++ b/src/windows/wslcsession/WSLCVolumeMetadata.h
@@ -27,6 +27,10 @@ constexpr auto WSLCVhdVolumeDriver = "vhd";
 // Volume driver name for guest-backed volumes (passthrough to docker's built-in "local" driver).
 constexpr auto WSLCGuestVolumeDriver = "guest";
 
+// The level at which a volume exists: "local" (machine level) or "global" (cluster-wide).
+// Every WSLC volume is machine level.
+constexpr auto WSLCVolumeScope = "local";
+
 struct WSLCVolumeMetadata
 {
     std::string Driver;

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -252,7 +252,6 @@ class StringUnitTests
         VERIFY_ARE_EQUAL(std::wstring{L"1e+03MB"}, FormatHumanReadableSize(999'900'000));
     }
 
-    // The prune commands report reclaimed space with four significant digits.
     TEST_METHOD(FormatHumanReadableSize_SupportsReclaimedSpacePrecision)
     {
         const std::vector<std::pair<uint64_t, std::wstring>> TestCases{

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -5,7 +5,7 @@
 #include "string.hpp"
 
 using wsl::windows::common::string::FormatBytes;
-using wsl::windows::common::string::FormatDockerSize;
+using wsl::windows::common::string::FormatHumanReadableSize;
 using wsl::windows::common::string::FormatStorageSize;
 using wsl::windows::common::string::ParseStorageSize;
 using wsl::windows::common::string::StorageSizeUnit;
@@ -228,9 +228,9 @@ class StringUnitTests
         VERIFY_ARE_EQUAL(std::wstring{L"119.86 MB"}, FormatBytes(119'856'765));
     }
 
-    // Docker renders image sizes with units.HumanSizeWithPrecision(size, 3), which is base 1000 with
-    // three significant digits, no space, and "kB" rather than "KB".
-    TEST_METHOD(FormatDockerSize_MatchesDockerPrecision)
+    // Image sizes are rendered with three significant digits, base 1000, no space, and "kB" rather
+    // than "KB".
+    TEST_METHOD(FormatHumanReadableSize_MatchesImageSizePrecision)
     {
         const std::vector<std::pair<uint64_t, std::wstring>> TestCases{
             {0, L"0B"},
@@ -245,11 +245,28 @@ class StringUnitTests
 
         for (const auto& [bytes, expected] : TestCases)
         {
-            VERIFY_ARE_EQUAL(expected, FormatDockerSize(bytes));
+            VERIFY_ARE_EQUAL(expected, FormatHumanReadableSize(bytes));
         }
 
         // Three significant digits switch to exponent form just below the next unit, matching Go's %g.
-        VERIFY_ARE_EQUAL(std::wstring{L"1e+03MB"}, FormatDockerSize(999'900'000));
+        VERIFY_ARE_EQUAL(std::wstring{L"1e+03MB"}, FormatHumanReadableSize(999'900'000));
+    }
+
+    // The prune commands report reclaimed space with four significant digits.
+    TEST_METHOD(FormatHumanReadableSize_SupportsReclaimedSpacePrecision)
+    {
+        const std::vector<std::pair<uint64_t, std::wstring>> TestCases{
+            {0, L"0B"},
+            {999, L"999B"},
+            {12'288, L"12.29kB"},
+            {119'856'765, L"119.9MB"},
+            {1'090'000'000, L"1.09GB"},
+        };
+
+        for (const auto& [bytes, expected] : TestCases)
+        {
+            VERIFY_ARE_EQUAL(expected, FormatHumanReadableSize(bytes, 4));
+        }
     }
 
     TEST_METHOD(StorageSize_BytesToTextRoundTrips)

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -5108,7 +5108,10 @@ class WSLCTests
         auto vhdInspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::InspectVolume>(output.get());
         VERIFY_ARE_EQUAL(vhdInspect.Name, vhdVolumeName);
         VERIFY_ARE_EQUAL(vhdInspect.Driver, std::string("vhd"));
-        VERIFY_IS_TRUE(vhdInspect.DriverOpts.contains("SizeBytes"));
+        VERIFY_ARE_EQUAL(vhdInspect.Scope, std::string("local"));
+        VERIFY_IS_FALSE(vhdInspect.Mountpoint.empty());
+        VERIFY_IS_TRUE(vhdInspect.Options.has_value());
+        VERIFY_IS_TRUE(vhdInspect.Options->contains("SizeBytes"));
 
         // Verify InspectVolume returns correct details for the guest volume (no driver opts).
         output.reset();
@@ -5118,7 +5121,9 @@ class WSLCTests
         auto guestInspect = wsl::shared::FromJson<wsl::windows::common::wslc_schema::InspectVolume>(output.get());
         VERIFY_ARE_EQUAL(guestInspect.Name, guestVolumeName);
         VERIFY_ARE_EQUAL(guestInspect.Driver, std::string("guest"));
-        VERIFY_IS_TRUE(guestInspect.DriverOpts.empty());
+        VERIFY_ARE_EQUAL(guestInspect.Scope, std::string("local"));
+        VERIFY_IS_FALSE(guestInspect.Mountpoint.empty());
+        VERIFY_IS_FALSE(guestInspect.Options.has_value());
 
         // Verify InspectVolume fails for a non-existent volume.
         output.reset();

--- a/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRemoveTests.cpp
@@ -254,8 +254,9 @@ private:
         VERIFY_ARE_EQUAL(mount->Destination, "/data");
 
         const auto volumeName = wsl::shared::string::MultiByteToWide(mount->Name);
+        const auto volumeLabels = InspectVolume(volumeName).Labels;
         VERIFY_IS_TRUE(
-            InspectVolume(volumeName).Labels.contains("com.docker.volume.anonymous"),
+            volumeLabels.has_value() && volumeLabels->contains("com.docker.volume.anonymous"),
             L"The volume returned by container inspect is not anonymous");
         return volumeName;
     }

--- a/test/windows/wslc/e2e/WSLCE2EVolumeCreateTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeCreateTests.cpp
@@ -107,8 +107,9 @@ class WSLCE2EVolumeCreateTests
 
         VerifyVolumeIsListed(TestVolumeName);
         auto inspect = InspectVolume(TestVolumeName);
-        VERIFY_ARE_EQUAL("1", inspect.Labels["A"]);
-        VERIFY_ARE_EQUAL("2", inspect.Labels["B"]);
+        VERIFY_IS_TRUE(inspect.Labels.has_value());
+        VERIFY_ARE_EQUAL("1", inspect.Labels->at("A"));
+        VERIFY_ARE_EQUAL("2", inspect.Labels->at("B"));
     }
 
 private:

--- a/test/windows/wslc/e2e/WSLCE2EVolumeInspectTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeInspectTests.cpp
@@ -69,6 +69,31 @@ class WSLCE2EVolumeInspectTests
         VERIFY_ARE_EQUAL("guest", inspect.Driver);
     }
 
+    // Every volume reports the same field set: Labels and Options are null rather than empty
+    // objects, Scope is always "local", and Status is only present when the driver reports one.
+    WSLC_TEST_METHOD(WSLCE2E_Volume_Inspect_ReportsFullFieldSet)
+    {
+        auto result = RunWslc(std::format(L"volume create {}", TestVolumeName1));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        result = RunWslc(std::format(L"volume inspect --format json {}", TestVolumeName1));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto document = VerifyCompactJsonOutput(result);
+        VERIFY_ARE_EQUAL(1u, document.size());
+        const auto& volume = document[0];
+
+        VERIFY_ARE_EQUAL(7u, volume.size());
+        VERIFY_IS_TRUE(volume["CreatedAt"].is_string());
+        VERIFY_ARE_EQUAL("guest", volume["Driver"].get<std::string>());
+        VERIFY_IS_TRUE(volume["Labels"].is_null());
+        VERIFY_IS_FALSE(volume["Mountpoint"].get<std::string>().empty());
+        VERIFY_ARE_EQUAL(WideToMultiByte(TestVolumeName1), volume["Name"].get<std::string>());
+        VERIFY_IS_TRUE(volume["Options"].is_null());
+        VERIFY_ARE_EQUAL("local", volume["Scope"].get<std::string>());
+        VERIFY_IS_FALSE(volume.contains("Status"));
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Volume_Inspect_FormatJson_IsSingleLine)
     {
         auto result = RunWslc(std::format(L"volume create {}", TestVolumeName1));

--- a/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumePruneTests.cpp
@@ -56,7 +56,9 @@ class WSLCE2EVolumePruneTests
         const auto result = RunWslc(L"volume prune");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"Total reclaimed space:"));
+        // The deleted-volume block, and the blank line that follows it, are only written when
+        // something was actually removed.
+        result.Verify({.Stdout = L"Total reclaimed space: 0B\r\n"});
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Volume_Prune_NoAllFlag_PreservesNamedVolumes)
@@ -70,9 +72,8 @@ class WSLCE2EVolumePruneTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         auto output = result.GetStdoutLines();
-        VERIFY_ARE_EQUAL(2u, output.size());
-        VERIFY_ARE_EQUAL(output[0], L"");
-        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, output[1].find(L"Total reclaimed space:"));
+        VERIFY_ARE_EQUAL(1u, output.size());
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, output[0].find(L"Total reclaimed space:"));
 
         VerifyVolumeIsListed(TestVolumeName);
     }
@@ -88,10 +89,11 @@ class WSLCE2EVolumePruneTests
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
         auto output = result.GetStdoutLines();
-        VERIFY_ARE_EQUAL(3u, output.size());
-        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, output[0].find(std::format(L"Deleted: {}", TestVolumeName)));
-        VERIFY_ARE_EQUAL(output[1], L"");
-        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, output[2].find(L"Total reclaimed space:"));
+        VERIFY_ARE_EQUAL(4u, output.size());
+        VERIFY_ARE_EQUAL(output[0], L"Deleted Volumes:");
+        VERIFY_ARE_EQUAL(output[1], TestVolumeName);
+        VERIFY_ARE_EQUAL(output[2], L"");
+        VERIFY_ARE_NOT_EQUAL(std::wstring::npos, output[3].find(L"Total reclaimed space:"));
 
         VerifyVolumeIsNotListed(TestVolumeName);
     }
@@ -111,8 +113,9 @@ class WSLCE2EVolumePruneTests
         const auto result = RunWslc(L"volume prune --all");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName)));
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName2)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(L"Deleted Volumes:"));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestVolumeName));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestVolumeName2));
 
         VerifyVolumeIsNotListed(TestVolumeName);
         VerifyVolumeIsNotListed(TestVolumeName2);
@@ -136,9 +139,7 @@ class WSLCE2EVolumePruneTests
         const auto result = RunWslc(L"volume prune --all");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_FALSE(
-            result.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName)),
-            L"Volume in use by a running container must not be pruned");
+        VERIFY_IS_FALSE(result.StdoutContainsLine(TestVolumeName), L"Volume in use by a running container must not be pruned");
 
         VerifyVolumeIsListed(TestVolumeName);
     }
@@ -154,15 +155,14 @@ class WSLCE2EVolumePruneTests
         const auto filteredPrune = RunWslc(L"volume prune --all --filter label=wslc.test.never=present");
         filteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
         VERIFY_IS_FALSE(
-            filteredPrune.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName)),
-            L"Filtered prune should not have deleted the non-matching volume");
+            filteredPrune.StdoutContainsLine(TestVolumeName), L"Filtered prune should not have deleted the non-matching volume");
         VerifyVolumeIsListed(TestVolumeName);
 
         // Subsequent unfiltered prune --all should still remove it, proving
         // the filter was the reason it survived.
         const auto unfilteredPrune = RunWslc(L"volume prune --all");
         unfilteredPrune.Verify({.Stderr = L"", .ExitCode = 0});
-        VERIFY_IS_TRUE(unfilteredPrune.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName)));
+        VERIFY_IS_TRUE(unfilteredPrune.StdoutContainsLine(TestVolumeName));
         VerifyVolumeIsNotListed(TestVolumeName);
     }
 
@@ -181,10 +181,8 @@ class WSLCE2EVolumePruneTests
         const auto result = RunWslc(L"volume prune --all --filter label=wslc.test.prune=keep");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName)));
-        VERIFY_IS_FALSE(
-            result.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName2)),
-            L"Volume without the matching label must not be deleted");
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestVolumeName));
+        VERIFY_IS_FALSE(result.StdoutContainsLine(TestVolumeName2), L"Volume without the matching label must not be deleted");
 
         VerifyVolumeIsNotListed(TestVolumeName);
         VerifyVolumeIsListed(TestVolumeName2);
@@ -205,10 +203,9 @@ class WSLCE2EVolumePruneTests
         const auto result = RunWslc(L"volume prune --all --filter label!=wslc.test.keep");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        VERIFY_IS_TRUE(result.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName2)));
+        VERIFY_IS_TRUE(result.StdoutContainsLine(TestVolumeName2));
         VERIFY_IS_FALSE(
-            result.StdoutContainsLine(std::format(L"Deleted: {}", TestVolumeName)),
-            L"Labeled volume must be preserved when prune negates that label");
+            result.StdoutContainsLine(TestVolumeName), L"Labeled volume must be preserved when prune negates that label");
 
         VerifyVolumeIsListed(TestVolumeName);
         VerifyVolumeIsNotListed(TestVolumeName2);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Brings `wslc volume inspect` and `wslc volume prune` output in line with the equivalent docker commands, continuing the CLI output parity work started for the network commands.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### `volume inspect`

The inspect payload was missing fields that docker always reports, and rendered absent maps as empty objects rather than `null`.

- Added `Mountpoint`, sourced from the mountpoint docker reports for the volume, and plumbed through both the guest and VHD volume implementations on their create and open paths.
- Added `Scope`, which is always `local` — every WSLC volume is machine level. The constant lives alongside the existing driver-name constants in `WSLCVolumeMetadata.h`.
- `Labels` and `Options` are now `std::optional` and serialize as `null` when absent instead of `{}`.
- `Status` is omitted entirely when the driver reports nothing. VHD volumes continue to populate it with `HostPath`, `SizeBytes` and, on a recovery failure, `Error`.
- Renamed `DriverOpts` to `Options` on the read path. These are the same data under a read/write naming split — `DriverOpts` is the create-request spelling and remains unchanged, `Options` is the inspect spelling.

`InspectVolume` now uses an explicit `to_json` rather than the nlohmann macro, following the existing `IPAMConfig` convention in the same header, since the null-vs-empty and omit-when-empty behaviour cannot be expressed through the macro.

### `volume prune`

- Deleted volumes are now printed under a `Deleted Volumes:` header as bare names, replacing the per-line `Deleted: <name>` form. This matches the header already used by `network prune`.
- The blank line before the reclaimed-space total is only written when something was actually deleted. It was previously emitted unconditionally, so a no-op prune produced a stray leading blank line.
- Reclaimed space is now reported with four significant digits (`12.29kB`) rather than a two-decimal-place value with a space (`12.29 KB`).

`WSLCCLI_VolumePruneDeleted` is replaced by `WSLCCLI_VolumePruneDeletedHeader`; only the `en-US` resources are touched.

### `FormatDockerSize`

Renamed to `FormatHumanReadableSize` and given a `Precision` parameter defaulting to 3. Image sizes keep precision 3; the prune reclaimed-space total uses 4. The only other caller, `ImageTasks.cpp`, is unaffected behaviourally.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Full `cmake --build .` completes with no errors.
- Added `WSLCE2E_Volume_Inspect_ReportsFullFieldSet`, asserting the exact seven-key inspect payload, that `Labels` and `Options` are `null`, that `Scope` is `local`, that `Mountpoint` is non-empty, and that `Status` is absent.
- Added `FormatHumanReadableSize_SupportsReclaimedSpacePrecision` covering the precision-4 cases, and renamed the existing precision-3 test.
- Updated the `volume prune` e2e tests for the new header, bare names, and conditional blank line, including an exact-output assertion that a prune with nothing to delete emits only the reclaimed-space line.
- Updated `WSLCTests.cpp` volume inspect coverage for `Options`, `Scope` and `Mountpoint`, and the volume-create and container-remove e2e tests for the optional `Labels`.