### PR TITLE
Support full duplex traffic and half close socket in NAT localhost relay

### DIFF
--- a/src/linux/init/localhost.cpp
+++ b/src/linux/init/localhost.cpp
@@ -664,7 +664,7 @@ void RunLocalHostRelay(sockaddr_vm hvSocketAddress, int listenSocket)
                         }
 
                         LOG_ERROR("accept4 failed, {}", error);
-                        break;
+                        THROW_ERRNO(error);
                     }
 
                     THROW_ERRNO_IF(EOVERFLOW, nextConnectionId > c_connectionIdMask);

--- a/src/linux/init/localhost.cpp
+++ b/src/linux/init/localhost.cpp
@@ -1,8 +1,10 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 #include "common.h"
 #include <memory>
+#include <array>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 #include <iostream>
 
@@ -228,127 +230,478 @@ int MonitorListeningSockets(wsl::shared::SocketChannel& channel)
 
     return result;
 }
+
+enum class RelayEndpoint : uint64_t
+{
+    HvSocket = 0,
+    TcpSocket = 1
+};
+
+constexpr uint64_t c_listenerEventKey = 0;
+constexpr uint64_t c_relayEndpointBit = uint64_t{1} << 63;
+constexpr uint64_t c_connectionIdMask = ~c_relayEndpointBit;
+
+uint64_t RelayEventKey(uint64_t connectionId, RelayEndpoint endpoint)
+{
+    WI_ASSERT(connectionId <= c_connectionIdMask);
+    return connectionId | (endpoint == RelayEndpoint::TcpSocket ? c_relayEndpointBit : 0);
+}
+
+void SetNonBlocking(int fd)
+{
+    const int flags = fcntl(fd, F_GETFL, 0);
+    THROW_LAST_ERROR_IF(flags < 0);
+    THROW_LAST_ERROR_IF(fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0);
+}
+
+class RelayConnection
+{
+public:
+    RelayConnection(int epollFd, uint64_t connectionId, wil::unique_fd&& relaySocket) :
+        m_epollFd(epollFd), m_connectionId(connectionId), m_relaySocket(std::move(relaySocket))
+    {
+        SetNonBlocking(m_relaySocket.get());
+        AddToEpoll(RelayEndpoint::HvSocket, EPOLLIN | EPOLLRDHUP);
+    }
+
+    bool Done() const noexcept
+    {
+        return m_done;
+    }
+
+    void Stop() noexcept
+    {
+        m_done = true;
+    }
+
+    void HandleEvent(RelayEndpoint endpoint, uint32_t events)
+    {
+        if (m_done)
+        {
+            return;
+        }
+
+        if (m_state == State::ReadingMessage)
+        {
+            WI_ASSERT(endpoint == RelayEndpoint::HvSocket);
+            ReadMessage();
+            if (m_state == State::ReadingMessage || m_done)
+            {
+                return;
+            }
+        }
+
+        if (m_state == State::Connecting && endpoint == RelayEndpoint::TcpSocket && (events & (EPOLLOUT | EPOLLERR | EPOLLHUP)))
+        {
+            CompleteConnect();
+        }
+
+        if (m_state == State::Connecting || m_state == State::Relaying)
+        {
+            auto& writeDirection = DirectionForDestination(endpoint);
+            if (!writeDirection.Empty() && (events & (EPOLLOUT | EPOLLERR | EPOLLHUP)))
+            {
+                Write(writeDirection);
+            }
+
+            auto& readDirection = DirectionForSource(endpoint);
+            if (!readDirection.SourceEof && readDirection.Empty() && (events & (EPOLLIN | EPOLLRDHUP | EPOLLHUP)))
+            {
+                Read(readDirection);
+            }
+
+            if (events & EPOLLERR)
+            {
+                int socketError{};
+                socklen_t socketErrorSize = sizeof(socketError);
+                THROW_LAST_ERROR_IF(getsockopt(Fd(endpoint), SOL_SOCKET, SO_ERROR, &socketError, &socketErrorSize) < 0);
+                if (socketError != 0)
+                {
+                    THROW_ERRNO(socketError);
+                }
+            }
+
+            HalfCloseIfDrained(m_relayToTcp);
+            HalfCloseIfDrained(m_tcpToRelay);
+            m_done = m_relayToTcp.DestinationShutdown && m_tcpToRelay.DestinationShutdown;
+
+            if (!m_done)
+            {
+                UpdateInterests();
+            }
+        }
+    }
+
+private:
+    enum class State
+    {
+        ReadingMessage,
+        Connecting,
+        Relaying
+    };
+
+    struct Direction
+    {
+        Direction(RelayEndpoint source, RelayEndpoint destination, size_t bufferSize = 0) :
+            Source(source), Destination(destination), Buffer(bufferSize)
+        {
+        }
+
+        bool Empty() const noexcept
+        {
+            return Size == 0;
+        }
+
+        RelayEndpoint Source;
+        RelayEndpoint Destination;
+        std::vector<gsl::byte> Buffer;
+        size_t Offset{};
+        size_t Size{};
+        bool SourceEof{};
+        bool DestinationShutdown{};
+    };
+
+    int Fd(RelayEndpoint endpoint) const noexcept
+    {
+        return endpoint == RelayEndpoint::HvSocket ? m_relaySocket.get() : m_tcpSocket.get();
+    }
+
+    Direction& DirectionForSource(RelayEndpoint endpoint)
+    {
+        return endpoint == RelayEndpoint::HvSocket ? m_relayToTcp : m_tcpToRelay;
+    }
+
+    Direction& DirectionForDestination(RelayEndpoint endpoint)
+    {
+        return endpoint == RelayEndpoint::HvSocket ? m_tcpToRelay : m_relayToTcp;
+    }
+
+    uint32_t EventsFor(RelayEndpoint endpoint) const
+    {
+        if (m_state == State::ReadingMessage)
+        {
+            return EPOLLIN | EPOLLRDHUP;
+        }
+
+        if (m_state == State::Connecting && endpoint == RelayEndpoint::TcpSocket)
+        {
+            return EPOLLOUT | EPOLLRDHUP;
+        }
+
+        uint32_t events{};
+        const auto& readDirection = endpoint == RelayEndpoint::HvSocket ? m_relayToTcp : m_tcpToRelay;
+        if (!readDirection.SourceEof && readDirection.Empty())
+        {
+            events |= EPOLLIN | EPOLLRDHUP;
+        }
+
+        const auto& writeDirection = endpoint == RelayEndpoint::HvSocket ? m_tcpToRelay : m_relayToTcp;
+        if (!writeDirection.Empty())
+        {
+            events |= EPOLLOUT;
+        }
+
+        return events;
+    }
+
+    void AddToEpoll(RelayEndpoint endpoint, uint32_t events)
+    {
+        epoll_event event{};
+        event.events = events;
+        event.data.u64 = RelayEventKey(m_connectionId, endpoint);
+        THROW_LAST_ERROR_IF(epoll_ctl(m_epollFd, EPOLL_CTL_ADD, Fd(endpoint), &event) < 0);
+
+        if (endpoint == RelayEndpoint::HvSocket)
+        {
+            m_relayEvents = events;
+        }
+        else
+        {
+            m_tcpEvents = events;
+        }
+    }
+
+    void UpdateInterest(RelayEndpoint endpoint, uint32_t events)
+    {
+        auto& currentEvents = endpoint == RelayEndpoint::HvSocket ? m_relayEvents : m_tcpEvents;
+        if (currentEvents == events)
+        {
+            return;
+        }
+
+        if (events == 0)
+        {
+            THROW_LAST_ERROR_IF(epoll_ctl(m_epollFd, EPOLL_CTL_DEL, Fd(endpoint), nullptr) < 0);
+            currentEvents = 0;
+            return;
+        }
+
+        epoll_event event{};
+        event.events = events;
+        event.data.u64 = RelayEventKey(m_connectionId, endpoint);
+        const int operation = currentEvents == 0 ? EPOLL_CTL_ADD : EPOLL_CTL_MOD;
+        THROW_LAST_ERROR_IF(epoll_ctl(m_epollFd, operation, Fd(endpoint), &event) < 0);
+        currentEvents = events;
+    }
+
+    void UpdateInterests()
+    {
+        UpdateInterest(RelayEndpoint::HvSocket, EventsFor(RelayEndpoint::HvSocket));
+        if (m_tcpSocket)
+        {
+            UpdateInterest(RelayEndpoint::TcpSocket, EventsFor(RelayEndpoint::TcpSocket));
+        }
+    }
+
+    void ReadMessage()
+    {
+        while (m_messageBytes < sizeof(m_message))
+        {
+            auto* destination = reinterpret_cast<char*>(&m_message) + m_messageBytes;
+            const auto bytesRead = TEMP_FAILURE_RETRY(read(m_relaySocket.get(), destination, sizeof(m_message) - m_messageBytes));
+            if (bytesRead > 0)
+            {
+                m_messageBytes += static_cast<size_t>(bytesRead);
+                continue;
+            }
+
+            if (bytesRead == 0)
+            {
+                m_done = true;
+                return;
+            }
+
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+                return;
+            }
+
+            THROW_LAST_ERROR();
+        }
+
+        THROW_ERRNO_IF(
+            EINVAL,
+            m_message.Header.MessageType != LxInitMessageStartSocketRelay || m_message.Header.MessageSize != sizeof(m_message) ||
+                m_message.BufferSize == 0);
+
+        const auto bufferSize = static_cast<size_t>(m_message.BufferSize);
+        m_relayToTcp = Direction(RelayEndpoint::HvSocket, RelayEndpoint::TcpSocket, bufferSize);
+        m_tcpToRelay = Direction(RelayEndpoint::TcpSocket, RelayEndpoint::HvSocket, bufferSize);
+
+        sockaddr* socketAddress{};
+        socklen_t socketAddressSize{};
+        sockaddr_in ipv4Address{};
+        sockaddr_in6 ipv6Address{};
+
+        if (m_message.Family == AF_INET)
+        {
+            ipv4Address.sin_family = AF_INET;
+            ipv4Address.sin_port = htons(m_message.Port);
+            ipv4Address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+            socketAddress = reinterpret_cast<sockaddr*>(&ipv4Address);
+            socketAddressSize = sizeof(ipv4Address);
+        }
+        else if (m_message.Family == AF_INET6)
+        {
+            ipv6Address.sin6_family = AF_INET6;
+            ipv6Address.sin6_port = htons(m_message.Port);
+            ipv6Address.sin6_addr = IN6ADDR_LOOPBACK_INIT;
+            socketAddress = reinterpret_cast<sockaddr*>(&ipv6Address);
+            socketAddressSize = sizeof(ipv6Address);
+        }
+        else
+        {
+            THROW_ERRNO(EINVAL);
+        }
+
+        m_tcpSocket.reset(socket(socketAddress->sa_family, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, IPPROTO_TCP));
+        THROW_LAST_ERROR_IF(!m_tcpSocket);
+
+        const int result = connect(m_tcpSocket.get(), socketAddress, socketAddressSize);
+        if (result < 0 && errno != EINPROGRESS)
+        {
+            const int error = errno;
+            LOG_ERROR("Failed to connect to port: {}, family: {}, errno: {}", m_message.Port, m_message.Family, error);
+            THROW_ERRNO(error);
+        }
+
+        m_state = result == 0 ? State::Relaying : State::Connecting;
+        AddToEpoll(RelayEndpoint::TcpSocket, EventsFor(RelayEndpoint::TcpSocket));
+        UpdateInterest(RelayEndpoint::HvSocket, EventsFor(RelayEndpoint::HvSocket));
+    }
+
+    void CompleteConnect()
+    {
+        int socketError{};
+        socklen_t socketErrorSize = sizeof(socketError);
+        THROW_LAST_ERROR_IF(getsockopt(m_tcpSocket.get(), SOL_SOCKET, SO_ERROR, &socketError, &socketErrorSize) < 0);
+        if (socketError != 0)
+        {
+            LOG_ERROR("Failed to connect to port: {}, family: {}, errno: {}", m_message.Port, m_message.Family, socketError);
+            THROW_ERRNO(socketError);
+        }
+
+        m_state = State::Relaying;
+        UpdateInterests();
+    }
+
+    void Read(Direction& direction)
+    {
+        WI_ASSERT(direction.Empty());
+        const auto bytesRead = TEMP_FAILURE_RETRY(read(Fd(direction.Source), direction.Buffer.data(), direction.Buffer.size()));
+        if (bytesRead > 0)
+        {
+            direction.Offset = 0;
+            direction.Size = static_cast<size_t>(bytesRead);
+        }
+        else if (bytesRead == 0)
+        {
+            direction.SourceEof = true;
+        }
+        else if (errno != EAGAIN && errno != EWOULDBLOCK)
+        {
+            THROW_LAST_ERROR();
+        }
+    }
+
+    void Write(Direction& direction)
+    {
+        WI_ASSERT(!direction.Empty());
+        const auto bytesWritten =
+            TEMP_FAILURE_RETRY(send(Fd(direction.Destination), direction.Buffer.data() + direction.Offset, direction.Size, MSG_NOSIGNAL));
+        if (bytesWritten > 0)
+        {
+            direction.Offset += static_cast<size_t>(bytesWritten);
+            direction.Size -= static_cast<size_t>(bytesWritten);
+            if (direction.Empty())
+            {
+                direction.Offset = 0;
+            }
+        }
+        else if (bytesWritten == 0)
+        {
+            THROW_ERRNO(EPIPE);
+        }
+        else if (bytesWritten < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+        {
+            THROW_LAST_ERROR();
+        }
+    }
+
+    void HalfCloseIfDrained(Direction& direction)
+    {
+        if (m_state != State::Relaying || !direction.SourceEof || !direction.Empty() || direction.DestinationShutdown)
+        {
+            return;
+        }
+
+        if (shutdown(Fd(direction.Destination), SHUT_WR) < 0)
+        {
+            LOG_ERROR("shutdown({}) failed, {}", Fd(direction.Destination), errno);
+        }
+
+        direction.DestinationShutdown = true;
+    }
+
+    int m_epollFd;
+    uint64_t m_connectionId;
+    wil::unique_fd m_relaySocket;
+    wil::unique_fd m_tcpSocket;
+    State m_state = State::ReadingMessage;
+    LX_INIT_START_SOCKET_RELAY m_message{};
+    size_t m_messageBytes{};
+    Direction m_relayToTcp{RelayEndpoint::HvSocket, RelayEndpoint::TcpSocket};
+    Direction m_tcpToRelay{RelayEndpoint::TcpSocket, RelayEndpoint::HvSocket};
+    uint32_t m_relayEvents{};
+    uint32_t m_tcpEvents{};
+    bool m_done{};
+};
 } // namespace
 
 void RunLocalHostRelay(sockaddr_vm hvSocketAddress, int listenSocket)
 {
-    pollfd pollDescriptors[] = {{listenSocket, POLLIN}};
+    SetNonBlocking(listenSocket);
+
+    wil::unique_fd epollFd{epoll_create1(EPOLL_CLOEXEC)};
+    THROW_LAST_ERROR_IF(!epollFd);
+
+    epoll_event listenerEvent{};
+    listenerEvent.events = EPOLLIN;
+    listenerEvent.data.u64 = c_listenerEventKey;
+    THROW_LAST_ERROR_IF(epoll_ctl(epollFd.get(), EPOLL_CTL_ADD, listenSocket, &listenerEvent) < 0);
+
+    std::unordered_map<uint64_t, std::unique_ptr<RelayConnection>> connections;
+    uint64_t nextConnectionId = 1;
+    std::array<epoll_event, 64> events{};
+
     for (;;)
     {
-        int result = poll(pollDescriptors, COUNT_OF(pollDescriptors), -1);
-        if (result < 0)
+        const int eventCount = TEMP_FAILURE_RETRY(epoll_wait(epollFd.get(), events.data(), static_cast<int>(events.size()), -1));
+        THROW_LAST_ERROR_IF(eventCount < 0);
+
+        for (int index = 0; index < eventCount; ++index)
         {
-            LOG_ERROR("poll failed {}", errno);
-            return;
-        }
-
-        if ((pollDescriptors[0].revents & POLLIN) == 0)
-        {
-            LOG_ERROR("unexpected revents {:x}", pollDescriptors[0].revents);
-            return;
-        }
-
-        // Accept a connection and start a relay worker thread.
-        wil::unique_fd relaySocket{UtilAcceptVsock(listenSocket, hvSocketAddress)};
-        THROW_LAST_ERROR_IF(!relaySocket);
-
-        std::thread([relaySocket = std::move(relaySocket)]() {
-            try
+            const auto eventKey = events[index].data.u64;
+            if (eventKey == c_listenerEventKey)
             {
-                // Read a message to determine which TCP port to connect to.
-                std::vector<gsl::byte> buffer(sizeof(LX_INIT_START_SOCKET_RELAY));
-                auto bytesRead = UtilReadBuffer(relaySocket.get(), buffer);
-                if (bytesRead == 0)
-                {
-                    return;
-                }
-
-                auto* message = gslhelpers::try_get_struct<LX_INIT_START_SOCKET_RELAY>(gsl::make_span(buffer.data(), bytesRead));
-                THROW_ERRNO_IF(EINVAL, !message || (message->Header.MessageType != LxInitMessageStartSocketRelay));
-
-                // Connect to the actual socket address and set up a relay.
-                //
-                // N.B. During the time setting up the relay the server may have
-                //      stopped listening.
-                sockaddr* socketAddress;
-                int socketAddressSize;
-                sockaddr_in sockaddrIn{};
-                sockaddr_in6 sockaddrIn6{};
-
-                if (message->Family == AF_INET)
-                {
-                    sockaddrIn.sin_family = AF_INET;
-                    sockaddrIn.sin_port = htons(message->Port);
-                    sockaddrIn.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-                    socketAddress = reinterpret_cast<sockaddr*>(&sockaddrIn);
-                    socketAddressSize = sizeof(sockaddrIn);
-                }
-                else if (message->Family == AF_INET6)
-                {
-                    sockaddrIn6.sin6_family = AF_INET6;
-                    sockaddrIn6.sin6_port = htons(message->Port);
-                    sockaddrIn6.sin6_addr = IN6ADDR_LOOPBACK_INIT;
-                    socketAddress = reinterpret_cast<sockaddr*>(&sockaddrIn6);
-                    socketAddressSize = sizeof(sockaddrIn6);
-                }
-                else
-                {
-                    THROW_ERRNO(EINVAL);
-                }
-
-                wil::unique_fd tcpSocket{socket(socketAddress->sa_family, SOCK_STREAM, IPPROTO_TCP)};
-                THROW_LAST_ERROR_IF(!tcpSocket);
-
-                if (TEMP_FAILURE_RETRY(connect(tcpSocket.get(), socketAddress, socketAddressSize)) < 0)
-                {
-                    LOG_ERROR("Failed to connect to port: {}, family: {}, errno: {}", message->Port, message->Family, errno);
-                    return;
-                }
-
-                // Resize the buffer to be the requested size.
-                buffer.resize(message->BufferSize);
-
-                // Begin relaying data.
-                int outFd[2] = {tcpSocket.get(), relaySocket.get()};
-                pollfd pollDescriptors[] = {{relaySocket.get(), POLLIN}, {tcpSocket.get(), POLLIN}};
-
                 for (;;)
                 {
-                    if ((pollDescriptors[0].fd == -1) || (pollDescriptors[1].fd == -1))
+                    sockaddr_vm peerAddress = hvSocketAddress;
+                    socklen_t peerAddressSize = sizeof(peerAddress);
+                    wil::unique_fd relaySocket{accept4(
+                        listenSocket, reinterpret_cast<sockaddr*>(&peerAddress), &peerAddressSize, SOCK_NONBLOCK | SOCK_CLOEXEC)};
+                    if (!relaySocket)
                     {
-                        return;
-                    }
-
-                    THROW_LAST_ERROR_IF(poll(pollDescriptors, COUNT_OF(pollDescriptors), -1) < 0);
-
-                    bytesRead = 0;
-                    for (int Index = 0; Index < COUNT_OF(pollDescriptors); Index += 1)
-                    {
-                        if (pollDescriptors[Index].revents & POLLIN)
+                        const int error = errno;
+                        if (error == EAGAIN || error == EWOULDBLOCK)
                         {
-                            bytesRead = UtilReadBuffer(pollDescriptors[Index].fd, buffer);
-                            if (bytesRead == 0)
-                            {
-                                pollDescriptors[Index].fd = -1;
-                                shutdown(outFd[Index], SHUT_WR);
-                            }
-                            else if (bytesRead < 0)
-                            {
-                                return;
-                            }
-                            else if (UtilWriteBuffer(outFd[Index], buffer.data(), bytesRead) < 0)
-                            {
-                                return;
-                            }
+                            break;
                         }
-                    }
-                }
-            }
-            CATCH_LOG()
-        }).detach();
-    }
 
-    return;
+                        if (error == EINTR || error == ECONNABORTED || error == EPROTO)
+                        {
+                            continue;
+                        }
+
+                        LOG_ERROR("accept4 failed, {}", error);
+                        break;
+                    }
+
+                    THROW_ERRNO_IF(EOVERFLOW, nextConnectionId > c_connectionIdMask);
+                    const auto connectionId = nextConnectionId++;
+                    try
+                    {
+                        connections.emplace(connectionId, std::make_unique<RelayConnection>(epollFd.get(), connectionId, std::move(relaySocket)));
+                    }
+                    CATCH_LOG();
+                }
+
+                continue;
+            }
+
+            const auto connectionId = eventKey & c_connectionIdMask;
+            const auto endpoint = (eventKey & c_relayEndpointBit) ? RelayEndpoint::TcpSocket : RelayEndpoint::HvSocket;
+            const auto connection = connections.find(connectionId);
+            if (connection == connections.end())
+            {
+                continue;
+            }
+
+            try
+            {
+                connection->second->HandleEvent(endpoint, events[index].events);
+            }
+            catch (...)
+            {
+                LOG_CAUGHT_EXCEPTION();
+                connection->second->Stop();
+            }
+        }
+
+        // Closing the uniquely owned sockets removes their epoll registrations after the final fd reference is closed.
+        // Defer erasure until the full batch is processed because events already returned by epoll_wait() remain cached here.
+        std::erase_if(connections, [](const auto& entry) { return entry.second->Done(); });
+    }
 }
 
 // Create a thread to monitor for connections to relay.

--- a/src/windows/common/HandleIO.cpp
+++ b/src/windows/common/HandleIO.cpp
@@ -8,6 +8,7 @@ using wsl::windows::common::io::AcceptHandle;
 using wsl::windows::common::io::BufferWrapper;
 using wsl::windows::common::io::DockerIORelayHandle;
 using wsl::windows::common::io::EventHandle;
+using wsl::windows::common::io::HalfCloseRelayHandle;
 using wsl::windows::common::io::HandleWrapper;
 using wsl::windows::common::io::HTTPChunkBasedReadHandle;
 using wsl::windows::common::io::IOHandleStatus;
@@ -274,8 +275,8 @@ HANDLE EventHandle::GetHandle() const
 
 // ReadHandle
 
-ReadHandle::ReadHandle(HandleWrapper&& MovedHandle, std::function<void(const gsl::span<char>& Buffer)>&& OnRead) :
-    Handle(std::move(MovedHandle)), OnRead(OnRead), Offset(InitializeFileOffset(Handle.Get()))
+ReadHandle::ReadHandle(HandleWrapper&& MovedHandle, std::function<void(const gsl::span<char>& Buffer)>&& OnRead, size_t BufferSize) :
+    Handle(std::move(MovedHandle)), OnRead(std::move(OnRead)), Buffer(BufferSize), Offset(InitializeFileOffset(Handle.Get()))
 {
     Overlapped.hEvent = Event.get();
 }
@@ -1612,6 +1613,23 @@ void DockerIORelayHandle::OnRead(const gsl::span<char>& Buffer)
     {
         // If no handle is active, expect a header.
         ProcessNextHeader();
+    }
+}
+
+// HalfCloseRelayHandle
+
+HalfCloseRelayHandle::HalfCloseRelayHandle(HandleWrapper&& Input, SOCKET OutputSocket, size_t BufferSize) :
+    RelayHandle(std::move(Input), HandleWrapper{OutputSocket}, BufferSize), m_shutdownSocket(OutputSocket)
+{
+}
+
+void HalfCloseRelayHandle::Schedule()
+{
+    RelayHandle::Schedule();
+    if (State == IOHandleStatus::Completed && !m_shutdownDone)
+    {
+        m_shutdownDone = true;
+        LOG_LAST_ERROR_IF(shutdown(m_shutdownSocket, SD_SEND) == SOCKET_ERROR);
     }
 }
 

--- a/src/windows/common/HandleIO.h
+++ b/src/windows/common/HandleIO.h
@@ -104,7 +104,7 @@ public:
     NON_COPYABLE(ReadHandle);
     NON_MOVABLE(ReadHandle);
 
-    ReadHandle(HandleWrapper&& MovedHandle, std::function<void(const gsl::span<char>& Buffer)>&& OnRead);
+    ReadHandle(HandleWrapper&& MovedHandle, std::function<void(const gsl::span<char>& Buffer)>&& OnRead, size_t BufferSize = LX_RELAY_BUFFER_SIZE);
     virtual ~ReadHandle();
 
     void Schedule() override;
@@ -473,6 +473,22 @@ private:
     WriteHandle* ActiveHandle = nullptr;
     size_t RemainingBytes = 0;
 };
+
+class HalfCloseRelayHandle : public RelayHandle<ReadHandle>
+{
+public:
+    NON_COPYABLE(HalfCloseRelayHandle);
+    NON_MOVABLE(HalfCloseRelayHandle);
+
+    HalfCloseRelayHandle(HandleWrapper&& Input, SOCKET OutputSocket, size_t BufferSize = LX_RELAY_BUFFER_SIZE);
+
+    void Schedule() override;
+
+private:
+    SOCKET m_shutdownSocket;
+    bool m_shutdownDone = false;
+};
+
 class MultiHandleWait
 {
 public:

--- a/src/windows/common/relay.cpp
+++ b/src/windows/common/relay.cpp
@@ -18,6 +18,7 @@ Abstract:
 
 using wsl::windows::common::relay::ScopedMultiRelay;
 using wsl::windows::common::relay::ScopedRelay;
+namespace io = wsl::windows::common::io;
 
 namespace {
 
@@ -281,130 +282,25 @@ wsl::windows::common::relay::InterruptableWrite(
 
 void wsl::windows::common::relay::BidirectionalRelay(_In_ HANDLE LeftHandle, _In_ HANDLE RightHandle, _In_ size_t BufferSize, _In_ RelayFlags Flags)
 {
-    std::vector<gsl::byte> leftBuffer(BufferSize);
-    const auto leftReadSpan = gsl::make_span(leftBuffer);
-    OVERLAPPED leftOverlapped = {0};
-    const wil::unique_event leftOverlappedEvent(wil::EventOptions::None);
-    leftOverlapped.hEvent = leftOverlappedEvent.get();
-    LARGE_INTEGER leftOffset{};
+    io::MultiHandleWait ioWait;
 
-    std::vector<gsl::byte> rightBuffer(BufferSize);
-    const auto rightReadSpan = gsl::make_span(rightBuffer);
-    OVERLAPPED rightOverlapped = {0};
-    const wil::unique_event rightOverlappedEvent(wil::EventOptions::None);
-    rightOverlapped.hEvent = rightOverlappedEvent.get();
-    LARGE_INTEGER rightOffset{};
-
-    bool leftReadPending = false;
-    bool rightReadPending = false;
-    auto cancelReads = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&] {
-        DWORD bytes;
-        if (leftReadPending)
+    auto addRelay = [&](HANDLE Input, HANDLE Output, bool OutputIsSocket) {
+        std::unique_ptr<io::OverlappedIOHandle> relay;
+        if (OutputIsSocket)
         {
-            CancelIoEx(LeftHandle, &leftOverlapped);
-            GetOverlappedResult(LeftHandle, &leftOverlapped, &bytes, TRUE);
-        }
-
-        if (rightReadPending)
-        {
-            CancelIoEx(RightHandle, &rightOverlapped);
-            GetOverlappedResult(RightHandle, &rightOverlapped, &bytes, TRUE);
-        }
-    });
-
-    DWORD bytesWritten;
-    const HANDLE waitObjects[] = {leftOverlapped.hEvent, rightOverlapped.hEvent};
-    for (;;)
-    {
-        if ((LeftHandle == nullptr) || (RightHandle == nullptr))
-        {
-            break;
-        }
-
-        DWORD leftBytesRead = 0;
-        if (!leftReadPending && LeftHandle)
-        {
-            if (!ReadFile(LeftHandle, leftReadSpan.data(), gsl::narrow_cast<DWORD>(leftReadSpan.size()), &leftBytesRead, &leftOverlapped))
-            {
-                THROW_LAST_ERROR_IF(GetLastError() != ERROR_IO_PENDING);
-            }
-
-            leftReadPending = true;
-        }
-
-        DWORD rightBytesRead = 0;
-        if (!rightReadPending && RightHandle)
-        {
-            if (!ReadFile(RightHandle, rightReadSpan.data(), gsl::narrow_cast<DWORD>(rightReadSpan.size()), &rightBytesRead, &rightOverlapped))
-            {
-                THROW_LAST_ERROR_IF(GetLastError() != ERROR_IO_PENDING);
-            }
-
-            rightReadPending = true;
-        }
-
-        const DWORD waitResult = WaitForMultipleObjects(RTL_NUMBER_OF(waitObjects), waitObjects, FALSE, INFINITE);
-        if (waitResult == WAIT_OBJECT_0)
-        {
-            LOG_LAST_ERROR_IF_MSG(
-                !GetOverlappedResult(LeftHandle, &leftOverlapped, &leftBytesRead, FALSE), "WSAGetLastError %d", WSAGetLastError());
-
-            leftReadPending = false;
-            if (leftBytesRead == 0)
-            {
-                LeftHandle = nullptr;
-                if (WI_IsFlagSet(Flags, RelayFlags::RightIsSocket))
-                {
-                    LOG_LAST_ERROR_IF(shutdown(reinterpret_cast<SOCKET>(RightHandle), SD_SEND) == SOCKET_ERROR);
-                }
-            }
-            else if (RightHandle != nullptr)
-            {
-                auto writeSpan = leftReadSpan.first(leftBytesRead);
-                bytesWritten = InterruptableWrite(RightHandle, writeSpan, {}, &leftOverlapped);
-                if (bytesWritten == 0)
-                {
-                    break;
-                }
-
-                leftOffset.QuadPart += leftBytesRead;
-                leftOverlapped.Offset = leftOffset.LowPart;
-                leftOverlapped.OffsetHigh = leftOffset.HighPart;
-            }
-        }
-        else if (waitResult == (WAIT_OBJECT_0 + 1))
-        {
-            LOG_LAST_ERROR_IF_MSG(
-                !GetOverlappedResult(RightHandle, &rightOverlapped, &rightBytesRead, FALSE), "WSAGetLastError %d", WSAGetLastError());
-
-            rightReadPending = false;
-            if (rightBytesRead == 0)
-            {
-                RightHandle = nullptr;
-                if (WI_IsFlagSet(Flags, RelayFlags::LeftIsSocket))
-                {
-                    LOG_LAST_ERROR_IF(shutdown(reinterpret_cast<SOCKET>(LeftHandle), SD_SEND) == SOCKET_ERROR);
-                }
-            }
-            else if (LeftHandle != nullptr)
-            {
-                auto writeSpan = rightReadSpan.first(rightBytesRead);
-                bytesWritten = InterruptableWrite(LeftHandle, writeSpan, {}, &rightOverlapped);
-                if (bytesWritten == 0)
-                {
-                    break;
-                }
-
-                rightOffset.QuadPart += rightBytesRead;
-                rightOverlapped.Offset = rightOffset.LowPart;
-                rightOverlapped.OffsetHigh = rightOffset.HighPart;
-            }
+            relay = std::make_unique<io::HalfCloseRelayHandle>(io::HandleWrapper{Input}, reinterpret_cast<SOCKET>(Output), BufferSize);
         }
         else
         {
-            THROW_HR_MSG(E_FAIL, "WaitForMultipleObjects %d", waitResult);
+            relay = std::make_unique<io::RelayHandle<io::ReadHandle>>(io::HandleWrapper{Input}, io::HandleWrapper{Output}, BufferSize);
         }
-    }
+
+        ioWait.AddHandle(std::move(relay));
+    };
+
+    addRelay(LeftHandle, RightHandle, WI_IsFlagSet(Flags, RelayFlags::RightIsSocket));
+    addRelay(RightHandle, LeftHandle, WI_IsFlagSet(Flags, RelayFlags::LeftIsSocket));
+    ioWait.Run(std::nullopt);
 }
 
 bool wsl::windows::common::relay::StandardInputRelay(HANDLE ConsoleHandle, HANDLE OutputHandle, std::function<void()>&& UpdateTerminalSize, HANDLE ExitEvent)

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -2006,11 +2006,12 @@ class NetworkTests
         return listenSocket;
     }
 
-    static std::tuple<unique_kill_process, bool, wil::unique_handle> BindGuestPortHelper(std::wstring_view BindSpec)
+    static std::tuple<unique_kill_process, bool, wil::unique_handle> BindGuestPortHelper(
+        std::wstring_view BindSpec, std::wstring_view ConnectSpec = L"STDOUT")
     {
         auto [stdErrRead, stdErrWrite] = CreateSubprocessPipe(false, true);
         auto [stdOutRead, stdOutWrite] = CreateSubprocessPipe(false, true);
-        const std::wstring wslCmd = L"socat -dd " + std::wstring(BindSpec) + L" STDOUT";
+        const std::wstring wslCmd = L"socat -dd " + std::wstring(BindSpec) + L" " + std::wstring(ConnectSpec);
         auto cmd = LxssGenerateWslCommandLine(wslCmd.data());
 
         auto process = LxsstuStartProcess(cmd.data(), nullptr, stdOutWrite.get(), stdErrWrite.get());
@@ -2059,9 +2060,10 @@ class NetworkTests
         return std::tuple(std::move(process), success, std::move(stdOutRead));
     }
 
-    static std::tuple<unique_kill_process, wil::unique_handle> BindGuestPort(std::wstring_view BindSpec, bool ExpectSuccess)
+    static std::tuple<unique_kill_process, wil::unique_handle> BindGuestPort(
+        std::wstring_view BindSpec, bool ExpectSuccess, std::wstring_view ConnectSpec = L"STDOUT")
     {
-        auto [process, success, read] = BindGuestPortHelper(BindSpec);
+        auto [process, success, read] = BindGuestPortHelper(BindSpec, ConnectSpec);
 
         VERIFY_ARE_EQUAL(ExpectSuccess, success);
 
@@ -2628,6 +2630,24 @@ class NetworkTests
         }
     }
 
+    static wil::unique_socket ConnectToLocalhostRelay(ADDRESS_FAMILY addressFamily, unsigned short port)
+    {
+        wil::unique_socket hostSocket;
+        SOCKADDR_INET address{};
+        address.si_family = addressFamily;
+        INETADDR_SETLOOPBACK(reinterpret_cast<PSOCKADDR>(&address));
+        SS_PORT(&address) = htons(port);
+
+        auto connectToRelay = [&]() {
+            hostSocket.reset(socket(addressFamily, SOCK_STREAM, IPPROTO_TCP));
+            THROW_HR_IF(E_ABORT, !hostSocket);
+            THROW_HR_IF(E_FAIL, connect(hostSocket.get(), reinterpret_cast<SOCKADDR*>(&address), sizeof(address)) == SOCKET_ERROR);
+        };
+
+        wsl::shared::retry::RetryWithTimeout<void>(connectToRelay, std::chrono::seconds(1), std::chrono::minutes(1));
+        return hostSocket;
+    }
+
     WSL2_TEST_METHOD(NatLocalhostRelay)
     {
         WslKeepAlive keepAlive;
@@ -2643,6 +2663,118 @@ class NetworkTests
 
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(L"test -f /proc/net/tcp6"), 1L);
         ValidateLocalhostRelayTraffic(AF_INET);
+    }
+
+    WSL2_TEST_METHOD(NatLocalhostRelayHalfClose)
+    {
+        WslKeepAlive keepAlive;
+
+        constexpr auto scriptPath = L"/tmp/wsl-relay-half-close";
+        DistroFileChange script(scriptPath, false);
+        script.SetContent(L"#!/bin/sh\ninput=$(cat)\nprintf '%s' \"$input\"\n");
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"chmod +x {}", scriptPath)), 0L);
+
+        auto [guestProcess, _] = BindGuestPort(L"TCP4-LISTEN:1235,bind=127.0.0.1", true, std::format(L"EXEC:{}", scriptPath));
+        auto hostSocket = ConnectToLocalhostRelay(AF_INET, 1235);
+
+        constexpr DWORD timeout = 10'000;
+        VERIFY_ARE_NOT_EQUAL(
+            setsockopt(hostSocket.get(), SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout), sizeof(timeout)), SOCKET_ERROR);
+
+        constexpr std::string_view payload = "response-after-host-half-close";
+        WriteSocket(hostSocket.get(), payload.data(), payload.size());
+        VERIFY_ARE_EQUAL(shutdown(hostSocket.get(), SD_SEND), 0);
+        VERIFY_ARE_EQUAL(ReadToString(hostSocket.get()), payload);
+    }
+
+    WSL2_TEST_METHOD(NatLocalhostRelayFullDuplex)
+    {
+        WslKeepAlive keepAlive;
+
+        constexpr auto scriptPath = L"/tmp/wsl-relay-full-duplex";
+        constexpr auto sendSignalPath = L"/tmp/wsl-relay-full-duplex-send";
+        constexpr auto drainSignalPath = L"/tmp/wsl-relay-full-duplex-drain";
+        DistroFileChange script(scriptPath, false);
+        script.SetContent(std::format(
+                              L"#!/bin/sh\n"
+                              L"while [ ! -e {0} ]; do sleep 0.1; done\n"
+                              L"printf 'response-while-forward-blocked'\n"
+                              L"while [ ! -e {1} ]; do sleep 0.1; done\n"
+                              L"cat >/dev/null\n",
+                              sendSignalPath,
+                              drainSignalPath)
+                              .c_str());
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"chmod +x {}", scriptPath)), 0L);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"rm -f {} {}", sendSignalPath, drainSignalPath)), 0L);
+        auto cleanupSignals = wil::scope_exit_log(
+            WI_DIAGNOSTICS_INFO, [&]() { LxsstuLaunchWsl(std::format(L"rm -f {} {}", sendSignalPath, drainSignalPath)); });
+
+        auto [guestProcess, _] = BindGuestPort(L"TCP4-LISTEN:1236,bind=127.0.0.1", true, std::format(L"EXEC:{}", scriptPath));
+        auto hostSocket = ConnectToLocalhostRelay(AF_INET, 1236);
+
+        constexpr DWORD timeout = 10'000;
+        constexpr int socketBufferSize = 16 * 1024;
+        VERIFY_ARE_NOT_EQUAL(
+            setsockopt(hostSocket.get(), SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout), sizeof(timeout)), SOCKET_ERROR);
+        VERIFY_ARE_NOT_EQUAL(
+            setsockopt(hostSocket.get(), SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char*>(&timeout), sizeof(timeout)), SOCKET_ERROR);
+        VERIFY_ARE_NOT_EQUAL(
+            setsockopt(hostSocket.get(), SOL_SOCKET, SO_RCVBUF, reinterpret_cast<const char*>(&socketBufferSize), sizeof(socketBufferSize)),
+            SOCKET_ERROR);
+        VERIFY_ARE_NOT_EQUAL(
+            setsockopt(hostSocket.get(), SOL_SOCKET, SO_SNDBUF, reinterpret_cast<const char*>(&socketBufferSize), sizeof(socketBufferSize)),
+            SOCKET_ERROR);
+
+        // The guest does not read from the connection until drainSignalPath exists. Fill the host-to-guest path
+        // until it applies backpressure, then trigger a guest-to-host write and verify that it progresses independently.
+        u_long nonBlocking = 1;
+        VERIFY_ARE_EQUAL(ioctlsocket(hostSocket.get(), FIONBIO, &nonBlocking), 0);
+
+        const std::string payload(64 * 1024, 'x');
+        bool sendBlocked = false;
+        const auto sendDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        while (std::chrono::steady_clock::now() < sendDeadline)
+        {
+            const auto bytesSent = send(hostSocket.get(), payload.data(), static_cast<int>(payload.size()), 0);
+            if (bytesSent > 0)
+            {
+                continue;
+            }
+
+            const auto error = WSAGetLastError();
+            THROW_HR_IF(HRESULT_FROM_WIN32(error), error != WSAEWOULDBLOCK);
+            sendBlocked = true;
+            break;
+        }
+        VERIFY_IS_TRUE(sendBlocked);
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"touch {}", sendSignalPath)), 0L);
+
+        constexpr std::string_view response = "response-while-forward-blocked";
+        std::string received;
+        wsl::shared::retry::RetryWithTimeout<void>(
+            [&]() {
+                std::array<char, 64> receiveBuffer{};
+                const auto bytesReceived = recv(hostSocket.get(), receiveBuffer.data(), static_cast<int>(receiveBuffer.size()), 0);
+                if (bytesReceived == SOCKET_ERROR)
+                {
+                    const auto error = WSAGetLastError();
+                    THROW_HR_IF(HRESULT_FROM_WIN32(error), error != WSAEWOULDBLOCK);
+                }
+                else
+                {
+                    THROW_HR_IF(E_UNEXPECTED, bytesReceived == 0);
+                    received.append(receiveBuffer.data(), static_cast<size_t>(bytesReceived));
+                }
+
+                THROW_HR_IF(E_PENDING, received.size() < response.size());
+            },
+            std::chrono::milliseconds(100),
+            std::chrono::seconds(10));
+        VERIFY_ARE_EQUAL(received, response);
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"touch {}", drainSignalPath)), 0L);
+        VERIFY_ARE_EQUAL(shutdown(hostSocket.get(), SD_SEND), 0);
     }
 
     static void TestNonRootNamespaceEphemeralBind()

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -32,6 +32,7 @@ Abstract:
 #include "WslCoreConfigInterface.h"
 #include "CommandLine.h"
 #include "retryshared.h"
+#include "relay.hpp"
 
 #define LXSST_TEST_USERNAME L"kerneltest"
 
@@ -7928,6 +7929,50 @@ Error code: Wsl/InstallDistro/WSL_E_INVALID_JSON\r\n",
         }
 
         VERIFY_ARE_EQUAL(baselineCodePage, GetConsoleOutputCP(), L"Destruction restores the code page saved on the first call");
+    }
+
+    TEST_METHOD(BidirectionalRelayContinuesAfterHalfClose)
+    {
+        auto [leftPeer, leftRelay] = MakeSocketPair();
+        auto [rightPeer, rightRelay] = MakeSocketPair();
+
+        constexpr DWORD timeout = 5000;
+        THROW_LAST_ERROR_IF(
+            setsockopt(leftPeer.get(), SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout), sizeof(timeout)) == SOCKET_ERROR);
+        THROW_LAST_ERROR_IF(
+            setsockopt(rightPeer.get(), SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout), sizeof(timeout)) == SOCKET_ERROR);
+
+        HRESULT relayResult = S_OK;
+        std::thread relayThread([&]() {
+            relayResult = wil::ResultFromException(
+                [&]() { wsl::windows::common::relay::SocketRelay(leftRelay.get(), rightRelay.get(), 0x20000); });
+        });
+
+        auto cleanup = wil::scope_exit([&]() {
+            leftPeer.reset();
+            leftRelay.reset();
+            rightPeer.reset();
+            rightRelay.reset();
+            if (relayThread.joinable())
+            {
+                relayThread.join();
+            }
+        });
+
+        // Closing the left-to-right direction must propagate EOF without stopping the opposite direction.
+        VERIFY_ARE_EQUAL(shutdown(leftPeer.get(), SD_SEND), 0);
+        char byte{};
+        VERIFY_ARE_EQUAL(recv(rightPeer.get(), &byte, sizeof(byte), 0), 0);
+
+        constexpr std::string_view response = "response-after-half-close";
+        WriteSocket(rightPeer.get(), response.data(), response.size());
+        VERIFY_ARE_EQUAL(shutdown(rightPeer.get(), SD_SEND), 0);
+
+        VERIFY_ARE_EQUAL(ReadToString(leftPeer.get()), response);
+
+        relayThread.join();
+        VERIFY_ARE_EQUAL(relayResult, S_OK);
+        cleanup.release();
     }
 
 }; // namespace UnitTests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This is a continuation of @wangxin12's work in #40171.

The original localhost relay, on both sides, would:
1. Block the other direction's traffic if one direction's write would block.
2. Close both sides if one side's read is closed. Which causes problems in half close socket scenarios.

This PR makes these changes to support full duplex traffic and half close socket in NAT localhost relay:
1. Refactor the windows bi-directional relay with `MultiHandleWait` with a new half close capable relay handle.
2. Refactor the Linux relay with a fully event driven non-blocking epoll loop. Which also avoids creating a new thread for each connection.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #10688
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Add tests:
NetworkTests::NetworkTests::NatLocalhostRelayHalfClose
NetworkTests::NetworkTests::NatLocalhostRelayFullDuplex
UnitTests::UnitTests::BidirectionalRelayContinuesAfterHalfClose