### PR TITLE
wslc: consolidate size formatting on FormatHumanReadableSize

### DIFF
--- a/src/windows/common/string.cpp
+++ b/src/windows/common/string.cpp
@@ -375,45 +375,26 @@ std::optional<uint64_t> wsl::windows::common::string::ParseStorageSize(std::wstr
     return static_cast<uint64_t>(bytes);
 }
 
-std::wstring wsl::windows::common::string::FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace)
+std::wstring wsl::windows::common::string::FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision, StorageSizeUnit Unit)
 {
-    constexpr size_t c_unitCount = 6;
-    constexpr std::array<std::wstring_view, c_unitCount> c_decimalUnits{L"B", L"KB", L"MB", L"GB", L"TB", L"PB"};
-    constexpr std::array<std::wstring_view, c_unitCount> c_binaryUnits{L"B", L"KiB", L"MiB", L"GiB", L"TiB", L"PiB"};
+    constexpr size_t c_unitCount = 9;
+    constexpr std::array<std::wstring_view, c_unitCount> c_decimalUnits{
+        L"B", L"kB", L"MB", L"GB", L"TB", L"PB", L"EB", L"ZB", L"YB"};
+    constexpr std::array<std::wstring_view, c_unitCount> c_binaryUnits{
+        L"B", L"KiB", L"MiB", L"GiB", L"TiB", L"PiB", L"EiB", L"ZiB", L"YiB"};
 
     const double base = Unit == StorageSizeUnit::Decimal ? 1000.0 : 1024.0;
     const auto& units = Unit == StorageSizeUnit::Decimal ? c_decimalUnits : c_binaryUnits;
 
-    double value = static_cast<double>(Bytes);
+    auto value = static_cast<double>(Bytes);
     size_t unitIndex = 0;
     while (value >= base && unitIndex + 1 < c_unitCount)
     {
         value /= base;
-        ++unitIndex;
-    }
-
-    const auto formattedValue = unitIndex == 0 ? std::to_wstring(Bytes) : std::format(L"{:.{}f}", value, DecimalPlaces);
-    return std::format(L"{}{}{}", formattedValue, IncludeSpace ? L" " : L"", units[unitIndex]);
-}
-
-std::wstring wsl::windows::common::string::FormatBytes(uint64_t Bytes)
-{
-    return FormatStorageSize(Bytes, StorageSizeUnit::Decimal, 2, true);
-}
-
-std::wstring wsl::windows::common::string::FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision)
-{
-    constexpr std::wstring_view c_units[] = {L"B", L"kB", L"MB", L"GB", L"TB", L"PB", L"EB", L"ZB", L"YB"};
-
-    auto value = static_cast<double>(Bytes);
-    size_t unitIndex = 0;
-    while (value >= 1000.0 && unitIndex + 1 < std::size(c_units))
-    {
-        value /= 1000.0;
         unitIndex++;
     }
 
-    return std::format(L"{:.{}g}{}", value, Precision, c_units[unitIndex]);
+    return std::format(L"{:.{}g}{}", value, Precision, units[unitIndex]);
 }
 
 std::wstring wsl::windows::common::string::TruncateId(_In_ std::wstring_view id, bool shortenLength)

--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -31,13 +31,10 @@ enum class StorageSizeUnit
 
 std::optional<uint64_t> ParseStorageSize(std::wstring_view String, StorageSizeUnit Unit);
 
-std::wstring FormatStorageSize(uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace = false);
-
-std::wstring FormatBytes(uint64_t Bytes);
-
-// Formats a size as base 1000 with no space and the given number of significant digits
-// (119856765 -> "120MB" at precision 3, "119.9MB" at 4).
-std::wstring FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision = 3);
+// Formats a size with the given number of significant digits and no space before the unit, matching
+// docker's go-units. Decimal uses base 1000 (kB, MB, GB) and Binary uses base 1024 (KiB, MiB, GiB).
+// 119856765 -> "120MB" at precision 3, "119.9MB" at precision 4.
+std::wstring FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision = 3, StorageSizeUnit Unit = StorageSizeUnit::Decimal);
 
 std::vector<std::string> InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize);
 

--- a/src/windows/wslc/services/ImageProgressCallback.cpp
+++ b/src/windows/wslc/services/ImageProgressCallback.cpp
@@ -20,7 +20,9 @@ Abstract:
 namespace wsl::windows::wslc::services {
 using namespace wsl::shared;
 using namespace wsl::windows::common::vt;
-using wsl::windows::common::string::FormatBytes;
+using wsl::windows::common::string::FormatHumanReadableSize;
+
+constexpr uint32_t c_progressPrecision = 4;
 
 auto ImageProgressCallback::MoveToLine(int line)
 {
@@ -133,18 +135,18 @@ std::wstring ImageProgressCallback::GenerateStatusLine(LPCSTR status, LPCSTR id,
 
         // Docker's reported total is an estimate of the compressed layer size, so the actual bytes
         // transferred can exceed it. Drop the total in that case to avoid displaying a count over 100%.
-        auto progress = FormatBytes(current);
+        auto progress = FormatHumanReadableSize(current, c_progressPrecision);
 
         if (current <= total)
         {
-            progress += std::format(L"/{}", FormatBytes(total));
+            progress += std::format(L"/{}", FormatHumanReadableSize(total, c_progressPrecision));
         }
 
         line = std::format(L"{}: {} [{}] {}", safeId, safeStatus, bar, progress);
     }
     else if (current != 0)
     {
-        line = std::format(L"{}: {} {}", safeId, safeStatus, FormatBytes(current));
+        line = std::format(L"{}: {} {}", safeId, safeStatus, FormatHumanReadableSize(current, c_progressPrecision));
     }
     else
     {

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -41,6 +41,20 @@ using wsl::windows::common::string::StorageSizeUnit;
 
 namespace {
 
+// Docker reports memory in binary units and network and block IO in decimal units.
+constexpr uint32_t c_statsMemoryPrecision = 4;
+constexpr uint32_t c_statsIoPrecision = 3;
+
+std::string FormatStatsMemory(uint64_t Bytes)
+{
+    return WideToMultiByte(FormatHumanReadableSize(Bytes, c_statsMemoryPrecision, StorageSizeUnit::Binary));
+}
+
+std::string FormatStatsIo(uint64_t Bytes)
+{
+    return WideToMultiByte(FormatHumanReadableSize(Bytes, c_statsIoPrecision));
+}
+
 nlohmann::json ComputeContainerStatsJson(const wsl::windows::common::docker_schema::ContainerStats& stats)
 {
     // Calculate CPU %
@@ -98,22 +112,15 @@ nlohmann::json ComputeContainerStatsJson(const wsl::windows::common::docker_sche
     }
 
     const auto& containerName = stats.name.empty() ? stats.id : stats.name;
-    // Docker reports memory in binary units and network and block IO in decimal units.
-    constexpr uint32_t c_memoryPrecision = 4;
-    constexpr uint32_t c_ioPrecision = 3;
-    const auto formatMemory = [](uint64_t bytes) {
-        return WideToMultiByte(FormatHumanReadableSize(bytes, c_memoryPrecision, StorageSizeUnit::Binary));
-    };
-    const auto formatIo = [](uint64_t bytes) { return WideToMultiByte(FormatHumanReadableSize(bytes, c_ioPrecision)); };
 
     return {
         {"ID", stats.id},
         {"Name", containerName},
         {"CPUPerc", std::format("{:.2f}%", cpuPercent)},
-        {"MemUsage", std::format("{} / {}", formatMemory(stats.memory_stats.usage), formatMemory(stats.memory_stats.limit))},
+        {"MemUsage", std::format("{} / {}", FormatStatsMemory(stats.memory_stats.usage), FormatStatsMemory(stats.memory_stats.limit))},
         {"MemPerc", std::format("{:.2f}%", memPercent)},
-        {"NetIO", std::format("{} / {}", formatIo(netRxBytes), formatIo(netTxBytes))},
-        {"BlockIO", std::format("{} / {}", formatIo(blkReadBytes), formatIo(blkWriteBytes))},
+        {"NetIO", std::format("{} / {}", FormatStatsIo(netRxBytes), FormatStatsIo(netTxBytes))},
+        {"BlockIO", std::format("{} / {}", FormatStatsIo(blkReadBytes), FormatStatsIo(blkWriteBytes))},
         {"PIDs", stats.pids_stats.current},
     };
 }

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -36,8 +36,7 @@ using namespace wsl::windows::common::wslutil;
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::models;
 using namespace wsl::windows::wslc::services;
-using wsl::windows::common::string::FormatBytes;
-using wsl::windows::common::string::FormatStorageSize;
+using wsl::windows::common::string::FormatHumanReadableSize;
 using wsl::windows::common::string::StorageSizeUnit;
 
 namespace {
@@ -99,18 +98,22 @@ nlohmann::json ComputeContainerStatsJson(const wsl::windows::common::docker_sche
     }
 
     const auto& containerName = stats.name.empty() ? stats.id : stats.name;
-    const auto formatBinaryBytes = [](uint64_t bytes) {
-        return WideToMultiByte(FormatStorageSize(bytes, StorageSizeUnit::Binary, 2, true));
+    // Docker reports memory in binary units and network and block IO in decimal units.
+    constexpr uint32_t c_memoryPrecision = 4;
+    constexpr uint32_t c_ioPrecision = 3;
+    const auto formatMemory = [](uint64_t bytes) {
+        return WideToMultiByte(FormatHumanReadableSize(bytes, c_memoryPrecision, StorageSizeUnit::Binary));
     };
+    const auto formatIo = [](uint64_t bytes) { return WideToMultiByte(FormatHumanReadableSize(bytes, c_ioPrecision)); };
 
     return {
         {"ID", stats.id},
         {"Name", containerName},
         {"CPUPerc", std::format("{:.2f}%", cpuPercent)},
-        {"MemUsage", std::format("{} / {}", formatBinaryBytes(stats.memory_stats.usage), formatBinaryBytes(stats.memory_stats.limit))},
+        {"MemUsage", std::format("{} / {}", formatMemory(stats.memory_stats.usage), formatMemory(stats.memory_stats.limit))},
         {"MemPerc", std::format("{:.2f}%", memPercent)},
-        {"NetIO", std::format("{} / {}", formatBinaryBytes(netRxBytes), formatBinaryBytes(netTxBytes))},
-        {"BlockIO", std::format("{} / {}", formatBinaryBytes(blkReadBytes), formatBinaryBytes(blkWriteBytes))},
+        {"NetIO", std::format("{} / {}", formatIo(netRxBytes), formatIo(netTxBytes))},
+        {"BlockIO", std::format("{} / {}", formatIo(blkReadBytes), formatIo(blkWriteBytes))},
         {"PIDs", stats.pids_stats.current},
     };
 }
@@ -118,6 +121,8 @@ nlohmann::json ComputeContainerStatsJson(const wsl::windows::common::docker_sche
 } // namespace
 
 namespace wsl::windows::wslc::task {
+
+constexpr uint32_t c_reclaimedSpacePrecision = 4;
 
 static bool TryInspectContainer(Terminal& terminal, Session& session, const std::string& containerId, std::optional<wslc_schema::InspectContainer>& inspectData)
 {
@@ -1069,6 +1074,7 @@ void PruneContainers(CLIExecutionContext& context)
     }
 
     context.Terminal.Output(L"\n");
-    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_ContainerPruneSpaceReclaimedBytes(FormatBytes(result.SpaceReclaimed)));
+    context.Terminal.Output(
+        L"{}\n", Localization::WSLCCLI_ContainerPruneSpaceReclaimedBytes(FormatHumanReadableSize(result.SpaceReclaimed, c_reclaimedSpacePrecision)));
 }
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -34,9 +34,10 @@ using namespace wsl::windows::common::wslutil;
 using namespace wsl::windows::wslc::execution;
 using namespace wsl::windows::wslc::models;
 using namespace wsl::windows::wslc::services;
-using wsl::windows::common::string::FormatBytes;
 
 namespace wsl::windows::wslc::task {
+
+constexpr uint32_t c_reclaimedSpacePrecision = 4;
 
 namespace {
 
@@ -438,6 +439,7 @@ void PruneImages(CLIExecutionContext& context)
     }
 
     context.Terminal.Output(L"\n");
-    context.Terminal.Output(L"{}\n", Localization::WSLCCLI_ImagePruneSpaceReclaimedBytes(FormatBytes(result.SpaceReclaimed)));
+    context.Terminal.Output(
+        L"{}\n", Localization::WSLCCLI_ImagePruneSpaceReclaimedBytes(FormatHumanReadableSize(result.SpaceReclaimed, c_reclaimedSpacePrecision)));
 }
 } // namespace wsl::windows::wslc::task

--- a/src/windows/wslcsession/WSLCSession.cpp
+++ b/src/windows/wslcsession/WSLCSession.cpp
@@ -30,7 +30,7 @@ using io::MultiHandleWait;
 using io::OverlappedIOHandle;
 using io::WriteHandle;
 using wsl::shared::Localization;
-using wsl::windows::common::string::FormatBytes;
+using wsl::windows::common::string::FormatHumanReadableSize;
 using wsl::windows::service::wslc::UserCOMCallback;
 using wsl::windows::service::wslc::UserHandle;
 using wsl::windows::service::wslc::WSLCExecutionContext;
@@ -42,6 +42,7 @@ constexpr auto c_containerdSocket = "/run/containerd/containerd.sock";
 constexpr auto c_storageVhdFilename = wsl::windows::wslc::DefaultStorageVhdName;
 constexpr DWORD c_processTerminateTimeoutMs = 30 * 1000;
 constexpr DWORD c_processKillTimeoutMs = 10 * 1000;
+constexpr uint32_t c_progressPrecision = 4;
 
 // Default grace period to keep an otherwise-idle VM running before tearing it down (used when the
 // session's IdleTimeoutSec setting is 0/unset). This avoids thrashing the VM (repeated
@@ -1432,8 +1433,8 @@ try
             {
                 auto currentBytes = static_cast<ULONGLONG>(std::max<int64_t>(entry.current, 0));
                 auto totalBytes = static_cast<ULONGLONG>(std::max<int64_t>(entry.total, 0));
-                auto current = FormatBytes(currentBytes);
-                auto total = FormatBytes(totalBytes);
+                auto current = FormatHumanReadableSize(currentBytes, c_progressPrecision);
+                auto total = FormatHumanReadableSize(totalBytes, c_progressPrecision);
                 reportProgress(std::format("{}{} {} / {}", logPrefix(it->second), entry.id, current, total), entry.id.c_str(), currentBytes, totalBytes);
             }
             else if (reportedSteps.insert(entry.id).second)

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -4,9 +4,7 @@
 #include "Common.h"
 #include "string.hpp"
 
-using wsl::windows::common::string::FormatBytes;
 using wsl::windows::common::string::FormatHumanReadableSize;
-using wsl::windows::common::string::FormatStorageSize;
 using wsl::windows::common::string::ParseStorageSize;
 using wsl::windows::common::string::StorageSizeUnit;
 
@@ -16,8 +14,7 @@ struct StorageSizeFormatCase
 {
     uint64_t Bytes;
     StorageSizeUnit Unit;
-    uint32_t DecimalPlaces;
-    bool IncludeSpace;
+    uint32_t Precision;
     std::wstring Expected;
 };
 
@@ -25,8 +22,7 @@ struct StorageSizeTextRoundTripCase
 {
     std::wstring Text;
     StorageSizeUnit Unit;
-    uint32_t DecimalPlaces;
-    bool IncludeSpace;
+    uint32_t Precision;
 };
 
 void VerifyDockerStorageSize(const std::string& Input, StorageSizeUnit Unit, std::optional<uint64_t> Expected)
@@ -206,34 +202,29 @@ class StringUnitTests
         }
     }
 
-    TEST_METHOD(FormatStorageSize_UsesRequestedPrecision)
+    // Memory sizes are rendered in binary units with four significant digits and no space, matching
+    // docker's units.BytesSize.
+    TEST_METHOD(FormatHumanReadableSize_SupportsBinaryUnits)
     {
         const std::vector<StorageSizeFormatCase> TestCases{
-            {0, StorageSizeUnit::Decimal, 0, false, L"0B"},
-            {999, StorageSizeUnit::Decimal, 2, true, L"999 B"},
-            {1'000, StorageSizeUnit::Decimal, 0, false, L"1KB"},
-            {119'856'765, StorageSizeUnit::Decimal, 0, false, L"120MB"},
-            {119'856'765, StorageSizeUnit::Decimal, 1, false, L"119.9MB"},
-            {119'856'765, StorageSizeUnit::Decimal, 2, false, L"119.86MB"},
-            {1'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00TB"},
-            {1'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1.00PB"},
-            {1'000'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2, false, L"1000.00PB"},
-            {1'023, StorageSizeUnit::Binary, 2, true, L"1023 B"},
-            {1'024, StorageSizeUnit::Binary, 0, false, L"1KiB"},
-            {1'536, StorageSizeUnit::Binary, 1, false, L"1.5KiB"},
-            {1'610'612'736, StorageSizeUnit::Binary, 0, false, L"2GiB"},
-            {1'610'612'736, StorageSizeUnit::Binary, 1, false, L"1.5GiB"},
-            {1ULL << 40, StorageSizeUnit::Binary, 2, false, L"1.00TiB"},
-            {1ULL << 50, StorageSizeUnit::Binary, 2, false, L"1.00PiB"},
-            {1ULL << 60, StorageSizeUnit::Binary, 2, false, L"1024.00PiB"},
+            {0, StorageSizeUnit::Binary, 4, L"0B"},
+            {1'023, StorageSizeUnit::Binary, 4, L"1023B"},
+            {1'024, StorageSizeUnit::Binary, 4, L"1KiB"},
+            {1'536, StorageSizeUnit::Binary, 4, L"1.5KiB"},
+            {44'000, StorageSizeUnit::Binary, 4, L"42.97KiB"},
+            {1'610'612'736, StorageSizeUnit::Binary, 4, L"1.5GiB"},
+            {8ULL << 30, StorageSizeUnit::Binary, 4, L"8GiB"},
+            {1ULL << 40, StorageSizeUnit::Binary, 4, L"1TiB"},
+            {1ULL << 50, StorageSizeUnit::Binary, 4, L"1PiB"},
+            {1'536, StorageSizeUnit::Binary, 3, L"1.5KiB"},
+            {1'000, StorageSizeUnit::Decimal, 4, L"1kB"},
+            {1'610'612'736, StorageSizeUnit::Decimal, 4, L"1.611GB"},
         };
 
         for (const auto& TestCase : TestCases)
         {
-            VERIFY_ARE_EQUAL(TestCase.Expected, FormatStorageSize(TestCase.Bytes, TestCase.Unit, TestCase.DecimalPlaces, TestCase.IncludeSpace));
+            VERIFY_ARE_EQUAL(TestCase.Expected, FormatHumanReadableSize(TestCase.Bytes, TestCase.Precision, TestCase.Unit));
         }
-
-        VERIFY_ARE_EQUAL(std::wstring{L"119.86 MB"}, FormatBytes(119'856'765));
     }
 
     // Image sizes are rendered with three significant digits, base 1000, no space, and "kB" rather
@@ -278,24 +269,26 @@ class StringUnitTests
 
     TEST_METHOD(StorageSize_BytesToTextRoundTrips)
     {
-        const auto VerifyRoundTrip = [](uint64_t Bytes, StorageSizeUnit Unit, uint32_t DecimalPlaces, bool IncludeSpace = false) {
-            const auto text = FormatStorageSize(Bytes, Unit, DecimalPlaces, IncludeSpace);
+        // The parser accepts suffixes up to peta, matching docker's unit map, so the round trip is
+        // only defined below one exabyte.
+        const auto VerifyRoundTrip = [](uint64_t Bytes, StorageSizeUnit Unit, uint32_t Precision) {
+            const auto text = FormatHumanReadableSize(Bytes, Precision, Unit);
             VERIFY_ARE_EQUAL(std::optional<uint64_t>{Bytes}, ParseStorageSize(text, Unit));
         };
 
-        VerifyRoundTrip(0, StorageSizeUnit::Decimal, 0);
-        VerifyRoundTrip(32, StorageSizeUnit::Decimal, 0, true);
-        VerifyRoundTrip(1'500, StorageSizeUnit::Decimal, 1);
-        VerifyRoundTrip(1'536, StorageSizeUnit::Binary, 1);
-        VerifyRoundTrip(1'000'000'000'000'000'000ULL, StorageSizeUnit::Decimal, 2);
-        VerifyRoundTrip(1ULL << 60, StorageSizeUnit::Binary, 2);
+        VerifyRoundTrip(0, StorageSizeUnit::Decimal, 3);
+        VerifyRoundTrip(32, StorageSizeUnit::Decimal, 3);
+        VerifyRoundTrip(1'500, StorageSizeUnit::Decimal, 3);
+        VerifyRoundTrip(1'536, StorageSizeUnit::Binary, 3);
+        VerifyRoundTrip(1'250'000'000'000ULL, StorageSizeUnit::Decimal, 4);
+        VerifyRoundTrip(1ULL << 50, StorageSizeUnit::Binary, 4);
 
         uint64_t decimalFactor = 1'000;
         uint64_t binaryFactor = 1'024;
         for (size_t index = 0; index < 5; ++index)
         {
-            VerifyRoundTrip(32 * decimalFactor, StorageSizeUnit::Decimal, 0);
-            VerifyRoundTrip(32 * binaryFactor, StorageSizeUnit::Binary, 0, true);
+            VerifyRoundTrip(32 * decimalFactor, StorageSizeUnit::Decimal, 3);
+            VerifyRoundTrip(32 * binaryFactor, StorageSizeUnit::Binary, 3);
             decimalFactor *= 1'000;
             binaryFactor *= 1'024;
         }
@@ -304,18 +297,18 @@ class StringUnitTests
     TEST_METHOD(StorageSize_TextToBytesRoundTrips)
     {
         const std::vector<StorageSizeTextRoundTripCase> TestCases{
-            {L"0B", StorageSizeUnit::Decimal, 0, false},
-            {L"32 B", StorageSizeUnit::Decimal, 0, true},
-            {L"32KB", StorageSizeUnit::Decimal, 0, false},
-            {L"32.5MB", StorageSizeUnit::Decimal, 1, false},
-            {L"1GB", StorageSizeUnit::Decimal, 0, false},
-            {L"1.25TB", StorageSizeUnit::Decimal, 2, false},
-            {L"1PB", StorageSizeUnit::Decimal, 0, false},
-            {L"32KiB", StorageSizeUnit::Binary, 0, false},
-            {L"1.5MiB", StorageSizeUnit::Binary, 1, false},
-            {L"1GiB", StorageSizeUnit::Binary, 0, false},
-            {L"1.25 TiB", StorageSizeUnit::Binary, 2, true},
-            {L"1PiB", StorageSizeUnit::Binary, 0, false},
+            {L"0B", StorageSizeUnit::Decimal, 3},
+            {L"32B", StorageSizeUnit::Decimal, 3},
+            {L"32kB", StorageSizeUnit::Decimal, 3},
+            {L"32.5MB", StorageSizeUnit::Decimal, 3},
+            {L"1GB", StorageSizeUnit::Decimal, 3},
+            {L"1.25TB", StorageSizeUnit::Decimal, 3},
+            {L"1PB", StorageSizeUnit::Decimal, 3},
+            {L"32KiB", StorageSizeUnit::Binary, 3},
+            {L"1.5MiB", StorageSizeUnit::Binary, 3},
+            {L"1GiB", StorageSizeUnit::Binary, 3},
+            {L"1.25TiB", StorageSizeUnit::Binary, 3},
+            {L"1PiB", StorageSizeUnit::Binary, 3},
         };
 
         for (const auto& TestCase : TestCases)
@@ -323,7 +316,7 @@ class StringUnitTests
             const auto bytes = ParseStorageSize(TestCase.Text, TestCase.Unit);
             VERIFY_IS_TRUE(bytes.has_value());
 
-            const auto text = FormatStorageSize(bytes.value(), TestCase.Unit, TestCase.DecimalPlaces, TestCase.IncludeSpace);
+            const auto text = FormatHumanReadableSize(bytes.value(), TestCase.Precision, TestCase.Unit);
             VERIFY_ARE_EQUAL(TestCase.Text, text);
             VERIFY_ARE_EQUAL(bytes, ParseStorageSize(text, TestCase.Unit));
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Consolidates the three size-formatting helpers in `wsl::windows::common::string` down to one. `FormatStorageSize` and `FormatBytes` are removed; `FormatHumanReadableSize` gains an optional `StorageSizeUnit` so it can render binary units:

```cpp
std::wstring FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision = 3, StorageSizeUnit Unit = StorageSizeUnit::Decimal);
```

This also brings several call sites into line with docker. `ParseStorageSize` and `StorageSizeUnit` are unchanged.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The three "Total reclaimed space" messages previously disagreed (image/container used `FormatBytes`, volume used `FormatHumanReadableSize`); all now use precision 4. `image ls` and `volume prune` output is unchanged.

Two smaller corrections fall out: the decimal table uses lowercase `kB` per go-units' `decimapAbbrs`, and the binary table extends to `YiB` to match `binaryAbbrs`.

`ParseStorageSize`'s suffix map is `"kmgtp"`, so anything formatting to `EB`/`EiB` or larger cannot be parsed back. That mirrors go-units and already applied to the decimal path; round-trip tests are scoped below 1 EB accordingly.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Full build, 0 errors; `clang-format` v19.1.5 clean across all 7 changed files.
- `StringUnitTests` 11/11. `FormatStorageSize_UsesRequestedPrecision` is replaced by `FormatHumanReadableSize_SupportsBinaryUnits`; both round-trip tests re-expressed against the new signature.
- `*WSLCCLI*` 415/415.
