### PR TITLE
Match docker's keyset for wslc volume list --format json

### DIFF
--- a/src/shared/inc/JsonUtils.h
+++ b/src/shared/inc/JsonUtils.h
@@ -185,24 +185,4 @@ struct adl_serializer<wsl::shared::string::MacAddress>
     }
 };
 
-#ifdef WIN32
-template <>
-struct adl_serializer<WSLCVolumeInformation>
-{
-    static void to_json(json& j, const WSLCVolumeInformation& volume)
-    {
-        j = json{{"Name", std::string(volume.Name)}, {"Driver", std::string(volume.Driver)}};
-    }
-
-    static void from_json(const json& j, WSLCVolumeInformation& volume)
-    {
-        std::string name = j.at("Name").get<std::string>();
-        std::string driver = j.at("Driver").get<std::string>();
-
-        strncpy_s(volume.Name, sizeof(volume.Name), name.c_str(), _TRUNCATE);
-        strncpy_s(volume.Driver, sizeof(volume.Driver), driver.c_str(), _TRUNCATE);
-    }
-};
-#endif
-
 } // namespace nlohmann

--- a/src/windows/inc/wslc_schema.h
+++ b/src/windows/inc/wslc_schema.h
@@ -335,4 +335,17 @@ struct NetworkListEntry
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkListEntry, Id, Name, Driver, Scope, Created, EnableIPv4, EnableIPv6, Internal, Labels);
 };
 
+// The volume properties carried from the session to the CLI for "volume list". Values keep their
+// native types; the CLI renders the string output.
+struct VolumeListEntry
+{
+    std::string Name;
+    std::string Driver;
+    std::string Mountpoint;
+    std::string Scope;
+    std::map<std::string, std::string> Labels;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(VolumeListEntry, Name, Driver, Mountpoint, Scope, Labels);
+};
+
 } // namespace wsl::windows::common::wslc_schema

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -758,7 +758,7 @@ interface IWSLCSession : IUnknown
     // Volume management.
     HRESULT CreateVolume([in] const WSLCVolumeOptions* Options, [out] WSLCVolumeInformation* VolumeInfo);
     HRESULT DeleteVolume([in] LPCSTR Name);
-    HRESULT ListVolumes([in, unique, size_is(FiltersCount)] const WSLCFilter* Filters, [in] ULONG FiltersCount, [out, size_is(, *Count)] WSLCVolumeInformation** Volumes, [out] ULONG* Count);
+    HRESULT ListVolumes([in, unique, size_is(FiltersCount)] const WSLCFilter* Filters, [in] ULONG FiltersCount, [out] LPSTR* Output);
     HRESULT InspectVolume([in] LPCSTR Name, [out] LPSTR* Output);
 
     HRESULT Authenticate([in] LPCSTR ServerAddress, [in] LPCSTR Username, [in] LPCSTR Password, [out] LPSTR* IdentityToken);

--- a/src/windows/wslc/core/ExecutionContextData.h
+++ b/src/windows/wslc/core/ExecutionContextData.h
@@ -56,7 +56,7 @@ namespace details {
     DEFINE_DATA_MAPPING(Containers, std::vector<wsl::windows::wslc::models::ContainerInformation>);
     DEFINE_DATA_MAPPING(ContainerOptions, wsl::windows::wslc::models::ContainerOptions);
     DEFINE_DATA_MAPPING(Images, std::vector<wsl::windows::wslc::models::ImageInformation>);
-    DEFINE_DATA_MAPPING(Volumes, std::vector<WSLCVolumeInformation>);
+    DEFINE_DATA_MAPPING(Volumes, std::vector<wsl::windows::common::wslc_schema::VolumeListEntry>);
     DEFINE_DATA_MAPPING(Networks, std::vector<wsl::windows::common::wslc_schema::NetworkListEntry>);
     DEFINE_DATA_MAPPING(NetworkEndpointOptions, wsl::windows::wslc::models::NetworkEndpointOptions);
 } // namespace details

--- a/src/windows/wslc/services/VolumeModel.h
+++ b/src/windows/wslc/services/VolumeModel.h
@@ -33,4 +33,21 @@ struct PruneVolumesResult
     ULONGLONG SpaceReclaimed{};
 };
 
+// The shape emitted by "volume list --format json"; every value is reported as a string.
+struct VolumeOutputInformation
+{
+    std::string Availability;
+    std::string Driver;
+    std::string Group;
+    std::string Labels;
+    std::string Links;
+    std::string Mountpoint;
+    std::string Name;
+    std::string Scope;
+    std::string Size;
+    std::string Status;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(VolumeOutputInformation, Availability, Driver, Group, Labels, Links, Mountpoint, Name, Scope, Size, Status);
+};
+
 } // namespace wsl::windows::wslc::models

--- a/src/windows/wslc/services/VolumeService.cpp
+++ b/src/windows/wslc/services/VolumeService.cpp
@@ -60,7 +60,8 @@ void VolumeService::Delete(models::Session& session, const std::string& name)
     THROW_IF_FAILED(session.Get()->DeleteVolume(name.c_str()));
 }
 
-std::vector<WSLCVolumeInformation> VolumeService::List(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
+std::vector<wsl::windows::common::wslc_schema::VolumeListEntry> VolumeService::List(
+    models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters)
 {
     std::vector<WSLCFilter> filterEntries;
     filterEntries.reserve(filters.size());
@@ -69,19 +70,11 @@ std::vector<WSLCVolumeInformation> VolumeService::List(models::Session& session,
         filterEntries.push_back({.Key = key.c_str(), .Value = value.c_str()});
     }
 
-    wil::unique_cotaskmem_array_ptr<WSLCVolumeInformation> rawVolumes;
-    ULONG count = 0;
+    wil::unique_cotaskmem_ansistring output;
     THROW_IF_FAILED(session.Get()->ListVolumes(
-        filterEntries.empty() ? nullptr : filterEntries.data(), static_cast<ULONG>(filterEntries.size()), &rawVolumes, &count));
+        filterEntries.empty() ? nullptr : filterEntries.data(), static_cast<ULONG>(filterEntries.size()), &output));
 
-    std::vector<WSLCVolumeInformation> volumes;
-    volumes.reserve(count);
-    for (auto ptr = rawVolumes.get(), end = rawVolumes.get() + count; ptr != end; ++ptr)
-    {
-        volumes.push_back(*ptr);
-    }
-
-    return volumes;
+    return FromJson<std::vector<wsl::windows::common::wslc_schema::VolumeListEntry>>(output.get());
 }
 
 wsl::windows::common::wslc_schema::InspectVolume VolumeService::Inspect(models::Session& session, const std::string& name)

--- a/src/windows/wslc/services/VolumeService.h
+++ b/src/windows/wslc/services/VolumeService.h
@@ -24,7 +24,8 @@ struct VolumeService
 {
     static WSLCVolumeInformation Create(models::Session& session, const models::CreateVolumeOptions& createOptions);
     static void Delete(models::Session& session, const std::string& name);
-    static std::vector<WSLCVolumeInformation> List(models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
+    static std::vector<wsl::windows::common::wslc_schema::VolumeListEntry> List(
+        models::Session& session, const std::vector<std::pair<std::string, std::string>>& filters = {});
     static wsl::windows::common::wslc_schema::InspectVolume Inspect(models::Session& session, const std::string& name);
     static models::PruneVolumesResult Prune(
         Terminal& terminal, models::Session& session, bool all, const std::vector<std::pair<std::string, std::string>>& filters = {});

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -33,6 +33,41 @@ namespace wsl::windows::wslc::task {
 
 constexpr uint32_t c_reclaimedSpacePrecision = 4;
 
+namespace {
+
+    // Reported for the fields that only carry a value when volume usage data or swarm cluster
+    // information is available, neither of which applies here.
+    constexpr std::string_view c_notAvailable = "N/A";
+
+    // Shared by the table and json output so the two cannot drift.
+    VolumeOutputInformation ToVolumeOutput(const wslc_schema::VolumeListEntry& volume)
+    {
+        VolumeOutputInformation entry;
+        entry.Availability = c_notAvailable;
+        entry.Driver = volume.Driver;
+        entry.Group = c_notAvailable;
+        entry.Links = c_notAvailable;
+        entry.Mountpoint = volume.Mountpoint;
+        entry.Name = volume.Name;
+        entry.Scope = volume.Scope;
+        entry.Size = c_notAvailable;
+        entry.Status = c_notAvailable;
+
+        for (const auto& [key, value] : volume.Labels)
+        {
+            if (!entry.Labels.empty())
+            {
+                entry.Labels += ",";
+            }
+
+            entry.Labels += std::format("{}={}", key, value);
+        }
+
+        return entry;
+    }
+
+} // namespace
+
 static bool TryInspectVolume(Terminal& terminal, Session& session, const std::string& volumeName, std::optional<wslc_schema::InspectVolume>& inspectData)
 {
     try
@@ -177,7 +212,7 @@ void ListVolumes(CLIExecutionContext& context)
     {
         for (const auto& volume : volumes)
         {
-            context.Terminal.Output(L"{}\n", ToJsonW(volume, c_jsonCompactIndent));
+            context.Terminal.Output(L"{}\n", ToJsonW(ToVolumeOutput(volume), c_jsonCompactIndent));
         }
 
         break;

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -39,7 +39,7 @@ namespace {
     // information is available, neither of which applies here.
     constexpr std::string_view c_notAvailable = "N/A";
 
-    // Shared by the table and json output so the two cannot drift.
+    // Converts session volume entries into the all-string shape used for "volume list --format json".
     VolumeOutputInformation ToVolumeOutput(const wslc_schema::VolumeListEntry& volume)
     {
         VolumeOutputInformation entry;

--- a/src/windows/wslcsession/IWSLCVolume.h
+++ b/src/windows/wslcsession/IWSLCVolume.h
@@ -40,6 +40,9 @@ public:
     // The user-specified labels on this volume (excludes the WSLC metadata label).
     virtual const std::map<std::string, std::string>& Labels() const noexcept = 0;
 
+    // The path at which the volume is mounted inside the utility VM.
+    virtual const std::string& Mountpoint() const noexcept = 0;
+
     // The status of the volume as {Code, Message}: S_OK with an empty message when the volume
     // opened successfully and is usable, otherwise a failure HRESULT and a human-readable reason
     // (e.g. the backing VHD is missing).

--- a/src/windows/wslcsession/WSLCGuestVolume.h
+++ b/src/windows/wslcsession/WSLCGuestVolume.h
@@ -69,6 +69,10 @@ public:
     {
         return m_labels;
     }
+    const std::string& Mountpoint() const noexcept override
+    {
+        return m_mountpoint;
+    }
 
     void Delete() override;
     std::string Inspect() const override;

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -2776,16 +2776,14 @@ try
 }
 CATCH_RETURN();
 
-HRESULT WSLCSession::ListVolumes(const WSLCFilter* Filters, ULONG FiltersCount, WSLCVolumeInformation** Volumes, ULONG* Count)
+HRESULT WSLCSession::ListVolumes(const WSLCFilter* Filters, ULONG FiltersCount, LPSTR* Output)
 try
 {
     WSLCExecutionContext context(this);
 
-    RETURN_HR_IF_NULL(E_POINTER, Volumes);
-    RETURN_HR_IF_NULL(E_POINTER, Count);
+    RETURN_HR_IF_NULL(E_POINTER, Output);
 
-    *Volumes = nullptr;
-    *Count = 0;
+    *Output = nullptr;
 
     auto filters = wsl::windows::common::wslutil::ParseKeyMultiValuePairs(Filters, FiltersCount);
 
@@ -2794,16 +2792,9 @@ try
 
     auto volumeList = m_runtime.Volumes().ListVolumes(std::move(filters));
 
-    if (volumeList.empty())
-    {
-        return S_OK;
-    }
+    std::string json = wsl::shared::ToJson(volumeList);
+    *Output = wil::make_unique_ansistring<wil::unique_cotaskmem_ansistring>(json.c_str()).release();
 
-    auto output = wil::make_unique_cotaskmem<WSLCVolumeInformation[]>(volumeList.size());
-    memcpy(output.get(), volumeList.data(), volumeList.size() * sizeof(WSLCVolumeInformation));
-
-    *Count = static_cast<ULONG>(volumeList.size());
-    *Volumes = output.release();
     return S_OK;
 }
 CATCH_RETURN();

--- a/src/windows/wslcsession/WSLCSession.h
+++ b/src/windows/wslcsession/WSLCSession.h
@@ -180,8 +180,7 @@ public:
     IFACEMETHOD(CreateVolume)(_In_ const WSLCVolumeOptions* Options, _Out_ WSLCVolumeInformation* VolumeInfo) override;
     IFACEMETHOD(DeleteVolume)(_In_ LPCSTR Name) override;
     IFACEMETHOD(ListVolumes)
-    (_In_reads_opt_(FiltersCount) const WSLCFilter* Filters, _In_ ULONG FiltersCount, _Out_ WSLCVolumeInformation** Volumes, _Out_ ULONG* Count)
-        override;
+    (_In_reads_opt_(FiltersCount) const WSLCFilter* Filters, _In_ ULONG FiltersCount, _Out_ LPSTR* Output) override;
     IFACEMETHOD(InspectVolume)(_In_ LPCSTR Name, _Out_ LPSTR* Output) override;
     IFACEMETHOD(PruneVolumes)
     (_In_reads_opt_(FiltersCount) const WSLCFilter* Filters,

--- a/src/windows/wslcsession/WSLCVhdVolume.h
+++ b/src/windows/wslcsession/WSLCVhdVolume.h
@@ -77,6 +77,10 @@ public:
     {
         return m_labels;
     }
+    const std::string& Mountpoint() const noexcept override
+    {
+        return m_mountpoint;
+    }
 
     std::pair<HRESULT, std::string> Status() const override
     {

--- a/src/windows/wslcsession/WSLCVolumes.cpp
+++ b/src/windows/wslcsession/WSLCVolumes.cpp
@@ -141,7 +141,7 @@ void WSLCVolumes::DeleteVolume(LPCSTR Name)
     m_expectedEvents.emplace_back(Name, VolumeEvent::Destroy);
 }
 
-std::vector<WSLCVolumeInformation> WSLCVolumes::ListVolumes(std::map<std::string, std::vector<std::string>>&& Filters) const
+std::vector<wsl::windows::common::wslc_schema::VolumeListEntry> WSLCVolumes::ListVolumes(std::map<std::string, std::vector<std::string>>&& Filters) const
 {
     // Pull the driver filter out and forward everything else to docker for filtering.
     // Driver filter is special-cased because our driver concept doesn't map 1:1 to docker's.
@@ -169,7 +169,7 @@ std::vector<WSLCVolumeInformation> WSLCVolumes::ListVolumes(std::map<std::string
 
     auto lock = m_lock.lock_shared();
 
-    std::vector<WSLCVolumeInformation> result;
+    std::vector<wsl::windows::common::wslc_schema::VolumeListEntry> result;
     result.reserve(dockerVolumeNames.size());
 
     for (const auto& [name, vol] : m_volumes)
@@ -186,7 +186,14 @@ std::vector<WSLCVolumeInformation> WSLCVolumes::ListVolumes(std::map<std::string
             continue;
         }
 
-        result.push_back(vol->GetVolumeInformation());
+        wsl::windows::common::wslc_schema::VolumeListEntry entry;
+        entry.Name = vol->Name();
+        entry.Driver = vol->Driver();
+        entry.Mountpoint = vol->Mountpoint();
+        entry.Scope = WSLCVolumeScope;
+        entry.Labels = vol->Labels();
+
+        result.push_back(std::move(entry));
     }
 
     return result;

--- a/src/windows/wslcsession/WSLCVolumes.h
+++ b/src/windows/wslcsession/WSLCVolumes.h
@@ -18,6 +18,7 @@ Abstract:
 #include "WSLCVolumeMetadata.h"
 #include "DockerHTTPClient.h"
 #include "DockerEventTracker.h"
+#include <wslc_schema.h>
 
 namespace wsl::windows::service::wslc {
 
@@ -40,7 +41,7 @@ public:
 
     void DeleteVolume(_In_ LPCSTR Name);
 
-    std::vector<WSLCVolumeInformation> ListVolumes(std::map<std::string, std::vector<std::string>>&& Filters) const;
+    std::vector<wsl::windows::common::wslc_schema::VolumeListEntry> ListVolumes(std::map<std::string, std::vector<std::string>>&& Filters) const;
 
     struct PruneVolumesResult
     {

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -654,16 +654,18 @@ class WSLCTests
         return std::move(deletedImages);
     }
 
+    std::vector<wsl::windows::common::wslc_schema::VolumeListEntry> ListVolumeEntries(const std::vector<WSLCFilter>& Filters = {})
+    {
+        wil::unique_cotaskmem_ansistring output;
+        VERIFY_SUCCEEDED(m_defaultSession->ListVolumes(Filters.empty() ? nullptr : Filters.data(), static_cast<ULONG>(Filters.size()), &output));
+
+        return wsl::shared::FromJson<std::vector<wsl::windows::common::wslc_schema::VolumeListEntry>>(output.get());
+    }
+
     std::set<std::string> ListVolumes(const std::vector<WSLCFilter>& Filters = {})
     {
-        const WSLCFilter* filtersPtr = Filters.empty() ? nullptr : Filters.data();
-        const ULONG filtersCount = static_cast<ULONG>(Filters.size());
-
-        wil::unique_cotaskmem_array_ptr<WSLCVolumeInformation> volumes;
-        VERIFY_SUCCEEDED(m_defaultSession->ListVolumes(filtersPtr, filtersCount, volumes.addressof(), volumes.size_address<ULONG>()));
-
         std::set<std::string> names;
-        for (const auto& v : volumes)
+        for (const auto& v : ListVolumeEntries(Filters))
         {
             names.insert(v.Name);
         }
@@ -5062,11 +5064,12 @@ class WSLCTests
         WSLCVolumeInformation volInfo{};
         VERIFY_SUCCEEDED(m_defaultSession->CreateVolume(&vhdOptions, &volInfo));
 
-        wil::unique_cotaskmem_array_ptr<WSLCVolumeInformation> volumes;
-        VERIFY_SUCCEEDED(m_defaultSession->ListVolumes(nullptr, 0, volumes.addressof(), volumes.size_address<ULONG>()));
+        auto volumes = ListVolumeEntries();
         VERIFY_ARE_EQUAL(1u, volumes.size());
-        VERIFY_ARE_EQUAL(std::string(volumes[0].Name), vhdVolumeName);
-        VERIFY_ARE_EQUAL(std::string(volumes[0].Driver), std::string("vhd"));
+        VERIFY_ARE_EQUAL(volumes[0].Name, vhdVolumeName);
+        VERIFY_ARE_EQUAL(volumes[0].Driver, std::string("vhd"));
+        VERIFY_IS_FALSE(volumes[0].Mountpoint.empty());
+        VERIFY_ARE_EQUAL(volumes[0].Scope, std::string("local"));
 
         // Verify that a guest volume cannot be created with the same name as an existing vhd volume.
         WSLCVolumeOptions duplicateGuestOptions{};
@@ -5088,7 +5091,7 @@ class WSLCTests
         duplicateVhdOptions.DriverOptsCount = ARRAYSIZE(driverOpts);
         VERIFY_ARE_EQUAL(m_defaultSession->CreateVolume(&duplicateVhdOptions, &volInfo), HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
 
-        VERIFY_SUCCEEDED(m_defaultSession->ListVolumes(nullptr, 0, volumes.addressof(), volumes.size_address<ULONG>()));
+        volumes = ListVolumeEntries();
         VERIFY_ARE_EQUAL(2u, volumes.size());
 
         std::map<std::string, std::string> namesToDrivers;
@@ -5131,10 +5134,10 @@ class WSLCTests
 
         // Delete the VHD volume and verify only the guest volume remains.
         VERIFY_SUCCEEDED(m_defaultSession->DeleteVolume(vhdVolumeName.c_str()));
-        VERIFY_SUCCEEDED(m_defaultSession->ListVolumes(nullptr, 0, volumes.addressof(), volumes.size_address<ULONG>()));
+        volumes = ListVolumeEntries();
         VERIFY_ARE_EQUAL(1u, volumes.size());
-        VERIFY_ARE_EQUAL(std::string(volumes[0].Name), guestVolumeName);
-        VERIFY_ARE_EQUAL(std::string(volumes[0].Driver), std::string("guest"));
+        VERIFY_ARE_EQUAL(volumes[0].Name, guestVolumeName);
+        VERIFY_ARE_EQUAL(volumes[0].Driver, std::string("guest"));
     }
 
     WSLC_TEST_METHOD(ListVolumesFilters)
@@ -5166,22 +5169,15 @@ class WSLCTests
             const WSLCFilter* filtersPtr = filters.empty() ? nullptr : filters.data();
             const ULONG filtersCount = static_cast<ULONG>(filters.size());
 
-            wil::unique_cotaskmem_array_ptr<WSLCVolumeInformation> volumes;
-            VERIFY_ARE_EQUAL(
-                expected, m_defaultSession->ListVolumes(filtersPtr, filtersCount, volumes.addressof(), volumes.size_address<ULONG>()));
+            wil::unique_cotaskmem_ansistring output;
+            VERIFY_ARE_EQUAL(expected, m_defaultSession->ListVolumes(filtersPtr, filtersCount, &output));
         };
 
         auto expectList = [&](const std::vector<std::string>& expected,
                               const std::vector<WSLCFilter>& filters = {},
                               const std::source_location& source = std::source_location::current()) {
-            const WSLCFilter* filtersPtr = filters.empty() ? nullptr : filters.data();
-            const ULONG filtersCount = static_cast<ULONG>(filters.size());
-
-            wil::unique_cotaskmem_array_ptr<WSLCVolumeInformation> volumes;
-            VERIFY_SUCCEEDED(m_defaultSession->ListVolumes(filtersPtr, filtersCount, volumes.addressof(), volumes.size_address<ULONG>()));
-
             std::vector<std::string> names;
-            for (const auto& v : volumes)
+            for (const auto& v : ListVolumeEntries(filters))
             {
                 names.emplace_back(v.Name);
             }

--- a/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIExecutionUnitTests.cpp
@@ -144,7 +144,7 @@ class WSLCCLIExecutionUnitTests
             }
             else if (dataType == Data::Volumes)
             {
-                std::vector<WSLCVolumeInformation> volumes;
+                std::vector<wsl::windows::common::wslc_schema::VolumeListEntry> volumes;
                 dataMap.Add<Data::Volumes>(std::move(volumes));
                 handled = true;
             }

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -228,7 +228,7 @@ void VerifyVolumeIsListed(const std::wstring& volumeName)
 {
     auto result = RunWslc(L"volume list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
-    auto volumes = ParseNdjsonOutputAs<WSLCVolumeInformation>(result);
+    auto volumes = ParseNdjsonOutputAs<VolumeListOutput>(result);
     for (const auto& vol : volumes)
     {
         if (vol.Name == wsl::shared::string::WideToMultiByte(volumeName))
@@ -244,7 +244,7 @@ void VerifyVolumeIsNotListed(const std::wstring& volumeName)
 {
     auto result = RunWslc(L"volume list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
-    auto volumes = ParseNdjsonOutputAs<WSLCVolumeInformation>(result);
+    auto volumes = ParseNdjsonOutputAs<VolumeListOutput>(result);
     for (const auto& vol : volumes)
     {
         if (vol.Name == wsl::shared::string::WideToMultiByte(volumeName))
@@ -460,7 +460,7 @@ void EnsureVolumeDoesNotExist(const std::wstring& volumeName)
 {
     auto result = RunWslc(L"volume list --format json");
     result.Verify({.Stderr = L"", .ExitCode = 0});
-    auto volumes = ParseNdjsonOutputAs<WSLCVolumeInformation>(result);
+    auto volumes = ParseNdjsonOutputAs<VolumeListOutput>(result);
     for (const auto& vol : volumes)
     {
         if (vol.Name == wsl::shared::string::WideToMultiByte(volumeName))

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -78,6 +78,22 @@ struct NetworkListOutput
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(NetworkListOutput, CreatedAt, Driver, ID, IPv4, IPv6, Internal, Labels, Name, Scope);
 };
 
+struct VolumeListOutput
+{
+    std::string Availability;
+    std::string Driver;
+    std::string Group;
+    std::string Labels;
+    std::string Links;
+    std::string Mountpoint;
+    std::string Name;
+    std::string Scope;
+    std::string Size;
+    std::string Status;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(VolumeListOutput, Availability, Driver, Group, Labels, Links, Mountpoint, Name, Scope, Size, Status);
+};
+
 struct TestImage
 {
     std::wstring Name;

--- a/test/windows/wslc/e2e/WSLCE2EVolumeListTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EVolumeListTests.cpp
@@ -88,7 +88,7 @@ class WSLCE2EVolumeListTests
         result = RunWslc(L"volume list --format json");
         result.Verify({.Stderr = L"", .ExitCode = 0});
 
-        auto volumes = ParseNdjsonOutputAs<WSLCVolumeInformation>(result);
+        auto volumes = ParseNdjsonOutputAs<VolumeListOutput>(result);
         VERIFY_ARE_EQUAL(2U, volumes.size());
 
         std::vector<std::string> names;
@@ -100,6 +100,31 @@ class WSLCE2EVolumeListTests
 
         VERIFY_ARE_NOT_EQUAL(names.end(), std::find(names.begin(), names.end(), WideToMultiByte(TestVolumeName)));
         VERIFY_ARE_NOT_EQUAL(names.end(), std::find(names.begin(), names.end(), WideToMultiByte(TestVolumeName2)));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Volume_List_ReportsFullFieldSet)
+    {
+        auto result = RunWslc(std::format(L"volume create --label env=prod {}", TestVolumeName));
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        result = RunWslc(L"volume list --format json");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+
+        const auto entries = ParseNdjsonOutput(result);
+        VERIFY_ARE_EQUAL(1u, entries.size());
+        const auto& volume = entries[0];
+
+        VERIFY_ARE_EQUAL(10u, volume.size());
+        VERIFY_ARE_EQUAL("N/A", volume["Availability"].get<std::string>());
+        VERIFY_ARE_EQUAL("guest", volume["Driver"].get<std::string>());
+        VERIFY_ARE_EQUAL("N/A", volume["Group"].get<std::string>());
+        VERIFY_ARE_EQUAL("env=prod", volume["Labels"].get<std::string>());
+        VERIFY_ARE_EQUAL("N/A", volume["Links"].get<std::string>());
+        VERIFY_IS_FALSE(volume["Mountpoint"].get<std::string>().empty());
+        VERIFY_ARE_EQUAL(WideToMultiByte(TestVolumeName), volume["Name"].get<std::string>());
+        VERIFY_ARE_EQUAL("local", volume["Scope"].get<std::string>());
+        VERIFY_ARE_EQUAL("N/A", volume["Size"].get<std::string>());
+        VERIFY_ARE_EQUAL("N/A", volume["Status"].get<std::string>());
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Volume_List_Filter_MalformedValue)
@@ -243,7 +268,7 @@ private:
     {
         auto result = RunWslc(std::format(L"volume list --format json {}", filterArgs));
         result.Verify({.Stderr = L"", .ExitCode = 0});
-        const auto volumes = ParseNdjsonOutputAs<WSLCVolumeInformation>(result);
+        const auto volumes = ParseNdjsonOutputAs<VolumeListOutput>(result);
         std::set<std::string> names;
         for (const auto& v : volumes)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

`wslc volume list --format json` emitted only two keys, `Name` and `Driver`, while `docker volume ls --format json` emits ten. This reshapes the volume list path so the JSON keyset matches docker's.

The blocker was that `WSLCVolumeInformation` is two fixed `char[]` arrays and cannot carry a label map. This applies the same fix already used for `network list` in #41377: `IWSLCSession::ListVolumes` now returns a JSON string via `[out] LPSTR*` instead of a struct array. `ListVolumes` is not part of `WSLCCompat.idl`, so no SDK-facing or public ABI surface changes.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The command now outputs:

```json
{"Availability":"N/A","Driver":"guest","Group":"N/A","Labels":"env=prod","Links":"N/A","Mountpoint":"/var/lib/docker/volumes/parity-check-vol/_data","Name":"parity-check-vol","Scope":"local","Size":"N/A","Status":"N/A"}
```

The keyset is derived from `volumeContext` in `cli/command/formatter/volume.go`, whose `MarshalJSON` calls `formatter.MarshalJSON`. Per `cli/command/formatter/reflect.go`, that reflects over exported methods taking no arguments and returning a single value, which yields exactly `Availability, Driver, Group, Labels, Links, Mountpoint, Name, Scope, Size, Status`. Note that docker's header map for volumes also lists `ID`, but `volumeContext` has no `ID()` method, so `ID` is reachable only from Go templates and never appears in JSON.

`Links` and `Size` report `N/A` because docker only populates them when `UsageData` is set, and `Group`, `Availability`, and `Status` report `N/A` because docker only populates those for swarm cluster volumes. Both conditions are permanently false here, matching what docker prints outside a cluster.

Layering follows the existing image and network pattern, where a session-layer transport struct with native types is converted by a CLI-layer helper into an all-string output struct that is what actually gets serialized:

- `wslc_schema::VolumeListEntry` is the new transport struct: `Name`, `Driver`, `Mountpoint`, `Scope`, `Labels`.
- `IWSLCVolume` gains a `Mountpoint()` accessor. Both `WSLCGuestVolumeImpl` and `WSLCVhdVolumeImpl` already stored `m_mountpoint`; this just exposes it.
- `models::VolumeOutputInformation` is the new CLI output struct, converted by `ToVolumeOutput()` in `VolumeTasks.cpp`.

`WSLCVolumeInformation` is retained for `CreateVolume`, which still uses it. Its now-unused `adl_serializer` in `JsonUtils.h` is removed, since the volume list path was its only consumer.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Built clean, deployed with `tools\deploy\deploy-to-host.ps1`, and ran `bin\x64\Debug\test.bat /name:*Volume*`: **Total=106, Passed=106, Failed=0, Blocked=0, Not Run=0, Skipped=0**.

Added `WSLCE2E_Volume_List_ReportsFullFieldSet`, which asserts the field count is exactly 10 and checks every key and value, so an accidental added or dropped key fails the test instead of silently passing.

Updated the existing tests that consumed the old shape:

- `WSLCTests::ListVolumesFilters` and the volume lifecycle tests now go through a new `ListVolumeEntries()` helper that parses the JSON, mirroring the existing `ListNetworks()` test helper. The lifecycle test additionally asserts `Mountpoint` is non-empty and `Scope` is `local`.
- The e2e helpers and `WSLCE2EVolumeListTests` parse into a new `VolumeListOutput` mirror struct, matching how `NetworkListOutput` is already handled.

Also manually confirmed the rendered output shown above, and that `volume list` (table) and `volume list --quiet` are unaffected