### PR TITLE
CLI: Mount PR followup & fix two docker parser bugs

### DIFF
--- a/src/windows/common/MountSpecParsing.cpp
+++ b/src/windows/common/MountSpecParsing.cpp
@@ -84,11 +84,16 @@ namespace {
         FieldDefinition{L"destination", Field::Target, Family::General, false, Support::Supported},
         FieldDefinition{L"readonly", Field::ReadOnly, Family::General, true, Support::Supported},
         FieldDefinition{L"ro", Field::ReadOnly, Family::General, true, Support::Supported},
+        // The WSLC mount transport and Docker request model have no end-to-end consistency setting.
         FieldDefinition{L"consistency", Field::Consistency, Family::General, false, Support::Unsupported},
+        // The WSLC mount transport and Docker request model do not carry Docker bind options.
+        // "enabled" requires no non-default bind behavior and is accepted below.
         FieldDefinition{L"bind-propagation", Field::BindPropagation, Family::Bind, false, Support::Unsupported},
         FieldDefinition{L"bind-nonrecursive", Field::BindNonRecursive, Family::Bind, true, Support::Unsupported},
         FieldDefinition{L"bind-recursive", Field::BindRecursive, Family::Bind, false, Support::ValueDependent},
+        // The mount pipeline relies on Docker's default volume copy-up behavior and does not carry VolumeOptions.
         FieldDefinition{L"volume-nocopy", Field::VolumeNoCopy, Family::Volume, true, Support::Unsupported},
+        // Inline mounts reference volumes by name; the volume creation API owns labels, drivers, and driver options.
         FieldDefinition{L"volume-label", Field::VolumeLabel, Family::Volume, false, Support::Unsupported},
         FieldDefinition{L"volume-driver", Field::VolumeDriver, Family::Volume, false, Support::Unsupported},
         FieldDefinition{L"volume-opt", Field::VolumeOption, Family::Volume, false, Support::Unsupported},

--- a/src/windows/common/MountSpecParsing.cpp
+++ b/src/windows/common/MountSpecParsing.cpp
@@ -173,21 +173,14 @@ namespace {
 
     std::optional<uint32_t> ParseDockerTmpfsMode(const std::wstring& value)
     {
-        if (value.empty() || value.front() == L'-')
-        {
-            return std::nullopt;
-        }
-
-        size_t position = value.front() == L'+' ? 1 : 0;
-        if (position == value.size())
+        if (value.empty())
         {
             return std::nullopt;
         }
 
         uint64_t result = 0;
-        for (; position < value.size(); ++position)
+        for (const auto digit : value)
         {
-            const auto digit = value[position];
             if (digit < L'0' || digit > L'7')
             {
                 return std::nullopt;
@@ -253,7 +246,10 @@ Spec ParseDockerMountString(const std::wstring& value)
         case Family::General:
             break;
         case Family::Bind:
-            mount.HasBindOptions = true;
+            if (definition->Id != Field::BindRecursive || keyValue.Value != L"enabled")
+            {
+                mount.HasBindOptions = true;
+            }
             break;
         case Family::Volume:
             mount.HasVolumeOptions = true;
@@ -417,15 +413,15 @@ Spec ParseDockerMountString(const std::wstring& value)
     Type type;
     if (mount.Type == L"bind")
     {
-        type = Type::Bind;
+        type = WSLCMountTypeBind;
     }
     else if (mount.Type == L"volume")
     {
-        type = Type::Volume;
+        type = WSLCMountTypeVolume;
     }
     else if (mount.Type == L"tmpfs")
     {
-        type = Type::Tmpfs;
+        type = WSLCMountTypeTmpfs;
     }
     else
     {
@@ -495,15 +491,16 @@ Spec ParseDockerVolumeString(const std::wstring& value)
     if (IsValidNamedVolumeName(rawSource))
     {
         return {
-            .MountType = Type::Volume,
+            .MountType = WSLCMountTypeVolume,
             .Source = rawSource,
             .Target = WideToMultiByte(target),
             .ReadOnly = readOnly,
         };
     }
 
-    std::wstring source;
-    if (FAILED(wil::GetFullPathNameW(rawSource.c_str(), source)))
+    std::error_code error;
+    auto source = wsl::windows::common::filesystem::GetCanonicalPath(rawSource, error);
+    if (error)
     {
         ThrowParse(Localization::WSLCCLI_VolumeHostPathInvalid(value, rawSource));
     }
@@ -514,8 +511,8 @@ Spec ParseDockerVolumeString(const std::wstring& value)
     }
 
     return {
-        .MountType = Type::Bind,
-        .Source = std::move(source),
+        .MountType = WSLCMountTypeBind,
+        .Source = source.wstring(),
         .Target = WideToMultiByte(target),
         .ReadOnly = readOnly,
         .BindSource = BindSourcePolicy::CreateIfMissing,
@@ -529,7 +526,7 @@ Spec ParseDockerTmpfsString(const std::wstring& value)
     const auto options = colon == std::wstring::npos ? std::wstring_view{} : std::wstring_view{value}.substr(colon + 1);
 
     return {
-        .MountType = Type::Tmpfs,
+        .MountType = WSLCMountTypeTmpfs,
         .Target = WideToMultiByte(target),
         .TmpfsOptions = WideToMultiByte(std::wstring{options}),
     };
@@ -547,7 +544,8 @@ void ValidateMountSpec(const Spec& mount)
         ThrowValidation(Localization::WSLCCLI_MountTargetAbsoluteError());
     }
 
-    if (mount.MountType != Type::Tmpfs && (mount.TmpfsSizeBytes.has_value() || mount.TmpfsMode.has_value() || mount.TmpfsOptions.has_value()))
+    if (mount.MountType != WSLCMountTypeTmpfs &&
+        (mount.TmpfsSizeBytes.has_value() || mount.TmpfsMode.has_value() || mount.TmpfsOptions.has_value()))
     {
         ThrowValidation(Localization::WSLCCLI_MountTmpfsOptionsTypeError());
     }
@@ -559,7 +557,7 @@ void ValidateMountSpec(const Spec& mount)
 
     switch (mount.MountType)
     {
-    case Type::Bind:
+    case WSLCMountTypeBind:
         if (mount.Source.empty())
         {
             ThrowValidation(Localization::WSLCCLI_MountSourceRequiredError());
@@ -571,14 +569,14 @@ void ValidateMountSpec(const Spec& mount)
         }
         break;
 
-    case Type::Volume:
+    case WSLCMountTypeVolume:
         if (!mount.Source.empty() && !IsValidNamedVolumeName(mount.Source))
         {
             ThrowValidation(Localization::WSLCCLI_MountVolumeSourceInvalidError());
         }
         break;
 
-    case Type::Tmpfs:
+    case WSLCMountTypeTmpfs:
         if (!mount.Source.empty())
         {
             ThrowValidation(Localization::WSLCCLI_MountTmpfsSourceUnsupportedError());
@@ -610,7 +608,7 @@ void ValidateMountCollection(std::span<const Spec> mounts)
 
 std::string FormatTmpfsOptions(const Spec& mount)
 {
-    WI_ASSERT(mount.MountType == Type::Tmpfs);
+    WI_ASSERT(mount.MountType == WSLCMountTypeTmpfs);
 
     if (mount.TmpfsOptions.has_value())
     {
@@ -636,8 +634,6 @@ std::string FormatTmpfsOptions(const Spec& mount)
 
 std::string NormalizeDestination(std::string destination)
 {
-    std::replace(destination.begin(), destination.end(), '\\', '/');
-
     std::vector<std::string> components;
     size_t start = 0;
     while (start <= destination.size())

--- a/src/windows/common/MountSpecParsing.h
+++ b/src/windows/common/MountSpecParsing.h
@@ -14,6 +14,7 @@ Abstract:
 
 #pragma once
 
+#include "wslc.h"
 #include <cstdint>
 #include <exception>
 #include <optional>
@@ -24,14 +25,7 @@ Abstract:
 
 namespace wsl::windows::common::mount {
 
-inline constexpr std::string_view c_dockerCliMountGrammarVersion = "25.0.3";
-
-enum class Type
-{
-    Bind,
-    Volume,
-    Tmpfs,
-};
+using Type = WSLCMountType;
 
 enum class BindSourcePolicy
 {
@@ -41,7 +35,7 @@ enum class BindSourcePolicy
 
 struct Spec
 {
-    Type MountType = Type::Volume;
+    Type MountType = WSLCMountTypeVolume;
     std::wstring Source;
     std::string Target;
     bool ReadOnly = false;

--- a/src/windows/common/WSLCContainerLauncher.cpp
+++ b/src/windows/common/WSLCContainerLauncher.cpp
@@ -230,7 +230,7 @@ void WSLCContainerLauncher::AddUlimit(const std::string& Name, std::int64_t Soft
 void wsl::windows::common::WSLCContainerLauncher::AddVolume(const std::wstring& HostPath, const std::string& ContainerPath, bool ReadOnly)
 {
     AddMount({
-        .MountType = mount::Type::Bind,
+        .MountType = WSLCMountTypeBind,
         .Source = HostPath,
         .Target = ContainerPath,
         .ReadOnly = ReadOnly,
@@ -241,7 +241,7 @@ void wsl::windows::common::WSLCContainerLauncher::AddVolume(const std::wstring& 
 void wsl::windows::common::WSLCContainerLauncher::AddNamedVolume(const std::string& Name, const std::string& ContainerPath, bool ReadOnly)
 {
     AddMount({
-        .MountType = mount::Type::Volume,
+        .MountType = WSLCMountTypeVolume,
         .Source = wsl::shared::string::MultiByteToWide(Name),
         .Target = ContainerPath,
         .ReadOnly = ReadOnly,
@@ -251,20 +251,7 @@ void wsl::windows::common::WSLCContainerLauncher::AddNamedVolume(const std::stri
 void wsl::windows::common::WSLCContainerLauncher::AddMount(const mount::Spec& Mount)
 {
     WSLCMountSpec mount{};
-    switch (Mount.MountType)
-    {
-    case mount::Type::Bind:
-        mount.Type = WSLCMountTypeBind;
-        break;
-
-    case mount::Type::Volume:
-        mount.Type = WSLCMountTypeVolume;
-        break;
-
-    case mount::Type::Tmpfs:
-        mount.Type = WSLCMountTypeTmpfs;
-        break;
-    }
+    mount.Type = Mount.MountType;
 
     if (!Mount.Source.empty())
     {
@@ -273,7 +260,7 @@ void wsl::windows::common::WSLCContainerLauncher::AddMount(const mount::Spec& Mo
 
     mount.Target = m_mountTargets.emplace_back(Mount.Target).c_str();
     mount.ReadOnly = Mount.ReadOnly ? TRUE : FALSE;
-    if (Mount.MountType == mount::Type::Bind && Mount.BindSource == mount::BindSourcePolicy::CreateIfMissing)
+    if (Mount.MountType == WSLCMountTypeBind && Mount.BindSource == mount::BindSourcePolicy::CreateIfMissing)
     {
         WI_SetFlag(mount.Flags, WSLCMountSpecFlagsCreateSourceIfMissing);
     }
@@ -292,7 +279,6 @@ void wsl::windows::common::WSLCContainerLauncher::AddMount(const mount::Spec& Mo
 
     if (Mount.TmpfsOptions.has_value())
     {
-        WI_SetFlag(mount.Flags, WSLCMountSpecFlagsTmpfsOptions);
         mount.TmpfsOptions = m_mountTmpfsOptions.emplace_back(Mount.TmpfsOptions.value()).c_str();
     }
 
@@ -315,7 +301,7 @@ void wsl::windows::common::WSLCContainerLauncher::AddLabel(const std::string& Ke
 void wsl::windows::common::WSLCContainerLauncher::AddTmpfs(const std::string& ContainerPath, const std::string& Options)
 {
     AddMount({
-        .MountType = mount::Type::Tmpfs,
+        .MountType = WSLCMountTypeTmpfs,
         .Target = ContainerPath,
         .TmpfsOptions = Options,
     });

--- a/src/windows/service/inc/wslc.idl
+++ b/src/windows/service/inc/wslc.idl
@@ -261,10 +261,9 @@ typedef enum _WSLCMountSpecFlags
     WSLCMountSpecFlagsTmpfsSize = 1,
     WSLCMountSpecFlagsTmpfsMode = 2,
     WSLCMountSpecFlagsCreateSourceIfMissing = 4,
-    WSLCMountSpecFlagsTmpfsOptions = 8,
 } WSLCMountSpecFlags;
 
-cpp_quote("#define WSLCMountSpecFlagsValid (WSLCMountSpecFlagsTmpfsSize | WSLCMountSpecFlagsTmpfsMode | WSLCMountSpecFlagsCreateSourceIfMissing | WSLCMountSpecFlagsTmpfsOptions)")
+cpp_quote("#define WSLCMountSpecFlagsValid (WSLCMountSpecFlagsTmpfsSize | WSLCMountSpecFlagsTmpfsMode | WSLCMountSpecFlagsCreateSourceIfMissing)")
 cpp_quote("DEFINE_ENUM_FLAG_OPERATORS(WSLCMountSpecFlags);")
 
 typedef struct _WSLCMountSpec

--- a/src/windows/wslc/services/ContainerModel.cpp
+++ b/src/windows/wslc/services/ContainerModel.cpp
@@ -176,7 +176,7 @@ VolumeMount VolumeMount::Parse(const std::wstring& value)
     volume.m_host = std::move(mountSpec.Source);
     volume.m_containerPath = std::move(mountSpec.Target);
     volume.m_isReadOnlyMode = mountSpec.ReadOnly;
-    volume.m_isNamedVolume = mountSpec.MountType == mount::Type::Volume;
+    volume.m_isNamedVolume = mountSpec.MountType == WSLCMountTypeVolume;
     return volume;
 }
 
@@ -256,23 +256,6 @@ std::vector<std::wstring> EnvironmentVariable::ParseFile(const std::wstring& fil
     }
 
     return envVars;
-}
-
-void ValidateUniqueMountDestinations(const ContainerOptions& options)
-{
-    try
-    {
-        mount::ValidateMountCollection(options.Mounts);
-    }
-    catch (const mount::MountException& ex)
-    {
-        if (ex.Error() == mount::ValidationError::DuplicateDestination)
-        {
-            THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::WSLCCLI_DuplicateMountDestinationError(MultiByteToWide(ex.Destination())));
-        }
-
-        throw;
-    }
 }
 
 CidFile::CidFile(const std::optional<std::wstring>& path)

--- a/src/windows/wslc/services/ContainerModel.h
+++ b/src/windows/wslc/services/ContainerModel.h
@@ -311,8 +311,6 @@ private:
     bool m_isNamedVolume = false;
 };
 
-void ValidateUniqueMountDestinations(const ContainerOptions& options);
-
 class CidFile
 {
 public:

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -839,8 +839,6 @@ void SetContainerOptionsFromArgs(CLIExecutionContext& context)
         options.Mounts.insert(options.Mounts.end(), std::make_move_iterator(tmpfs.begin()), std::make_move_iterator(tmpfs.end()));
     }
 
-    ValidateUniqueMountDestinations(options);
-
     for (const auto& label : context.Args.GetAllValues<ArgType::Label>())
     {
         options.Labels.push_back(label);

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -695,7 +695,7 @@ PreparedBindMount PrepareBindMount(const std::wstring& source, const std::string
         hostPath = wsl::windows::common::filesystem::GetCanonicalPath(hostPath, ec);
         if (ec)
         {
-            THROW_HR_WITH_USER_ERROR(E_FAIL, Localization::MessageWslcFailedToMountVolume(source, ec.message()));
+            THROW_HR_WITH_USER_ERROR(HRESULT_FROM_WIN32(ec.value()), Localization::MessageWslcFailedToMountVolume(source, ec.message()));
         }
 
         if (std::filesystem::is_regular_file(hostPath))

--- a/src/windows/wslcsession/WSLCContainer.cpp
+++ b/src/windows/wslcsession/WSLCContainer.cpp
@@ -430,15 +430,14 @@ auto MountVolumes(std::vector<WSLCVolumeMount>& volumes, WSLCVirtualMachine& par
         const auto sourceExists = std::filesystem::exists(volume.HostPath, error);
         if (error)
         {
-            throw wsl::windows::common::mount::MountValidationException(
-                Localization::MessageWslcBindSourcePathError(volume.HostPath, error.message()));
+            THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcBindSourcePathError(volume.HostPath, error.message()));
         }
 
         if (!sourceExists)
         {
             if (!volume.CreateSourceIfMissing)
             {
-                throw wsl::windows::common::mount::MountValidationException(Localization::MessageWslcBindSourcePathNotFound(volume.HostPath));
+                THROW_HR_WITH_USER_ERROR(E_INVALIDARG, Localization::MessageWslcBindSourcePathNotFound(volume.HostPath));
             }
 
             auto result = wil::CreateDirectoryDeepNoThrow(volume.HostPath.c_str());
@@ -455,18 +454,6 @@ auto MountVolumes(std::vector<WSLCVolumeMount>& volumes, WSLCVirtualMachine& par
     }
 
     return std::move(errorCleanup);
-}
-
-auto MountVolumesWithUserError(std::vector<WSLCVolumeMount>& volumes, WSLCVirtualMachine& parentVM)
-{
-    try
-    {
-        return MountVolumes(volumes, parentVM);
-    }
-    catch (const wsl::windows::common::mount::MountValidationException& ex)
-    {
-        THROW_HR_WITH_USER_ERROR(E_INVALIDARG, ex.Reason());
-    }
 }
 
 WSLCContainerState DockerStateToWSLCState(ContainerState state)
@@ -546,6 +533,9 @@ std::map<std::string, std::string> StripInternalLabels(std::optional<std::map<st
     return StripInternalLabels(std::move(labels).value_or(std::map<std::string, std::string>{}));
 }
 
+// Validate every mount representation as one collection before preparing VM shares or calling Docker.
+// Docker handles duplicate destinations differently across Binds, Mounts, and Tmpfs and can create named volumes while processing the request.
+// This service-boundary check gives every caller consistent duplicate semantics and keeps invalid requests side-effect free.
 std::vector<wsl::windows::common::mount::Spec> ConvertAndValidateMounts(const WSLCContainerOptions& containerOptions)
 {
     namespace mount = wsl::windows::common::mount;
@@ -565,39 +555,31 @@ std::vector<wsl::windows::common::mount::Spec> ConvertAndValidateMounts(const WS
             i,
             value.Flags);
 
-        mount::Type type;
         switch (value.Type)
         {
         case WSLCMountTypeBind:
-            type = mount::Type::Bind;
-            break;
-
         case WSLCMountTypeVolume:
-            type = mount::Type::Volume;
-            break;
-
         case WSLCMountTypeTmpfs:
-            type = mount::Type::Tmpfs;
             break;
 
         default:
             THROW_HR_MSG(E_INVALIDARG, "Mount at index %lu has invalid type: %d", i, value.Type);
         }
 
+        const auto type = value.Type;
         THROW_HR_IF_MSG(
             E_INVALIDARG,
-            type != mount::Type::Bind && WI_IsFlagSet(value.Flags, WSLCMountSpecFlagsCreateSourceIfMissing),
+            type != WSLCMountTypeBind && WI_IsFlagSet(value.Flags, WSLCMountSpecFlagsCreateSourceIfMissing),
             "Mount at index %lu specifies create-source-if-missing for a non-bind mount",
             i);
         THROW_HR_IF_MSG(
             E_INVALIDARG,
-            type != mount::Type::Tmpfs && WI_IsFlagSet(value.Flags, WSLCMountSpecFlagsTmpfsOptions),
+            type != WSLCMountTypeTmpfs && value.TmpfsOptions != nullptr,
             "Mount at index %lu specifies tmpfs options for a non-tmpfs mount",
             i);
         THROW_HR_IF_MSG(
             E_INVALIDARG,
-            WI_IsFlagSet(value.Flags, WSLCMountSpecFlagsTmpfsOptions) &&
-                WI_IsAnyFlagSet(value.Flags, WSLCMountSpecFlagsTmpfsSize | WSLCMountSpecFlagsTmpfsMode),
+            value.TmpfsOptions != nullptr && WI_IsAnyFlagSet(value.Flags, WSLCMountSpecFlagsTmpfsSize | WSLCMountSpecFlagsTmpfsMode),
             "Mount at index %lu combines legacy and structured tmpfs options",
             i);
 
@@ -610,9 +592,7 @@ std::vector<wsl::windows::common::mount::Spec> ConvertAndValidateMounts(const WS
                                                                                              : mount::BindSourcePolicy::RequireExisting,
             .TmpfsSizeBytes = WI_IsFlagSet(value.Flags, WSLCMountSpecFlagsTmpfsSize) ? std::optional<int64_t>{value.TmpfsSizeBytes} : std::nullopt,
             .TmpfsMode = WI_IsFlagSet(value.Flags, WSLCMountSpecFlagsTmpfsMode) ? std::optional<uint32_t>{value.TmpfsMode} : std::nullopt,
-            .TmpfsOptions = WI_IsFlagSet(value.Flags, WSLCMountSpecFlagsTmpfsOptions)
-                                ? std::optional<std::string>{value.TmpfsOptions != nullptr ? value.TmpfsOptions : ""}
-                                : std::nullopt,
+            .TmpfsOptions = value.TmpfsOptions != nullptr ? std::optional<std::string>{value.TmpfsOptions} : std::nullopt,
         });
     }
 
@@ -621,7 +601,7 @@ std::vector<wsl::windows::common::mount::Spec> ConvertAndValidateMounts(const WS
         mount::ValidateMountCollection(mounts);
         for (const auto& mount : mounts)
         {
-            if (mount.MountType == mount::Type::Bind)
+            if (mount.MountType == WSLCMountTypeBind)
             {
                 if (mount.BindSource == mount::BindSourcePolicy::CreateIfMissing)
                 {
@@ -706,35 +686,28 @@ enum class MissingBindSource
 
 PreparedBindMount PrepareBindMount(const std::wstring& source, const std::string& target, bool readOnly, MissingBindSource missingSource)
 {
-    GUID volumeId;
-    THROW_IF_FAILED(CoCreateGuid(&volumeId));
-
-    auto parentVMPath = std::format("/mnt/{}", wsl::shared::string::GuidToString<char>(volumeId));
     std::filesystem::path hostPath = source;
     THROW_HR_WITH_USER_ERROR_IF(E_INVALIDARG, Localization::MessagePathNotAbsolute(source), !hostPath.is_absolute());
 
     std::wstring sourceFilename;
     {
         std::error_code ec;
-        hostPath = std::filesystem::canonical(hostPath, ec);
-        if (!ec)
-        {
-            if (std::filesystem::is_regular_file(hostPath))
-            {
-                sourceFilename = hostPath.filename().wstring();
-                hostPath = hostPath.parent_path();
-            }
-        }
-        else if (ec == std::errc::no_such_file_or_directory)
-        {
-            hostPath = source;
-        }
-        else
+        hostPath = wsl::windows::common::filesystem::GetCanonicalPath(hostPath, ec);
+        if (ec)
         {
             THROW_HR_WITH_USER_ERROR(E_FAIL, Localization::MessageWslcFailedToMountVolume(source, ec.message()));
         }
+
+        if (std::filesystem::is_regular_file(hostPath))
+        {
+            sourceFilename = hostPath.filename().wstring();
+            hostPath = hostPath.parent_path();
+        }
     }
 
+    GUID volumeId;
+    THROW_IF_FAILED(CoCreateGuid(&volumeId));
+    auto parentVMPath = std::format("/mnt/{}", wsl::shared::string::GuidToString<char>(volumeId));
     auto dockerSource = sourceFilename.empty() ? parentVMPath : std::format("{}/{}", parentVMPath, sourceFilename);
     return {
         .Volume =
@@ -1129,7 +1102,7 @@ void WSLCContainerImpl::Start(WSLCContainerStartFlags Flags, const WSLCProcessSt
         Localization::MessageWslcVolumeNotAvailable(wsl::shared::string::Join(unavailableVolumes, ',')),
         !unavailableVolumes.empty());
 
-    auto volumeCleanup = MountVolumesWithUserError(m_mountedVolumes, m_runtime.Vm());
+    auto volumeCleanup = MountVolumes(m_mountedVolumes, m_runtime.Vm());
 
     auto portCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [this]() { UnmapPorts(); });
     MapPorts();
@@ -2154,7 +2127,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
 
         switch (mount.MountType)
         {
-        case wsl::windows::common::mount::Type::Bind:
+        case WSLCMountTypeBind:
         {
             // Docker's colon-delimited bind format cannot represent ':' in the target.
             const auto missingSource = mount.BindSource == wsl::windows::common::mount::BindSourcePolicy::CreateIfMissing
@@ -2167,12 +2140,12 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
             break;
         }
 
-        case wsl::windows::common::mount::Type::Volume:
+        case WSLCMountTypeVolume:
             dockerMount.Source = wsl::shared::string::WideToMultiByte(mount.Source);
             dockerMount.Type = "volume";
             break;
 
-        case wsl::windows::common::mount::Type::Tmpfs:
+        case WSLCMountTypeTmpfs:
             if (mount.TmpfsOptions.has_value())
             {
                 request.HostConfig.Tmpfs[mount.Target] = mount.TmpfsOptions.value();
@@ -2335,7 +2308,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
     // Docker validates structured bind sources during container creation, so their VM paths must exist here.
     // Release the temporary shares before returning; Start remounts them for the container lifetime.
     auto result = [&]() {
-        auto volumeCleanup = MountVolumesWithUserError(volumes, virtualMachine);
+        auto volumeCleanup = MountVolumes(volumes, virtualMachine);
         return DockerClient.CreateContainer(request, containerName);
     }();
 
@@ -2399,7 +2372,7 @@ std::shared_ptr<WSLCContainerImpl> WSLCContainerImpl::Create(
 
     for (const auto& mount : mounts)
     {
-        if (mount.MountType == wsl::windows::common::mount::Type::Volume && !mount.Source.empty())
+        if (mount.MountType == WSLCMountTypeVolume && !mount.Source.empty())
         {
             namedVolumes.emplace_back(wsl::shared::string::WideToMultiByte(mount.Source));
         }

--- a/test/windows/WSLCTests.cpp
+++ b/test/windows/WSLCTests.cpp
@@ -9934,7 +9934,7 @@ class WSLCTests
 
             VerifyPatternMatch(
                 wsl::shared::string::WideToMultiByte(comError->Message.get()),
-                "Failed to create volume '*test-volume\\subfolder': Access is denied. ");
+                "Failed to create volume '*test-volume\\subfolder': Access is denied.");
         }
 
         // Validate that files mounts are correctly recovered when a container is loaded from storage

--- a/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIArgumentUnitTests.cpp
@@ -416,16 +416,16 @@ class WSLCCLIArgumentUnitTests
         // mount strings -> mount::Spec
         {
             const auto volume = ValidateAndGetCached<ArgType::Volume>(LR"(C:\hostPath:/containerPath)");
-            VERIFY_ARE_EQUAL(static_cast<int>(mount::Type::Bind), static_cast<int>(volume.MountType));
+            VERIFY_ARE_EQUAL(static_cast<int>(WSLCMountTypeBind), static_cast<int>(volume.MountType));
             VERIFY_ARE_EQUAL(static_cast<int>(mount::BindSourcePolicy::CreateIfMissing), static_cast<int>(volume.BindSource));
 
             const auto tmpfs = ValidateAndGetCached<ArgType::TMPFS>(L"/tmp:size=64k");
-            VERIFY_ARE_EQUAL(static_cast<int>(mount::Type::Tmpfs), static_cast<int>(tmpfs.MountType));
+            VERIFY_ARE_EQUAL(static_cast<int>(WSLCMountTypeTmpfs), static_cast<int>(tmpfs.MountType));
             VERIFY_IS_TRUE(tmpfs.TmpfsOptions.has_value());
             VERIFY_ARE_EQUAL(std::string("size=64k"), tmpfs.TmpfsOptions.value());
 
             const auto structured = ValidateAndGetCached<ArgType::Mount>(L"type=volume,source=data-volume,target=/data");
-            VERIFY_ARE_EQUAL(static_cast<int>(mount::Type::Volume), static_cast<int>(structured.MountType));
+            VERIFY_ARE_EQUAL(static_cast<int>(WSLCMountTypeVolume), static_cast<int>(structured.MountType));
             VERIFY_ARE_EQUAL(std::wstring(L"data-volume"), structured.Source);
         }
 

--- a/test/windows/wslc/WSLCCLIMountParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIMountParserUnitTests.cpp
@@ -62,34 +62,34 @@ namespace {
     };
 
     constexpr ValidMountCase c_validMountCases[] = {
-        {L"type=volume,target=/data", mount::Type::Volume, L"", "/data", false, {}, {}, ""},
-        {L"source=data-volume,target=/data", mount::Type::Volume, L"data-volume", "/data", false, {}, {}, ""},
+        {L"type=volume,target=/data", WSLCMountTypeVolume, L"", "/data", false, {}, {}, ""},
+        {L"source=data-volume,target=/data", WSLCMountTypeVolume, L"data-volume", "/data", false, {}, {}, ""},
         {L"type=volume,source=data-volume,target=/path:voldir",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/path:voldir",
          false,
          {},
          {},
          ""},
-        {L"TYPE=VOLUME,SOURCE=data-volume,TARGET=/data", mount::Type::Volume, L"data-volume", "/data", false, {}, {}, ""},
-        {L"type=VoLuMe,source=data-volume,target=/data", mount::Type::Volume, L"data-volume", "/data", false, {}, {}, ""},
-        {L"type=volume,src=data-volume,dst=/data", mount::Type::Volume, L"data-volume", "/data", false, {}, {}, ""},
-        {L"type=volume,src=data-volume,destination=/data", mount::Type::Volume, L"data-volume", "/data", false, {}, {}, ""},
-        {L"type=volume,source=first,source=second,target=/data", mount::Type::Volume, L"second", "/data", false, {}, {}, ""},
+        {L"TYPE=VOLUME,SOURCE=data-volume,TARGET=/data", WSLCMountTypeVolume, L"data-volume", "/data", false, {}, {}, ""},
+        {L"type=VoLuMe,source=data-volume,target=/data", WSLCMountTypeVolume, L"data-volume", "/data", false, {}, {}, ""},
+        {L"type=volume,src=data-volume,dst=/data", WSLCMountTypeVolume, L"data-volume", "/data", false, {}, {}, ""},
+        {L"type=volume,src=data-volume,destination=/data", WSLCMountTypeVolume, L"data-volume", "/data", false, {}, {}, ""},
+        {L"type=volume,source=first,source=second,target=/data", WSLCMountTypeVolume, L"second", "/data", false, {}, {}, ""},
         {L"type=volume,source=data-volume,target=/first,target=/second",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/second",
          false,
          {},
          {},
          ""},
-        {L"type=volume,type=bind,source=C:\\data,target=/data", mount::Type::Bind, L"C:\\data", "/data", false, {}, {}, ""},
-        {L"type=volume,source=data-volume,target=/data,readonly", mount::Type::Volume, L"data-volume", "/data", true, {}, {}, ""},
-        {L"type=volume,source=data-volume,target=/data,ro", mount::Type::Volume, L"data-volume", "/data", true, {}, {}, ""},
+        {L"type=volume,type=bind,source=C:\\data,target=/data", WSLCMountTypeBind, L"C:\\data", "/data", false, {}, {}, ""},
+        {L"type=volume,source=data-volume,target=/data,readonly", WSLCMountTypeVolume, L"data-volume", "/data", true, {}, {}, ""},
+        {L"type=volume,source=data-volume,target=/data,ro", WSLCMountTypeVolume, L"data-volume", "/data", true, {}, {}, ""},
         {L"type=volume,source=data-volume,target=/data,readonly=1",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          true,
@@ -97,7 +97,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=t",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          true,
@@ -105,7 +105,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=T",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          true,
@@ -113,7 +113,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=TRUE",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          true,
@@ -121,7 +121,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=true",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          true,
@@ -129,7 +129,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=True",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          true,
@@ -137,7 +137,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=0",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          false,
@@ -145,7 +145,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=f",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          false,
@@ -153,7 +153,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=F",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          false,
@@ -161,7 +161,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=FALSE",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          false,
@@ -169,7 +169,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=false",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          false,
@@ -177,7 +177,7 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=False",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          false,
@@ -185,63 +185,70 @@ namespace {
          {},
          ""},
         {L"type=volume,source=data-volume,target=/data,readonly=true,readonly=false",
-         mount::Type::Volume,
+         WSLCMountTypeVolume,
          L"data-volume",
          "/data",
          false,
          {},
          {},
          ""},
-        {L"type=bind,\"source=C:\\mount,a\",target=/data", mount::Type::Bind, L"C:\\mount,a", "/data", false, {}, {}, ""},
+        {L"type=volume,source=data-volume,target=/data,bind-recursive=enabled",
+         WSLCMountTypeVolume,
+         L"data-volume",
+         "/data",
+         false,
+         {},
+         {},
+         ""},
+        {L"type=bind,\"source=C:\\mount,a\",target=/data", WSLCMountTypeBind, L"C:\\mount,a", "/data", false, {}, {}, ""},
         {L"type=bind,source=C:\\mount with spaces,target=/data",
-         mount::Type::Bind,
+         WSLCMountTypeBind,
          L"C:\\mount with spaces",
          "/data",
          false,
          {},
          {},
          ""},
-        {L"type=bind,source=C:\\mount,target=/path:mntdir", mount::Type::Bind, L"C:\\mount", "/path:mntdir", false, {}, {}, ""},
-        {L"type=bind,source=C:\\,target=/data", mount::Type::Bind, L"C:\\", "/data", false, {}, {}, ""},
-        {L"type=bind,source=\\\\server\\share,target=/data", mount::Type::Bind, L"\\\\server\\share", "/data", false, {}, {}, ""},
+        {L"type=bind,source=C:\\mount,target=/path:mntdir", WSLCMountTypeBind, L"C:\\mount", "/path:mntdir", false, {}, {}, ""},
+        {L"type=bind,source=C:\\,target=/data", WSLCMountTypeBind, L"C:\\", "/data", false, {}, {}, ""},
+        {L"type=bind,source=\\\\server\\share,target=/data", WSLCMountTypeBind, L"\\\\server\\share", "/data", false, {}, {}, ""},
         {L"type=bind,source=C:\\mount,target=/data,bind-recursive=enabled",
-         mount::Type::Bind,
+         WSLCMountTypeBind,
          L"C:\\mount",
          "/data",
          false,
          {},
          {},
          ""},
-        {L"type=volume,source=A_,target=/data", mount::Type::Volume, L"A_", "/data", false, {}, {}, ""},
-        {L"type=volume,source=data.volume-1,target=/data", mount::Type::Volume, L"data.volume-1", "/data", false, {}, {}, ""},
-        {L"type=tmpfs,target=/tmp", mount::Type::Tmpfs, L"", "/tmp", false, {}, {}, ""},
-        {L"type=tmpfs,target=/path:tmpfs", mount::Type::Tmpfs, L"", "/path:tmpfs", false, {}, {}, ""},
-        {L"type=tmpfs,target=/tmp,readonly", mount::Type::Tmpfs, L"", "/tmp", true, {}, {}, "ro"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=0", mount::Type::Tmpfs, L"", "/tmp", false, 0, {}, ""},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1", mount::Type::Tmpfs, L"", "/tmp", false, 1, {}, "size=1"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1024", mount::Type::Tmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1536", mount::Type::Tmpfs, L"", "/tmp", false, 1536, {}, "size=1536"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1k", mount::Type::Tmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1KB", mount::Type::Tmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1KiB", mount::Type::Tmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1MB", mount::Type::Tmpfs, L"", "/tmp", false, 1LL << 20, {}, "size=1m"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1MiB", mount::Type::Tmpfs, L"", "/tmp", false, 1LL << 20, {}, "size=1m"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1GB", mount::Type::Tmpfs, L"", "/tmp", false, 1LL << 30, {}, "size=1g"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1.5MB", mount::Type::Tmpfs, L"", "/tmp", false, 1536LL << 10, {}, "size=1536k"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=+1MB", mount::Type::Tmpfs, L"", "/tmp", false, 1LL << 20, {}, "size=1m"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=1e3", mount::Type::Tmpfs, L"", "/tmp", false, 1000, {}, "size=1000"},
-        {L"type=tmpfs,target=/tmp,tmpfs-mode=0000", mount::Type::Tmpfs, L"", "/tmp", false, {}, 0, ""},
-        {L"type=tmpfs,target=/tmp,tmpfs-mode=0700", mount::Type::Tmpfs, L"", "/tmp", false, {}, 0700, "mode=700"},
-        {L"type=tmpfs,target=/tmp,tmpfs-mode=+0700", mount::Type::Tmpfs, L"", "/tmp", false, {}, 0700, "mode=700"},
+        {L"type=volume,source=A_,target=/data", WSLCMountTypeVolume, L"A_", "/data", false, {}, {}, ""},
+        {L"type=volume,source=data.volume-1,target=/data", WSLCMountTypeVolume, L"data.volume-1", "/data", false, {}, {}, ""},
+        {L"type=tmpfs,target=/tmp", WSLCMountTypeTmpfs, L"", "/tmp", false, {}, {}, ""},
+        {L"type=tmpfs,target=/path:tmpfs", WSLCMountTypeTmpfs, L"", "/path:tmpfs", false, {}, {}, ""},
+        {L"type=tmpfs,target=/tmp,readonly", WSLCMountTypeTmpfs, L"", "/tmp", true, {}, {}, "ro"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=0", WSLCMountTypeTmpfs, L"", "/tmp", false, 0, {}, ""},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1", WSLCMountTypeTmpfs, L"", "/tmp", false, 1, {}, "size=1"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1024", WSLCMountTypeTmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1536", WSLCMountTypeTmpfs, L"", "/tmp", false, 1536, {}, "size=1536"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1k", WSLCMountTypeTmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1KB", WSLCMountTypeTmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1KiB", WSLCMountTypeTmpfs, L"", "/tmp", false, 1024, {}, "size=1k"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1MB", WSLCMountTypeTmpfs, L"", "/tmp", false, 1LL << 20, {}, "size=1m"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1MiB", WSLCMountTypeTmpfs, L"", "/tmp", false, 1LL << 20, {}, "size=1m"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1GB", WSLCMountTypeTmpfs, L"", "/tmp", false, 1LL << 30, {}, "size=1g"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1.5MB", WSLCMountTypeTmpfs, L"", "/tmp", false, 1536LL << 10, {}, "size=1536k"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=+1MB", WSLCMountTypeTmpfs, L"", "/tmp", false, 1LL << 20, {}, "size=1m"},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=1e3", WSLCMountTypeTmpfs, L"", "/tmp", false, 1000, {}, "size=1000"},
+        {L"type=tmpfs,target=/tmp,tmpfs-mode=0000", WSLCMountTypeTmpfs, L"", "/tmp", false, {}, 0, ""},
+        {L"type=tmpfs,target=/tmp,tmpfs-mode=0700", WSLCMountTypeTmpfs, L"", "/tmp", false, {}, 0700, "mode=700"},
         {L"type=tmpfs,target=/tmp,tmpfs-size=1MB,tmpfs-mode=0700,readonly",
-         mount::Type::Tmpfs,
+         WSLCMountTypeTmpfs,
          L"",
          "/tmp",
          true,
          1LL << 20,
          0700,
          "ro,mode=700,size=1m"},
-        {L"type=tmpfs,target=/tmp,tmpfs-size=0,tmpfs-mode=0000,readonly=false", mount::Type::Tmpfs, L"", "/tmp", false, 0, 0, ""},
+        {L"type=tmpfs,target=/tmp,tmpfs-size=0,tmpfs-mode=0000,readonly=false", WSLCMountTypeTmpfs, L"", "/tmp", false, 0, 0, ""},
     };
 
     const InvalidMountCase c_invalidMountCases[] = {
@@ -339,8 +346,6 @@ namespace {
          Localization::WSLCCLI_MountOptionFamilyMismatchError(L"volume-*", L"bind")},
         {L"type=volume,source=data-volume,target=/data,bind-propagation=rprivate",
          Localization::WSLCCLI_MountOptionFamilyMismatchError(L"bind-*", L"volume")},
-        {L"type=volume,source=data-volume,target=/data,bind-recursive=enabled",
-         Localization::WSLCCLI_MountOptionFamilyMismatchError(L"bind-*", L"volume")},
         {L"type=volume,source=data-volume,target=/data,tmpfs-size=1m",
          Localization::WSLCCLI_MountOptionFamilyMismatchError(L"tmpfs-*", L"volume")},
         {L"type=tmpfs,target=/tmp,volume-label=a=b", Localization::WSLCCLI_MountOptionFamilyMismatchError(L"volume-*", L"tmpfs")},
@@ -357,6 +362,7 @@ namespace {
         {L"type=tmpfs,target=/tmp,tmpfs-size=9223372036854775808",
          Localization::WSLCCLI_MountInvalidValueError(L"tmpfs-size", L"9223372036854775808")},
         {L"type=tmpfs,target=/tmp,tmpfs-mode=", Localization::WSLCCLI_MountInvalidValueError(L"tmpfs-mode", L"")},
+        {L"type=tmpfs,target=/tmp,tmpfs-mode=+0700", Localization::WSLCCLI_MountInvalidValueError(L"tmpfs-mode", L"+0700")},
         {L"type=tmpfs,target=/tmp,tmpfs-mode=-1", Localization::WSLCCLI_MountInvalidValueError(L"tmpfs-mode", L"-1")},
         {L"type=tmpfs,target=/tmp,tmpfs-mode=8", Localization::WSLCCLI_MountInvalidValueError(L"tmpfs-mode", L"8")},
         {L"type=tmpfs,target=/tmp,tmpfs-mode=0899", Localization::WSLCCLI_MountInvalidValueError(L"tmpfs-mode", L"0899")},
@@ -394,7 +400,7 @@ class WSLCCLIMountParserUnitTests
                 VERIFY_ARE_EQUAL(testCase.TmpfsMode.value(), actual.TmpfsMode.value());
             }
 
-            const auto actualTmpfsOptions = actual.MountType == mount::Type::Tmpfs ? mount::FormatTmpfsOptions(actual) : std::string{};
+            const auto actualTmpfsOptions = actual.MountType == WSLCMountTypeTmpfs ? mount::FormatTmpfsOptions(actual) : std::string{};
             VERIFY_ARE_EQUAL(std::string(testCase.TmpfsOptions), actualTmpfsOptions);
         }
     }
@@ -434,18 +440,34 @@ class WSLCCLIMountParserUnitTests
     TEST_METHOD(Volume_ValidCases)
     {
         const auto bind = mount::ParseDockerVolumeString(LR"(C:\hostPath:/data:ro)");
-        VERIFY_ARE_EQUAL(static_cast<int>(mount::Type::Bind), static_cast<int>(bind.MountType));
+        VERIFY_ARE_EQUAL(static_cast<int>(WSLCMountTypeBind), static_cast<int>(bind.MountType));
         VERIFY_ARE_EQUAL(std::wstring(LR"(C:\hostPath)"), bind.Source);
         VERIFY_ARE_EQUAL(std::string("/data"), bind.Target);
         VERIFY_IS_TRUE(bind.ReadOnly);
         VERIFY_ARE_EQUAL(static_cast<int>(mount::BindSourcePolicy::CreateIfMissing), static_cast<int>(bind.BindSource));
 
+        const auto relativeBind = mount::ParseDockerVolumeString(L".\\mount:/data");
+        VERIFY_ARE_EQUAL(std::filesystem::weakly_canonical(std::filesystem::current_path() / L"mount").wstring(), relativeBind.Source);
+
         const auto volume = mount::ParseDockerVolumeString(L"named-volume:/data");
-        VERIFY_ARE_EQUAL(static_cast<int>(mount::Type::Volume), static_cast<int>(volume.MountType));
+        VERIFY_ARE_EQUAL(static_cast<int>(WSLCMountTypeVolume), static_cast<int>(volume.MountType));
         VERIFY_ARE_EQUAL(std::wstring(L"named-volume"), volume.Source);
         VERIFY_ARE_EQUAL(std::string("/data"), volume.Target);
         VERIFY_IS_FALSE(volume.ReadOnly);
         VERIFY_ARE_EQUAL(static_cast<int>(mount::BindSourcePolicy::RequireExisting), static_cast<int>(volume.BindSource));
+    }
+
+    TEST_METHOD(Volume_InvalidHostPath)
+    {
+        try
+        {
+            (void)mount::ParseDockerVolumeString(L"::/container:ro");
+            VERIFY_FAIL(L"Expected MountParseException for an invalid host path");
+        }
+        catch (const mount::MountParseException& ex)
+        {
+            VERIFY_ARE_EQUAL(Localization::WSLCCLI_VolumeHostPathInvalid(L"::/container:ro", L":"), ex.Reason());
+        }
     }
 
     TEST_METHOD(Mount_DotRelativeBindSourceUsesCurrentDirectory)
@@ -458,28 +480,28 @@ class WSLCCLIMountParserUnitTests
     TEST_METHOD(Mount_TypedSpecsAreValidated)
     {
         const mount::Spec relativeBind{
-            .MountType = mount::Type::Bind,
+            .MountType = WSLCMountTypeBind,
             .Source = L"relative",
             .Target = "/data",
         };
         VERIFY_THROWS(mount::ValidateMountSpec(relativeBind), mount::MountValidationException);
 
         const mount::Spec relativeTarget{
-            .MountType = mount::Type::Volume,
+            .MountType = WSLCMountTypeVolume,
             .Source = L"data-volume",
             .Target = "data",
         };
         VERIFY_THROWS(mount::ValidateMountSpec(relativeTarget), mount::MountValidationException);
 
         const mount::Spec tmpfsWithSource{
-            .MountType = mount::Type::Tmpfs,
+            .MountType = WSLCMountTypeTmpfs,
             .Source = L"data-volume",
             .Target = "/data",
         };
         VERIFY_THROWS(mount::ValidateMountSpec(tmpfsWithSource), mount::MountValidationException);
 
         const mount::Spec bindWithTmpfsOptions{
-            .MountType = mount::Type::Bind,
+            .MountType = WSLCMountTypeBind,
             .Source = L"C:\\data",
             .Target = "/data",
             .TmpfsSizeBytes = 1024,
@@ -487,14 +509,14 @@ class WSLCCLIMountParserUnitTests
         VERIFY_THROWS(mount::ValidateMountSpec(bindWithTmpfsOptions), mount::MountValidationException);
 
         const mount::Spec negativeTmpfsSize{
-            .MountType = mount::Type::Tmpfs,
+            .MountType = WSLCMountTypeTmpfs,
             .Target = "/data",
             .TmpfsSizeBytes = -1,
         };
         VERIFY_THROWS(mount::ValidateMountSpec(negativeTmpfsSize), mount::MountValidationException);
 
         const mount::Spec tmpfs{
-            .MountType = mount::Type::Tmpfs,
+            .MountType = WSLCMountTypeTmpfs,
             .Target = "/data",
             .TmpfsSizeBytes = 1024,
             .TmpfsMode = 0700,
@@ -502,8 +524,8 @@ class WSLCCLIMountParserUnitTests
         VERIFY_NO_THROW(mount::ValidateMountSpec(tmpfs));
 
         const mount::Spec duplicateMounts[] = {
-            {.MountType = mount::Type::Tmpfs, .Target = "/data"},
-            {.MountType = mount::Type::Volume, .Source = L"data-volume", .Target = "/data/"},
+            {.MountType = WSLCMountTypeTmpfs, .Target = "/data"},
+            {.MountType = WSLCMountTypeVolume, .Source = L"data-volume", .Target = "/data/"},
         };
         try
         {
@@ -515,33 +537,12 @@ class WSLCCLIMountParserUnitTests
             VERIFY_ARE_EQUAL(static_cast<int>(mount::ValidationError::DuplicateDestination), static_cast<int>(ex.Error()));
             VERIFY_ARE_EQUAL(std::string("/data"), ex.Destination());
         }
-    }
 
-    TEST_METHOD(Mount_DuplicateDestinationsAreRejected)
-    {
-        ContainerOptions options;
-        options.Mounts = {
-            mount::ParseDockerTmpfsString(L"/data"),
-            {.MountType = mount::Type::Volume, .Source = L"data-volume", .Target = "/data/"},
+        const mount::Spec distinctBackslashMounts[] = {
+            {.MountType = WSLCMountTypeTmpfs, .Target = "/data\\cache"},
+            {.MountType = WSLCMountTypeVolume, .Source = L"data-volume", .Target = "/data/cache"},
         };
-        VERIFY_THROWS(ValidateUniqueMountDestinations(options), wil::ResultException);
-
-        options.Mounts = {
-            {.MountType = mount::Type::Tmpfs, .Target = "/data/../cache"},
-            {.MountType = mount::Type::Volume, .Source = L"data-volume", .Target = "/cache"},
-        };
-        VERIFY_THROWS(ValidateUniqueMountDestinations(options), wil::ResultException);
-    }
-
-    TEST_METHOD(Mount_UniqueDestinationsAreAccepted)
-    {
-        ContainerOptions options;
-        options.Mounts = {
-            mount::ParseDockerTmpfsString(L"/cache"),
-            {.MountType = mount::Type::Volume, .Source = L"data-volume", .Target = "/data"},
-            {.MountType = mount::Type::Bind, .Source = L"C:\\logs", .Target = "/logs"},
-        };
-        VERIFY_NO_THROW(ValidateUniqueMountDestinations(options));
+        VERIFY_NO_THROW(mount::ValidateMountCollection(distinctBackslashMounts));
     }
 };
 

--- a/test/windows/wslc/WSLCCLITmpfsParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLITmpfsParserUnitTests.cpp
@@ -41,7 +41,7 @@ class WSLCCLITmpfsParserUnitTests
         for (const auto& [input, expectedTarget, expectedOptions] : validTmpfsSpecs)
         {
             const auto result = mount::ParseDockerTmpfsString(input);
-            VERIFY_ARE_EQUAL(static_cast<int>(mount::Type::Tmpfs), static_cast<int>(result.MountType));
+            VERIFY_ARE_EQUAL(static_cast<int>(WSLCMountTypeTmpfs), static_cast<int>(result.MountType));
             VERIFY_ARE_EQUAL(expectedTarget, result.Target);
             VERIFY_IS_TRUE(result.TmpfsOptions.has_value());
             VERIFY_ARE_EQUAL(expectedOptions, result.TmpfsOptions.value());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Follows up the initial Docker-compatible `--mount` implementation from #41337 by closing the two remaining Docker CLI 25.0.3 parser gaps and addressing the late review feedback submitted around the merge.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Match Docker's `tmpfs-mode` parsing by rejecting signed values such as `tmpfs-mode=+0700`.
- Treat `bind-recursive=enabled` as a no-op before option-family validation, matching Docker behavior for bind and volume mounts.
- Preserve backslashes in Linux container destinations so paths such as `/data\cache` remain distinct from `/data/cache`.
- Use the shared `filesystem::GetCanonicalPath()` helper for legacy volume sources and prepared bind mounts while preserving malformed-path rejection and missing-source behavior.
- Keep duplicate-destination enforcement at the service boundary, covering all mount representations before VM share preparation or Docker volume creation, and remove the redundant CLI preflight.
- Use the shared `WSLCMountType` values throughout the parser, launcher, transport, service, and tests, removing enum conversion switches.
- Use a null `TmpfsOptions` pointer to represent an unset value and remove the redundant transport flag.
- Throw localized bind-source errors directly from `MountVolumes()` and remove the intermediary exception wrapper.
- Defer bind-mount GUID allocation until after source-path validation.
- Remove the unused Docker grammar version constant.
- Document why the currently unsupported consistency, bind, and volume options cannot be represented by the WSLC mount pipeline.
- Add regression coverage for Docker parity, malformed legacy host paths, relative bind canonicalization, and distinct slash/backslash destinations.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Clean `wsltests` rebuild and full x64 Debug build.
- `WSLCCLIMountParserUnitTests`.
- `WSLCCLITmpfsParserUnitTests`.
- `WSLCCLIArgumentUnitTests`.
- `WSLCVolumeMountUnitTests`.
- Structured mount and tmpfs create/run E2E coverage.
- Legacy volume create/run E2E coverage, including the malformed host-path regression.
