### PR TITLE
Harden Windows macros against dangling-else ambiguity

### DIFF
--- a/src/windows/common/ExecutionContext.h
+++ b/src/windows/common/ExecutionContext.h
@@ -35,7 +35,7 @@ namespace wsl::windows::common {
         { \
             THROW_HR_WITH_USER_ERROR(Result, Message); \
         } \
-    } while (false)
+    } while (false);
 
 #define EMIT_USER_WARNING(Warning) \
     do \
@@ -44,7 +44,7 @@ namespace wsl::windows::common {
         { \
             context->EmitUserWarning(Warning); \
         } \
-    } while (false)
+    } while (false);
 
 /* List of ExecutionContext that can be passed to ExecutionContext().
  * Note: ExecutionContext makes the assumption that the parent context always has

--- a/src/windows/common/ExecutionContext.h
+++ b/src/windows/common/ExecutionContext.h
@@ -29,16 +29,22 @@ namespace wsl::windows::common {
     } while (false);
 
 #define THROW_HR_WITH_USER_ERROR_IF(Result, Message, Condition) \
-    if (Condition) \
+    do \
     { \
-        THROW_HR_WITH_USER_ERROR(Result, Message); \
-    }
+        if (Condition) \
+        { \
+            THROW_HR_WITH_USER_ERROR(Result, Message); \
+        } \
+    } while (false)
 
 #define EMIT_USER_WARNING(Warning) \
-    if (::wsl::windows::common::ExecutionContext* context = ::wsl::windows::common::ExecutionContext::Current(); context != nullptr) \
+    do \
     { \
-        context->EmitUserWarning(Warning); \
-    }
+        if (::wsl::windows::common::ExecutionContext* context = ::wsl::windows::common::ExecutionContext::Current(); context != nullptr) \
+        { \
+            context->EmitUserWarning(Warning); \
+        } \
+    } while (false)
 
 /* List of ExecutionContext that can be passed to ExecutionContext().
  * Note: ExecutionContext makes the assumption that the parent context always has


### PR DESCRIPTION

## Summary of the Pull Request

Hardens `EMIT_USER_WARNING` and `THROW_HR_WITH_USER_ERROR_IF` in `src/windows/common/ExecutionContext.h` by wrapping them in `do { ... } while (false)` statement wrappers. This is the Windows counterpart to the Linux fix in [#41504](https://github.com/microsoft/WSL/pull/41504).

## PR Checklist

- [x] **Closes:** Fixes dangling-else vulnerability on Windows (follow-up to #41504)
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

&lt;!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here --&gt;
## Detailed Description of the Pull Request / Additional comments

Both `EMIT_USER_WARNING` and `THROW_HR_WITH_USER_ERROR_IF` were defined as bare `if` statements, leaving Windows callers vulnerable to dangling-else misassociation when the macros are used without braces:

```cpp
if (condition)
    EMIT_USER_WARNING(L"msg");
else
    // This else incorrectly binds to the macro's inner if
```
This change wraps both macros in do { ... } while (false) so they always expand to a single statement. This brings the Windows header into parity with the already-hardened Linux definition from #41504 and prevents the outer else from binding to the inner if generated by the macro.

## Validation Steps Performed
- Verified that EMIT_USER_WARNING and THROW_HR_WITH_USER_ERROR_IF now expand to single statements when used in if/else contexts without braces.
- Reviewed the Linux counterpart (#41504) to ensure consistency between platforms.
