### PR TITLE
Skip publishing helper DCAT script as artifact

### DIFF
--- a/.pipelines/dcat-stage.yml
+++ b/.pipelines/dcat-stage.yml
@@ -60,4 +60,3 @@ stages:
 
                 New-Item -ItemType Directory -Path $outputPath -Force | Out-Null
                 Copy-Item $jsonFiles.FullName $outputPath
-                Copy-Item "$(Pipeline.Workspace)\s\wsl-release-scripts\scripts\Dcat\Update-DcatSubmission.ps1" $outputPath


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The build pipeline fails to create the DCAT pipeline artifacts because it tries to publish a helper script that isn't signed. Since this script doesn't do much and it is only used internally, it doesn't seem worth it to set up signing for it. So, I'm just removing it from the published files.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
