### PR TITLE
Fix unnecessary delay in the port tracking loop

### DIFF
--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -23,8 +23,6 @@
 
 constexpr size_t c_bind_timeout_seconds = 60;
 constexpr auto c_sock_diag_refresh_delay = std::chrono::milliseconds(500);
-constexpr auto c_sock_diag_poll_timeout = std::chrono::milliseconds(10);
-constexpr auto c_bpf_poll_timeout = std::chrono::milliseconds(500);
 
 GnsPortTracker::GnsPortTracker(
     std::shared_ptr<wsl::shared::SocketChannel> hvSocketChannel,
@@ -54,11 +52,10 @@ void GnsPortTracker::RunPortRefresh()
         // Netlink will sometimes return EBUSY. Don't fail for that
         try
         {
-            std::promise<void> resume;
-            auto result = PortRefreshResult{ListAllocatedPorts(), time(nullptr), std::bind(&std::promise<void>::set_value, &resume)};
-            m_allocatedPortsRefresh.set_value(result);
+            auto result = PortRefreshResult{ListAllocatedPorts(), time(nullptr)};
+            m_events.post(TrackerEvent{std::move(result)});
 
-            resume.get_future().wait();
+            m_portRefreshResume.get();
         }
         catch (const NetlinkTransactionError& e)
         {
@@ -74,8 +71,7 @@ void GnsPortTracker::RunPortRefresh()
 
 int GnsPortTracker::ProcessSecCompNotification(seccomp_notif* notification)
 {
-    seccomp_notif notificationCopy = *notification;
-    m_request.post(notificationCopy);
+    m_events.post(TrackerEvent{*notification});
     return m_reply.get();
 }
 
@@ -88,103 +84,93 @@ void GnsPortTracker::Run()
 
     std::thread{std::bind(&GnsPortTracker::RunPortRefresh, this)}.detach();
 
-    auto future = std::make_optional(m_allocatedPortsRefresh.get_future());
-    std::optional<PortRefreshResult> refreshResult;
+    bool portRefreshAwaitingAcknowledgement = false;
 
     for (;;)
     {
-        std::optional<BindCall> bindCall;
-        try
+        auto event = m_events.get();
+        if (const auto* notification = std::get_if<seccomp_notif>(&event))
         {
-            bindCall = ReadNextRequest();
-        }
-        catch (const std::exception& e)
-        {
-            GNS_LOG_ERROR("Failed to read bind request, {}", e.what());
-        }
-
-        if (bindCall.has_value())
-        {
-            int result = 0;
-            if (bindCall->Request.has_value())
-            {
-                PortAllocation& allocationRequest = bindCall->Request.value();
-                result = HandleRequest(allocationRequest);
-                if (result == 0)
-                {
-                    TrackPort(allocationRequest);
-                    GNS_LOG_INFO(
-                        "Tracking bind call: family ({}) port ({}) protocol ({})",
-                        allocationRequest.Family,
-                        allocationRequest.Port,
-                        allocationRequest.Protocol);
-                }
-            }
-
+            std::optional<BindCall> bindCall;
             try
             {
-                CompleteRequest(bindCall->CallId, result);
+                bindCall = ReadRequest(*notification);
             }
             catch (const std::exception& e)
             {
-                GNS_LOG_ERROR("Failed to complete bind request, {}", e.what());
+                GNS_LOG_ERROR("Failed to read bind request, {}", e.what());
             }
 
-            if (bindCall->PortZeroBind.has_value())
+            if (bindCall.has_value())
             {
+                int result = 0;
+                if (bindCall->Request.has_value())
+                {
+                    PortAllocation& allocationRequest = bindCall->Request.value();
+                    result = HandleRequest(allocationRequest);
+                    if (result == 0)
+                    {
+                        TrackPort(allocationRequest);
+                        GNS_LOG_INFO(
+                            "Tracking bind call: family ({}) port ({}) protocol ({})",
+                            allocationRequest.Family,
+                            allocationRequest.Port,
+                            allocationRequest.Protocol);
+                    }
+                }
+
                 try
                 {
-                    auto allocation = ResolvePortZeroBind(std::move(bindCall->PortZeroBind.value()));
-                    if (allocation.has_value())
-                    {
-                        const auto portResult = HandleRequest(allocation.value());
-                        if (portResult == 0)
-                        {
-                            TrackPort(std::move(allocation.value()));
-                        }
-                        else
-                        {
-                            GNS_LOG_ERROR(
-                                "Failed to register resolved port-0 bind: family ({}) port ({}) protocol ({}), error {}",
-                                allocation->Family,
-                                allocation->Port,
-                                allocation->Protocol,
-                                portResult);
-                        }
-                    }
+                    CompleteRequest(result);
                 }
                 catch (const std::exception& e)
                 {
-                    GNS_LOG_ERROR("Failed to resolve port-0 bind, {}", e.what());
+                    GNS_LOG_ERROR("Failed to complete bind request, {}", e.what());
+                }
+
+                if (bindCall->PortZeroBind.has_value())
+                {
+                    try
+                    {
+                        auto allocation = ResolvePortZeroBind(std::move(bindCall->PortZeroBind.value()));
+                        if (allocation.has_value())
+                        {
+                            const auto portResult = HandleRequest(allocation.value());
+                            if (portResult == 0)
+                            {
+                                TrackPort(std::move(allocation.value()));
+                            }
+                            else
+                            {
+                                GNS_LOG_ERROR(
+                                    "Failed to register resolved port-0 bind: family ({}) port ({}) protocol ({}), error {}",
+                                    allocation->Family,
+                                    allocation->Port,
+                                    allocation->Protocol,
+                                    portResult);
+                            }
+                        }
+                    }
+                    catch (const std::exception& e)
+                    {
+                        GNS_LOG_ERROR("Failed to resolve port-0 bind, {}", e.what());
+                    }
                 }
             }
         }
-
-        // If bindCall is empty, then the read() timed out. Look for any closed port
-        if (future.has_value() && future->wait_for(c_sock_diag_poll_timeout) == std::future_status::ready)
+        else
         {
-            refreshResult.emplace(future->get());
-            future.reset();
-            m_allocatedPortsRefresh = {};
+            auto refreshResult = std::get<PortRefreshResult>(std::move(event));
+            OnRefreshAllocatedPorts(refreshResult.Ports, refreshResult.Timestamp);
 
-            // If this loop's iteration had a bind call, it's possible that RefreshAllocatedPort
-            // was called before the bind called was processed. Make sure that the port list
-            // is up to date (If this is called, the next block will schedule another refresh)
-            if (!bindCall.has_value())
-            {
-                OnRefreshAllocatedPorts(refreshResult->Ports, refreshResult->Timestamp);
-            }
+            portRefreshAwaitingAcknowledgement = true;
         }
 
         // Only look at bound ports if there's something to deallocate to avoid wasting cycles
-        if (refreshResult.has_value())
+        if (portRefreshAwaitingAcknowledgement && !m_allocatedPorts.empty())
         {
-            if (!m_allocatedPorts.empty())
-            {
-                future = m_allocatedPortsRefresh.get_future();
-                refreshResult->Resume(); // This will resume the sock_diag thread
-                refreshResult.reset();
-            }
+            m_portRefreshResume.post(true);
+            portRefreshAwaitingAcknowledgement = false;
         }
     }
 }
@@ -344,17 +330,8 @@ int GnsPortTracker::HandleRequest(const PortAllocation& Port)
     return error;
 }
 
-std::optional<GnsPortTracker::BindCall> GnsPortTracker::ReadNextRequest()
+std::optional<GnsPortTracker::BindCall> GnsPortTracker::ReadRequest(const seccomp_notif& Notification)
 {
-    // Read the call information
-    auto request_value = m_request.try_get(c_bpf_poll_timeout);
-    if (!request_value.has_value())
-    {
-        return {};
-    }
-
-    auto callInfo = request_value.value();
-
     // This logic needs to be defensive because the calling process is blocked until
     // CompleteRequest() is called, so if the call information can't be processed because
     // the caller has done something wrong (bad pointer, fd, or protocol), just let it go through
@@ -362,17 +339,18 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::ReadNextRequest()
 
     try
     {
-        return GetCallInfo(callInfo.id, callInfo.pid, callInfo.data.arch, callInfo.data.nr, gsl::make_span(callInfo.data.args));
+        return GetCallInfo(
+            Notification.id, Notification.pid, Notification.data.arch, Notification.data.nr, gsl::make_span(Notification.data.args));
     }
     catch (const std::exception& e)
     {
-        GNS_LOG_ERROR("Failed to read bind() call info with ID {} for pid {}, {}", callInfo.id, callInfo.pid, e.what());
-        return {{{}, {}, callInfo.id}};
+        GNS_LOG_ERROR("Failed to read bind() call info with ID {} for pid {}, {}", Notification.id, Notification.pid, e.what());
+        return {{{}, {}, Notification.id}};
     }
 }
 
 std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
-    uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<unsigned long long>& Arguments)
+    uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<const unsigned long long>& Arguments)
 {
     auto ParseSocket = [&](int Socket, size_t AddressPtr, size_t AddressLength) -> std::optional<BindCall> {
         if (AddressLength < sizeof(sockaddr) || AddressLength > sizeof(sockaddr_storage))
@@ -583,7 +561,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
 #endif
 }
 
-void GnsPortTracker::CompleteRequest(uint64_t id, int result)
+void GnsPortTracker::CompleteRequest(int result)
 {
     m_reply.post(result);
 }

--- a/src/linux/init/GnsPortTracker.cpp
+++ b/src/linux/init/GnsPortTracker.cpp
@@ -88,26 +88,41 @@ void GnsPortTracker::Run()
 
     for (;;)
     {
-        auto event = m_events.get();
-        if (const auto* notification = std::get_if<seccomp_notif>(&event))
+        try
         {
-            std::optional<BindCall> bindCall;
-            try
-            {
-                bindCall = ReadRequest(*notification);
-            }
-            catch (const std::exception& e)
-            {
-                GNS_LOG_ERROR("Failed to read bind request, {}", e.what());
-            }
-
-            if (bindCall.has_value())
-            {
-                int result = 0;
-                if (bindCall->Request.has_value())
+            auto resumeRefresh = wil::scope_exit([&]() {
+                try
                 {
-                    PortAllocation& allocationRequest = bindCall->Request.value();
-                    result = HandleRequest(allocationRequest);
+                    if (portRefreshAwaitingAcknowledgement && !m_allocatedPorts.empty())
+                    {
+                        m_portRefreshResume.post(true);
+                        portRefreshAwaitingAcknowledgement = false;
+                    }
+                }
+                CATCH_LOG()
+            });
+
+            auto event = m_events.get();
+            if (const auto* notification = std::get_if<seccomp_notif>(&event))
+            {
+                int result = EIO;
+                auto replyGuard = wil::scope_exit([&]() {
+                    try
+                    {
+                        CompleteRequest(result);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        GNS_LOG_ERROR("Failed to complete bind request, {}", e.what());
+                    }
+                });
+
+                auto bindCall = ReadRequest(*notification);
+                if (bindCall.Request.has_value())
+                {
+                    PortAllocation& allocationRequest = bindCall.Request.value();
+                    const auto requestResult = HandleRequest(allocationRequest);
+                    result = requestResult;
                     if (result == 0)
                     {
                         TrackPort(allocationRequest);
@@ -118,21 +133,19 @@ void GnsPortTracker::Run()
                             allocationRequest.Protocol);
                     }
                 }
-
-                try
+                else
                 {
-                    CompleteRequest(result);
-                }
-                catch (const std::exception& e)
-                {
-                    GNS_LOG_ERROR("Failed to complete bind request, {}", e.what());
+                    // No host reservation is needed. This also allows port-zero binds to complete before resolving the assigned port.
+                    result = 0;
                 }
 
-                if (bindCall->PortZeroBind.has_value())
+                replyGuard.reset();
+
+                if (bindCall.PortZeroBind.has_value())
                 {
                     try
                     {
-                        auto allocation = ResolvePortZeroBind(std::move(bindCall->PortZeroBind.value()));
+                        auto allocation = ResolvePortZeroBind(std::move(bindCall.PortZeroBind.value()));
                         if (allocation.has_value())
                         {
                             const auto portResult = HandleRequest(allocation.value());
@@ -157,21 +170,15 @@ void GnsPortTracker::Run()
                     }
                 }
             }
-        }
-        else
-        {
-            auto refreshResult = std::get<PortRefreshResult>(std::move(event));
-            OnRefreshAllocatedPorts(refreshResult.Ports, refreshResult.Timestamp);
+            else
+            {
+                auto refreshResult = std::get<PortRefreshResult>(std::move(event));
+                portRefreshAwaitingAcknowledgement = true;
 
-            portRefreshAwaitingAcknowledgement = true;
+                OnRefreshAllocatedPorts(refreshResult.Ports, refreshResult.Timestamp);
+            }
         }
-
-        // Only look at bound ports if there's something to deallocate to avoid wasting cycles
-        if (portRefreshAwaitingAcknowledgement && !m_allocatedPorts.empty())
-        {
-            m_portRefreshResume.post(true);
-            portRefreshAwaitingAcknowledgement = false;
-        }
+        CATCH_LOG()
     }
 }
 
@@ -330,7 +337,7 @@ int GnsPortTracker::HandleRequest(const PortAllocation& Port)
     return error;
 }
 
-std::optional<GnsPortTracker::BindCall> GnsPortTracker::ReadRequest(const seccomp_notif& Notification)
+GnsPortTracker::BindCall GnsPortTracker::ReadRequest(const seccomp_notif& Notification)
 {
     // This logic needs to be defensive because the calling process is blocked until
     // CompleteRequest() is called, so if the call information can't be processed because
@@ -345,24 +352,23 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::ReadRequest(const seccom
     catch (const std::exception& e)
     {
         GNS_LOG_ERROR("Failed to read bind() call info with ID {} for pid {}, {}", Notification.id, Notification.pid, e.what());
-        return {{{}, {}, Notification.id}};
+        return {{}, {}, Notification.id};
     }
 }
 
-std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
-    uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<const unsigned long long>& Arguments)
+GnsPortTracker::BindCall GnsPortTracker::GetCallInfo(uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<const unsigned long long>& Arguments)
 {
-    auto ParseSocket = [&](int Socket, size_t AddressPtr, size_t AddressLength) -> std::optional<BindCall> {
+    auto ParseSocket = [&](int Socket, size_t AddressPtr, size_t AddressLength) -> BindCall {
         if (AddressLength < sizeof(sockaddr) || AddressLength > sizeof(sockaddr_storage))
         {
-            return {{{}, {}, CallId}}; // Invalid sockaddr. Let it go through.
+            return {{}, {}, CallId}; // Invalid sockaddr. Let it go through.
         }
 
         auto networkNamespace = std::filesystem::read_symlink(std::format("/proc/{}/ns/net", Pid)).string();
         if (networkNamespace != m_networkNamespace)
         {
             GNS_LOG_INFO("Skipping bind() call for pid {} in network namespace {}", Pid, networkNamespace.c_str());
-            return {{{}, {}, CallId}}; // Different network namespace. Let it go through.
+            return {{}, {}, CallId}; // Different network namespace. Let it go through.
         }
 
         auto processMemory = m_seccompDispatcher->ReadProcessMemory(CallId, Pid, AddressPtr, AddressLength);
@@ -376,7 +382,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
         if ((address.sa_family != AF_INET && address.sa_family != AF_INET6) ||
             (address.sa_family == AF_INET6 && AddressLength < sizeof(sockaddr_in6)))
         {
-            return {{{}, {}, CallId}}; // This is a non IP call, or invalid sockaddr_in6. Let it go through
+            return {{}, {}, CallId}; // This is a non IP call, or invalid sockaddr_in6. Let it go through
         }
 
         // Read the port.  The port *happens* to be in the same spot in memory for both sockaddr_in
@@ -398,17 +404,17 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
                 auto dupFd = DuplicateSocketFd(Pid, Socket);
                 if (!dupFd)
                 {
-                    return {{{}, {}, CallId}};
+                    return {{}, {}, CallId};
                 }
                 if (!m_seccompDispatcher->ValidateCookie(CallId))
                 {
-                    return {{{}, {}, CallId}};
+                    return {{}, {}, CallId};
                 }
-                return {{{}, DeferredPortLookup{Pid, std::move(dupFd), protocol}, CallId}};
+                return {{}, DeferredPortLookup{Pid, std::move(dupFd), protocol}, CallId};
             }
             catch (const std::exception&)
             {
-                return {{{}, {}, CallId}}; // Can't determine protocol, just let it through
+                return {{}, {}, CallId}; // Can't determine protocol, just let it through
             }
         }
 
@@ -436,7 +442,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
             throw RuntimeErrorWithSourceLocation(std::format("Invalid call id {}", CallId));
         }
 
-        return {{{PortAllocation(port, address.sa_family, protocol, storedAddress)}, {}, CallId}};
+        return {PortAllocation(port, address.sa_family, protocol, storedAddress), {}, CallId};
     };
 
     // listen() can trigger an implicit autobind (assigning an ephemeral port) on a socket that
@@ -446,25 +452,25 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
     // bind()+listen() case), resolve the port synchronously here. Otherwise defer resolution to
     // ResolvePortZeroBind(), the same as a bind(port=0) call, since the port isn't assigned until
     // the listen() syscall (which performs the implicit autobind) actually completes in-kernel.
-    auto ParseListen = [&](int Socket) -> std::optional<BindCall> {
+    auto ParseListen = [&](int Socket) -> BindCall {
         try
         {
             auto networkNamespace = std::filesystem::read_symlink(std::format("/proc/{}/ns/net", Pid)).string();
             if (networkNamespace != m_networkNamespace)
             {
                 GNS_LOG_INFO("Skipping listen() call for pid {} in network namespace {}", Pid, networkNamespace.c_str());
-                return {{{}, {}, CallId}}; // Different network namespace. Let it go through.
+                return {{}, {}, CallId}; // Different network namespace. Let it go through.
             }
 
             const int protocol = GetSocketProtocol(Pid, Socket);
             auto dupFd = DuplicateSocketFd(Pid, Socket);
             if (!dupFd)
             {
-                return {{{}, {}, CallId}};
+                return {{}, {}, CallId};
             }
             if (!m_seccompDispatcher->ValidateCookie(CallId))
             {
-                return {{{}, {}, CallId}};
+                return {{}, {}, CallId};
             }
 
             // If the socket was already explicitly bind()'d - the common case of a normal
@@ -494,15 +500,15 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
 
                 if (port != 0)
                 {
-                    return {{{PortAllocation(port, static_cast<int>(storage.ss_family), protocol, address)}, {}, CallId}};
+                    return {PortAllocation(port, static_cast<int>(storage.ss_family), protocol, address), {}, CallId};
                 }
             }
 
-            return {{{}, DeferredPortLookup{Pid, std::move(dupFd), protocol}, CallId}};
+            return {{}, DeferredPortLookup{Pid, std::move(dupFd), protocol}, CallId};
         }
         catch (const std::exception&)
         {
-            return {{{}, {}, CallId}}; // Not an IP socket (or can't determine its protocol), just let it through
+            return {{}, {}, CallId}; // Not an IP socket (or can't determine its protocol), just let it through
         }
     };
 
@@ -536,7 +542,7 @@ std::optional<GnsPortTracker::BindCall> GnsPortTracker::GetCallInfo(
 
         if (Arguments[0] != SYS_BIND)
         {
-            return {{{}, {}, CallId}}; // Not a bind or listen call, just let the call go through
+            return {{}, {}, CallId}; // Not a bind or listen call, just let the call go through
         }
         // Grab the first 3 parameters
         auto processMemory = m_seccompDispatcher->ReadProcessMemory(CallId, Pid, Arguments[1], sizeof(uint32_t) * 3);

--- a/src/linux/init/GnsPortTracker.h
+++ b/src/linux/init/GnsPortTracker.h
@@ -149,9 +149,9 @@ private:
 
     ActivePorts ListAllocatedPorts();
 
-    std::optional<BindCall> ReadRequest(const seccomp_notif& Notification);
+    BindCall ReadRequest(const seccomp_notif& Notification);
 
-    std::optional<BindCall> GetCallInfo(uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<const unsigned long long>& Arguments);
+    BindCall GetCallInfo(uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<const unsigned long long>& Arguments);
 
     int RequestPort(const PortAllocation& Port, bool Allocate);
 

--- a/src/linux/init/GnsPortTracker.h
+++ b/src/linux/init/GnsPortTracker.h
@@ -5,8 +5,8 @@
 #include <set>
 #include <utility>
 #include <optional>
+#include <variant>
 #include <NetlinkChannel.h>
-#include <future>
 #include <functional>
 #include <memory>
 #include <time.h>
@@ -134,8 +134,9 @@ private:
     {
         ActivePorts Ports;
         time_t Timestamp;
-        std::function<void()> Resume;
     };
+
+    using TrackerEvent = std::variant<seccomp_notif, PortRefreshResult>;
 
     bool IsMirroredMode() const
     {
@@ -148,15 +149,15 @@ private:
 
     ActivePorts ListAllocatedPorts();
 
-    std::optional<BindCall> ReadNextRequest();
+    std::optional<BindCall> ReadRequest(const seccomp_notif& Notification);
 
-    std::optional<BindCall> GetCallInfo(uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<unsigned long long>& Arguments);
+    std::optional<BindCall> GetCallInfo(uint64_t CallId, pid_t Pid, int Arch, int SysCallNumber, const gsl::span<const unsigned long long>& Arguments);
 
     int RequestPort(const PortAllocation& Port, bool Allocate);
 
     int HandleRequest(const PortAllocation& Request);
 
-    void CompleteRequest(uint64_t Id, int Result);
+    void CompleteRequest(int Result);
 
     static int GetSocketProtocol(int Pid, int Fd);
 
@@ -169,10 +170,10 @@ private:
     std::map<PortAllocation, std::optional<time_t>> m_allocatedPorts;
     std::shared_ptr<wsl::shared::SocketChannel> m_hvSocketChannel;
     NetlinkChannel m_channel;
-    std::promise<PortRefreshResult> m_allocatedPortsRefresh;
 
-    WaitableValue<seccomp_notif> m_request;
+    WaitableValue<TrackerEvent> m_events;
     WaitableValue<int> m_reply;
+    WaitableValue<bool> m_portRefreshResume;
 
     std::shared_ptr<SecCompDispatcher> m_seccompDispatcher;
 

--- a/src/linux/init/waitablevalue.h
+++ b/src/linux/init/waitablevalue.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <mutex>
 #include <condition_variable>
+#include <utility>
 
 /**
  * @brief Class that contains a value T that can contain a single value and
@@ -21,14 +22,14 @@ public:
      *
      * @param[in] value Value to be stored.
      */
-    void post(T& value)
+    void post(T value)
     {
         std::unique_lock lck(m_mtx);
         while (m_value.has_value())
         {
             m_cv.wait(lck);
         }
-        m_value = value;
+        m_value.emplace(std::move(value));
         m_cv.notify_all();
     }
 
@@ -44,7 +45,7 @@ public:
         {
             m_cv.wait(lck);
         }
-        auto return_value = m_value.value();
+        auto return_value = std::move(m_value.value());
         m_value.reset();
         m_cv.notify_all();
         return return_value;
@@ -67,10 +68,10 @@ public:
                 return std::nullopt;
             }
         }
-        auto return_value = m_value.value();
+        auto return_value = std::move(m_value.value());
         m_value.reset();
         m_cv.notify_all();
-        return {return_value};
+        return {std::move(return_value)};
     }
 
 private:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Before this change, an additional 10ms delay was added in the port tracker loop presumably to make the main loop slower than the worker loop. So, the worker result does not get super dated. This is not reliable. And the 10ms delay also slows down every consecutive bind call.

This PR refactors the thread synchronization method. So, the timing between those two loops is more deterministic. And removes the performance penalty for all bind calls.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #41470
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Measure 100 consecutive bind calls for different AF.
| Type | Before | After |
| --- | --- | --- |
| netlink | 1030ms | 56ms |
| UDS | 1008ms | 57ms |
| UDP bind 0 | 2174ms | 1135ms |

The extra UDP bind 0 time is from the `getsockname` poll. Which is required.