### PR TITLE
Don't fail the installation if DeprovisionMsix() fails

### DIFF
--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -76,8 +76,7 @@ void TrustPackageCertificate(LPCWSTR Path)
 #endif
 
 winrt::Windows::Management::Deployment::DeploymentResult WaitForDeploymentOperation(
-    const winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Management::Deployment::DeploymentResult, winrt::Windows::Management::Deployment::DeploymentProgress>& operation,
-    const std::source_location& source = std::source_location::current())
+    const winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Management::Deployment::DeploymentResult, winrt::Windows::Management::Deployment::DeploymentProgress>& operation)
 {
     // IAsyncOperation::get() installs a completion delegate whose implementation resides in this DLL. The operation can retain
     // that delegate after get() returns, allowing its final Release() to call into the DLL after MSI unloads it.
@@ -89,12 +88,6 @@ winrt::Windows::Management::Deployment::DeploymentResult WaitForDeploymentOperat
     {
         Sleep(10);
         status = operation.Status();
-    }
-
-    if (status == winrt::Windows::Foundation::AsyncStatus::Error)
-    {
-        const auto error = operation.ErrorCode();
-        THROW_HR_MSG(error, "Source: %hs() - %hs:%lu", source.function_name(), source.file_name(), source.line());
     }
 
     if (status == winrt::Windows::Foundation::AsyncStatus::Canceled)
@@ -109,8 +102,14 @@ void ThrowIfOperationError(
     const winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Management::Deployment::DeploymentResult, winrt::Windows::Management::Deployment::DeploymentProgress>& operation,
     const std::source_location& source = std::source_location::current())
 {
-    const auto result = WaitForDeploymentOperation(operation, source);
-    THROW_IF_FAILED_MSG(result.ExtendedErrorCode(), "%ls", result.ErrorText().c_str());
+    const auto result = WaitForDeploymentOperation(operation);
+    THROW_IF_FAILED_MSG(
+        result.ExtendedErrorCode(),
+        "%ls Source: %hs() - %hs:%lu",
+        result.ErrorText().c_str(),
+        source.function_name(),
+        source.file_name(),
+        source.line());
 }
 
 std::wstring GetMsiProperty(MSIHANDLE install, LPCWSTR name)

--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -105,11 +105,11 @@ void ThrowIfOperationError(
     const auto result = WaitForDeploymentOperation(operation);
     THROW_IF_FAILED_MSG(
         result.ExtendedErrorCode(),
-        "%ls Source: %hs() - %hs:%lu",
+        "%ls Source: %hs() - %hs:%u",
         result.ErrorText().c_str(),
         source.function_name(),
         source.file_name(),
-        source.line());
+        static_cast<unsigned int>(source.line()));
 }
 
 std::wstring GetMsiProperty(MSIHANDLE install, LPCWSTR name)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change solves a regression introduced in https://github.com/microsoft/WSL/pull/41415  which causes `WaitForDeploymentOperation()` to throw on error instead of just returning the error to the caller, which causes installation failures on builds that don't support direct MSI execution. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
