### PR TITLE
Keep mirrored autobind ports within the host range

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3657,10 +3657,20 @@ try
 
     // Mirrored networking reserves this exact range on the Windows host. Keep ports outside the range out of Linux
     // autobind selection even if a distro later widens ip_local_port_range. Explicit bind() calls are unaffected.
+    constexpr auto ReservedPortsPath = "/proc/sys/net/ipv4/ip_local_reserved_ports";
     std::string ReservedPorts;
+    {
+        std::ifstream ExistingReservedPorts{ReservedPortsPath};
+        std::getline(ExistingReservedPorts, ReservedPorts);
+    }
+
     if (Start > 1)
     {
-        ReservedPorts = std::format("1-{}", Start - 1);
+        if (!ReservedPorts.empty())
+        {
+            ReservedPorts += ',';
+        }
+        ReservedPorts += std::format("1-{}", Start - 1);
     }
 
     if (End < USHRT_MAX)
@@ -3672,7 +3682,7 @@ try
         ReservedPorts += std::format("{}-{}", End + 1, USHRT_MAX);
     }
 
-    return WriteToFile("/proc/sys/net/ipv4/ip_local_reserved_ports", ReservedPorts.c_str());
+    return WriteToFile(ReservedPortsPath, ReservedPorts.c_str());
 }
 CATCH_RETURN_ERRNO()
 

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3650,7 +3650,29 @@ try
     //      https://tldp.org/HOWTO/Linux+IPv6-HOWTO/ch11s03.html.
     //
 
-    return WriteToFile("/proc/sys/net/ipv4/ip_local_port_range", Content.c_str());
+    if (WriteToFile("/proc/sys/net/ipv4/ip_local_port_range", Content.c_str()) < 0)
+    {
+        return -1;
+    }
+
+    // Mirrored networking reserves this exact range on the Windows host. Keep ports outside the range out of Linux
+    // autobind selection even if a distro later widens ip_local_port_range. Explicit bind() calls are unaffected.
+    std::string ReservedPorts;
+    if (Start > 1)
+    {
+        ReservedPorts = std::format("1-{}", Start - 1);
+    }
+
+    if (End < USHRT_MAX)
+    {
+        if (!ReservedPorts.empty())
+        {
+            ReservedPorts += ',';
+        }
+        ReservedPorts += std::format("{}-{}", End + 1, USHRT_MAX);
+    }
+
+    return WriteToFile("/proc/sys/net/ipv4/ip_local_reserved_ports", ReservedPorts.c_str());
 }
 CATCH_RETURN_ERRNO()
 

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -49,6 +49,18 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         }
     };
 
+    auto parseEphemeralPortRangeSize = [&](const char* name, const char* value, const wchar_t* fileName, unsigned long fileLine) {
+        int number = 0;
+        if (FAILED(wil::ResultFromException([&]() { number = std::stoi(value); })) || number < 2 || number > 8192 || (number % 2) != 0)
+        {
+            EMIT_USER_WARNING(shared::Localization::MessageConfigInvalidInteger(value, name, fileName, fileLine));
+        }
+        else
+        {
+            EphemeralPortRangeSize = number;
+        }
+    };
+
     auto parseDnsTunnelingIp = [&](const char* name, const char* value, const wchar_t* fileName, unsigned long fileLine) {
         // If the IP is invalid, DNS tunneling is disabled.
         in_addr address{};
@@ -125,6 +137,7 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
         ConfigKey(ConfigSetting::Experimental::DnsTunnelingIpAddress, std::move(parseDnsTunnelingIp)),
         ConfigKey(ConfigSetting::Experimental::InitialAutoProxyTimeout, InitialAutoProxyTimeout),
         ConfigKey(ConfigSetting::Experimental::IgnoredPorts, std::move(parseIgnoredPorts)),
+        ConfigKey(ConfigSetting::Experimental::EphemeralPortRangeSize, std::move(parseEphemeralPortRangeSize)),
         ConfigKey(ConfigSetting::Experimental::HostAddressLoopback, EnableHostAddressLoopback),
         ConfigKey(ConfigSetting::Experimental::SetVersionDebug, SetVersionDebug),
         ConfigKey(ConfigSetting::Experimental::Swiotlb, MemoryString(SwiotlbSizeBytes)),

--- a/src/windows/common/WslCoreConfig.cpp
+++ b/src/windows/common/WslCoreConfig.cpp
@@ -50,14 +50,15 @@ void wsl::core::Config::ParseConfigFile(_In_opt_ LPCWSTR ConfigFilePath, _In_opt
     };
 
     auto parseEphemeralPortRangeSize = [&](const char* name, const char* value, const wchar_t* fileName, unsigned long fileLine) {
-        int number = 0;
-        if (FAILED(wil::ResultFromException([&]() { number = std::stoi(value); })) || number < 2 || number > 8192 || (number % 2) != 0)
+        char* end{};
+        const long number = strtol(value, &end, 0);
+        if (*value == '\0' || *end != '\0' || number < 2 || number > 8192 || (number % 2) != 0)
         {
             EMIT_USER_WARNING(shared::Localization::MessageConfigInvalidInteger(value, name, fileName, fileLine));
         }
         else
         {
-            EphemeralPortRangeSize = number;
+            EphemeralPortRangeSize = static_cast<int>(number);
         }
     };
 

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -32,6 +32,7 @@ Abstract:
         T_SET(c, KernelModulesPath), T_SET(c, KernelPath), T_VALUE(c, LoadDefaultKernelModules), \
         T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), T_VALUE(c, MaximumProcessorCount), \
         T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), T_ENUM(c, NetworkingMode), \
+        T_VALUE(c, EphemeralPortRangeSize), \
         T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_VALUE(c, SwiotlbSizeBytes), \
         T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
@@ -291,6 +292,7 @@ namespace ConfigSetting {
         static constexpr auto AutoProxy = "experimental.autoProxy";
         static constexpr auto InitialAutoProxyTimeout = "experimental.initialAutoProxyTimeout";
         static constexpr auto IgnoredPorts = "experimental.ignoredPorts";
+        static constexpr auto EphemeralPortRangeSize = "experimental.ephemeralPortRangeSize";
         static constexpr auto HostAddressLoopback = "experimental.hostAddressLoopback";
         static constexpr auto SetVersionDebug = "experimental.setVersionDebug";
         static constexpr auto Swiotlb = "experimental.swiotlb";
@@ -379,6 +381,7 @@ struct Config
     FirewallConfiguration FirewallConfig;
     ConfigKeyPresence FirewallConfigPresence = ConfigKeyPresence::Absent;
     std::set<uint16_t> IgnoredPorts;
+    int EphemeralPortRangeSize = 4096;
     bool EnableHostAddressLoopback = false;
     std::filesystem::path CrashDumpFolder;
     int MaxCrashDumpCount = 10;

--- a/src/windows/common/WslCoreConfig.h
+++ b/src/windows/common/WslCoreConfig.h
@@ -32,9 +32,8 @@ Abstract:
         T_SET(c, KernelModulesPath), T_SET(c, KernelPath), T_VALUE(c, LoadDefaultKernelModules), \
         T_PRESENT(c, LoadKernelModulesPresence), T_VALUE(c, MaximumMemorySizeBytes), T_VALUE(c, MaximumProcessorCount), \
         T_ENUM(c, MemoryReclaim), T_VALUE(c, MemorySizeBytes), T_VALUE(c, MountDeviceTimeout), T_ENUM(c, NetworkingMode), \
-        T_VALUE(c, EphemeralPortRangeSize), \
-        T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), T_VALUE(c, SwiotlbSizeBytes), \
-        T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
+        T_VALUE(c, EphemeralPortRangeSize), T_VALUE(c, ProcessorCount), T_SET(c, SwapFilePath), T_VALUE(c, SwapSizeBytes), \
+        T_VALUE(c, SwiotlbSizeBytes), T_SET(c, SystemDistroPath), T_VALUE(c, VhdSizeBytes), T_VALUE(c, VmIdleTimeout), T_SET(c, VmSwitch)
 
 namespace wsl::core {
 constexpr auto ToString(ConfigKeyPresence key)

--- a/src/windows/service/exe/MirroredNetworking.cpp
+++ b/src/windows/service/exe/MirroredNetworking.cpp
@@ -254,7 +254,7 @@ void MirroredNetworking::Initialize()
     m_gnsRpcServer = GnsRpcServer::GetOrCreate();
     m_guestNetworkService.CreateGuestNetworkService(
         m_config.FirewallConfig.Enabled(), m_config.IgnoredPorts, m_runtimeId, m_gnsRpcServer->GetServerUuid(), s_GuestNetworkServiceCallback, this);
-    m_ephemeralPortRange = m_guestNetworkService.AllocateEphemeralPortRange();
+    m_ephemeralPortRange = m_guestNetworkService.AllocateEphemeralPortRange(m_config.EphemeralPortRangeSize);
 
     networking::ConfigureHyperVFirewall(m_config.FirewallConfig, wsl::windows::common::wslutil::c_vmOwner);
 

--- a/src/windows/service/exe/WslCoreGuestNetworkService.cpp
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.cpp
@@ -112,13 +112,14 @@ void wsl::core::networking::GuestNetworkService::SetGuestNetworkServiceState(_In
     THROW_IF_FAILED(result);
 }
 
-std::pair<uint16_t, uint16_t> wsl::core::networking::GuestNetworkService::AllocateEphemeralPortRange()
+std::pair<uint16_t, uint16_t> wsl::core::networking::GuestNetworkService::AllocateEphemeralPortRange(uint32_t PortCount)
 {
     FAIL_FAST_IF(!IsFlowSteeringSupportedByHns());
+    THROW_HR_IF(E_INVALIDARG, PortCount < 2 || PortCount > 8192 || (PortCount % 2) != 0);
 
     const auto lock = m_dataLock.lock_exclusive();
 
-    HANDLE port{nullptr};
+    HANDLE port{};
     auto releasePortOnError = wil::scope_exit([&] {
         if (port)
         {
@@ -126,25 +127,24 @@ std::pair<uint16_t, uint16_t> wsl::core::networking::GuestNetworkService::Alloca
         }
     });
 
-    // N.B. Use an odd number of ports to avoid Linux kernel warning about preferring different parity for start / end values.
-    static constexpr auto c_ephemeralPortRangeSize = 4095;
-    THROW_IF_FAILED(m_allocatePortRange.value()(m_service.get(), c_ephemeralPortRangeSize, &m_reservedPortRange, &port));
-
-    WI_ASSERT(m_reservedPortRange.endingPort - m_reservedPortRange.startingPort == c_ephemeralPortRangeSize);
+    // HCN accepts the difference between the inclusive range endpoints, rather than the number of ports.
+    const auto portRangeSize = static_cast<uint16_t>(PortCount - 1);
+    THROW_IF_FAILED(m_allocatePortRange.value()(m_service.get(), portRangeSize, &m_reservedPortRange, &port));
+    WI_ASSERT(m_reservedPortRange.endingPort - m_reservedPortRange.startingPort == portRangeSize);
 
     // Count the overlap of the guest's reserved ephemeral range with the host ephemeral range
     // and seed the in-use counters accordingly.
     m_hostTcpEphemeralPortsInUse = ComputeHostEphemeralOverlap(IPPROTO_TCP);
     m_hostUdpEphemeralPortsInUse = ComputeHostEphemeralOverlap(IPPROTO_UDP);
 
-    // setting the port to zero as we do not expect any bind requests to be sent to wslcore for ports in this range
+    // Port zero is a sentinel for the HCN range reservation. Guest bind requests never use this map entry because
+    // ports inside m_reservedPortRange return before the individual-reservation lookup.
     m_reservedPorts.emplace(std::make_pair(HCN_PORT_PROTOCOL_TCP, static_cast<uint16_t>(0)), HcnPortReservation{port, 1});
-
-    // ownership of the port was transferred successfully
     releasePortOnError.release();
 
     WSL_LOG(
         "GuestNetworkService::AllocateEphemeralPortRange",
+        TraceLoggingValue(PortCount, "requestedPortCount"),
         TraceLoggingValue(m_reservedPortRange.startingPort, "startingPort"),
         TraceLoggingValue(m_reservedPortRange.endingPort, "endingPort"));
 

--- a/src/windows/service/exe/WslCoreGuestNetworkService.h
+++ b/src/windows/service/exe/WslCoreGuestNetworkService.h
@@ -38,7 +38,7 @@ public:
 
     void SetGuestNetworkServiceState(_In_ wsl::shared::hns::GuestNetworkServiceState State) const;
 
-    std::pair<uint16_t, uint16_t> AllocateEphemeralPortRange();
+    std::pair<uint16_t, uint16_t> AllocateEphemeralPortRange(uint32_t PortCount);
 
     int OnPortAllocationRequest(const SOCKADDR_INET& Address, _In_ int Protocol, _In_ bool Allocate) noexcept;
 

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1645,6 +1645,11 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
         newConfig += L"[wsl2]\n";
     }
 
+    if (Default.ephemeralPortRangeSize.has_value())
+    {
+        newConfig += L"\n[experimental]\nephemeralPortRangeSize=" + std::to_wstring(*Default.ephemeralPortRangeSize) + L"\n[wsl2]\n";
+    }
+
     if (Default.virtioFsAggregateShares.has_value())
     {
         newConfig += L"\n[experimental]\n";

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -1647,7 +1647,8 @@ std::wstring LxssGenerateTestConfig(TestConfigDefaults Default)
 
     if (Default.ephemeralPortRangeSize.has_value())
     {
-        newConfig += L"\n[experimental]\nephemeralPortRangeSize=" + std::to_wstring(*Default.ephemeralPortRangeSize) + L"\n[wsl2]\n";
+        newConfig +=
+            L"\n[experimental]\nephemeralPortRangeSize=" + std::to_wstring(*Default.ephemeralPortRangeSize) + L"\n[wsl2]\n";
     }
 
     if (Default.virtioFsAggregateShares.has_value())

--- a/test/windows/Common.h
+++ b/test/windows/Common.h
@@ -575,6 +575,7 @@ struct TestConfigDefaults
     std::optional<std::wstring> systemDistro;
     std::optional<bool> sparse;
     std::optional<bool> hostAddressLoopback;
+    std::optional<int> ephemeralPortRangeSize;
     int crashDumpCount = 100;
     std::optional<std::wstring> CrashDumpFolder;
     std::optional<bool> isolateDistroCgroup;

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4428,6 +4428,47 @@ class MirroredTests
         auto udpPort = NetworkTests::BindGuestPort(L"UDP4-LISTEN:0", true);
     }
 
+    WSL2_TEST_METHOD(ConfigurableEphemeralPortRangeSize)
+    {
+        MIRRORED_NETWORKING_TEST_ONLY();
+
+        constexpr int portCount = 8192;
+        m_config->Update(LxssGenerateTestConfig(
+            {.networkingMode = wsl::core::NetworkingMode::Mirrored, .ephemeralPortRangeSize = portCount}));
+        WaitForMirroredStateInLinux();
+
+        auto [output, warnings] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range", 0);
+        VERIFY_IS_TRUE(warnings.empty());
+
+        uint32_t startPort{};
+        uint32_t endPort{};
+        std::wistringstream range{output};
+        range >> startPort >> endPort;
+        VERIFY_IS_FALSE(range.fail());
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(portCount), endPort - startPort + 1);
+
+        std::wstring expectedReservedPorts;
+        if (startPort > 1)
+        {
+            expectedReservedPorts = std::format(L"1-{}", startPort - 1);
+        }
+        if (endPort < USHRT_MAX)
+        {
+            if (!expectedReservedPorts.empty())
+            {
+                expectedReservedPorts += L',';
+            }
+            expectedReservedPorts += std::format(L"{}-{}", endPort + 1, USHRT_MAX);
+        }
+
+        std::tie(output, warnings) = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_reserved_ports", 0);
+        VERIFY_IS_TRUE(warnings.empty());
+        VERIFY_ARE_EQUAL(expectedReservedPorts + L'\n', output);
+
+        auto tcpPort = NetworkTests::BindGuestPort(L"TCP4-LISTEN:0", true);
+        auto udpPort = NetworkTests::BindGuestPort(L"UDP4-LISTEN:0", true);
+    }
+
     WSL2_TEST_METHOD(PortZeroBindIsTracked)
     {
         MIRRORED_NETWORKING_TEST_ONLY();

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2179,6 +2179,35 @@ class NetworkTests
         return {std::move(process), assignedPort};
     }
 
+    // Create a connected socket without an explicit bind and return the
+    // kernel-assigned source port. The TCP path uses a real guest loopback
+    // listener, matching #41227's localhost connect() failure mode.
+    static uint16_t GetGuestConnectedSourcePort(int Protocol)
+    {
+        const std::wstring command = Protocol == IPPROTO_TCP ? L"timeout 10s perl -MSocket -e '"
+                                                               L"socket(S,AF_INET,SOCK_STREAM,0) or die;"
+                                                               L"bind(S,sockaddr_in(0,inet_aton(\"127.0.0.1\"))) or die;"
+                                                               L"listen(S,1) or die;"
+                                                               L"my $server=(sockaddr_in(getsockname(S)))[0];"
+                                                               L"socket(C,AF_INET,SOCK_STREAM,0) or die;"
+                                                               L"connect(C,sockaddr_in($server,inet_aton(\"127.0.0.1\"))) or die;"
+                                                               L"my $source=(sockaddr_in(getsockname(C)))[0];"
+                                                               L"accept(A,S) or die;"
+                                                               L"print \"$source\\n\"'"
+                                                             : L"perl -MSocket -e '"
+                                                               L"socket(C,AF_INET,SOCK_DGRAM,0) or die;"
+                                                               L"connect(C,sockaddr_in(9,inet_aton(\"127.0.0.1\"))) or die;"
+                                                               L"my $source=(sockaddr_in(getsockname(C)))[0];"
+                                                               L"print \"$source\\n\"'";
+
+        auto [output, warnings] = LxsstuLaunchWslAndCaptureOutput(command.c_str(), 0);
+        VERIFY_IS_TRUE(warnings.empty());
+
+        const auto assignedPort = static_cast<uint16_t>(std::stoul(output));
+        VERIFY_IS_TRUE(assignedPort > 0);
+        return assignedPort;
+    }
+
     // Create a TCP listening socket in the guest via listen() WITHOUT ever calling bind() first
     // (implicit autobind to an ephemeral port on the wildcard address, e.g. INADDR_ANY:0).
     // This exercises the seccomp listen() trap added for the implicit-autobind port tracking fix,
@@ -4424,6 +4453,15 @@ class MirroredTests
         m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored}));
         WaitForMirroredStateInLinux();
 
+        auto [output, warnings] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range", 0);
+        VERIFY_IS_TRUE(warnings.empty());
+        uint32_t startPort{};
+        uint32_t endPort{};
+        std::wistringstream range{output};
+        range >> startPort >> endPort;
+        VERIFY_IS_FALSE(range.fail());
+        VERIFY_ARE_EQUAL(4096u, endPort - startPort + 1);
+
         auto tcpPort = NetworkTests::BindGuestPort(L"TCP4-LISTEN:0", true);
         auto udpPort = NetworkTests::BindGuestPort(L"UDP4-LISTEN:0", true);
     }
@@ -4433,8 +4471,7 @@ class MirroredTests
         MIRRORED_NETWORKING_TEST_ONLY();
 
         constexpr int portCount = 8192;
-        m_config->Update(LxssGenerateTestConfig(
-            {.networkingMode = wsl::core::NetworkingMode::Mirrored, .ephemeralPortRangeSize = portCount}));
+        m_config->Update(LxssGenerateTestConfig({.networkingMode = wsl::core::NetworkingMode::Mirrored, .ephemeralPortRangeSize = portCount}));
         WaitForMirroredStateInLinux();
 
         auto [output, warnings] = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_port_range", 0);
@@ -4447,26 +4484,36 @@ class MirroredTests
         VERIFY_IS_FALSE(range.fail());
         VERIFY_ARE_EQUAL(static_cast<uint32_t>(portCount), endPort - startPort + 1);
 
-        std::wstring expectedReservedPorts;
+        std::tie(output, warnings) = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_reserved_ports", 0);
+        VERIFY_IS_TRUE(warnings.empty());
         if (startPort > 1)
         {
-            expectedReservedPorts = std::format(L"1-{}", startPort - 1);
+            VERIFY_ARE_NOT_EQUAL(output.find(std::format(L"1-{}", startPort - 1)), std::wstring::npos);
         }
         if (endPort < USHRT_MAX)
         {
-            if (!expectedReservedPorts.empty())
-            {
-                expectedReservedPorts += L',';
-            }
-            expectedReservedPorts += std::format(L"{}-{}", endPort + 1, USHRT_MAX);
+            VERIFY_ARE_NOT_EQUAL(output.find(std::format(L"{}-{}", endPort + 1, USHRT_MAX)), std::wstring::npos);
         }
 
-        std::tie(output, warnings) = LxsstuLaunchWslAndCaptureOutput(L"cat /proc/sys/net/ipv4/ip_local_reserved_ports", 0);
-        VERIFY_IS_TRUE(warnings.empty());
-        VERIFY_ARE_EQUAL(expectedReservedPorts + L'\n', output);
+        auto restorePortRange = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [startPort, endPort] {
+            LxsstuLaunchWsl(std::format(L"sysctl -w net.ipv4.ip_local_port_range=\"{} {}\"", startPort, endPort).c_str());
+        });
 
-        auto tcpPort = NetworkTests::BindGuestPort(L"TCP4-LISTEN:0", true);
-        auto udpPort = NetworkTests::BindGuestPort(L"UDP4-LISTEN:0", true);
+        // Reproduce the original failure mode: a distro widens the Linux
+        // ephemeral range after boot. Port-zero autobind must still select a
+        // port inside the exact range reserved by HCN on the Windows host.
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"sysctl -w net.ipv4.ip_local_port_range=\"1024 65535\""), 0);
+        auto [tcpProcess, assignedPort] = NetworkTests::BindGuestPortZero();
+        VERIFY_IS_TRUE(assignedPort >= startPort);
+        VERIFY_IS_TRUE(assignedPort <= endPort);
+
+        const auto tcpConnectPort = NetworkTests::GetGuestConnectedSourcePort(IPPROTO_TCP);
+        VERIFY_IS_TRUE(tcpConnectPort >= startPort);
+        VERIFY_IS_TRUE(tcpConnectPort <= endPort);
+
+        const auto udpConnectPort = NetworkTests::GetGuestConnectedSourcePort(IPPROTO_UDP);
+        VERIFY_IS_TRUE(udpConnectPort >= startPort);
+        VERIFY_IS_TRUE(udpConnectPort <= endPort);
     }
 
     WSL2_TEST_METHOD(PortZeroBindIsTracked)

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2272,6 +2272,30 @@ Usage:
             std::format(L"wsl: Invalid value '' for config key 'wsl2.networkingMode' in {}:21 (Valid values: Bridged, Consomme, Mirrored, Nat, None, VirtioProxy)\r\n", wslConfigPath));
 
         validateWarnings(
+            L"ephemeralPortRangeSize=1",
+            std::format(
+                L"wsl: Invalid integer value '1' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            L"[experimental]\n");
+
+        validateWarnings(
+            L"ephemeralPortRangeSize=65536",
+            std::format(
+                L"wsl: Invalid integer value '65536' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            L"[experimental]\n");
+
+        validateWarnings(
+            L"ephemeralPortRangeSize=8194",
+            std::format(
+                L"wsl: Invalid integer value '8194' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            L"[experimental]\n");
+
+        validateWarnings(
+            L"ephemeralPortRangeSize=4097",
+            std::format(
+                L"wsl: Invalid integer value '4097' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            L"[experimental]\n");
+
+        validateWarnings(
             L"ipv6=true\nipv6=false",
             std::format(L"wsl: Duplicated config key 'wsl2.ipv6' in {}:22 (Conflicting key: 'wsl2.ipv6' in {}:21)\r\n", wslConfigPath, wslConfigPath));
 

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2271,34 +2271,43 @@ Usage:
             L"networkingMode=",
             std::format(L"wsl: Invalid value '' for config key 'wsl2.networkingMode' in {}:21 (Valid values: Bridged, Consomme, Mirrored, Nat, None, VirtioProxy)\r\n", wslConfigPath));
 
+        validateWarnings(L"ephemeralPortRangeSize=2", L"", L"[experimental]\n");
+
+        validateWarnings(L"ephemeralPortRangeSize=4096", L"", L"[experimental]\n");
+
+        validateWarnings(
+            L"ephemeralPortRangeSize=",
+            std::format(L"wsl: Invalid integer value '' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            L"[experimental]\n");
+
+        validateWarnings(
+            L"ephemeralPortRangeSize=-2",
+            std::format(L"wsl: Invalid integer value '-2' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            L"[experimental]\n");
+
         validateWarnings(
             L"ephemeralPortRangeSize=1",
-            std::format(
-                L"wsl: Invalid integer value '1' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            std::format(L"wsl: Invalid integer value '1' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
             L"[experimental]\n");
 
         validateWarnings(
             L"ephemeralPortRangeSize=65536",
-            std::format(
-                L"wsl: Invalid integer value '65536' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            std::format(L"wsl: Invalid integer value '65536' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
             L"[experimental]\n");
 
         validateWarnings(
             L"ephemeralPortRangeSize=8194",
-            std::format(
-                L"wsl: Invalid integer value '8194' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            std::format(L"wsl: Invalid integer value '8194' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
             L"[experimental]\n");
 
         validateWarnings(
             L"ephemeralPortRangeSize=4097",
-            std::format(
-                L"wsl: Invalid integer value '4097' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            std::format(L"wsl: Invalid integer value '4097' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
             L"[experimental]\n");
 
         validateWarnings(
             L"ephemeralPortRangeSize=4096abc",
-            std::format(
-                L"wsl: Invalid integer value '4096abc' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            std::format(L"wsl: Invalid integer value '4096abc' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
             L"[experimental]\n");
 
         validateWarnings(

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -2296,6 +2296,12 @@ Usage:
             L"[experimental]\n");
 
         validateWarnings(
+            L"ephemeralPortRangeSize=4096abc",
+            std::format(
+                L"wsl: Invalid integer value '4096abc' for key 'experimental.ephemeralPortRangeSize' in {}:2\r\n", wslConfigPath),
+            L"[experimental]\n");
+
+        validateWarnings(
             L"ipv6=true\nipv6=false",
             std::format(L"wsl: Duplicated config key 'wsl2.ipv6' in {}:22 (Conflicting key: 'wsl2.ipv6' in {}:21)\r\n", wslConfigPath, wslConfigPath));
 


### PR DESCRIPTION
## Summary of the Pull Request

Mirrored networking reserves a host ephemeral port range in HCN and initially
configures Linux to use the same range. If a distribution later expands
`net.ipv4.ip_local_port_range`, Linux autobind can select a source port outside
the HCN allocation. Localhost TCP connections from those ports then remain in
`SYN-RECV`.

This change reserves the complement of the HCN allocation in
`net.ipv4.ip_local_reserved_ports`. Linux can still change
`ip_local_port_range`, but automatic TCP and UDP assignments remain inside the
host range. Explicit binds are unaffected. Existing reserved-port entries are
preserved when the complement is installed.

It also adds `experimental.ephemeralPortRangeSize`, with a default of 4096 and
validation for even values from 2 through 8192, so the allocated HCN range and
Linux reservation can be covered by regression tests.

## PR Checklist

- [x] **Closes:** #41227
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on our docs repo and link it here

## Detailed Description

`GuestNetworkService::AllocateEphemeralPortRange()` now accepts the configured
port count and returns the inclusive range allocated by HCN. Mirrored
networking passes that exact range to init.

Init continues to set `ip_local_port_range` to the HCN range. It reads the
current `ip_local_reserved_ports` value, preserves it, and appends the ranges
below and above the HCN allocation. A later change to `ip_local_port_range`
therefore cannot let root-namespace autobind escape the host reservation.

Configuration parsing rejects odd values, values outside 2-8192, empty or
negative values, and trailing characters. Invalid values use the existing
invalid-integer warning and fall back to the 4096-port default without
disabling mirrored networking.

The reservation is scoped to the initial root network namespace. A later
explicit write to `ip_local_reserved_ports`, or a newly created network
namespace, has its own lifecycle; this PR targets the issue's root-distro case
where `ip_local_port_range` alone is changed after boot.

## Regression Coverage

`NetworkTests::ConfigurableEphemeralPortRangeSize` now verifies:

- an 8192-port HCN allocation and the installed reserved-port complement;
- widening Linux `ip_local_port_range` to `1024 65535` after boot;
- an explicit TCP bind-to-zero remains within the HCN range;
- a real guest loopback TCP `connect()` completes and its implicit source port
  remains within the HCN range;
- UDP `connect()` autobind also selects a source port within the HCN range.

The default mirrored-mode test asserts the existing 4096-port behavior.
Configuration tests cover the legal minimum, default, empty, negative, odd,
out-of-range, and trailing-character values.

## Validation

The original implementation was built as WSL 2.9.9.3 and manually validated
against the #41227 reproduction: expanding the range changed 0/20 successful
connections before the fix to 20/20 after the fix.

For the current rebased head:

- changed-line clang-format produces no diff;
- whitespace/diff validation passes;
- the change applies cleanly to current `master`.

The new head still requires the repository's full Windows build and the added
TAEF paths to run in a Windows test environment.
