### PR TITLE
[release/2.7] Backport additional fixes

### DIFF
--- a/msipackage/package.wix.in
+++ b/msipackage/package.wix.in
@@ -483,6 +483,11 @@
         <CustomAction Id="InstallMsix.SetProperty" Return="check" Property="InstallMsix" Value='[DATABASE]' Execute='immediate' />
         <CustomAction Id="CalculateWslSettingsProtocolIds" Impersonate="no" BinaryRef="wslinstall.dll" DllEntry="CalculateWslSettingsProtocolIds" Return="check" Execute='immediate' />
 
+        <!-- Disable WSLService before StopServices so SCM rejects activation attempts
+             from COM clients while it is being stopped on uninstall. -->
+        <CustomAction Id="DisableWslService" Impersonate="no" BinaryRef="wslinstall.dll" DllEntry="DisableWslService" Return="ignore" Execute="deferred" />
+        <CustomAction Id="EnableWslService" Impersonate="no" BinaryRef="wslinstall.dll" DllEntry="EnableWslService" Return="ignore" Execute="rollback" />
+
         <!-- See https://learn.microsoft.com/en-us/windows/win32/msi/examples-of-conditional-statement-syntax -->
         <InstallExecuteSequence>
             <Custom Action="ValidateInstall" After="InstallInitialize" Condition="(not INSTALLED) and (not SKIPVALIDATION = 1)" />
@@ -537,6 +542,11 @@
             <?endif?>
 
             <Custom Action="FinalizeInstall" After="PublishFeatures"/>
+
+            <!-- Rollback CA must be sequenced before the forward action so it is registered
+                 in the rollback script first. -->
+            <Custom Action="EnableWslService" Before="DisableWslService" Condition='REMOVE~="ALL"' />
+            <Custom Action="DisableWslService" Before="StopServices" Condition='REMOVE~="ALL"' />
 
         </InstallExecuteSequence>
 

--- a/packages.config
+++ b/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.DXCore.Linux.arm64fre" version="10.0.26100.1-240331-1435.ge-release" targetFramework="native" />
   <package id="Microsoft.Extensions.Hosting" version="10.0.0" />
   <package id="Microsoft.Identity.MSAL.WSL.Proxy" version="0.1.1" />
-  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.9" />
-  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.9" />
+  <package id="Microsoft.NETCore.App.Runtime.win-arm64" version="10.0.11" />
+  <package id="Microsoft.NETCore.App.Runtime.win-x64" version="10.0.11" />
   <package id="Microsoft.RemoteDesktop.Client.MSRDC.SessionHost" version="1.2.7214" />
   <package id="Microsoft.Taef" version="10.100.251104001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.251108.1" targetFramework="native" />

--- a/src/linux/init/config.cpp
+++ b/src/linux/init/config.cpp
@@ -394,7 +394,7 @@ try
             return;
         }
 
-        auto Value = UtilGetEnvironmentVariable(Query->Buffer);
+        auto Value = UtilGetEnvironmentVariable(wsl::shared::string::FromMessageBuffer<LX_INIT_QUERY_ENVIRONMENT_VARIABLE>(Message));
         wsl::shared::MessageWriter<LX_INIT_QUERY_ENVIRONMENT_VARIABLE> Response(LxInitMessageQueryEnvironmentVariable);
         Response.WriteString(Value);
         Transaction.Send<LX_INIT_QUERY_ENVIRONMENT_VARIABLE>(Response.Span());
@@ -427,7 +427,8 @@ try
         }
         else
         {
-            success = CreateLoginSession(Config, CreateSession->Buffer, CreateSession->Uid);
+            success = CreateLoginSession(
+                Config, wsl::shared::string::FromMessageBuffer<LX_INIT_CREATE_LOGIN_SESSION>(Message), CreateSession->Uid);
         }
 
         break;

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -2967,7 +2967,7 @@ Return Value:
                     return;
                 }
 
-                Target = GetMountTarget(Message->Buffer);
+                Target = GetMountTarget(wsl::shared::string::FromMessageBuffer<LX_MINI_INIT_UNMOUNT_MESSAGE>(Buffer));
 
                 Step = LxMiniInitMountStepUnmount;
                 Result = umount(Target.c_str());

--- a/src/shared/inc/stringshared.h
+++ b/src/shared/inc/stringshared.h
@@ -140,6 +140,12 @@ inline const char* FromSpan(gsl::span<gsl::byte> Span, size_t Offset = 0)
     return String.data();
 }
 
+template <typename T>
+inline const char* FromMessageBuffer(const gsl::span<gsl::byte>& Span)
+{
+    return FromSpan(Span, offsetof(T, Buffer));
+}
+
 constexpr auto c_defaultHostName = "localhost";
 
 inline std::string CleanHostname(const std::string_view Hostname)

--- a/src/windows/service/exe/LxssUserSession.cpp
+++ b/src/windows/service/exe/LxssUserSession.cpp
@@ -3379,8 +3379,9 @@ void LxssUserSessionImpl::_ProcessImportResultMessage(
         {
             if (Message.TerminalProfileIndex != 0)
             {
-                const auto terminalProfileSpan = Span.subspan(Message.TerminalProfileIndex);
-                const std::string_view terminalProfile(reinterpret_cast<const char*>(terminalProfileSpan.data()), Message.TerminalProfileSize);
+                const auto terminalProfileSpan = Span.subspan(Message.TerminalProfileIndex, Message.TerminalProfileSize);
+                const std::string_view terminalProfile(
+                    reinterpret_cast<const char*>(terminalProfileSpan.data()), terminalProfileSpan.size());
                 _CreateTerminalProfile(terminalProfile, iconPath, Configuration, Registration);
             }
             else

--- a/src/windows/wslinstall/DllMain.cpp
+++ b/src/windows/wslinstall/DllMain.cpp
@@ -940,6 +940,50 @@ extern "C" UINT __stdcall CalculateWslSettingsProtocolIds(MSIHANDLE install)
     return NOERROR;
 }
 
+static void SetWslServiceStartType(DWORD StartType)
+{
+    const wil::unique_schandle manager{OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT)};
+    THROW_LAST_ERROR_IF(!manager);
+
+    const wil::unique_schandle service{OpenServiceW(manager.get(), L"WSLService", SERVICE_CHANGE_CONFIG)};
+    if (!service)
+    {
+        const auto error = GetLastError();
+        if (error == ERROR_SERVICE_DOES_NOT_EXIST)
+        {
+            return;
+        }
+        THROW_WIN32(error);
+    }
+
+    THROW_IF_WIN32_BOOL_FALSE(ChangeServiceConfigW(
+        service.get(), SERVICE_NO_CHANGE, StartType, SERVICE_NO_CHANGE, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
+}
+
+extern "C" UINT __stdcall DisableWslService(MSIHANDLE install)
+{
+    try
+    {
+        WSL_INSTALL_LOG("DisableWslService");
+        SetWslServiceStartType(SERVICE_DISABLED);
+    }
+    CATCH_LOG();
+
+    return NOERROR;
+}
+
+extern "C" UINT __stdcall EnableWslService(MSIHANDLE install)
+{
+    try
+    {
+        WSL_INSTALL_LOG("EnableWslService");
+        SetWslServiceStartType(SERVICE_AUTO_START);
+    }
+    CATCH_LOG();
+
+    return NOERROR;
+}
+
 EXTERN_C BOOL STDAPICALLTYPE DllMain(_In_ HINSTANCE Instance, _In_ DWORD Reason, _In_opt_ LPVOID Reserved)
 {
     wil::DLLMain(Instance, Reason, Reserved);

--- a/src/windows/wslinstall/wslinstall.def
+++ b/src/windows/wslinstall/wslinstall.def
@@ -14,3 +14,5 @@ EXPORTS
     RemoveRegistryKeyProtections
     UnregisterLspCategories
     CalculateWslSettingsProtocolIds
+    DisableWslService
+    EnableWslService

--- a/src/windows/wslrelay/main.cpp
+++ b/src/windows/wslrelay/main.cpp
@@ -112,7 +112,7 @@ try
         sockaddr_in address{};
         address.sin_family = AF_INET;
         address.sin_port = htons(port);
-        address.sin_addr.s_addr = htonl(INADDR_ANY);
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
         THROW_LAST_ERROR_IF(bind(listenSocket.get(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) == SOCKET_ERROR);
 
         THROW_LAST_ERROR_IF(listen(listenSocket.get(), 1) == SOCKET_ERROR);


### PR DESCRIPTION
Backports the following security and servicing fixes from `master` to `release/2.7`:

- #40402 (`909d5eb8`) Validate NUL termination of flexible-array buffers in Linux init messages.
- #40625 (`c28bd152`) Disable the WSL service before stopping it during uninstall to close the restart race, and restore its start mode on rollback.
- #41260 (`5eb21381`) Restrict KdRelay to the loopback interface.
- #41332 (`8edd976b`) Update the bundled .NET runtime from 10.0.9 to 10.0.11 for the July and August security servicing fixes.
- #41495 (`f2d87e07`) Validate `TerminalProfileSize` against the received import-result buffer.

Backport adaptations:

- The WSLC-specific handler from #40402 is omitted because that implementation is not present in `release/2.7`; the shared `FromMessageBuffer` helper is included for the two applicable Linux init handlers.
- The .NET change is resolved directly from the release branch's 10.0.9 baseline to 10.0.11.
- #40792 is intentionally excluded because its virtiofs lifetime fix requires a dedicated backport of the newer overlapped-I/O architecture.

Validation:

- `cmake --build . --target init wslservice wslrelay wsl wslinstall -- -m`
- The full build compiles all affected targets but remains blocked by the existing `wslserviceproxystub` unresolved `WSLCCompat_ProxyFileInfo` / `wslc_ProxyFileInfo` symbols on this release checkout.