### PR TITLE
Fix activating a stopping service treated as OOM

### DIFF
--- a/src/windows/service/exe/LxssUserSessionFactory.cpp
+++ b/src/windows/service/exe/LxssUserSessionFactory.cpp
@@ -167,7 +167,6 @@ HRESULT LxssUserSessionFactory::CreateInstance(_In_ IUnknown* pUnkOuter, _In_ RE
     }
     CATCH_RETURN()
 
-
     WSL_LOG("LxssUserSessionCreateInstanceEnd", TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
 
     return S_OK;

--- a/src/windows/service/exe/LxssUserSessionFactory.cpp
+++ b/src/windows/service/exe/LxssUserSessionFactory.cpp
@@ -167,6 +167,7 @@ HRESULT LxssUserSessionFactory::CreateInstance(_In_ IUnknown* pUnkOuter, _In_ RE
     }
     CATCH_RETURN()
 
+
     WSL_LOG("LxssUserSessionCreateInstanceEnd", TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
 
     return S_OK;

--- a/src/windows/service/exe/LxssUserSessionFactory.cpp
+++ b/src/windows/service/exe/LxssUserSessionFactory.cpp
@@ -165,13 +165,7 @@ HRESULT LxssUserSessionFactory::CreateInstance(_In_ IUnknown* pUnkOuter, _In_ RE
         const auto userSession = wil::MakeOrThrow<LxssUserSession>(instance);
         THROW_IF_FAILED(userSession.CopyTo(riid, ppCreated));
     }
-    catch (...)
-    {
-        const auto result = wil::ResultFromCaughtException();
-
-        // Note: S_FALSE will cause COM to retry if the service is stopping.
-        return result == CO_E_SERVER_STOPPING ? S_FALSE : result;
-    }
+    CATCH_RETURN()
 
     WSL_LOG("LxssUserSessionCreateInstanceEnd", TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
 

--- a/src/windows/service/exe/WSLCSessionManagerFactory.cpp
+++ b/src/windows/service/exe/WSLCSessionManagerFactory.cpp
@@ -57,13 +57,7 @@ HRESULT WSLCSessionManagerFactory::CreateInstance(_In_ IUnknown* pUnkOuter, _In_
 
         THROW_IF_FAILED(g_sessionManager.CopyTo(riid, ppCreated));
     }
-    catch (...)
-    {
-        const auto result = wil::ResultFromCaughtException();
-
-        // Note: S_FALSE will cause COM to retry if the service is stopping.
-        return result == CO_E_SERVER_STOPPING ? S_FALSE : result;
-    }
+    CATCH_RETURN()
 
     return S_OK;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The current factory function for LxssUserSession and WSLCSessionManager translates the error code `CO_E_SERVER_STOPPING` to `S_FALSE`. Which combined with `*ppCreated == NULL` causes COM to treat this as an OOM. Leading to error messages like this when activating a stopping service:
```
Not enough memory resources are available to complete this operation.
Error code: Wsl/E_OUTOFMEMORY
```

This PR removes this conversion. So, COM actually retries when the service is stopping. And returns `CO_E_SERVER_EXEC_FAILURE` if the retry times out. 

## Note

The original `S_FALSE will cause COM to retry if the service is stopping.` comment is confusing. There is no public documentation on this behavior. And after reading the Windows source code. It's actually the `CO_E_SERVER_STOPPING` code that will tell COM to retry. And COM will retry up to 4 mins. 
I'm not sure if the original code intended to retry or to not retry. This PR's current change assumes we should retry here. If the intention is to fail fast without the COM retry, a fix would be converting the error code to a failure like `HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS)` instead. So it's not treated as OOM by COM and produces correct error messages on the client side.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #41449 partially. Why the WSLC VM got into that stuck stopping state is unclear.
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested by injecting a `CO_E_SERVICE_STOPPING` in the factory. And:
1. Manually activate the COM service.
2. Call wsl.

Before the fix:
The manual activation fails immediately, and wsl call reports `Wsl/E_OUTOFMEMORY`

After the fix:
The manual activation fails after 2-4 minutes*, and wsl call reports `Wsl/CO_E_SERVER_EXEC_FAILURE`

\* The first two run waited for 4 min. The third run waited for 2 min.