### PR TITLE
Revert "Mount plugin folders on behalf of the user owning the wsl session" (#41331)

### DIFF
--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2055,8 +2055,7 @@ void WslCoreVm::MountRootNamespaceFolder(_In_ LPCWSTR HostPath, _In_ LPCWSTR Gue
     auto lock = m_lock.lock_exclusive();
 
     const auto flags = (ReadOnly ? hcs::Plan9ShareFlags::ReadOnly : hcs::Plan9ShareFlags::None) | hcs::Plan9ShareFlags::AllowOptions;
-    wsl::windows::common::hcs::AddPlan9Share(
-        m_system.get(), Name, Name, HostPath, LX_INIT_UTILITY_VM_PLAN9_PORT, flags, m_userToken.get());
+    wsl::windows::common::hcs::AddPlan9Share(m_system.get(), Name, Name, HostPath, LX_INIT_UTILITY_VM_PLAN9_PORT, flags);
 
     wsl::shared::MessageWriter<LX_MINI_INIT_MOUNT_FOLDER_MESSAGE> message(LxMiniInitMountFolder);
     message.WriteString(message->PathIndex, GuestPath);

--- a/test/windows/PluginTests.cpp
+++ b/test/windows/PluginTests.cpp
@@ -83,7 +83,7 @@ class PluginTests
         return true;
     }
 
-    void ConfigurePlugin(PluginTestType testCase, LPCWSTR mountFolder = L"") const
+    void ConfigurePlugin(PluginTestType testCase) const
     {
         StopWslService();
         if (!DeleteFile(logFile.c_str()))
@@ -94,7 +94,6 @@ class PluginTests
         const auto testKey = OpenTestRegistryKey(KEY_SET_VALUE);
         WriteDword(testKey.get(), nullptr, c_testType, static_cast<DWORD>(testCase));
         WriteString(testKey.get(), nullptr, c_logFile, logFile.c_str());
-        WriteString(testKey.get(), nullptr, c_mountFolder, mountFolder);
 
         const auto lxssKey =
             CreateKey(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Lxss\\Plugins", KEY_SET_VALUE, nullptr, 0);
@@ -164,62 +163,6 @@ class PluginTests
 
         ConfigurePlugin(PluginTestType::Success);
         StartWsl(0);
-        ValidateLogFile(ExpectedOutput);
-    }
-
-    WSL2_TEST_METHOD(MountFolderAccess)
-    {
-        const auto testFolder = std::filesystem::current_path() / "deny-write";
-        VERIFY_IS_TRUE(std::filesystem::create_directory(testFolder));
-
-        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testFolder); });
-
-        const auto user = wil::get_token_information<TOKEN_USER>();
-        EXPLICIT_ACCESSW access{};
-        access.grfAccessPermissions = FILE_ADD_FILE;
-        access.grfAccessMode = DENY_ACCESS;
-        access.grfInheritance = NO_INHERITANCE;
-        access.Trustee.TrusteeForm = TRUSTEE_IS_SID;
-        access.Trustee.ptstrName = static_cast<LPWSTR>(user->User.Sid);
-
-        PACL acl = nullptr;
-        wil::unique_hlocal descriptor;
-        THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
-            testFolder.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &acl, nullptr, &descriptor));
-
-        wsl::windows::common::security::unique_acl newAcl;
-        THROW_IF_WIN32_ERROR(SetEntriesInAclW(1, &access, acl, &newAcl));
-        THROW_IF_WIN32_ERROR(SetNamedSecurityInfoW(
-            const_cast<LPWSTR>(testFolder.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, newAcl.get(), nullptr));
-
-        const auto testFile = testFolder / L"plugin-test.txt";
-        wil::unique_hfile deniedFile{CreateFileW(testFile.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr)};
-        VERIFY_IS_TRUE(!deniedFile);
-        VERIFY_ARE_EQUAL(GetLastError(), ERROR_ACCESS_DENIED);
-
-        auto resetAcl = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
-            wsl::windows::common::security::unique_acl restoredAcl;
-            access.grfAccessPermissions = 0;
-            access.grfAccessMode = REVOKE_ACCESS;
-
-            THROW_IF_WIN32_ERROR(SetEntriesInAclW(1, &access, acl, &restoredAcl));
-
-            THROW_IF_WIN32_ERROR(SetNamedSecurityInfoW(
-                const_cast<LPWSTR>(testFolder.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, restoredAcl.get(), nullptr));
-        });
-
-        ConfigurePlugin(PluginTestType::MountFolderAccess, testFolder.c_str());
-
-        constexpr auto ExpectedOutput =
-            LR"(Plugin loaded. TestMode=18
-                VM created (settings->CustomConfigurationFlags=0)
-                /bin/sh: line 1: /test-plugin-access/plugin-test.txt: Permission denied
-                Distribution started, name=test_distro, package=, PidNs=*, InitPid=*, Flavor=debian, Version=13
-                Distribution Stopping, name=test_distro, package=, PidNs=*, Flavor=debian, Version=13
-                VM Stopping)";
-
-        StartWsl(0);
-        VERIFY_IS_FALSE(std::filesystem::exists(testFile));
         ValidateLogFile(ExpectedOutput);
     }
 

--- a/test/windows/PluginTests.h
+++ b/test/windows/PluginTests.h
@@ -37,13 +37,11 @@ enum class PluginTestType
     InitPidIsDifferent,
     FailToRegisterUnregisterDistro,
     RunDistroCommand,
-    GetUsername,
-    MountFolderAccess
+    GetUsername
 };
 
 constexpr auto c_testType = L"TestType";
 constexpr auto c_logFile = L"LogFile";
-constexpr auto c_mountFolder = L"MountFolder";
 
 inline wil::unique_hkey OpenTestRegistryKey(REGSAM AccessMask)
 {

--- a/test/windows/testplugin/Plugin.cpp
+++ b/test/windows/testplugin/Plugin.cpp
@@ -100,21 +100,6 @@ HRESULT OnVmStarted(const WSLSessionInformation* Session, const WSLVmCreationSet
             return E_ABORT;
         }
     }
-    else if (g_testType == PluginTestType::MountFolderAccess)
-    {
-        const auto key = OpenTestRegistryKey(KEY_READ);
-        const auto mountSource = ReadString(key.get(), nullptr, c_mountFolder);
-
-        RETURN_IF_FAILED(
-            g_api->MountFolder(Session->SessionId, mountSource.c_str(), L"/test-plugin-access", false, L"test-plugin-access"));
-
-        std::vector<const char*> arguments = {"/bin/sh", "-c", "{ echo test > /test-plugin-access/plugin-test.txt; } 2>&1", nullptr};
-        wil::unique_socket socket;
-        RETURN_IF_FAILED(g_api->ExecuteBinary(Session->SessionId, arguments[0], arguments.data(), &socket));
-
-        const auto output = ReadFromSocket(socket.get());
-        g_logfile.write(output.data(), output.size());
-    }
     else if (g_testType == PluginTestType::ApiErrors)
     {
         auto result = g_api->MountFolder(Session->SessionId, L"C:\\DoesNotExit", L"/dummy", true, L"test-plugin-mount");
@@ -364,7 +349,7 @@ EXTERN_C __declspec(dllexport) HRESULT WSLPLUGINAPI_ENTRYPOINTV1(const WSLPlugin
         THROW_HR_IF(E_UNEXPECTED, !g_logfile);
 
         g_testType = static_cast<PluginTestType>(ReadDword(key.get(), nullptr, c_testType, static_cast<DWORD>(PluginTestType::Invalid)));
-        THROW_HR_IF(E_INVALIDARG, static_cast<DWORD>(g_testType) <= 0 || static_cast<DWORD>(g_testType) > static_cast<DWORD>(PluginTestType::MountFolderAccess));
+        THROW_HR_IF(E_INVALIDARG, static_cast<DWORD>(g_testType) <= 0 || static_cast<DWORD>(g_testType) > static_cast<DWORD>(PluginTestType::GetUsername));
 
         g_logfile << "Plugin loaded. TestMode=" << static_cast<DWORD>(g_testType) << std::endl;
         g_api = Api;


### PR DESCRIPTION
Temporarily reverts the plugin-mount-identity portion of #41351 (the backport of #41331 to release/2.7), which changed plugin folder mounts (MountRootNamespaceFolder / AddPlan9Share) to use the identity of the user owning the WSL session (m_userToken) instead of the service identity. Also reverts the accompanying MountFolderAccess test coverage.

Only the plugin-mount-identity change is reverted here; the other unrelated fixes bundled into #41351 (CI/pipeline changes, GSL warning suppression) are left intact.

This is a temporary revert; the change will be reapplied once the underlying issue is addressed.