### PR TITLE
Poll for the result of operations during MSI installation

### DIFF
--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -102,8 +102,7 @@ winrt::Windows::Management::Deployment::DeploymentResult WaitForDeploymentOperat
         throw winrt::hresult_canceled();
     }
 
-    auto result = operation.GetResults();
-    return result;
+    return operation.GetResults();
 }
 
 void ThrowIfOperationError(

--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -75,18 +75,43 @@ void TrustPackageCertificate(LPCWSTR Path)
 }
 #endif
 
-void ThrowIfOperationError(
-    const winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Management::Deployment::DeploymentResult, winrt::Windows::Management::Deployment::DeploymentProgress>& result,
+winrt::Windows::Management::Deployment::DeploymentResult WaitForDeploymentOperation(
+    const winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Management::Deployment::DeploymentResult, winrt::Windows::Management::Deployment::DeploymentProgress>& operation,
     const std::source_location& source = std::source_location::current())
 {
-    const auto status = result.get();
+    // IAsyncOperation::get() installs a completion delegate whose implementation resides in this DLL. The operation can retain
+    // that delegate after get() returns, allowing its final Release() to call into the DLL after MSI unloads it.
+    // To avoid this, poll until the operation is completed.
+    auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { operation.Close(); });
 
-    if (result.Status() == winrt::Windows::Foundation::AsyncStatus::Error)
+    auto status = operation.Status();
+    while (status == winrt::Windows::Foundation::AsyncStatus::Started)
     {
-        THROW_HR_MSG(result.ErrorCode(), "Source: %hs() - %hs:%lu", source.function_name(), source.file_name(), source.line());
+        Sleep(10);
+        status = operation.Status();
     }
 
-    THROW_IF_FAILED_MSG(status.ExtendedErrorCode(), "%ls", status.ErrorText().c_str());
+    if (status == winrt::Windows::Foundation::AsyncStatus::Error)
+    {
+        const auto error = operation.ErrorCode();
+        THROW_HR_MSG(error, "Source: %hs() - %hs:%lu", source.function_name(), source.file_name(), source.line());
+    }
+
+    if (status == winrt::Windows::Foundation::AsyncStatus::Canceled)
+    {
+        throw winrt::hresult_canceled();
+    }
+
+    auto result = operation.GetResults();
+    return result;
+}
+
+void ThrowIfOperationError(
+    const winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Management::Deployment::DeploymentResult, winrt::Windows::Management::Deployment::DeploymentProgress>& operation,
+    const std::source_location& source = std::source_location::current())
+{
+    const auto result = WaitForDeploymentOperation(operation, source);
+    THROW_IF_FAILED_MSG(result.ExtendedErrorCode(), "%ls", result.ErrorText().c_str());
 }
 
 std::wstring GetMsiProperty(MSIHANDLE install, LPCWSTR name)
@@ -530,7 +555,8 @@ try
     WSL_INSTALL_LOG("DeprovisionMsix");
 
     const winrt::Windows::Management::Deployment::PackageManager packageManager;
-    const auto result = packageManager.DeprovisionPackageForAllUsersAsync(wsl::windows::common::wslutil::c_msixPackageFamilyName).get();
+    const auto result = WaitForDeploymentOperation(
+        packageManager.DeprovisionPackageForAllUsersAsync(wsl::windows::common::wslutil::c_msixPackageFamilyName));
     LOG_IF_FAILED_MSG(result.ExtendedErrorCode(), "%ls", result.ErrorText().c_str());
 
     return NOERROR;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the custom action logic to poll for the completion of appx operations during the MSI installations.

Calling `.get()` registers a delegate that, due to a cppwinrt lifetime issue, might not get released until `wslinstall.dll` is unloaded, causing a crash since the release will jump into unloaded code. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
