### PR TITLE
Fix WSLC parser unit test argument overrides

### DIFF
--- a/test/windows/wslc/WSLCCLIParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIParserUnitTests.cpp
@@ -667,7 +667,7 @@ class WSLCCLIParserUnitTests
     // adjoined form. The inspect family depends on this for docker's `-f json`.
     TEST_METHOD(Value_AliasCarriesValue)
     {
-        std::vector<Argument> defs = {Argument::Create(ArgType::InspectFormat), Argument::Create(ArgType::ObjectId, false, Limit::Unlimited)};
+        std::vector<Argument> defs = {Argument::Create(ArgType::InspectFormat), Argument::Create(ArgType::ObjectId, {.Limit = Limit::Unlimited})};
 
         VERIFY_ARE_EQUAL(wsl::shared::c_jsonCompactIndent, ParseFlags(L"wslc -f json cont1", defs).GetValue<ArgType::InspectFormat>());
         VERIFY_ARE_EQUAL(wsl::shared::c_jsonCompactIndent, ParseFlags(L"wslc -f=json cont1", defs).GetValue<ArgType::InspectFormat>());


### PR DESCRIPTION
## Summary
- update the remaining `Argument::Create` parser test call to use `ArgumentOverrides`
- restore compilation after the argument factory API change

## Validation
- `./FormatSource.ps1 -ModifiedOnly $true`
- full build attempted; CMake configuration was blocked because the restored `Microsoft.WSL.Kernel.6.18.40.1-1` package did not contain `build/native/bin/x64/modules.vhd`