### PR TITLE
Update the contributing guide to point to the Microsoft Researcher portal instead of the deprecated secure@microsoft.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Thank you in advance for your contribution! We appreciate your help in making WS
 ## Notes for collecting WSL logs
 
 ### Important: Reporting BSODs and Security issues
-**Do not open GitHub issues for Windows crashes (BSODs) or security issues.** Instead, send Windows crashes or other security-related issues to secure@microsoft.com.
+**Do not open GitHub issues for Windows crashes (BSODs) or security issues.** Instead, report the issue on the [Microsoft Researcher Portal](https://msrc.microsoft.com/report/vulnerability/new)
 See the `10) Reporting a Windows crash (BSOD)` section below for detailed instructions.
 
 ### Reporting issues in Windows Console or WSL text rendering/user experience
@@ -110,8 +110,9 @@ Then reproduce the issue, and let the machine crash and reboot.
 
 After reboot, the kernel dump will be in `%SystemRoot%\MEMORY.DMP` (unless this path has been overridden in the advanced system settings).
 
-Please send this dump to: secure@microsoft.com .
-Make sure that the email body contains:
+Please upload the kernel dump on the [Microsoft Researcher Portal](https://msrc.microsoft.com/report/vulnerability/new)
+
+Make sure that the description contains:
 
 - The GitHub issue number, if any
 - That this dump is intended for the WSL team

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Thank you in advance for your contribution! We appreciate your help in making WS
 ## Notes for collecting WSL logs
 
 ### Important: Reporting BSODs and Security issues
-**Do not open GitHub issues for Windows crashes (BSODs) or security issues.** Instead, report the issue on the [Microsoft Researcher Portal](https://msrc.microsoft.com/report/vulnerability/new)
+**Do not open GitHub issues for Windows crashes (BSODs) or security issues.** Instead, report the issue on the [Microsoft Researcher Portal](https://msrc.microsoft.com/report/vulnerability/new).
 See the `10) Reporting a Windows crash (BSOD)` section below for detailed instructions.
 
 ### Reporting issues in Windows Console or WSL text rendering/user experience


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change updates the kernel dump instructions to point to the MSRC portal, instead of the now deprecated email alias for kernel dumps, as shown in #41364 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
