### PR TITLE
Invalidate the TestImageRegistry cache after running prune --all

### DIFF
--- a/test/windows/wslc/e2e/TestImageRegistry.cpp
+++ b/test/windows/wslc/e2e/TestImageRegistry.cpp
@@ -83,6 +83,12 @@ void TestImageRegistry::Restore(const TestImage& image, const std::wstring& sess
     Load(image, sessionName);
 }
 
+void TestImageRegistry::InvalidateSession(const std::wstring& sessionName)
+{
+    std::erase_if(m_loaded, [&](const auto& image) { return image.SessionName == sessionName; });
+    m_seededSessions.erase(sessionName);
+}
+
 void TestImageRegistry::Load(const TestImage& image, const std::wstring& sessionName)
 {
     auto result = RunWslc(FormatCommand(sessionName, std::format(L"image load --input \"{}\"", image.Path.wstring())));

--- a/test/windows/wslc/e2e/TestImageRegistry.h
+++ b/test/windows/wslc/e2e/TestImageRegistry.h
@@ -44,6 +44,9 @@ public:
     // through Delete, such as those exercising image prune, call this to restore the session.
     void Restore(const TestImage& image, const std::wstring& sessionName = L"");
 
+    // Discards cached image state for a session after an operation that can remove multiple images.
+    void InvalidateSession(const std::wstring& sessionName = L"");
+
 private:
     TestImageRegistry() = default;
 

--- a/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImagePruneTests.cpp
@@ -93,7 +93,10 @@ class WSLCE2EImagePruneTests
 
     WSLC_TEST_METHOD(WSLCE2E_Image_Prune_AllFlag)
     {
-        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { TestImageRegistry::Instance().Restore(DebianImage); });
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            TestImageRegistry::Instance().InvalidateSession();
+            TestImageRegistry::Instance().Restore(DebianImage);
+        });
 
         // --all should prune unused images (not just dangling)
         const auto result = RunWslc(L"image prune --all");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves an out-of-date test registry cache issue which can cause the following test failure: 

```
StartGroup: WSLCE2ETests::WSLCE2EContainerRunTests::WSLCE2E_Container_Run_PortMultipleMappings
Error: Verify: AreEqual(*expected.Stderr, *Stderr) - Values (, Image 'python:3.12-alpine' not found, pulling
3.12-alpine: Pulling from library/python
55afa1ecc21d: Already exists
0021712cb493: Already exists
7eec6ed36766: Already exists
5086b6265f8c: Already exists
Digest: sha256:d09d15e60962ca365d1cd544a48773bac9d33f2fb1b00f2aa0deec78ade7dc31
Status: Downloaded newer image for python:3.12-alpine
) [File: C:/Users/piboulay/repos/wsl/test/windows/wslc/e2e/WSLCExecutor.cpp, Function: WSLCE2ETests::WSLCExecutionResult::Verify, Line: 91]
EndGroup: WSLCE2ETests::WSLCE2EContainerRunTests::WSLCE2E_Container_Run_PortMultipleMappings [Failed
```

That's because `wslc prune --all` can get rid of the python image, which causes a pull in later tests, causing test failures

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
