### PR TITLE
Fix WSLC fallback gateway collision

### DIFF
--- a/src/windows/common/WslCoreNetworkEndpointSettings.cpp
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.cpp
@@ -7,6 +7,27 @@
 
 using namespace wsl::shared;
 
+SOCKADDR_INET wsl::core::networking::GetFallbackIpv4Gateway(const EndpointIpAddress& address)
+{
+    SOCKADDR_INET gateway{};
+    if (address.Address.si_family != AF_INET || address.PrefixLength > 32)
+    {
+        return gateway;
+    }
+
+    const uint32_t hostAddress = ntohl(address.Address.Ipv4.sin_addr.s_addr);
+    const uint32_t mask = (address.PrefixLength == 0) ? 0u : ~((1u << (32u - address.PrefixLength)) - 1u);
+    uint32_t gatewayAddress = (hostAddress & mask) | 1u;
+    if (gatewayAddress == hostAddress)
+    {
+        gatewayAddress = address.PrefixLength <= 30 ? (hostAddress & mask) | 2u : hostAddress ^ 1u;
+    }
+
+    gateway.si_family = AF_INET;
+    gateway.Ipv4.sin_addr.s_addr = htonl(gatewayAddress);
+    return gateway;
+}
+
 std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::GetEndpointSettings(const hns::HNSEndpoint& properties)
 {
     EndpointIpAddress address{};
@@ -107,13 +128,7 @@ std::shared_ptr<wsl::core::networking::NetworkSettings> wsl::core::networking::G
     }
     else if (address.Address.si_family == AF_INET)
     {
-        // Synthesize a gateway from the first host address in the subnet.
-        SOCKADDR_INET gatewayAddr{};
-        gatewayAddr.si_family = AF_INET;
-        const uint32_t hostAddr = ntohl(address.Address.Ipv4.sin_addr.s_addr);
-        const uint32_t mask = (address.PrefixLength == 0) ? 0u : ~((1u << (32u - address.PrefixLength)) - 1u);
-        gatewayAddr.Ipv4.sin_addr.s_addr = htonl((hostAddr & mask) | 1u);
-        route = EndpointRoute::DefaultRoute(AF_INET, gatewayAddr);
+        route = EndpointRoute::DefaultRoute(AF_INET, GetFallbackIpv4Gateway(address));
     }
 
     // Build IPv6 default route.

--- a/src/windows/common/WslCoreNetworkEndpointSettings.h
+++ b/src/windows/common/WslCoreNetworkEndpointSettings.h
@@ -275,6 +275,8 @@ struct EndpointRoute
     }
 };
 
+SOCKADDR_INET GetFallbackIpv4Gateway(const EndpointIpAddress& address);
+
 struct NetworkSettings
 {
     NetworkSettings() = default;

--- a/test/windows/NetworkTests.cpp
+++ b/test/windows/NetworkTests.cpp
@@ -320,6 +320,23 @@ class NetworkTests
         VERIFY_IS_FALSE(makeRoute(AF_INET6, L"::", 128).IsDefault());
     }
 
+    TEST_METHOD(FallbackIpv4Gateway)
+    {
+        const auto getGateway = [](const wchar_t* address, uint8_t prefixLength) {
+            wsl::core::networking::EndpointIpAddress endpoint{};
+            endpoint.Address = wsl::windows::common::string::StringToSockAddrInet(address);
+            endpoint.PrefixLength = prefixLength;
+            return wsl::windows::common::string::SockAddrInetToWstring(wsl::core::networking::GetFallbackIpv4Gateway(endpoint));
+        };
+
+        VERIFY_ARE_EQUAL(getGateway(L"198.18.0.1", 30), std::wstring(L"198.18.0.2"));
+        VERIFY_ARE_EQUAL(getGateway(L"198.18.0.2", 30), std::wstring(L"198.18.0.1"));
+        VERIFY_ARE_EQUAL(getGateway(L"198.18.0.0", 31), std::wstring(L"198.18.0.1"));
+        VERIFY_ARE_EQUAL(getGateway(L"198.18.0.1", 31), std::wstring(L"198.18.0.0"));
+        VERIFY_ARE_EQUAL(getGateway(L"198.18.0.4", 32), std::wstring(L"198.18.0.5"));
+        VERIFY_ARE_EQUAL(getGateway(L"198.18.0.5", 32), std::wstring(L"198.18.0.4"));
+    }
+
     WSL2_TEST_METHOD(RemoveAndAddDefaultRoute)
     {
         TestCase({{L"eth0", {{L"192.168.0.2", 24}}, L"192.168.0.1", {{L"fc00::2", 64}}, L"fc00::1"}});


### PR DESCRIPTION
WSLC can synthesize a default gateway equal to the guest address when the selected host adapter does not expose a gateway. Linux rejects that route with `EINVAL`, surfaced by WSLC as `E_UNEXPECTED`.

Select an adjacent fallback address when the usual first-host gateway collides with the guest address, while preserving existing gateway selection otherwise. Adds coverage for /30, /31, and /32 prefixes.

Fixes #41543