### PR TITLE
wslc: fix build by porting ObjectId argument to ArgumentOverrides syntax

### DIFF
--- a/test/windows/wslc/WSLCCLIParserUnitTests.cpp
+++ b/test/windows/wslc/WSLCCLIParserUnitTests.cpp
@@ -667,7 +667,7 @@ class WSLCCLIParserUnitTests
     // adjoined form. The inspect family depends on this for docker's `-f json`.
     TEST_METHOD(Value_AliasCarriesValue)
     {
-        std::vector<Argument> defs = {Argument::Create(ArgType::InspectFormat), Argument::Create(ArgType::ObjectId, false, Limit::Unlimited)};
+        std::vector<Argument> defs = {Argument::Create(ArgType::InspectFormat), Argument::Create(ArgType::ObjectId, {.Limit = Limit::Unlimited})};
 
         VERIFY_ARE_EQUAL(wsl::shared::c_jsonCompactIndent, ParseFlags(L"wslc -f json cont1", defs).GetValue<ArgType::InspectFormat>());
         VERIFY_ARE_EQUAL(wsl::shared::c_jsonCompactIndent, ParseFlags(L"wslc -f=json cont1", defs).GetValue<ArgType::InspectFormat>());


### PR DESCRIPTION
## Summary of the Pull Request

`master` does not currently compile. Two independently-correct PRs combined into a semantic merge conflict:

- **#41463** (`8544b7b0`, *alias `-f` to `--format` on inspect commands*) added a test that calls `Argument::Create` using the **old** positional signature `Create(type, required, limit, desc)`.
- **#41478** (`2dbe9953`, *CLI: Add explicit per-command argument overrides*) **replaced** that signature with `Create(ArgType type, ArgumentOverrides overrides = {})` and ported every call site it was aware of.

#41478 was validated against a base that predated #41463, and the two touch different lines, so git merged them with no textual conflict and no CI re-run. The result is a call site that cannot bind to any overload — there is only one `Create` declaration, so a 3-argument call is unconditionally ill-formed:


test\windows\wslc\WSLCCLIParserUnitTests.cpp(670,91): error C2660: 'wsl::windows::wslc::Argument::Create': function does not take 3 arguments while trying to match the argument list '(ArgType, bool, Limit)'


## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx
