### PR TITLE
CLI: Align alias listing with docker, Apple and other CLIs

### DIFF
--- a/src/windows/wslc/core/Command.cpp
+++ b/src/windows/wslc/core/Command.cpp
@@ -19,6 +19,7 @@ Abstract:
 #include "TableOutput.h"
 
 #include <algorithm>
+#include <typeinfo>
 
 using namespace wsl::shared;
 using namespace wsl::windows::common::wslutil;
@@ -28,6 +29,112 @@ using namespace wsl::windows::wslc::execution;
 namespace wsl::windows::wslc {
 
 std::wstring s_ExecutableName = L"wslc";
+
+namespace {
+    std::vector<std::wstring> WrapAliases(std::span<const std::wstring> aliases, std::optional<size_t> consoleWidth, size_t indent)
+    {
+        std::vector<std::wstring> lines;
+        std::wstring line(indent, L' ');
+
+        for (size_t i = 0; i < aliases.size(); ++i)
+        {
+            std::wstring token = aliases[i];
+            if (i + 1 < aliases.size())
+            {
+                token += L',';
+            }
+
+            const bool hasAlias = line.size() > indent;
+            const size_t requiredWidth = token.size() + (hasAlias ? 1 : 0);
+            if (hasAlias && consoleWidth.has_value() && line.size() + requiredWidth > *consoleWidth)
+            {
+                lines.emplace_back(std::move(line));
+                line.assign(indent, L' ');
+            }
+            else if (hasAlias)
+            {
+                line += L' ';
+            }
+
+            line += token;
+        }
+
+        if (line.size() > indent)
+        {
+            lines.emplace_back(std::move(line));
+        }
+
+        return lines;
+    }
+
+    std::wstring FormatCommandInvocation(const Command& command, std::wstring_view name)
+    {
+        std::wstring commandChain = command.FullName();
+        const auto firstSplit = commandChain.find_first_of(Command::ParentSplitChar);
+        if (firstSplit == std::wstring::npos)
+        {
+            return s_ExecutableName;
+        }
+
+        commandChain = commandChain.substr(firstSplit + 1);
+        const auto lastSplit = commandChain.find_last_of(Command::ParentSplitChar);
+        commandChain.replace(lastSplit == std::wstring::npos ? 0 : lastSplit + 1, std::wstring::npos, name);
+        std::ranges::replace(commandChain, Command::ParentSplitChar, L' ');
+
+        std::wstring invocation = s_ExecutableName;
+        invocation += L' ';
+        invocation += commandChain;
+        return invocation;
+    }
+
+    void AddCommandInvocations(const Command& command, std::vector<std::wstring>& invocations)
+    {
+        const auto addInvocation = [&](std::wstring_view name) {
+            auto invocation = FormatCommandInvocation(command, name);
+            if (std::ranges::find(invocations, invocation) == invocations.end())
+            {
+                invocations.emplace_back(std::move(invocation));
+            }
+        };
+
+        addInvocation(command.Name());
+        for (const auto alias : command.Aliases())
+        {
+            addInvocation(alias);
+        }
+    }
+
+    void FindCommandInvocations(const Command& target, const Command& parent, std::vector<std::wstring>& invocations)
+    {
+        for (const auto& command : parent.GetCommands())
+        {
+            if (typeid(target) == typeid(*command))
+            {
+                AddCommandInvocations(*command, invocations);
+            }
+
+            FindCommandInvocations(target, *command, invocations);
+        }
+    }
+
+    std::vector<std::wstring> GetCommandInvocations(const Command& command)
+    {
+        std::vector<std::wstring> invocations;
+        FindCommandInvocations(command, RootCommand(), invocations);
+
+        if (invocations.empty())
+        {
+            AddCommandInvocations(command, invocations);
+        }
+
+        if (invocations.size() == 1)
+        {
+            invocations.clear();
+        }
+
+        return invocations;
+    }
+} // namespace
 
 Command::Command(std::wstring_view name, std::vector<std::wstring_view>&& aliases, const std::wstring& parent) :
     m_name(name), m_aliases(std::move(aliases))
@@ -96,7 +203,11 @@ void Command::OutputHelp(Terminal& terminal, HelpOutput output, const CommandExc
         }
     }
 
-    auto commandAliases = Aliases();
+    std::vector<std::wstring> commandAliases;
+    if (fullHelp)
+    {
+        commandAliases = GetCommandInvocations(*this);
+    }
     auto commands = GetCommands();
     auto arguments = GetAllArguments();
     std::vector<Argument> helpArguments;
@@ -253,17 +364,17 @@ void Command::OutputHelp(Terminal& terminal, HelpOutput output, const CommandExc
     {
         terminal.Write(helpLevel, L"{}{}{}\n", HelpHeadingEmphasis, Localization::WSLCCLI_HeadingAliases(), Format::Default);
 
-        std::wstring aliasLine;
-        for (size_t i = 0; i < commandAliases.size(); ++i)
+        std::optional<size_t> consoleWidth;
+        if (const auto width = terminal.GetConsoleWidth(helpLevel); width.has_value() && *width > 0)
         {
-            if (i != 0)
-            {
-                aliasLine += L", ";
-            }
-            aliasLine += commandAliases[i];
+            consoleWidth = static_cast<size_t>(*width);
         }
 
-        terminal.Write(helpLevel, L"{}{}\n\n", std::wstring(c_helpRowIndent, L' '), aliasLine);
+        for (const auto& line : WrapAliases(commandAliases, consoleWidth, c_helpRowIndent))
+        {
+            terminal.Write(helpLevel, L"{}\n", line);
+        }
+        terminal.Write(helpLevel, L"\n");
     }
 
     // Col0: name/command

--- a/test/windows/wslc/e2e/WSLCE2EAliasTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EAliasTests.cpp
@@ -87,6 +87,10 @@ class WSLCE2EAliasTests
             VERIFY_IS_TRUE(result.StdoutContainsSubstring(startAliases));
         }
 
+        const auto containerResult = RunContainerExe(L"start --help");
+        containerResult.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(containerResult.StdoutContainsSubstring(L"Aliases:\r\n  container container start, container start\r\n"));
+
         const auto imageListResult = RunWslc(L"image list --help");
         imageListResult.Verify({.Stderr = L"", .ExitCode = 0});
         VERIFY_IS_TRUE(imageListResult.StdoutContainsSubstring(L"Aliases:\r\n  wslc image list, wslc image ls, wslc images\r\n"));

--- a/test/windows/wslc/e2e/WSLCE2EAliasTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EAliasTests.cpp
@@ -75,6 +75,26 @@ class WSLCE2EAliasTests
 
         VERIFY_ARE_EQUAL(wslcOutput, containerResult.Stdout.value());
     }
+
+    WSLC_TEST_METHOD(WSLCE2E_CommandHelp_ListsFullInvocationAliases)
+    {
+        const std::wstring startAliases = L"Aliases:\r\n  wslc container start, wslc start\r\n";
+
+        for (const auto commandLine : {L"container start --help", L"start --help"})
+        {
+            const auto result = RunWslc(commandLine);
+            result.Verify({.Stderr = L"", .ExitCode = 0});
+            VERIFY_IS_TRUE(result.StdoutContainsSubstring(startAliases));
+        }
+
+        const auto imageListResult = RunWslc(L"image list --help");
+        imageListResult.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(imageListResult.StdoutContainsSubstring(L"Aliases:\r\n  wslc image list, wslc image ls, wslc images\r\n"));
+
+        const auto volumeListResult = RunWslc(L"volume list --help");
+        volumeListResult.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(volumeListResult.StdoutContainsSubstring(L"Aliases:\r\n  wslc volume list, wslc volume ls\r\n"));
+    }
 };
 
 } // namespace WSLCE2ETests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Improves WSLC command help by displaying every registered invocation of a command as a fully qualified alias, including equivalent commands exposed at the root. This aligns with docker. If the list is longer than console width it wraps at the alias boundary and keeps at same indentation.

Example docker alias listing:
<img width="789" height="88" alt="image" src="https://github.com/user-attachments/assets/28898380-2610-47fd-ac5e-9c65dc024b3b" />

Example wslc alias listing with this change:
<img width="734" height="89" alt="image" src="https://github.com/user-attachments/assets/221c8693-423d-4d17-8428-231c0393b6c7" />

Note that the difference in ordering is due to docker treating "image ls" as the canonical and "image list" as the alias, while wslc treats "image list" as the canonical and "image ls" as the alias. This is the way the command is defined and not a result of the alias listing being incorrect. The canonical is listed first always in the alias list. 

The conventional order for alias lists is:

1. Canonical grouped command.
2. Grouped aliases in declared order.
3. Root-level shortcut or alias.

If there is only one command and no aliases nothing is printed at all (and the same is true for wslc).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Alias lists now:

- Use the executable name derived from `argv[0]`.
- Include grouped, root-level, and existing command aliases.
- Handle root-specific names such as `wslc images`.
- Wrap at the console width only between complete aliases.
- Remain unwrapped when output is redirected.

Added tests for aliases.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Ran `WSLCE2ETests::WSLCE2EAliasTests`: 3 passed, 0 failed.
- Deployed the generated MSI for manual testing.