### PR TITLE
Fix p9 drvfs read only mount regression

### DIFF
--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -235,7 +235,7 @@ Return Value:
     }
 }
 
-std::pair<std::string, std::string> ConvertDrvfsMountOptionsToPlan9(std::string_view Options, const wsl::linux::WslDistributionConfig& Config, bool PropagateHostReadOnlyOption)
+std::pair<std::string, std::string> ConvertDrvfsMountOptionsToPlan9(std::string_view Options, const wsl::linux::WslDistributionConfig& Config)
 
 /*++
 
@@ -249,8 +249,6 @@ Arguments:
     Options - Supplies the DrvFs mount options.
 
     Config - Supplies the distribution configuration.
-
-    PropagateHostReadOnlyOption - Supplies whether the read-only option should be propagated to the host share.
 
 Return Value:
 
@@ -266,17 +264,7 @@ Return Value:
     while (!Options.empty())
     {
         auto Option = UtilStringNextToken(Options, ",");
-        if (Option == "ro")
-        {
-            if (PropagateHostReadOnlyOption)
-            {
-                Plan9Options += ";ro";
-            }
-
-            StandardOptions += "ro,";
-        }
-        else if (
-            (Option == "metadata") || (StartsWith(Option, PLAN9_CASE_OPTION)) || (StartsWith(Option, "uid=")) ||
+        if ((Option == "metadata") || (StartsWith(Option, PLAN9_CASE_OPTION)) || (StartsWith(Option, "uid=")) ||
             (StartsWith(Option, "gid=")) || (StartsWith(Option, "umask=")) || (StartsWith(Option, "dmask=")) ||
             (StartsWith(Option, "fmask=")) || (StartsWith(Option, PLAN9_SYMLINK_ROOT_OPTION)))
         {
@@ -674,7 +662,7 @@ try
     //
 
     std::string MountOptions = "cache=mmap,";
-    auto ParsedOptions = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config, false);
+    auto ParsedOptions = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config);
     Plan9Options += ParsedOptions.first;
     MountOptions += ParsedOptions.second;
 
@@ -740,7 +728,12 @@ try
     //      behavior when creating virtiofs shares on the host.
     //
 
-    auto [Plan9Options, MountOptions] = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config, true);
+    auto [Plan9Options, MountOptions] = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config);
+    const auto ParsedOptions = mountutil::MountParseFlags(MountOptions);
+    if ((ParsedOptions.MountFlags & MS_RDONLY) != 0)
+    {
+        Plan9Options += ";ro";
+    }
 
     //
     // Construct a request to add a virtiofs share.

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -235,7 +235,7 @@ Return Value:
     }
 }
 
-std::pair<std::string, std::string> ConvertDrvfsMountOptionsToPlan9(std::string_view Options, const wsl::linux::WslDistributionConfig& Config)
+std::pair<std::string, std::string> ConvertDrvfsMountOptionsToPlan9(std::string_view Options, const wsl::linux::WslDistributionConfig& Config, bool PropagateHostReadOnlyOption)
 
 /*++
 
@@ -247,6 +247,10 @@ Routine Description:
 Arguments:
 
     Options - Supplies the DrvFs mount options.
+
+    Config - Supplies the distribution configuration.
+
+    PropagateHostReadOnlyOption - Supplies whether the read-only option should be propagated to the host share.
 
 Return Value:
 
@@ -264,7 +268,11 @@ Return Value:
         auto Option = UtilStringNextToken(Options, ",");
         if (Option == "ro")
         {
-            Plan9Options += ";ro";
+            if (PropagateHostReadOnlyOption)
+            {
+                Plan9Options += ";ro";
+            }
+
             StandardOptions += "ro,";
         }
         else if (
@@ -666,7 +674,7 @@ try
     //
 
     std::string MountOptions = "cache=mmap,";
-    auto ParsedOptions = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config);
+    auto ParsedOptions = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config, false);
     Plan9Options += ParsedOptions.first;
     MountOptions += ParsedOptions.second;
 
@@ -732,7 +740,7 @@ try
     //      behavior when creating virtiofs shares on the host.
     //
 
-    auto [Plan9Options, MountOptions] = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config);
+    auto [Plan9Options, MountOptions] = ConvertDrvfsMountOptionsToPlan9(Options ? Options : "", Config, true);
 
     //
     // Construct a request to add a virtiofs share.

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -529,10 +529,9 @@ public:
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mkdir -p '{}'", mountPoint)), 0);
         VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mount -t drvfs -o ro,umask=222 '{}' '{}'", testDir.string(), mountPoint)), 0);
 
-        auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"findmnt -n -o VFS-OPTIONS '{}'", mountPoint));
-        VERIFY_IS_TRUE(out.starts_with(L"ro"));
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"findmnt -rn -M '{}' -O ro", mountPoint)), 0);
 
-        std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"cat '{}/marker'", mountPoint));
+        auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"cat '{}/marker'", mountPoint));
         VERIFY_ARE_EQUAL(wsl::shared::string::MultiByteToWide(expected), out);
 
         VERIFY_ARE_NOT_EQUAL(LxsstuLaunchWsl(std::format(L"touch '{}/write-test'", mountPoint)), 0);

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -507,6 +507,38 @@ public:
         }
     }
 
+    static void DrvfsMountReadOnly()
+    {
+        constexpr auto mountPoint = L"/tmp/drvfs-read-only-test";
+        const auto testDir = std::filesystem::current_path() / "drvfs-read-only-test";
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            LxsstuLaunchWsl(std::format(L"umount '{}'", mountPoint));
+            LxsstuLaunchWsl(std::format(L"rmdir '{}'", mountPoint));
+
+            std::error_code ec;
+            std::filesystem::remove_all(testDir, ec);
+        });
+
+        std::filesystem::create_directories(testDir);
+        constexpr auto expected = "read-only mount marker";
+        {
+            std::ofstream markerFile(testDir / "marker");
+            markerFile << expected;
+        }
+
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mkdir -p '{}'", mountPoint)), 0);
+        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mount -t drvfs -o ro,umask=222 '{}' '{}'", testDir.string(), mountPoint)), 0);
+
+        auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"findmnt -n -o VFS-OPTIONS '{}'", mountPoint));
+        VERIFY_IS_TRUE(out.starts_with(L"ro"));
+
+        std::tie(out, err) = LxsstuLaunchWslAndCaptureOutput(std::format(L"cat '{}/marker'", mountPoint));
+        VERIFY_ARE_EQUAL(wsl::shared::string::MultiByteToWide(expected), out);
+
+        VERIFY_ARE_NOT_EQUAL(LxsstuLaunchWsl(std::format(L"touch '{}/write-test'", mountPoint)), 0);
+        VERIFY_IS_FALSE(std::filesystem::exists(testDir / "write-test"));
+    }
+
     // DrvFsTests Private Methods
 private:
     static VOID CreateDrvFsTestFiles(bool Metadata)
@@ -1410,6 +1442,11 @@ class WSL1 : public DrvFsTests
         WSL2_TEST_METHOD(DrvfsMountManyVirtioFsSharesLegacy) \
         { \
             DrvFsTests::DrvfsMountManyVirtioFsShares(DrvFsMode::##_mode##, false); \
+        } \
+\
+        WSL2_TEST_METHOD(DrvfsMountReadOnly) \
+        { \
+            DrvFsTests::DrvfsMountReadOnly(); \
         } \
     }
 

--- a/test/windows/DrvFsTests.cpp
+++ b/test/windows/DrvFsTests.cpp
@@ -509,33 +509,54 @@ public:
 
     static void DrvfsMountReadOnly()
     {
-        constexpr auto mountPoint = L"/tmp/drvfs-read-only-test";
         const auto testDir = std::filesystem::current_path() / "drvfs-read-only-test";
         auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-            LxsstuLaunchWsl(std::format(L"umount '{}'", mountPoint));
-            LxsstuLaunchWsl(std::format(L"rmdir '{}'", mountPoint));
-
             std::error_code ec;
             std::filesystem::remove_all(testDir, ec);
         });
 
-        std::filesystem::create_directories(testDir);
-        constexpr auto expected = "read-only mount marker";
+        struct TestCase
         {
-            std::ofstream markerFile(testDir / "marker");
-            markerFile << expected;
+            std::wstring_view Options;
+            bool ReadOnly;
+        };
+
+        constexpr TestCase testCases[] = {
+            {L"ro,umask=222", true},
+            {L"ro,rw", false},
+            {L"rw,ro", true},
+        };
+
+        for (size_t index = 0; index < std::size(testCases); ++index)
+        {
+            const auto& testCase = testCases[index];
+            const auto sourceDir = testDir / std::to_string(index);
+            const auto mountPoint = std::format(L"/tmp/drvfs-read-only-test-{}", index);
+            auto unmountCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+                LxsstuLaunchWsl(std::format(L"umount '{}'", mountPoint));
+                LxsstuLaunchWsl(std::format(L"rmdir '{}'", mountPoint));
+            });
+
+            std::filesystem::create_directories(sourceDir);
+            constexpr auto expected = "read-only mount marker";
+            {
+                std::ofstream markerFile(sourceDir / "marker");
+                markerFile << expected;
+            }
+
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mkdir -p '{}'", mountPoint)), 0);
+            VERIFY_ARE_EQUAL(
+                LxsstuLaunchWsl(std::format(L"mount -t drvfs -o '{}' '{}' '{}'", testCase.Options, sourceDir.string(), mountPoint)), 0);
+
+            VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"findmnt -rn -M '{}' -O {}", mountPoint, testCase.ReadOnly ? L"ro" : L"rw")), 0);
+
+            auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"cat '{}/marker'", mountPoint));
+            VERIFY_ARE_EQUAL(wsl::shared::string::MultiByteToWide(expected), out);
+
+            const auto writeResult = LxsstuLaunchWsl(std::format(L"touch '{}/write-test'", mountPoint));
+            VERIFY_ARE_EQUAL(testCase.ReadOnly, writeResult != 0);
+            VERIFY_ARE_EQUAL(!testCase.ReadOnly, std::filesystem::exists(sourceDir / "write-test"));
         }
-
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mkdir -p '{}'", mountPoint)), 0);
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"mount -t drvfs -o ro,umask=222 '{}' '{}'", testDir.string(), mountPoint)), 0);
-
-        VERIFY_ARE_EQUAL(LxsstuLaunchWsl(std::format(L"findmnt -rn -M '{}' -O ro", mountPoint)), 0);
-
-        auto [out, err] = LxsstuLaunchWslAndCaptureOutput(std::format(L"cat '{}/marker'", mountPoint));
-        VERIFY_ARE_EQUAL(wsl::shared::string::MultiByteToWide(expected), out);
-
-        VERIFY_ARE_NOT_EQUAL(LxsstuLaunchWsl(std::format(L"touch '{}/write-test'", mountPoint)), 0);
-        VERIFY_IS_FALSE(std::filesystem::exists(testDir / "write-test"));
     }
 
     // DrvFsTests Private Methods


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

#41129 introduces a regression where the ";ro" option is passed to the host for p9 shares. However, that option is not supported by the p9 server and causes the mount to fail.

This PR removes the special handling of "ro" in the common parser. And use `MountParseFlags` to add the required virtio option.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #41475
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Add tests:
DrvFsTests::WSL2Plan9::DrvfsMountReadOnly
DrvFsTests::WSL2VirtioFs::DrvfsMountReadOnly