### PR TITLE
Fix WSLC Plan9 mount and image-build failures

### DIFF
--- a/src/windows/service/exe/HcsVirtualMachine.cpp
+++ b/src/windows/service/exe/HcsVirtualMachine.cpp
@@ -373,6 +373,11 @@ HcsVirtualMachine::~HcsVirtualMachine()
     // GuestDeviceManager, so it must be released first for the device manager reset to be effective.
     m_networkEngine.reset();
     m_guestDeviceManager.reset();
+    if (m_plan9Server)
+    {
+        LOG_IF_FAILED(m_plan9Server->Teardown());
+        m_plan9Server.reset();
+    }
     m_computeSystem.reset();
 
     // Revoke VM access for attached disks
@@ -610,16 +615,19 @@ try
 
     if (!FeatureEnabled(WslcFeatureFlagsVirtioFs))
     {
+        auto runAsUser = wil::impersonate_token(m_userToken.get());
+        if (!m_plan9Server)
+        {
+            auto server =
+                wsl::windows::common::wslutil::CreateComServerAsUser<p9fs::Plan9FileSystem, IPlan9FileSystem>(m_userToken.get());
+            THROW_IF_FAILED(server->Init(&m_vmId, LX_INIT_UTILITY_VM_PLAN9_PORT));
+            THROW_IF_FAILED(server->Resume());
+            m_plan9Server = std::move(server);
+        }
+
         auto flags = hcs::Plan9ShareFlags::AllowOptions;
         WI_SetFlagIf(flags, hcs::Plan9ShareFlags::ReadOnly, ReadOnly);
-        hcs::AddPlan9Share(
-            m_computeSystem.get(),
-            shareName.c_str(),
-            shareName.c_str(),
-            WindowsPath,
-            LX_INIT_UTILITY_VM_PLAN9_PORT,
-            flags,
-            m_userToken.get());
+        THROW_IF_FAILED(m_plan9Server->AddSharePath(shareName.c_str(), WindowsPath, static_cast<UINT32>(flags)));
     }
     else
     {
@@ -653,8 +661,9 @@ try
 
     if (!it->second.has_value())
     {
+        auto runAsUser = wil::impersonate_token(m_userToken.get());
         auto shareName = wsl::shared::string::GuidToString<wchar_t>(it->first, wsl::shared::string::None);
-        hcs::RemovePlan9Share(m_computeSystem.get(), shareName.c_str(), LX_INIT_UTILITY_VM_PLAN9_PORT);
+        THROW_IF_FAILED(m_plan9Server->RemoveShare(shareName.c_str()));
     }
     else
     {

--- a/src/windows/service/exe/HcsVirtualMachine.h
+++ b/src/windows/service/exe/HcsVirtualMachine.h
@@ -100,6 +100,7 @@ private:
 
     // Shares: key is ShareId, value is nullopt for Plan9 or the aggregate DeviceInstanceId for VirtioFS.
     std::map<GUID, std::optional<GUID>, wsl::windows::common::helpers::GuidLess> m_shares;
+    wil::com_ptr<IPlan9FileSystem> m_plan9Server;
     std::optional<GUID> m_virtioFsDevice;
 
     std::filesystem::path m_vmSavedStateFile;

--- a/test/windows/PluginTests.cpp
+++ b/test/windows/PluginTests.cpp
@@ -667,6 +667,7 @@ class PluginTests
             WSLCProcessGetExitCode(<running>): {}
             WSLC RW folder mounted at: /mnt/wsl-plugin/plugin-rw-test
             Command: 'cat /mnt/wsl-plugin/plugin-rw-test/plugin-test.txt', status=0, stdout: Windows-content, stderr: 
+            Command: 'cat /mnt/wsl-plugin/plugin-rw-test/plugin-denied.txt', status=1, stdout: , stderr: *
             WSLC RO folder mounted at: /mnt/wsl-plugin/plugin-ro-test
             Command: 'echo fail > /mnt/wsl-plugin/plugin-ro-test/should-not-exist.txt', status=1, stdout: , stderr: *
             WSLCMountFolder(nonexistent): {}

--- a/test/windows/testplugin/Plugin.cpp
+++ b/test/windows/testplugin/Plugin.cpp
@@ -653,17 +653,7 @@ try
         static std::atomic<bool> done = false;
         if (!done.exchange(true))
         {
-            try
-            {
-                RunWslcSuccessChecks(Session);
-            }
-            catch (const wil::ResultException& exception)
-            {
-                const auto& failure = exception.GetFailureInfo();
-                g_logfile << "WSLC success checks failed: " << std::hex << failure.hr << std::dec << ", file=" << failure.pszFile
-                          << ", line=" << failure.uLineNumber << std::endl;
-                throw;
-            }
+            RunWslcSuccessChecks(Session);
         }
 
         return S_OK;

--- a/test/windows/testplugin/Plugin.cpp
+++ b/test/windows/testplugin/Plugin.cpp
@@ -496,6 +496,48 @@ void RunWslcSuccessChecks(const WSLCSessionInformation* Session)
                 file << "Windows-content";
             }
 
+            const auto deniedFilePath = std::wstring(testFolder) + L"plugin-denied.txt";
+            {
+                wil::unique_hfile deniedFile{
+                    CreateFileW(deniedFilePath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr)};
+                THROW_LAST_ERROR_IF(!deniedFile);
+            }
+
+            auto deniedFileCleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove(deniedFilePath); });
+
+            PACL originalAcl = nullptr;
+            wil::unique_hlocal originalDescriptor;
+            THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
+                deniedFilePath.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &originalAcl, nullptr, &originalDescriptor));
+
+            auto restoreAcl = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+                THROW_IF_WIN32_ERROR(SetNamedSecurityInfoW(
+                    const_cast<LPWSTR>(deniedFilePath.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, originalAcl, nullptr));
+            });
+
+            EXPLICIT_ACCESSW deniedAccess{};
+            deniedAccess.grfAccessPermissions = FILE_READ_DATA;
+            deniedAccess.grfAccessMode = DENY_ACCESS;
+            deniedAccess.grfInheritance = NO_INHERITANCE;
+            deniedAccess.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+            deniedAccess.Trustee.ptstrName = static_cast<LPWSTR>(Session->UserSid);
+
+            wsl::windows::common::security::unique_acl deniedAcl;
+            THROW_IF_WIN32_ERROR(SetEntriesInAclW(1, &deniedAccess, originalAcl, &deniedAcl));
+            THROW_IF_WIN32_ERROR(SetNamedSecurityInfoW(
+                const_cast<LPWSTR>(deniedFilePath.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, deniedAcl.get(), nullptr));
+
+            {
+                wil::unique_handle impersonationToken;
+                THROW_LAST_ERROR_IF(!DuplicateTokenEx(
+                    Session->UserToken, TOKEN_IMPERSONATE | TOKEN_QUERY, nullptr, SecurityImpersonation, TokenImpersonation, &impersonationToken));
+                auto revert = wil::impersonate_token(impersonationToken.get());
+                wil::unique_hfile deniedFile{
+                    CreateFileW(deniedFilePath.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+                const auto openError = GetLastError();
+                THROW_HR_IF(E_UNEXPECTED, deniedFile || openError != ERROR_ACCESS_DENIED);
+            }
+
             // Mount read-write and verify the file can be read from Linux.
             THROW_IF_FAILED(g_api->WSLCMountFolder(Session->SessionId, testFolder, rwMountpoint, false));
 
@@ -503,6 +545,9 @@ void RunWslcSuccessChecks(const WSLCSessionInformation* Session)
 
             auto readCmd = std::format("cat {}/{}", rwMountpoint, testFileName);
             runCommand(readCmd.c_str());
+
+            auto deniedReadCmd = std::format("cat {}/plugin-denied.txt", rwMountpoint);
+            runCommand(deniedReadCmd.c_str());
 
             THROW_IF_FAILED(g_api->WSLCUnmountFolder(Session->SessionId, rwMountpoint));
         }
@@ -608,7 +653,17 @@ try
         static std::atomic<bool> done = false;
         if (!done.exchange(true))
         {
-            RunWslcSuccessChecks(Session);
+            try
+            {
+                RunWslcSuccessChecks(Session);
+            }
+            catch (const wil::ResultException& exception)
+            {
+                const auto& failure = exception.GetFailureInfo();
+                g_logfile << "WSLC success checks failed: " << std::hex << failure.hr << std::dec << ", file=" << failure.pszFile
+                          << ", line=" << failure.uLineNumber << std::endl;
+                throw;
+            }
         }
 
         return S_OK;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

HCS-managed Plan9 shares fail to attach with EINVAL after a recent Windows update. This surfaces as E_FAIL in WSLC plugin and image-build tests. Example: https://github.com/microsoft/WSL/pull/41521/checks?check_run_id=101680158937

This PR uses WSL’s existing per-user Plan9 server pattern for WSLC share creation and cleanup, preserving the session user’s Windows file permissions. And adds a permission regression test.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Update test:

PluginTests::WslcSuccess