### PR TITLE
Enable tcp mtu probing in mirrored mode

### DIFF
--- a/src/linux/init/GnsEngine.cpp
+++ b/src/linux/init/GnsEngine.cpp
@@ -593,8 +593,9 @@ std::tuple<bool, int> GnsEngine::ProcessNextMessage(wsl::shared::Transaction& tr
             manager.ResetLoopbackRoutes();
         }
 
-        // EnableIpv4ArpFilter does not need to be called per interface as each interface gets mirrored
-        // It could be global if we had a single global Init message
+        // EnableIpv4ArpFilter and EnableTcpMtuProbing are global (not per-interface) settings, so they
+        // do not need to be called per interface. They are called here as each interface gets mirrored.
+        // They could be global if we had a single global Init message
         // If there are more global init requirements in the future, we should consider a new global message
         GNS_LOG_INFO("LxGnsMessageInitialIpConfigurationNotification: Enabling IPv4 arp_filter");
         manager.EnableIpv4ArpFilter();

--- a/src/linux/init/GnsEngine.cpp
+++ b/src/linux/init/GnsEngine.cpp
@@ -598,6 +598,9 @@ std::tuple<bool, int> GnsEngine::ProcessNextMessage(wsl::shared::Transaction& tr
         // If there are more global init requirements in the future, we should consider a new global message
         GNS_LOG_INFO("LxGnsMessageInitialIpConfigurationNotification: Enabling IPv4 arp_filter");
         manager.EnableIpv4ArpFilter();
+
+        GNS_LOG_INFO("LxGnsMessageInitialIpConfigurationNotification: Enabling TCP MTU probing");
+        manager.EnableTcpMtuProbing();
         break;
     }
     case LxGnsMessageSetupIpv6:

--- a/src/linux/init/NetworkManager.cpp
+++ b/src/linux/init/NetworkManager.cpp
@@ -501,6 +501,14 @@ void NetworkManager::ModifyNetSetting(int addressFamily, const char* settingName
     Syscall(write, fd.get(), settingValue, settingValueLen);
 }
 
+void NetworkManager::ModifyNetSetting(int addressFamily, const char* settingName, const char* settingValue, size_t settingValueLen)
+{
+    const std::filesystem::path settingFilePath =
+        std::format("/proc/sys/net/{}/{}", ((addressFamily == AF_INET) ? "ipv4" : "ipv6"), settingName);
+    wil::unique_fd fd(Syscall(open, settingFilePath.c_str(), (O_WRONLY | O_CLOEXEC)));
+    Syscall(write, fd.get(), settingValue, settingValueLen);
+}
+
 void NetworkManager::DisableRouterDiscovery()
 {
     ModifyNetSetting(AF_INET6, "accept_ra", "all", c_disableSetting, strlen(c_disableSetting));
@@ -540,6 +548,15 @@ void NetworkManager::EnableIpv4ArpFilter()
     // duplicate which causes the host fail DAD, and DHCP immediately requests a new address (this will just continue in a loop)
     ModifyNetSetting(AF_INET, "arp_filter", "all", c_enableSetting, strlen(c_enableSetting));
     ModifyNetSetting(AF_INET, "arp_filter", "default", c_enableSetting, strlen(c_enableSetting));
+}
+
+void NetworkManager::EnableTcpMtuProbing()
+{
+    // Sets /proc/sys/net/ipv4/tcp_mtu_probing to 2 (always enabled). This matches Windows, which has
+    // TCP PMTU black hole detection enabled by default. Note: a VPN/tunnel can advertise a bigger MTU
+    // than the physical adapters support, so the guest probes and converges on a working TCP MSS on its own.
+    constexpr char c_alwaysEnabledSetting[] = "2\n";
+    ModifyNetSetting(AF_INET, "tcp_mtu_probing", c_alwaysEnabledSetting, strlen(c_alwaysEnabledSetting));
 }
 
 wsl::shared::conncheck::ConnCheckResult NetworkManager::SendConnectRequest(const char* remoteAddress)

--- a/src/linux/init/NetworkManager.cpp
+++ b/src/linux/init/NetworkManager.cpp
@@ -553,8 +553,9 @@ void NetworkManager::EnableIpv4ArpFilter()
 void NetworkManager::EnableTcpMtuProbing()
 {
     // Sets /proc/sys/net/ipv4/tcp_mtu_probing to 2 (always enabled). This matches Windows, which has
-    // TCP PMTU black hole detection enabled by default. Note: a VPN/tunnel can advertise a bigger MTU
+    // PMTU black hole detection enabled by default. Note: a VPN/tunnel can advertise a bigger MTU
     // than the physical adapters support, so the guest probes and converges on a working TCP MSS on its own.
+    // tcp_mtu_probing is a global TCP setting that applies to both IPv4 and IPv6, so no separate v6 call is needed.
     constexpr char c_alwaysEnabledSetting[] = "2\n";
     ModifyNetSetting(AF_INET, "tcp_mtu_probing", c_alwaysEnabledSetting, strlen(c_alwaysEnabledSetting));
 }

--- a/src/linux/init/NetworkManager.h
+++ b/src/linux/init/NetworkManager.h
@@ -77,6 +77,8 @@ public:
 
     void EnableIpv4ArpFilter();
 
+    void EnableTcpMtuProbing();
+
     wsl::shared::conncheck::ConnCheckResult SendConnectRequest(const char* remoteAddress);
 
 private:
@@ -91,4 +93,7 @@ private:
     IpNeighborManager neighborManager;
 
     void ModifyNetSetting(int addressFamily, const char* settingName, const char* scope, const char* settingValue, size_t settingValueLen);
+
+    // Overload for global (non per-interface) settings that live directly under /proc/sys/net/<family>/.
+    void ModifyNetSetting(int addressFamily, const char* settingName, const char* settingValue, size_t settingValueLen);
 };

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -4917,6 +4917,7 @@ class MirroredTests
             {L"/proc/sys/net/ipv6/conf/default/use_tempaddr", L"0\n"},
             {L"/proc/sys/net/ipv4/conf/all/arp_filter", L"1\n"},
             {L"/proc/sys/net/ipv4/conf/all/rp_filter", L"0\n"},
+            {L"/proc/sys/net/ipv4/tcp_mtu_probing", L"2\n"},
         };
 
         settings.push_back({L"/proc/sys/net/ipv4/conf/" + NetworkTests::GetGelNicDeviceName() + L"/rp_filter", L"0\n"});


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Sets /proc/sys/net/ipv4/tcp_mtu_probing to 2 (always enabled). This matches Windows, which has
PMTU black hole detection enabled by default. Note: a VPN/tunnel can advertise a bigger MTU
than the physical adapters support, so the guest probes and converges on a working TCP MSS on its own.
tcp_mtu_probing is a global TCP setting that applies to both IPv4 and IPv6, so no separate v6 call is needed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested manually by the user in the linked github issue
