### PR TITLE
Reduce expected distro termination log noise

### DIFF
--- a/src/linux/init/init.cpp
+++ b/src/linux/init/init.cpp
@@ -2259,6 +2259,7 @@ Return Value:
 
 {
     UtilSetThreadName("init-distro");
+    const auto distroName = UtilGetEnvironmentVariable(LX_WSL2_DISTRO_NAME_ENV);
 
     //
     // Set the close-on-exec flag on the socket file descriptor inherited from mini_init.
@@ -2495,7 +2496,7 @@ Return Value:
         auto WaitResult = waitpid(distroInitPid.value(), &Status, WNOHANG);
         if (WaitResult > 0 || (WaitResult < 0 && errno == ECHILD))
         {
-            LOG_ERROR("Init has exited. Terminating distribution");
+            LOG_INFO("Distribution {} init process {} exited", distroName, distroInitPid.value());
             InitTerminateInstanceInternal(Config);
             return;
         }
@@ -2620,7 +2621,7 @@ Return Value:
 
             if (distroInitExited)
             {
-                LOG_ERROR("Init has exited. Terminating distribution");
+                LOG_INFO("Distribution {} init process {} exited", distroName, distroInitPid.value());
                 break;
             }
         }

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -4226,8 +4226,6 @@ int main(int Argc, char* Argv[])
                     auto CgroupDir = UtilGetDistroCgroupPath(Result);
                     if (access(CgroupDir.c_str(), F_OK) == 0)
                     {
-                        LOG_INFO("Process {} exited, removing cgroup {}", Result, CgroupDir);
-
                         //
                         // Recursively rmdir the cgroup subtree.
                         //

--- a/src/linux/plan9/p9handler.cpp
+++ b/src/linux/plan9/p9handler.cpp
@@ -1466,7 +1466,11 @@ AsyncTask HandleConnections(ISocket& listen, IShareList& shareList, CancelToken&
     }
     catch (...)
     {
-        LOG_CAUGHT_EXCEPTION();
+        if (util::LinuxErrorFromCaughtException() != LX_ECANCELED)
+        {
+            LOG_CAUGHT_EXCEPTION();
+        }
+
         token.Cancel();
     }
 


### PR DESCRIPTION
Expected distro shutdown currently produces several noisy messages that make normal termination look like a failure.

Treat distro init exit as informational and include the distro name and PID, remove the routine cgroup cleanup message, and suppress the expected Plan9 cancellation exception while retaining unexpected errors.