### PR TITLE
Fix incorrect string -> wstring conversion, causing utf16 corruption

### DIFF
--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -1253,7 +1253,7 @@ struct std::formatter<char*, wchar_t>
     template <typename TCtx>
     auto format(const char* str, TCtx& ctx) const
     {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
+        return std::format_to(ctx.out(), L"{}", wsl::shared::string::MultiByteToWide(str));
     }
 };
 
@@ -1269,7 +1269,7 @@ struct std::formatter<const char*, wchar_t>
     template <typename TCtx>
     auto format(const char* str, TCtx& ctx) const
     {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
+        return std::format_to(ctx.out(), L"{}", wsl::shared::string::MultiByteToWide(str));
     }
 };
 
@@ -1285,7 +1285,7 @@ struct std::formatter<char[N], wchar_t>
     template <typename TCtx>
     auto format(const char str[N], TCtx& ctx) const
     {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
+        return std::format_to(ctx.out(), L"{}", wsl::shared::string::MultiByteToWide(str));
     }
 };
 
@@ -1301,7 +1301,7 @@ struct std::formatter<std::basic_string<char, Traits, Allocator>, wchar_t>
     template <typename TCtx>
     auto format(const std::basic_string<char, Traits, Allocator>& str, TCtx& ctx) const
     {
-        return std::format_to(ctx.out(), "{}", wsl::shared::string::MultiByteToWide(str));
+        return std::format_to(ctx.out(), L"{}", wsl::shared::string::MultiByteToWide(str));
     }
 };
 

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -77,6 +77,14 @@ class StringUnitTests
 {
     WSL_TEST_CLASS(StringUnitTests)
 
+    TEST_METHOD(FormatUtf8StringAsWideString)
+    {
+        const std::string input{"安装依赖"};
+        const auto expected = wsl::shared::string::MultiByteToWide(input);
+
+        VERIFY_ARE_EQUAL(expected, std::format(L"{}", input));
+    }
+
     TEST_METHOD(ParseMemorySize_LegacyForms)
     {
         const std::vector<std::pair<LPCSTR, std::optional<uint64_t>>> TestCases{

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -119,6 +119,20 @@ class WSLCE2EImageBuildTests
         VERIFY_ARE_EQUAL(BuiltImage.NameAndTag(), wsl::shared::string::MultiByteToWide(inspectData.RepoTags.value()[0]));
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Image_Build_UnicodeOutput_Success)
+    {
+        auto testRoot = std::filesystem::current_path() / L"wslc-e2e-build-unicode-output";
+        auto cleanup = SetupTestDirectory(testRoot);
+
+        auto dockerfilePath = testRoot / L"Dockerfile";
+        WriteTestFileContent(dockerfilePath, "FROM debian:latest\nRUN echo 安装依赖\n");
+
+        auto buildResult = RunWslc(std::format(
+            L"build \"{}\" -f \"{}\" --output type=cacheonly", SharedOutputBuildContext().wstring(), dockerfilePath.wstring()));
+        buildResult.Verify({.ExitCode = 0});
+        VERIFY_IS_TRUE(buildResult.StderrContainsSubstring(wsl::shared::string::MultiByteToWide("安装依赖")));
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Image_Build_BuildArgsFileAndMultipleTags_Success)
     {
         auto imageCleanup1 = DeleteImageOnExit(BuiltImageTag1);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The issue was using `std::format_to` with a narrow string, which would actually convert the string back to utf8, and writing utf8 bytes on a wide string, causing corruption

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
