### PR TITLE
Fix CI unity build ODR errors for duplicate file-scope constants in wslc

### DIFF
--- a/src/windows/common/string.hpp
+++ b/src/windows/common/string.hpp
@@ -36,6 +36,10 @@ std::optional<uint64_t> ParseStorageSize(std::wstring_view String, StorageSizeUn
 // 119856765 -> "120MB" at precision 3, "119.9MB" at precision 4.
 std::wstring FormatHumanReadableSize(uint64_t Bytes, uint32_t Precision = 3, StorageSizeUnit Unit = StorageSizeUnit::Decimal);
 
+// Precision used when reporting the space reclaimed by prune, so that container, image and volume
+// prune agree on a single decimal place.
+inline constexpr uint32_t c_reclaimedSpacePrecision = 4;
+
 std::vector<std::string> InitializeStringSet(_In_count_(BufferSize) LPCSTR Buffer, _In_ SIZE_T BufferSize);
 
 bool IsPathComponentEqual(const std::wstring_view String1, const std::wstring_view String2);

--- a/src/windows/wslc/tasks/ContainerTasks.cpp
+++ b/src/windows/wslc/tasks/ContainerTasks.cpp
@@ -129,8 +129,6 @@ nlohmann::json ComputeContainerStatsJson(const wsl::windows::common::docker_sche
 
 namespace wsl::windows::wslc::task {
 
-constexpr uint32_t c_reclaimedSpacePrecision = 4;
-
 static bool TryInspectContainer(Terminal& terminal, Session& session, const std::string& containerId, std::optional<wslc_schema::InspectContainer>& inspectData)
 {
     try

--- a/src/windows/wslc/tasks/ImageTasks.cpp
+++ b/src/windows/wslc/tasks/ImageTasks.cpp
@@ -37,8 +37,6 @@ using namespace wsl::windows::wslc::services;
 
 namespace wsl::windows::wslc::task {
 
-constexpr uint32_t c_reclaimedSpacePrecision = 4;
-
 namespace {
 
     class DECLSPEC_UUID("91EF98A7-99A8-41C2-893C-43CDFB7DB69F") WSLCImageLoadCallback
@@ -74,7 +72,7 @@ namespace {
     };
 
     // Placeholder for values that are unavailable. wslc does not track image digests or layer sharing.
-    constexpr std::string_view c_notAvailable = "N/A";
+    constexpr std::string_view c_imageNotAvailable = "N/A";
 
     // Builds the representation of an image, shared by the table and json output so the two cannot
     // drift. Every value is emitted as a string, "<none>" is used for missing repository/tag data,
@@ -82,17 +80,17 @@ namespace {
     ImageOutputInformation ToImageOutput(const ImageInformation& image, bool truncate)
     {
         ImageOutputInformation entry;
-        entry.Containers = image.Containers < 0 ? std::string{c_notAvailable} : std::to_string(image.Containers);
+        entry.Containers = image.Containers < 0 ? std::string{c_imageNotAvailable} : std::to_string(image.Containers);
 
         entry.CreatedAt = EpochToLocalDisplayTime(image.Created);
         entry.CreatedSince = WideToMultiByte(FormatRelativeTime(image.Created));
         entry.Digest = c_none;
         entry.ID = truncate ? TruncateId(image.Id, true) : image.Id;
         entry.Repository = image.Repository.value_or(std::string{c_none});
-        entry.SharedSize = c_notAvailable;
+        entry.SharedSize = c_imageNotAvailable;
         entry.Size = WideToMultiByte(FormatHumanReadableSize(static_cast<uint64_t>(std::max<int64_t>(image.Size, 0))));
         entry.Tag = image.Tag.value_or(std::string{c_none});
-        entry.UniqueSize = c_notAvailable;
+        entry.UniqueSize = c_imageNotAvailable;
 
         return entry;
     }

--- a/src/windows/wslc/tasks/VolumeTasks.cpp
+++ b/src/windows/wslc/tasks/VolumeTasks.cpp
@@ -31,27 +31,25 @@ using wsl::windows::common::string::FormatHumanReadableSize;
 
 namespace wsl::windows::wslc::task {
 
-constexpr uint32_t c_reclaimedSpacePrecision = 4;
-
 namespace {
 
     // Reported for the fields that only carry a value when volume usage data or swarm cluster
     // information is available, neither of which applies here.
-    constexpr std::string_view c_notAvailable = "N/A";
+    constexpr std::string_view c_volumeNotAvailable = "N/A";
 
     // Converts session volume entries into the all-string shape used for "volume list --format json".
     VolumeOutputInformation ToVolumeOutput(const wslc_schema::VolumeListEntry& volume)
     {
         VolumeOutputInformation entry;
-        entry.Availability = c_notAvailable;
+        entry.Availability = c_volumeNotAvailable;
         entry.Driver = volume.Driver;
-        entry.Group = c_notAvailable;
-        entry.Links = c_notAvailable;
+        entry.Group = c_volumeNotAvailable;
+        entry.Links = c_volumeNotAvailable;
         entry.Mountpoint = volume.Mountpoint;
         entry.Name = volume.Name;
         entry.Scope = volume.Scope;
-        entry.Size = c_notAvailable;
-        entry.Status = c_notAvailable;
+        entry.Size = c_volumeNotAvailable;
+        entry.Status = c_volumeNotAvailable;
 
         for (const auto& [key, value] : volume.Labels)
         {

--- a/test/windows/StringUnitTests.cpp
+++ b/test/windows/StringUnitTests.cpp
@@ -4,6 +4,7 @@
 #include "Common.h"
 #include "string.hpp"
 
+using wsl::windows::common::string::c_reclaimedSpacePrecision;
 using wsl::windows::common::string::FormatHumanReadableSize;
 using wsl::windows::common::string::ParseStorageSize;
 using wsl::windows::common::string::StorageSizeUnit;
@@ -263,7 +264,7 @@ class StringUnitTests
 
         for (const auto& [bytes, expected] : TestCases)
         {
-            VERIFY_ARE_EQUAL(expected, FormatHumanReadableSize(bytes, 4));
+            VERIFY_ARE_EQUAL(expected, FormatHumanReadableSize(bytes, c_reclaimedSpacePrecision));
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix unity build failures caused by duplicate constexpr definitions across translation units that get concatenated when WSL_UNITY_BATCH_SIZE=4 (the CI configuration)
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
CI builds with -DWSL_UNITY_BATCH_SIZE=4, which concatenates groups of four source files into a single translation unit. When ContainerRestartCommand.cpp was added in #41435, it shifted glob indices so that ContainerTasks.cpp, ImageTasks.cpp, InspectTasks.cpp, and NetworkTasks.cpp landed in the same unity_20_cxx.cxx, causing C2374/C2086 redefinition errors:
D:\a\_work\1\s\src\windows\wslc\tasks\ImageTasks.cpp(40,20): error C2374: 'wsl::windows::wslc::task::c_reclaimedSpacePrecision': redefinition; multiple initialization [D:\a\_work\1\s\src\windows\wslc\wslclib.vcxproj]
  (compiling source file 'CMakeFiles/wslclib.dir/Unity/unity_20_cxx.cxx')
      D:\a\_work\1\s\src\windows\wslc\tasks\ContainerTasks.cpp(132,20):
      see declaration of 'wsl::windows::wslc::task::c_reclaimedSpacePrecision'
  
D:\a\_work\1\s\src\windows\wslc\tasks\ImageTasks.cpp(40,20): error C2086: 'const uint32_t wsl::windows::wslc::task::c_reclaimedSpacePrecision': redefinition [D:\a\_work\1\s\src\windows\wslc\wslclib.vcxproj]
  (compiling source file 'CMakeFiles/wslclib.dir/Unity/unity_20_cxx.cxx')
      D:\a\_work\1\s\src\windows\wslc\tasks\ContainerTasks.cpp(132,20):
      see declaration of 'wsl::windows::wslc::task::c_reclaimedSpacePrecision'
c_reclaimedSpacePrecision- was defined identically in ContainerTasks.cpp, ImageTasks.cpp, and VolumeTasks.cpp at namespace scope. Moved to string.hpp as inline constexpr next to FormatHumanReadableSize (the function it parameterizes). All three files already have using namespace wsl::windows::common::string;, so no call-site changes needed. Updated StringUnitTests.cpp to use the constant instead of a magic 4

c_notAvailable- was defined identically in ImageTasks.cpp and VolumeTasks.cpp inside anonymous namespaces. Anonymous namespaces merge when files are concatenated, so this is the same hazard. Currently safe at batch size 4 (the two files are 5 indices apart), but collides at batch size 8. Renamed to c_imageNotAvailable and c_volumeNotAvailable to reflect their distinct meanings (untracked image digests/layer sharing vs. absent volume usage/swarm data)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
