### PR TITLE
Sign DCAT script

### DIFF
--- a/.pipelines/build-job.yml
+++ b/.pipelines/build-job.yml
@@ -34,9 +34,6 @@ parameters:
   - name: artifactSuffix
     type: string
 
-  - name: esrp
-    type: object
-
   # x64-only features
   - name: includeTestArtifacts
     type: boolean
@@ -134,46 +131,11 @@ jobs:
             displayName: "Build ${{ target.target }} (${{ parameters.platform }})"
 
           - ${{ if eq(parameters.isRelease, true) }}:
-              - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-                displayName: "Sign ${{ target.target }} (${{ parameters.platform }})"
-                inputs:
-                  ConnectedServiceName: ${{ parameters.esrp.ConnectedServiceName}}
-                  signConfigType: ${{ parameters.esrp.signConfigType }}
-                  SessionTimeout: ${{ parameters.esrp.SessionTimeout }}
-                  MaxConcurrency: ${{ parameters.esrp.MaxConcurrency }}
-                  MaxRetryAttempts: ${{ parameters.esrp.MaxRetryAttempts }}
-                  ServiceEndpointUrl: ${{ parameters.esrp.ServiceEndpointUrl }}
-                  AuthAKVName: ${{ parameters.esrp.AuthAKVName }}
-                  AuthSignCertName: ${{ parameters.esrp.AuthSignCertName }}
-                  AppRegistrationClientId: ${{ parameters.esrp.AppRegistrationClientId }}
-                  AppRegistrationTenantId: ${{ parameters.esrp.AppRegistrationTenantId }}
-                  FolderPath: "bin\\${{ parameters.platform }}\\Release"
-                  Pattern: "${{ target.pattern }}"
-                  UseMSIAuthentication: true
-                  EsrpClientId: ${{ parameters.esrp.EsrpClientId }}
-                  inlineOperation: |
-                    [
-                          {
-                              "KeyCode": "CP-230012",
-                              "OperationCode": "SigntoolSign",
-                              "Parameters" : {
-                                    "OpusName" : "Microsoft",
-                                    "OpusInfo" : "http://www.microsoft.com",
-                                    "FileDigest" : "/fd \"SHA256\"",
-                                    "PageHash" : "/NPH",
-                                    "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                                },
-                                "ToolName" : "sign",
-                                "ToolVersion" : "1.0"
-                            },
-                            {
-                                "KeyCode" : "CP-230012",
-                                "OperationCode" : "SigntoolVerify",
-                                "Parameters" : {},
-                                "ToolName" : "sign",
-                                "ToolVersion" : "1.0"
-                            }
-                      ]
+              - template: sign-step.yml
+                parameters:
+                  displayName: 'Sign ${{ target.target }} (${{ parameters.platform }})'
+                  folderPath: 'bin\${{ parameters.platform }}\Release'
+                  pattern: '${{ target.pattern }}'
 
               - task: PowerShell@2
                 displayName: "Copy signed ${{ target.target }} to staging (${{ parameters.platform }})"
@@ -247,46 +209,11 @@ jobs:
               }
 
       - ${{ if eq(parameters.isRelease, true) }}:
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-            displayName: "Sign CAB (${{ parameters.platform }})"
-            inputs:
-              ConnectedServiceName: ${{ parameters.esrp.ConnectedServiceName}}
-              signConfigType: ${{ parameters.esrp.signConfigType }}
-              SessionTimeout: ${{ parameters.esrp.SessionTimeout }}
-              MaxConcurrency: ${{ parameters.esrp.MaxConcurrency }}
-              MaxRetryAttempts: ${{ parameters.esrp.MaxRetryAttempts }}
-              ServiceEndpointUrl: ${{ parameters.esrp.ServiceEndpointUrl }}
-              AuthAKVName: ${{ parameters.esrp.AuthAKVName }}
-              AuthSignCertName: ${{ parameters.esrp.AuthSignCertName }}
-              AppRegistrationClientId: ${{ parameters.esrp.AppRegistrationClientId }}
-              AppRegistrationTenantId: ${{ parameters.esrp.AppRegistrationTenantId }}
-              FolderPath: "$(ob_outputDirectory)\\bundle"
-              Pattern: "*.cab"
-              UseMSIAuthentication: true
-              EsrpClientId: ${{ parameters.esrp.EsrpClientId }}
-              inlineOperation: |
-                [
-                      {
-                          "KeyCode": "CP-230012",
-                          "OperationCode": "SigntoolSign",
-                          "Parameters" : {
-                                "OpusName" : "Microsoft",
-                                "OpusInfo" : "http://www.microsoft.com",
-                                "FileDigest" : "/fd \"SHA256\"",
-                                "PageHash" : "/NPH",
-                                "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                            },
-                            "ToolName" : "sign",
-                            "ToolVersion" : "1.0"
-                        },
-                        {
-                            "KeyCode" : "CP-230012",
-                            "OperationCode" : "SigntoolVerify",
-                            "Parameters" : {},
-                            "ToolName" : "sign",
-                            "ToolVersion" : "1.0"
-                        }
-                  ]
+          - template: sign-step.yml
+            parameters:
+              displayName: 'Sign CAB (${{ parameters.platform }})'
+              folderPath: '$(ob_outputDirectory)\bundle'
+              pattern: '*.cab'
 
       - powershell: |
           $binFolder = ".\bin\${{ parameters.platform }}\Release"

--- a/.pipelines/build-stage.yml
+++ b/.pipelines/build-stage.yml
@@ -49,21 +49,6 @@ parameters:
   - name: vsoProject
     type: string
 
-  - name: esrp
-    type: object
-    default:
-      ConnectedServiceName: "AzureConnection-AME"
-      signConfigType: "inlineSignParams"
-      SessionTimeout: 60
-      MaxConcurrency: 50
-      MaxRetryAttempts: 5
-      ServiceEndpointUrl: $(EsrpServiceEndpointUrl)
-      AuthAKVName: $(EsrpAuthAKVName)
-      AuthSignCertName: $(EsrpAuthSignCertName)
-      AppRegistrationClientId: $(EsrpAppRegistrationClientId)
-      AppRegistrationTenantId: $(EsrpAppRegistrationTenantId)
-      EsrpClientId: $(EsrpClientId)
-
 stages:
   # ── x64 build stage ──────────────────────────────────────────────────
   # Runs in parallel with build_arm64. Tests depend on this stage.
@@ -82,7 +67,6 @@ stages:
           pool: ${{ parameters.pool }}
           vsoOrg: ${{ parameters.vsoOrg }}
           vsoProject: ${{ parameters.vsoProject }}
-          esrp: ${{ parameters.esrp }}
           includeTestArtifacts: true
 
   # ── arm64 build stage (runs in parallel with build_x64) ──────────────
@@ -142,7 +126,6 @@ stages:
           pool: ${{ parameters.pool }}
           vsoOrg: ${{ parameters.vsoOrg }}
           vsoProject: ${{ parameters.vsoProject }}
-          esrp: ${{ parameters.esrp }}
           includeCodeQL: true
 
   # ── package stage (release and nightly only) ─────────────────────────
@@ -152,5 +135,4 @@ stages:
       parameters:
         isRelease: ${{ parameters.isRelease }}
         pool: ${{ parameters.pool }}
-        esrp: ${{ parameters.esrp }}
         nugetPackages: ${{ parameters.nugetPackages }}

--- a/.pipelines/dcat-stage.yml
+++ b/.pipelines/dcat-stage.yml
@@ -61,3 +61,9 @@ stages:
                 New-Item -ItemType Directory -Path $outputPath -Force | Out-Null
                 Copy-Item $jsonFiles.FullName $outputPath
                 Copy-Item "$(Pipeline.Workspace)\s\wsl-release-scripts\scripts\Dcat\Update-DcatSubmission.ps1" $outputPath
+
+          - template: sign-step.yml
+            parameters:
+              displayName: Sign DCAT scripts
+              folderPath: $(ob_outputDirectory)
+              pattern: '*.ps1'

--- a/.pipelines/package-stage.yml
+++ b/.pipelines/package-stage.yml
@@ -12,21 +12,6 @@ parameters:
     type: string
     default: ''
 
-  - name: esrp
-    type: object
-    default:
-      ConnectedServiceName: "AzureConnection-AME"
-      signConfigType: "inlineSignParams"
-      SessionTimeout: 60
-      MaxConcurrency: 50
-      MaxRetryAttempts: 5
-      ServiceEndpointUrl: $(EsrpServiceEndpointUrl)
-      AuthAKVName: $(EsrpAuthAKVName)
-      AuthSignCertName: $(EsrpAuthSignCertName)
-      AppRegistrationClientId: $(EsrpAppRegistrationClientId)
-      AppRegistrationTenantId: $(EsrpAppRegistrationTenantId)
-      EsrpClientId: $(EsrpClientId)
-
 stages:
   - stage: package
     dependsOn: [build_x64, build_arm64]
@@ -110,46 +95,11 @@ stages:
             displayName: Copy bundle to output
 
           - ${{ if eq(parameters.isRelease, true) }}:
-            - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-              displayName: "Sign the bundle"
-              inputs:
-                ConnectedServiceName: ${{ parameters.esrp.ConnectedServiceName}}
-                signConfigType: ${{ parameters.esrp.signConfigType }}
-                SessionTimeout: ${{ parameters.esrp.SessionTimeout }}
-                MaxConcurrency: ${{ parameters.esrp.MaxConcurrency }}
-                MaxRetryAttempts: ${{ parameters.esrp.MaxRetryAttempts }}
-                ServiceEndpointUrl: ${{ parameters.esrp.ServiceEndpointUrl }}
-                AuthAKVName: ${{ parameters.esrp.AuthAKVName }}
-                AuthSignCertName: ${{ parameters.esrp.AuthSignCertName }}
-                AppRegistrationClientId: ${{ parameters.esrp.AppRegistrationClientId }}
-                AppRegistrationTenantId: ${{ parameters.esrp.AppRegistrationTenantId }}
-                FolderPath: "$(ob_outputDirectory)\\bundle"
-                Pattern: "*.msixbundle"
-                UseMSIAuthentication: true
-                EsrpClientId: ${{ parameters.esrp.EsrpClientId }}
-                inlineOperation: |
-                  [
-                        {
-                            "KeyCode": "CP-230012",
-                            "OperationCode": "SigntoolSign",
-                            "Parameters" : {
-                                  "OpusName" : "Microsoft",
-                                  "OpusInfo" : "http://www.microsoft.com",
-                                  "FileDigest" : "/fd \"SHA256\"",
-                                  "PageHash" : "/NPH",
-                                  "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                              },
-                              "ToolName" : "sign",
-                              "ToolVersion" : "1.0"
-                          },
-                          {
-                              "KeyCode" : "CP-230012",
-                              "OperationCode" : "SigntoolVerify",
-                              "Parameters" : {},
-                              "ToolName" : "sign",
-                              "ToolVersion" : "1.0"
-                          }
-                    ]
+            - template: sign-step.yml
+              parameters:
+                displayName: Sign the bundle
+                folderPath: '$(ob_outputDirectory)\bundle'
+                pattern: '*.msixbundle'
 
           - ${{ if not(eq(parameters.isRelease, true)) }}:
             - powershell: |
@@ -203,40 +153,12 @@ stages:
                 displayName: Build ${{ package }}
 
           - ${{ if eq(parameters.isRelease, true) }}:
-              - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-                displayName: "Sign nuget packages"
-                inputs:
-                  ConnectedServiceName: ${{ parameters.esrp.ConnectedServiceName}}
-                  signConfigType: ${{ parameters.esrp.signConfigType }}
-                  SessionTimeout: ${{ parameters.esrp.SessionTimeout }}
-                  MaxConcurrency: ${{ parameters.esrp.MaxConcurrency }}
-                  MaxRetryAttempts: ${{ parameters.esrp.MaxRetryAttempts }}
-                  ServiceEndpointUrl: ${{ parameters.esrp.ServiceEndpointUrl }}
-                  AuthAKVName: ${{ parameters.esrp.AuthAKVName }}
-                  AuthSignCertName: ${{ parameters.esrp.AuthSignCertName }}
-                  AppRegistrationClientId: ${{ parameters.esrp.AppRegistrationClientId }}
-                  AppRegistrationTenantId: ${{ parameters.esrp.AppRegistrationTenantId }}
-                  FolderPath: '$(ob_outputDirectory)\nuget'
-                  Pattern: "*.nupkg"
-                  UseMSIAuthentication: true
-                  EsrpClientId: ${{ parameters.esrp.EsrpClientId }}
-                  inlineOperation: |
-                    [
-                        {
-                            "KeyCode": "CP-401405",
-                            "OperationCode": "NuGetSign",
-                            "Parameters" : {},
-                              "ToolName" : "sign",
-                              "ToolVersion" : "1.0"
-                          },
-                          {
-                              "KeyCode" : "CP-401405",
-                              "OperationCode" : "NuGetVerify",
-                              "Parameters" : {},
-                              "ToolName" : "sign",
-                              "ToolVersion" : "1.0"
-                          }
-                    ]
+              - template: sign-step.yml
+                parameters:
+                  displayName: Sign nuget packages
+                  folderPath: '$(ob_outputDirectory)\nuget'
+                  pattern: '*.nupkg'
+                  signingType: nuget
 
           - ${{ if ne(parameters.pool, '') }}:
             - task: PublishPipelineArtifact@1

--- a/.pipelines/sign-step.yml
+++ b/.pipelines/sign-step.yml
@@ -1,0 +1,79 @@
+parameters:
+  - name: displayName
+    type: string
+
+  - name: folderPath
+    type: string
+
+  - name: pattern
+    type: string
+
+  # authenticode: for binaries, installers, cabs and scripts.
+  # nuget: for .nupkg files.
+  - name: signingType
+    type: string
+    default: authenticode
+    values:
+      - authenticode
+      - nuget
+
+steps:
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+    displayName: '${{ parameters.displayName }}'
+    inputs:
+      ConnectedServiceName: AzureConnection-AME
+      signConfigType: inlineSignParams
+      SessionTimeout: 60
+      MaxConcurrency: 50
+      MaxRetryAttempts: 5
+      ServiceEndpointUrl: $(EsrpServiceEndpointUrl)
+      AuthAKVName: $(EsrpAuthAKVName)
+      AuthSignCertName: $(EsrpAuthSignCertName)
+      AppRegistrationClientId: $(EsrpAppRegistrationClientId)
+      AppRegistrationTenantId: $(EsrpAppRegistrationTenantId)
+      EsrpClientId: $(EsrpClientId)
+      UseMSIAuthentication: true
+      FolderPath: '${{ parameters.folderPath }}'
+      Pattern: '${{ parameters.pattern }}'
+      ${{ if eq(parameters.signingType, 'authenticode') }}:
+        inlineOperation: |
+          [
+              {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolSign",
+                  "Parameters": {
+                      "OpusName": "Microsoft",
+                      "OpusInfo": "http://www.microsoft.com",
+                      "FileDigest": "/fd \"SHA256\"",
+                      "PageHash": "/NPH",
+                      "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                  },
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0"
+              },
+              {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolVerify",
+                  "Parameters": {},
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0"
+              }
+          ]
+      ${{ elseif eq(parameters.signingType, 'nuget') }}:
+        inlineOperation: |
+          [
+              {
+                  "KeyCode": "CP-401405",
+                  "OperationCode": "NuGetSign",
+                  "Parameters": {},
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0"
+              },
+              {
+                  "KeyCode": "CP-401405",
+                  "OperationCode": "NuGetVerify",
+                  "Parameters": {},
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0"
+              }
+          ]


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The stage that prepares files for DCAT is failing because it publishes an unsigned script as a pipeline artifact.
This change signs that file.

To avoid repeating all the signing parameters, I created a template for the signing step that is reused any time we sign something.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Currently running a (non official) build for validation.