### PR TITLE
Fix unvalidated TerminalProfileSize during distribution import

### DIFF
--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -3509,8 +3509,8 @@ void LxssUserSessionImpl::_ProcessImportResultMessage(
         {
             if (Message.TerminalProfileIndex != 0)
             {
-                const auto terminalProfileSpan = Span.subspan(Message.TerminalProfileIndex);
-                const std::string_view terminalProfile(reinterpret_cast<const char*>(terminalProfileSpan.data()), Message.TerminalProfileSize);
+                const auto terminalProfileSpan = Span.subspan(Message.TerminalProfileIndex, Message.TerminalProfileSize);
+                const std::string_view terminalProfile(reinterpret_cast<const char*>(terminalProfileSpan.data()), terminalProfileSpan.size());
                 _CreateTerminalProfile(terminalProfile, iconPath, Configuration, Registration);
             }
             else

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -3510,7 +3510,8 @@ void LxssUserSessionImpl::_ProcessImportResultMessage(
             if (Message.TerminalProfileIndex != 0)
             {
                 const auto terminalProfileSpan = Span.subspan(Message.TerminalProfileIndex, Message.TerminalProfileSize);
-                const std::string_view terminalProfile(reinterpret_cast<const char*>(terminalProfileSpan.data()), terminalProfileSpan.size());
+                const std::string_view terminalProfile(
+                    reinterpret_cast<const char*>(terminalProfileSpan.data()), terminalProfileSpan.size());
                 _CreateTerminalProfile(terminalProfile, iconPath, Configuration, Registration);
             }
             else


### PR DESCRIPTION
## Summary

LxssUserSessionImpl::_ProcessImportResultMessage builds a string_view over the terminal profile data using the message's TerminalProfileSize field directly, without validating it against the size of the received buffer. If the value is inconsistent with the actual buffer length, the resulting string_view extends past the end of the buffer.

## Fix

Use the bounds-checked two-argument gsl::span::subspan(offset, count) overload instead of the single-argument form, matching the pattern already used a few lines above for ShortcutIconIndex/ShortcutIconSize. This ensures offset + count is validated against the span size before it's used to build the string_view.