### PR TITLE
[release/2.7] Make sure that message structures are correctly zero-initialized

### DIFF
--- a/src/linux/init/binfmt.cpp
+++ b/src/linux/init/binfmt.cpp
@@ -544,7 +544,7 @@ Return Value:
                 MESSAGE_HEADER Header;
                 LX_INIT_PROCESS_EXIT_STATUS ExitStatus;
                 LX_INIT_CREATE_PROCESS_RESPONSE Response;
-            } Reply;
+            } Reply{};
 
             Bytes = TEMP_FAILURE_RETRY(read(PollDescriptors[0].fd, &Reply, sizeof(Reply)));
             if (Bytes < 0)
@@ -1054,7 +1054,7 @@ Return Value:
         return;
     }
 
-    LX_INIT_WINDOW_SIZE_CHANGED ResizeMessage;
+    LX_INIT_WINDOW_SIZE_CHANGED ResizeMessage{};
     ResizeMessage.Header.MessageType = LxInitMessageWindowSizeChanged;
     ResizeMessage.Header.MessageSize = sizeof(ResizeMessage);
     ResizeMessage.Columns = WindowSize.ws_col;

--- a/src/linux/init/drvfs.cpp
+++ b/src/linux/init/drvfs.cpp
@@ -205,7 +205,7 @@ Return Value:
     // Query the interop server for which port to use.
     //
 
-    MESSAGE_HEADER QueryPortMessage;
+    MESSAGE_HEADER QueryPortMessage{};
     QueryPortMessage.MessageType = LxInitMessageQueryDrvfsElevated;
     QueryPortMessage.MessageSize = sizeof(QueryPortMessage);
 

--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -1234,7 +1234,7 @@ try
             SocketAddress.svm_port = -1;
         }
 
-        LX_INIT_CREATE_SESSION_RESPONSE Response;
+        LX_INIT_CREATE_SESSION_RESPONSE Response{};
         Response.Header.MessageType = LxInitMessageCreateSessionResponse;
         Response.Header.MessageSize = sizeof(Response);
         Response.Port = SocketAddress.svm_port;
@@ -1371,7 +1371,7 @@ Return Value:
     pid_t ChildPid;
     wsl::shared::SocketChannel ControlChannel;
 
-    LX_INIT_PROCESS_EXIT_STATUS ExitStatus;
+    LX_INIT_PROCESS_EXIT_STATUS ExitStatus{};
     unsigned int Index;
     bool InteropEnabled;
     InteropServer InteropServer;

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -3026,7 +3026,7 @@ Return Value:
 --*/
 try
 {
-    LX_MINI_INIT_MOUNT_RESULT_MESSAGE Message;
+    LX_MINI_INIT_MOUNT_RESULT_MESSAGE Message{};
     Message.Header.MessageSize = sizeof(Message);
     Message.Header.MessageType = LxMiniInitMessageMountStatus;
     Message.Result = Result;

--- a/src/linux/init/util.cpp
+++ b/src/linux/init/util.cpp
@@ -1189,7 +1189,7 @@ Return Value:
             return FeatureFlags;
         }
 
-        MESSAGE_HEADER Message;
+        MESSAGE_HEADER Message{};
         Message.MessageType = LxInitMessageQueryFeatureFlags;
         Message.MessageSize = sizeof(Message);
 
@@ -1259,7 +1259,7 @@ try
     wsl::shared::SocketChannel channel{UtilConnectUnix(WSL_INIT_INTEROP_SOCKET), "wslinfo"};
     THROW_LAST_ERROR_IF(channel.Socket() < 0);
 
-    MESSAGE_HEADER Message;
+    MESSAGE_HEADER Message{};
     Message.MessageType = LxInitMessageQueryNetworkingMode;
     Message.MessageSize = sizeof(Message);
 

--- a/src/windows/common/interop.cpp
+++ b/src/windows/common/interop.cpp
@@ -329,7 +329,7 @@ void CreateProcessVmMode(_In_ const GUID& VmId, _In_ const gsl::span<gsl::byte>&
             if (Result.Status == 0)
             {
                 // Process messages from the binfmt interpreter and wait for the process to exit.
-                LX_INIT_PROCESS_EXIT_STATUS ExitStatus;
+                LX_INIT_PROCESS_EXIT_STATUS ExitStatus{};
                 ExitStatus.Header.MessageType = LxInitMessageExitStatus;
                 ExitStatus.Header.MessageSize = sizeof(ExitStatus);
                 ExitStatus.ExitCode = ProcessInteropMessages(reinterpret_cast<HANDLE>(Sockets[3].get()), &Result);
@@ -553,7 +553,7 @@ void wsl::windows::common::interop::WorkerThread(_In_ wil::unique_handle&& Serve
 
                         // Process messages from the binfmt interpreter and wait for the
                         // process to exit.
-                        LX_INIT_PROCESS_EXIT_STATUS ExitStatus;
+                        LX_INIT_PROCESS_EXIT_STATUS ExitStatus{};
                         ExitStatus.Header.MessageType = LxInitMessageExitStatus;
                         ExitStatus.Header.MessageSize = sizeof(ExitStatus);
                         ExitStatus.ExitCode = ProcessInteropMessages(SignalPipe.first.get(), &Result);

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2130,7 +2130,7 @@ WslCoreVm::MountFileAsPersistentMemory(_In_ PCWSTR FilePath, _In_ bool ReadOnly)
 void WslCoreVm::WaitForPmemDeviceInVm(_In_ ULONG PmemId)
 {
     // Construct the mini_init message.
-    LX_MINI_INIT_WAIT_FOR_PMEM_DEVICE_MESSAGE message;
+    LX_MINI_INIT_WAIT_FOR_PMEM_DEVICE_MESSAGE message{};
     message.Header.MessageType = LxMiniInitMessageWaitForPmemDevice;
     message.Header.MessageSize = sizeof(message);
     message.PmemId = PmemId;
@@ -2444,7 +2444,7 @@ void WslCoreVm::ResizeDistribution(_In_ ULONG Lun, _In_ HANDLE OutputHandle, _In
 {
     auto lock = m_lock.lock_exclusive();
 
-    LX_MINI_INIT_RESIZE_DISTRIBUTION_MESSAGE message;
+    LX_MINI_INIT_RESIZE_DISTRIBUTION_MESSAGE message{};
     message.Header.MessageSize = sizeof(message);
     message.Header.MessageType = LxMiniInitMessageResizeDistribution;
     message.ScsiLun = Lun;
@@ -2523,7 +2523,7 @@ std::pair<int, LX_MINI_MOUNT_STEP> WslCoreVm::UnmountDisk(_In_ const AttachedDis
     }
 
     // Tell the guest to flush its IO caches and stop using the disk.
-    LX_MINI_INIT_DETACH_MESSAGE message;
+    LX_MINI_INIT_DETACH_MESSAGE message{};
     message.Header.MessageType = LxMiniInitMessageDetach;
     message.Header.MessageSize = sizeof(message);
     message.ScsiLun = State.Lun;


### PR DESCRIPTION
Backport of #41373 to `release/2.7`.

Several aggregate message structures were declared without value-initialization before their fields were assigned, leaving unassigned fields and padding indeterminate. This applies the original zero-initialization fix to the message types present in the release branch.

The `TrimDistribution` hunk from the original PR is omitted because that function is not present in `release/2.7`.