### PR TITLE
Enable discard for WSLc volumes

### DIFF
--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -641,13 +641,6 @@ void WSLCSession::ConfigureStorage(const WSLCSessionInitSettings& Settings, PSID
     }
 
     // Mount the device to /root.
-    //
-    // 'discard' is required so that blocks freed inside the guest are unmapped in the backing VHDX.
-    // Without it the dynamically expanding VHDX only ever grows: every image load extracts the incoming
-    // tar into /var/lib/docker/tmp before deduplicating it, and although that data is deleted right
-    // afterwards, ext4 satisfies the next extraction from a different region, so the VHD grows by
-    // roughly the tar size on each load even when nothing new is stored. See
-    // WSLCTests::LoadImageRepeatedDoesNotGrowStorageVhd.
     m_runtime.Vm().Mount(diskDevice.c_str(), c_containerdStorage, "ext4", "discard", 0);
     m_runtime.SetStorageMounted(true);
 

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -641,7 +641,14 @@ void WSLCSession::ConfigureStorage(const WSLCSessionInitSettings& Settings, PSID
     }
 
     // Mount the device to /root.
-    m_runtime.Vm().Mount(diskDevice.c_str(), c_containerdStorage, "ext4", "", 0);
+    //
+    // 'discard' is required so that blocks freed inside the guest are unmapped in the backing VHDX.
+    // Without it the dynamically expanding VHDX only ever grows: every image load extracts the incoming
+    // tar into /var/lib/docker/tmp before deduplicating it, and although that data is deleted right
+    // afterwards, ext4 satisfies the next extraction from a different region, so the VHD grows by
+    // roughly the tar size on each load even when nothing new is stored. See
+    // WSLCTests::LoadImageRepeatedDoesNotGrowStorageVhd.
+    m_runtime.Vm().Mount(diskDevice.c_str(), c_containerdStorage, "ext4", "discard", 0);
     m_runtime.SetStorageMounted(true);
 
     // Configure swap on a separate ephemeral VHD.

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -172,7 +172,7 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
     VirtualMachine.Ext4Format(device, opts.Uid, opts.Gid);
 
     auto virtualMachinePath = std::format("/mnt/wslc-volumes/{}", name);
-    VirtualMachine.Mount(device.c_str(), virtualMachinePath.c_str(), "ext4", "", 0);
+    VirtualMachine.Mount(device.c_str(), virtualMachinePath.c_str(), "ext4", "discard", 0);
 
     auto mountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.Unmount(virtualMachinePath.c_str()); });
 

--- a/src/windows/wslcsession/WSLCVhdVolume.cpp
+++ b/src/windows/wslcsession/WSLCVhdVolume.cpp
@@ -172,6 +172,8 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Create(
     VirtualMachine.Ext4Format(device, opts.Uid, opts.Gid);
 
     auto virtualMachinePath = std::format("/mnt/wslc-volumes/{}", name);
+
+    // These should match the mount options used in Open
     VirtualMachine.Mount(device.c_str(), virtualMachinePath.c_str(), "ext4", "discard", 0);
 
     auto mountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.Unmount(virtualMachinePath.c_str()); });
@@ -275,7 +277,8 @@ std::unique_ptr<WSLCVhdVolumeImpl> WSLCVhdVolumeImpl::Open(
         auto [attachedLun, device] = VirtualMachine.AttachDisk(hostPath.c_str(), false);
         auto attachCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.DetachDisk(attachedLun); });
 
-        VirtualMachine.Mount(device.c_str(), virtualMachinePath.c_str(), "ext4", "", 0);
+        // These should match the mount options used in Create
+        VirtualMachine.Mount(device.c_str(), virtualMachinePath.c_str(), "ext4", "discard", 0);
         auto mountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { VirtualMachine.Unmount(virtualMachinePath.c_str()); });
 
         RemoveLostFoundDirectory(VirtualMachine, Volume.Name, virtualMachinePath);

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1419,19 +1419,80 @@ class WSLCTests
 
     // Loading the same image tar repeatedly must not permanently grow the session storage VHD.
     //
-    // Docker's /images/load handler extracts the entire tar into a temporary directory under its data
+    // Docker's /images/load handler extracts the incoming tar into a temporary directory under its data
     // root (/var/lib/docker, which is the storage VHD) before inspecting any digest, so every call
     // writes roughly one tar's worth of data to the VHD even when the layers already exist and are
     // deduplicated. That temporary directory is deleted afterwards, but the VHD is a non-sparse
     // dynamically expanding VHDX mounted without 'discard', so the freed blocks are never returned to
-    // the host. The result is a VHD that grows by about the tar size on every load.
+    // the host, and ext4 tends to satisfy the next extraction from a different region rather than
+    // reusing the just-freed one. The result is a VHD that grows by about the tar size on every load.
+    //
+    // The size of the tar matters: a small tar is re-extracted into blocks the VHDX has already
+    // allocated, so the growth plateaus immediately and the bug does not reproduce. This test therefore
+    // builds a large image with incompressible layers (which is what a real from-source application
+    // image looks like once 'save' has written its uncompressed layers out) rather than reusing one of
+    // the small prebuilt test tars.
     WSLC_TEST_METHOD(LoadImageRepeatedDoesNotGrowStorageVhd)
     {
         SKIP_TEST_SERVER();
 
         constexpr auto c_sessionName = L"wslc-load-image-vhd-growth";
-        constexpr auto c_imageName = "debian:latest";
-        constexpr auto c_extraLoads = 4;
+        constexpr auto c_imageName = "wslc-test-load-growth:latest";
+        constexpr auto c_layerCount = 4;
+        constexpr auto c_layerSizeMb = 256;
+        constexpr auto c_extraLoads = 3;
+
+        // Build the image in the shared session (it already has debian:latest), then export it. Each
+        // layer is /dev/urandom so it cannot be compressed away, making the exported tar's size
+        // representative of the data the engine has to move on every load.
+        //
+        // Pass /p:LoadGrowthTar=<path> to run the loop against an existing tar (for example one produced
+        // by 'wslc build' + 'wslc save' for a real application image) instead of building one here.
+        WEX::Common::String existingTar;
+        WEX::TestExecution::RuntimeParameters::TryGetValue(L"LoadGrowthTar", existingTar);
+        const bool useExistingTar = !existingTar.IsEmpty();
+
+        auto contextDir = std::filesystem::current_path() / "build-context-load-growth";
+        const auto imageTar = useExistingTar ? std::filesystem::path{static_cast<LPCWSTR>(existingTar)}
+                                             : std::filesystem::current_path() / "wslc-load-growth.tar";
+
+        auto buildCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            if (useExistingTar)
+            {
+                return;
+            }
+
+            LOG_IF_FAILED(DeleteImageNoThrow(c_imageName, WSLCDeleteImageFlagsForce).first);
+
+            std::error_code ec;
+            std::filesystem::remove_all(contextDir, ec);
+            std::filesystem::remove(imageTar, ec);
+        });
+
+        if (!useExistingTar)
+        {
+            std::filesystem::create_directories(contextDir);
+
+            {
+                std::ofstream dockerfile(contextDir / "Dockerfile");
+                dockerfile << "FROM debian:latest\n";
+                for (auto i = 0; i < c_layerCount; i++)
+                {
+                    dockerfile << std::format(
+                        "RUN dd if=/dev/urandom bs=1M count={} of=/blob{}.bin status=none\n", c_layerSizeMb, i);
+                }
+            }
+
+            VERIFY_SUCCEEDED(BuildImageFromContext(contextDir, c_imageName));
+
+            wil::unique_handle tarFile{CreateFileW(
+                imageTar.c_str(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr)};
+            VERIFY_IS_FALSE(INVALID_HANDLE_VALUE == tarFile.get());
+            VERIFY_SUCCEEDED(m_defaultSession->SaveImage(ToCOMInputHandle(tarFile.get()), c_imageName, nullptr, nullptr));
+        }
+
+        const auto tarSize = static_cast<uint64_t>(std::filesystem::file_size(imageTar));
+        VERIFY_IS_TRUE(tarSize > 0);
 
         // A dedicated storage directory is required: the shared class storage is preloaded with the test
         // images and is written to by every other test in this class, so its size says nothing here.
@@ -1449,9 +1510,6 @@ class WSLCTests
         auto session = CreateSession(settings);
 
         const auto vhdPath = storageDir / wsl::windows::wslc::DefaultStorageVhdName;
-        const auto imageTar = GetTestImagePath(c_imageName);
-        const auto tarSize = static_cast<uint64_t>(std::filesystem::file_size(imageTar));
-        VERIFY_IS_TRUE(tarSize > 0);
 
         // Size on disk, which is what grows as the dynamically expanding VHDX allocates blocks.
         auto vhdSizeOnDisk = [&]() {
@@ -1498,7 +1556,10 @@ class WSLCTests
         // The first load legitimately grows the VHD: this is where the layers are actually registered.
         // Everything measured after it is overhead from re-loading content docker already has.
         loadImage();
-        ExpectImagePresent(*session, c_imageName);
+        if (!useExistingTar)
+        {
+            ExpectImagePresent(*session, c_imageName);
+        }
 
         const auto baselineVhdSize = vhdSizeOnDisk();
         const auto baselineGuestUsed = guestUsedBytes();
@@ -1529,6 +1590,20 @@ class WSLCTests
         const auto finalVhdSize = vhdSizeOnDisk();
         const auto finalGuestUsed = guestUsedBytes();
 
+        // The host-side VHD must not grow by roughly one tar per load. The budget allows a single tar of
+        // slack in total (with a floor so that small tars don't make this flaky), which is well under the
+        // c_extraLoads * tarSize that linear growth would produce.
+        constexpr uint64_t c_minimumGrowthBudget = 64ull * 1024 * 1024;
+        const auto growthBudget = std::max<uint64_t>(tarSize, c_minimumGrowthBudget);
+
+        LogInfo(
+            "Storage VHD grew by %llu bytes over %d reloads of a %llu byte tar (budget=%llu). Guest usage grew by %lld bytes.",
+            static_cast<unsigned long long>(finalVhdSize - baselineVhdSize),
+            c_extraLoads,
+            static_cast<unsigned long long>(tarSize),
+            static_cast<unsigned long long>(growthBudget),
+            static_cast<long long>(finalGuestUsed - baselineGuestUsed));
+
         // Reloading the same tar must not leave docker's extraction directory behind.
         VERIFY_ARE_EQUAL(0ull, guestTempEntryCount());
 
@@ -1537,21 +1612,9 @@ class WSLCTests
         // the guest rather than merely being unreclaimable on the host.
         VERIFY_IS_TRUE(finalGuestUsed < baselineGuestUsed + tarSize);
 
-        // The host-side VHD must not grow by roughly one tar per load. The budget allows a single tar of
-        // slack in total (with a floor so that small tars don't make this flaky), which is well under the
-        // c_extraLoads * tarSize that linear growth would produce.
-        constexpr uint64_t c_minimumGrowthBudget = 64ull * 1024 * 1024;
-        const auto growthBudget = std::max<uint64_t>(tarSize, c_minimumGrowthBudget);
         if (finalVhdSize >= baselineVhdSize + growthBudget)
         {
-            LogError(
-                "Storage VHD grew by %llu bytes over %d reloads of a %llu byte tar (budget=%llu). Guest usage grew by %lld "
-                "bytes, so the space is being written and then not reclaimed.",
-                static_cast<unsigned long long>(finalVhdSize - baselineVhdSize),
-                c_extraLoads,
-                static_cast<unsigned long long>(tarSize),
-                static_cast<unsigned long long>(growthBudget),
-                static_cast<long long>(finalGuestUsed - baselineGuestUsed));
+            LogError("The storage VHD is growing with each load: the space is being written and then not reclaimed.");
 
             VERIFY_FAIL();
         }

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1478,8 +1478,7 @@ class WSLCTests
                 dockerfile << "FROM debian:latest\n";
                 for (auto i = 0; i < c_layerCount; i++)
                 {
-                    dockerfile << std::format(
-                        "RUN dd if=/dev/urandom bs=1M count={} of=/blob{}.bin status=none\n", c_layerSizeMb, i);
+                    dockerfile << std::format("RUN dd if=/dev/urandom bs=1M count={} of=/blob{}.bin status=none\n", c_layerSizeMb, i);
                 }
             }
 

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -1417,6 +1417,148 @@ class WSLCTests
         VERIFY_ARE_EQUAL(EnumReferenceFormatDigest, loaded[0].second);
     }
 
+    // Loading the same image tar repeatedly must not permanently grow the session storage VHD.
+    //
+    // Docker's /images/load handler extracts the entire tar into a temporary directory under its data
+    // root (/var/lib/docker, which is the storage VHD) before inspecting any digest, so every call
+    // writes roughly one tar's worth of data to the VHD even when the layers already exist and are
+    // deduplicated. That temporary directory is deleted afterwards, but the VHD is a non-sparse
+    // dynamically expanding VHDX mounted without 'discard', so the freed blocks are never returned to
+    // the host. The result is a VHD that grows by about the tar size on every load.
+    WSLC_TEST_METHOD(LoadImageRepeatedDoesNotGrowStorageVhd)
+    {
+        SKIP_TEST_SERVER();
+
+        constexpr auto c_sessionName = L"wslc-load-image-vhd-growth";
+        constexpr auto c_imageName = "debian:latest";
+        constexpr auto c_extraLoads = 4;
+
+        // A dedicated storage directory is required: the shared class storage is preloaded with the test
+        // images and is written to by every other test in this class, so its size says nothing here.
+        const auto storageDir = std::filesystem::current_path() / "test-storage-load-image-growth";
+        std::error_code storageError;
+        std::filesystem::remove_all(storageDir, storageError);
+        std::filesystem::create_directories(storageDir);
+        auto storageCleanup = wil::scope_exit([&]() {
+            std::error_code ec;
+            std::filesystem::remove_all(storageDir, ec);
+        });
+
+        auto settings = GetDefaultSessionSettings(c_sessionName);
+        settings.StoragePath = storageDir.c_str();
+        auto session = CreateSession(settings);
+
+        const auto vhdPath = storageDir / wsl::windows::wslc::DefaultStorageVhdName;
+        const auto imageTar = GetTestImagePath(c_imageName);
+        const auto tarSize = static_cast<uint64_t>(std::filesystem::file_size(imageTar));
+        VERIFY_IS_TRUE(tarSize > 0);
+
+        // Size on disk, which is what grows as the dynamically expanding VHDX allocates blocks.
+        auto vhdSizeOnDisk = [&]() {
+            DWORD highPart{};
+            SetLastError(NO_ERROR);
+            const auto lowPart = GetCompressedFileSizeW(vhdPath.c_str(), &highPart);
+            THROW_LAST_ERROR_IF(lowPart == INVALID_FILE_SIZE && GetLastError() != NO_ERROR);
+
+            ULARGE_INTEGER size{};
+            size.LowPart = lowPart;
+            size.HighPart = highPart;
+            return static_cast<uint64_t>(size.QuadPart);
+        };
+
+        // Bytes used by the guest filesystem backing the docker data root.
+        auto guestUsedBytes = [&]() {
+            const auto result =
+                ExpectCommandResult(session.get(), {"/bin/sh", "-c", "df -k /var/lib/docker | awk 'NR == 2 {print $3}'"}, 0);
+
+            return std::stoull(result.Output.at(1)) * 1024;
+        };
+
+        // Entries left behind in the directory docker extracts the incoming tar into.
+        auto guestTempEntryCount = [&]() {
+            const auto result =
+                ExpectCommandResult(session.get(), {"/bin/sh", "-c", "ls -A /var/lib/docker/tmp 2>/dev/null | wc -l"}, 0);
+
+            return std::stoull(result.Output.at(1));
+        };
+
+        auto loadImage = [&]() {
+            wil::unique_handle tarFile{
+                CreateFileW(imageTar.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+            VERIFY_IS_FALSE(INVALID_HANDLE_VALUE == tarFile.get());
+
+            LARGE_INTEGER fileSize{};
+            VERIFY_IS_TRUE(GetFileSizeEx(tarFile.get(), &fileSize));
+            VERIFY_SUCCEEDED(session->LoadImage(ToCOMInputHandle(tarFile.get()), fileSize.QuadPart, nullptr, nullptr));
+
+            // Flush the guest page cache so the writes have reached the VHD before it is measured.
+            ExpectCommandResult(session.get(), {"/bin/sh", "-c", "sync"}, 0);
+        };
+
+        // The first load legitimately grows the VHD: this is where the layers are actually registered.
+        // Everything measured after it is overhead from re-loading content docker already has.
+        loadImage();
+        ExpectImagePresent(*session, c_imageName);
+
+        const auto baselineVhdSize = vhdSizeOnDisk();
+        const auto baselineGuestUsed = guestUsedBytes();
+
+        LogInfo(
+            "Tar size=%llu, baseline vhd size on disk=%llu, baseline guest used=%llu",
+            static_cast<unsigned long long>(tarSize),
+            static_cast<unsigned long long>(baselineVhdSize),
+            static_cast<unsigned long long>(baselineGuestUsed));
+
+        for (auto i = 0; i < c_extraLoads; i++)
+        {
+            loadImage();
+
+            const auto vhdSize = vhdSizeOnDisk();
+            const auto guestUsed = guestUsedBytes();
+
+            LogInfo(
+                "Load %d: vhd size on disk=%llu (+%lld), guest used=%llu (+%lld), temp entries=%llu",
+                i + 1,
+                static_cast<unsigned long long>(vhdSize),
+                static_cast<long long>(vhdSize - baselineVhdSize),
+                static_cast<unsigned long long>(guestUsed),
+                static_cast<long long>(guestUsed - baselineGuestUsed),
+                static_cast<unsigned long long>(guestTempEntryCount()));
+        }
+
+        const auto finalVhdSize = vhdSizeOnDisk();
+        const auto finalGuestUsed = guestUsedBytes();
+
+        // Reloading the same tar must not leave docker's extraction directory behind.
+        VERIFY_ARE_EQUAL(0ull, guestTempEntryCount());
+
+        // Docker deduplicates the identical layers, so the guest filesystem must not retain a tar's
+        // worth of data per load. A failure here means the temporary extraction is being leaked inside
+        // the guest rather than merely being unreclaimable on the host.
+        VERIFY_IS_TRUE(finalGuestUsed < baselineGuestUsed + tarSize);
+
+        // The host-side VHD must not grow by roughly one tar per load. The budget allows a single tar of
+        // slack in total (with a floor so that small tars don't make this flaky), which is well under the
+        // c_extraLoads * tarSize that linear growth would produce.
+        constexpr uint64_t c_minimumGrowthBudget = 64ull * 1024 * 1024;
+        const auto growthBudget = std::max<uint64_t>(tarSize, c_minimumGrowthBudget);
+        if (finalVhdSize >= baselineVhdSize + growthBudget)
+        {
+            LogError(
+                "Storage VHD grew by %llu bytes over %d reloads of a %llu byte tar (budget=%llu). Guest usage grew by %lld "
+                "bytes, so the space is being written and then not reclaimed.",
+                static_cast<unsigned long long>(finalVhdSize - baselineVhdSize),
+                c_extraLoads,
+                static_cast<unsigned long long>(tarSize),
+                static_cast<unsigned long long>(growthBudget),
+                static_cast<long long>(finalGuestUsed - baselineGuestUsed));
+
+            VERIFY_FAIL();
+        }
+
+        VERIFY_SUCCEEDED(session->Terminate());
+    }
+
     WSLC_TEST_METHOD(ImportImage)
     {
         SKIP_TEST_SERVER();


### PR DESCRIPTION
## Summary of the Pull Request
Enable `discard` for primary and secondary WSLc volumes.

## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
From an internal report, VHD size would grow with repeated calls to `LoadImage` with the same large tar.  The test in this PR was initially created targeting `debian:latest`, but it wasn't large enough to exhibit the behavior.  Synthetically adding a gigabyte of data into it and saving it did.

The test shows that it isn't additional guest storage that is increasing the VHD, and with `discard` the behavior is resolved.

Enabled `discard` for WSLc volumes, just as it is enabled for WSL:
https://github.com/microsoft/WSL/blob/58c89ade0240f9a43f179d967863fb14920e66a8/src/windows/service/exe/WslCoreVm.cpp#L1261

This causes the guest filesystem to TRIM blocks that are no longer in use, allowing their reuse and preventing the VHD from growing when the guest isn't actually taking up any more space.

## Validation Steps Performed
Added a new test that loads a tar over 1 GB in size repeatedly to ensure that the VHD does not grow in size after the initial load.