### PR TITLE
CLI: Add virtiofs mapshared regression test

### DIFF
--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1175,6 +1175,50 @@ class WSLCE2EContainerRunTests
         result.Verify({.Stdout = L"WSLC Mount Bind Test", .Stderr = L"", .ExitCode = 0});
     }
 
+    WSLC_TEST_METHOD(WSLCE2E_Container_Run_Volume_Bind_VirtioFs_MapShared_Success)
+    {
+        const auto hostDirectory = EnvTestFile1.parent_path();
+        const auto fileName = EnvTestFile1.filename().wstring();
+        VERIFY_IS_TRUE(DeleteFileW(EnvTestFile1.c_str()));
+
+        constexpr auto mapSharedScript =
+            LR"PY(
+import ctypes
+import mmap
+import os
+import sys
+
+with open('/proc/mounts', encoding='utf-8') as mounts_file:
+    mounts = (line.split() for line in mounts_file)
+    assert any(fields[1:3] == ['/data', 'virtiofs'] for fields in mounts)
+
+fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC, 0o777)
+try:
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mmap.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_long,
+    ]
+    libc.mmap.restype = ctypes.c_void_p
+    address = libc.mmap(None, 32 * 1024, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, fd, 0)
+    if address == ctypes.c_void_p(-1).value:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+finally:
+    os.close(fd)
+)PY";
+
+        auto result = RunWslc(std::format(
+            L"container run --rm --volume \"{}:/data\" {} python3 -c \"{}\" /data/{}", hostDirectory.wstring(), PythonImage.NameAndTag(), mapSharedScript, fileName));
+        result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(std::filesystem::exists(EnvTestFile1));
+        VERIFY_ARE_EQUAL(0ull, std::filesystem::file_size(EnvTestFile1));
+    }
+
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_Mount_Volume_Success)
     {
         auto result = RunWslc(std::format(

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1183,7 +1183,6 @@ class WSLCE2EContainerRunTests
 
         constexpr auto mapSharedScript =
             LR"PY(
-import ctypes
 import mmap
 import os
 import sys
@@ -1193,19 +1192,28 @@ with open('/proc/mounts', encoding='utf-8') as mounts_file:
     assert any(fields[1:3] == ['/data', 'virtiofs'] for fields in mounts)
 
 fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC, 0o777)
-libc = ctypes.CDLL(None, use_errno=True)
-libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_long]
-libc.mmap.restype = ctypes.c_void_p
-address = libc.mmap(None, 32 * 1024, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, fd, 0)
-assert address != ctypes.c_void_p(-1).value, os.strerror(ctypes.get_errno())
-os.close(fd)
+try:
+    os.ftruncate(fd, 32 * 1024)
+    with mmap.mmap(fd, 32 * 1024, flags=mmap.MAP_SHARED, prot=mmap.PROT_READ | mmap.PROT_WRITE) as mapping:
+        mapping[0:1] = b'W'
+        mapping.flush()
+        assert os.pread(fd, 1, 0) == b'W'
+finally:
+    os.close(fd)
 )PY";
 
         auto result = RunWslc(std::format(
             L"container run --rm --volume \"{}:/data\" {} python3 -c \"{}\" /data/{}", hostDirectory.wstring(), PythonImage.NameAndTag(), mapSharedScript, fileName));
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
         VERIFY_IS_TRUE(std::filesystem::exists(EnvTestFile1));
-        VERIFY_ARE_EQUAL(0ull, std::filesystem::file_size(EnvTestFile1));
+        VERIFY_ARE_EQUAL(32ull * 1024, std::filesystem::file_size(EnvTestFile1));
+
+        std::ifstream mappedFile(EnvTestFile1, std::ios::binary);
+        VERIFY_IS_TRUE(mappedFile.is_open());
+        char mappedValue{};
+        mappedFile.get(mappedValue);
+        VERIFY_IS_TRUE(mappedFile.good());
+        VERIFY_ARE_EQUAL('W', mappedValue);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_Mount_Volume_Success)

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1193,23 +1193,12 @@ with open('/proc/mounts', encoding='utf-8') as mounts_file:
     assert any(fields[1:3] == ['/data', 'virtiofs'] for fields in mounts)
 
 fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC, 0o777)
-try:
-    libc = ctypes.CDLL(None, use_errno=True)
-    libc.mmap.argtypes = [
-        ctypes.c_void_p,
-        ctypes.c_size_t,
-        ctypes.c_int,
-        ctypes.c_int,
-        ctypes.c_int,
-        ctypes.c_long,
-    ]
-    libc.mmap.restype = ctypes.c_void_p
-    address = libc.mmap(None, 32 * 1024, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, fd, 0)
-    if address == ctypes.c_void_p(-1).value:
-        error = ctypes.get_errno()
-        raise OSError(error, os.strerror(error))
-finally:
-    os.close(fd)
+libc = ctypes.CDLL(None, use_errno=True)
+libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_long]
+libc.mmap.restype = ctypes.c_void_p
+address = libc.mmap(None, 32 * 1024, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, fd, 0)
+assert address != ctypes.c_void_p(-1).value, os.strerror(ctypes.get_errno())
+os.close(fd)
 )PY";
 
         auto result = RunWslc(std::format(

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1189,7 +1189,8 @@ import sys
 
 with open('/proc/mounts', encoding='utf-8') as mounts_file:
     mounts = (line.split() for line in mounts_file)
-    assert any(fields[1:3] == ['/data', 'virtiofs'] for fields in mounts)
+    if not any(fields[1:3] == ['/data', 'virtiofs'] for fields in mounts):
+        raise RuntimeError('/data is not mounted as virtiofs')
 
 fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC, 0o777)
 try:
@@ -1197,7 +1198,8 @@ try:
     with mmap.mmap(fd, 32 * 1024, flags=mmap.MAP_SHARED, prot=mmap.PROT_READ | mmap.PROT_WRITE) as mapping:
         mapping[0:1] = b'W'
         mapping.flush()
-        assert os.pread(fd, 1, 0) == b'W'
+        if os.pread(fd, 1, 0) != b'W':
+            raise RuntimeError('MAP_SHARED write was not visible through the file')
 finally:
     os.close(fd)
 )PY";

--- a/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EContainerRunTests.cpp
@@ -1193,15 +1193,12 @@ with open('/proc/mounts', encoding='utf-8') as mounts_file:
         raise RuntimeError('/data is not mounted as virtiofs')
 
 fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC, 0o777)
-try:
-    os.ftruncate(fd, 32 * 1024)
-    with mmap.mmap(fd, 32 * 1024, flags=mmap.MAP_SHARED, prot=mmap.PROT_READ | mmap.PROT_WRITE) as mapping:
-        mapping[0:1] = b'W'
-        mapping.flush()
-        if os.pread(fd, 1, 0) != b'W':
-            raise RuntimeError('MAP_SHARED write was not visible through the file')
-finally:
-    os.close(fd)
+os.ftruncate(fd, 32 * 1024)
+with mmap.mmap(fd, 32 * 1024, flags=mmap.MAP_SHARED, prot=mmap.PROT_READ | mmap.PROT_WRITE) as mapping:
+    mapping[0:1] = b'W'
+    mapping.flush()
+    if os.pread(fd, 1, 0) != b'W':
+        raise RuntimeError('MAP_SHARED write was not visible through the file')
 )PY";
 
         auto result = RunWslc(std::format(
@@ -1209,13 +1206,7 @@ finally:
         result.Verify({.Stdout = L"", .Stderr = L"", .ExitCode = 0});
         VERIFY_IS_TRUE(std::filesystem::exists(EnvTestFile1));
         VERIFY_ARE_EQUAL(32ull * 1024, std::filesystem::file_size(EnvTestFile1));
-
-        std::ifstream mappedFile(EnvTestFile1, std::ios::binary);
-        VERIFY_IS_TRUE(mappedFile.is_open());
-        char mappedValue{};
-        mappedFile.get(mappedValue);
-        VERIFY_IS_TRUE(mappedFile.good());
-        VERIFY_ARE_EQUAL('W', mappedValue);
+        VERIFY_ARE_EQUAL(L'W', ReadFileContent(EnvTestFile1.wstring())[0]);
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Container_Run_Mount_Volume_Success)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary
Add an E2E regression test for `MAP_SHARED` on Windows-backed WSLC bind mounts. This confirms behavior enabled by a virtiofs fix. This is a test-only PR that adds a single test.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Confirm the bind mount uses virtiofs.
- Cover the behavior enabled by [Enable FUSE direct-io with mmap for WSL VirtioFS](https://github.com/microsoft/openvmm/commit/72aea697dbf26cc7cf43182ec9cd256d9c8c7cd5).
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->

## Validation Steps Performed
- Targeted E2E test passed.