### PR TITLE
CLI: Add global options to root help, adjust options usage

### DIFF
--- a/localization/strings/en-US/Resources.resw
+++ b/localization/strings/en-US/Resources.resw
@@ -2238,6 +2238,9 @@ Usage:
   <data name="WSLCCLI_Options" xml:space="preserve">
     <value>options</value>
   </data>
+  <data name="WSLCCLI_GlobalOptions" xml:space="preserve">
+    <value>global-options</value>
+  </data>
   <data name="WSLCCLI_AvailableCommandAliases" xml:space="preserve">
     <value>The following command aliases are available:</value>
   </data>

--- a/src/windows/wslc/core/Command.cpp
+++ b/src/windows/wslc/core/Command.cpp
@@ -281,6 +281,20 @@ void Command::OutputHelp(Terminal& terminal, HelpOutput output, const CommandExc
 
         terminal.Write(helpLevel, L"{}{}{}", HelpHeadingEmphasis, usageText, Format::Default);
 
+        if (commandChain.empty() && !globalArgs.empty())
+        {
+            terminal.Write(
+                helpLevel,
+                L" {}[{}{}{}{}{}]{}",
+                HelpMetaEmphasis,
+                Format::Default,
+                HelpPlaceholderEmphasis,
+                Localization::WSLCCLI_GlobalOptions(),
+                Format::Default,
+                HelpMetaEmphasis,
+                Format::Default);
+        }
+
         if (!commands.empty())
         {
             if (!arguments.empty())
@@ -312,7 +326,7 @@ void Command::OutputHelp(Terminal& terminal, HelpOutput output, const CommandExc
         {
             terminal.Write(
                 helpLevel,
-                L" {}[<{}{}{}{}{}>]{}",
+                L" {}[{}{}{}{}{}]{}",
                 HelpMetaEmphasis,
                 Format::Default,
                 HelpPlaceholderEmphasis,

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -91,11 +91,23 @@ class WSLCE2EGlobalTests
     {
         auto result = RunWslc(L"--help");
         result.Verify({.Stderr = L"", .ExitCode = 0});
-        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"Usage: wslc"));
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"Usage: wslc [global-options] [<command>] [options]"));
         VERIFY_IS_TRUE(result.StdoutContainsSubstring(c_copyrightPrefix));
         VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_RootCommandLongDesc()));
         VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_HeadingOptions()));
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_HeadingGlobalOptions()));
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"--session"));
         VERIFY_IS_FALSE(result.StdoutContainsSubstring(Localization::WSLCCLI_RunHelpForMoreInformation(L"wslc")));
+    }
+
+    WSLC_TEST_METHOD(WSLCE2E_Help_LeafCommandShowsGlobalOptionsForReference)
+    {
+        auto result = RunWslc(L"image list --help");
+        result.Verify({.Stderr = L"", .ExitCode = 0});
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"Usage: wslc image list [options]"));
+        VERIFY_IS_FALSE(result.StdoutContainsSubstring(L"global-options"));
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_HeadingGlobalOptions()));
+        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"--session"));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Help_CommandErrorRoutesToStderr)

--- a/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EGlobalTests.cpp
@@ -96,18 +96,7 @@ class WSLCE2EGlobalTests
         VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_RootCommandLongDesc()));
         VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_HeadingOptions()));
         VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_HeadingGlobalOptions()));
-        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"--session"));
         VERIFY_IS_FALSE(result.StdoutContainsSubstring(Localization::WSLCCLI_RunHelpForMoreInformation(L"wslc")));
-    }
-
-    WSLC_TEST_METHOD(WSLCE2E_Help_LeafCommandShowsGlobalOptionsForReference)
-    {
-        auto result = RunWslc(L"image list --help");
-        result.Verify({.Stderr = L"", .ExitCode = 0});
-        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"Usage: wslc image list [options]"));
-        VERIFY_IS_FALSE(result.StdoutContainsSubstring(L"global-options"));
-        VERIFY_IS_TRUE(result.StdoutContainsSubstring(Localization::WSLCCLI_HeadingGlobalOptions()));
-        VERIFY_IS_TRUE(result.StdoutContainsSubstring(L"--session"));
     }
 
     WSLC_TEST_METHOD(WSLCE2E_Help_CommandErrorRoutesToStderr)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Adds `[global-options]` to the root usage to clarify where global options belong.
- Uses `[options]` for option groups while retaining angle brackets for replaceable operands.

This aligns the usage string to be a bit cleaner and more consistent.

- Root: `wslc [global-options] [<command>] [options]`
- Run: `wslc run [options] <image> [<command>] [<arguments>...]`

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
