### PR TITLE
Host plugin Plan9 shares as the session user

### DIFF
--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -2638,7 +2638,7 @@ Return Value:
         return -1;
     }
 
-    int Result = MountPlan9(Name, Target, Message->ReadOnly, Message->HostPort);
+    int Result = MountPlan9(Name, Target, Message->ReadOnly, LX_INIT_UTILITY_VM_PLAN9_PLUGIN_PORT);
     Transaction.SendResultMessage<int32_t>(Result);
     return 0;
 }

--- a/src/linux/init/main.cpp
+++ b/src/linux/init/main.cpp
@@ -189,7 +189,7 @@ int MountSystemDistro(LX_MINI_INIT_MOUNT_DEVICE_TYPE DeviceType, unsigned int De
 
 int MountInit(const char* Target);
 
-int MountPlan9(const char* Name, const char* Target, bool ReadOnly, std::optional<int> BufferSize = {});
+int MountPlan9(const char* Name, const char* Target, bool ReadOnly, unsigned int HostPort = LX_INIT_UTILITY_VM_PLAN9_PORT, std::optional<int> BufferSize = {});
 
 int ProcessMessage(wsl::shared::Transaction& Transaction, LX_MESSAGE_TYPE Type, gsl::span<gsl::byte> Buffer, VmConfiguration& Config);
 
@@ -1897,7 +1897,7 @@ try
 }
 CATCH_RETURN_ERRNO()
 
-int MountPlan9(const char* Name, const char* Target, bool ReadOnly, std::optional<int> BufferSize)
+int MountPlan9(const char* Name, const char* Target, bool ReadOnly, unsigned int HostPort, std::optional<int> BufferSize)
 
 /*++
 
@@ -1913,6 +1913,8 @@ Arguments:
 
     ReadOnly - Supplies a boolean specifying if the share should be mounted as read-only.
 
+    HostPort - Supplies the host Plan 9 server port.
+
     BufferSize - Optionally supplies a buffer size to use for the hvsocket send / receive buffers and 9p msize.
 
 Return Value:
@@ -1924,7 +1926,7 @@ Return Value:
 try
 {
     int Size = BufferSize.value_or(LX_INIT_UTILITY_VM_PLAN9_BUFFER_SIZE);
-    wil::unique_fd Fd{UtilConnectVsock(LX_INIT_UTILITY_VM_PLAN9_PORT, true, Size)};
+    wil::unique_fd Fd{UtilConnectVsock(HostPort, true, Size)};
     if (!Fd)
     {
         return -1;
@@ -2636,7 +2638,7 @@ Return Value:
         return -1;
     }
 
-    int Result = MountPlan9(Name, Target, Message->ReadOnly);
+    int Result = MountPlan9(Name, Target, Message->ReadOnly, Message->HostPort);
     Transaction.SendResultMessage<int32_t>(Result);
     return 0;
 }

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1492,13 +1492,12 @@ typedef struct _LX_MINI_INIT_MOUNT_FOLDER_MESSAGE
     using TResponse = RESULT_MESSAGE<int32_t>;
 
     MESSAGE_HEADER Header;
-    unsigned int HostPort;
     bool ReadOnly;
     unsigned int PathIndex;
     unsigned int NameIndex;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(HostPort), FIELD(ReadOnly), STRING_FIELD(PathIndex), STRING_FIELD(NameIndex));
+    PRETTY_PRINT(FIELD(Header), FIELD(ReadOnly), STRING_FIELD(PathIndex), STRING_FIELD(NameIndex));
 } LX_MINI_INIT_MOUNT_FOLDER_MESSAGE, *PLX_MINI_INIT_MOUNT_FOLDER_MESSAGE;
 
 typedef struct _LX_MINI_INIT_RESIZE_DISTRIBUTION_RESPONSE

--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -118,6 +118,7 @@ Abstract:
 #define LX_INIT_UTILITY_VM_PLAN9_DRVFS_ADMIN_PORT (50003)
 #define LX_INIT_UTILITY_VM_VIRTIOFS_PORT (50004)
 #define LX_INIT_UTILITY_VM_CRASH_DUMP_PORT (50005)
+#define LX_INIT_UTILITY_VM_PLAN9_PLUGIN_PORT (50006)
 
 //
 // HvSocket buffer size for 9p connections.
@@ -1491,12 +1492,13 @@ typedef struct _LX_MINI_INIT_MOUNT_FOLDER_MESSAGE
     using TResponse = RESULT_MESSAGE<int32_t>;
 
     MESSAGE_HEADER Header;
+    unsigned int HostPort;
     bool ReadOnly;
     unsigned int PathIndex;
     unsigned int NameIndex;
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(ReadOnly), STRING_FIELD(PathIndex), STRING_FIELD(NameIndex));
+    PRETTY_PRINT(FIELD(Header), FIELD(HostPort), FIELD(ReadOnly), STRING_FIELD(PathIndex), STRING_FIELD(NameIndex));
 } LX_MINI_INIT_MOUNT_FOLDER_MESSAGE, *PLX_MINI_INIT_MOUNT_FOLDER_MESSAGE;
 
 typedef struct _LX_MINI_INIT_RESIZE_DISTRIBUTION_RESPONSE

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2111,7 +2111,7 @@ void WslCoreVm::MountRootNamespaceFolder(_In_ LPCWSTR HostPath, _In_ LPCWSTR Gue
 
     {
         auto runAsUser = wil::impersonate_token(m_userToken.get());
-        if (!m_pluginPlan9Server)
+        if (!m_pluginPlan9Server || m_pluginPlan9Server->IsRunning() != S_OK)
         {
             auto server =
                 wsl::windows::common::wslutil::CreateComServerAsUser<p9fs::Plan9FileSystem, IPlan9FileSystem>(m_userToken.get());

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -809,6 +809,12 @@ WslCoreVm::~WslCoreVm() noexcept
     // Close the handle to the VM. This will wait for any outstanding callbacks.
     m_system.reset();
 
+    if (m_pluginPlan9Server)
+    {
+        LOG_IF_FAILED(m_pluginPlan9Server->Teardown());
+        m_pluginPlan9Server.reset();
+    }
+
     // This loops helps against a potential crash in build <= Windows 11 22H2.
     for (const auto& e : m_plan9Servers)
     {
@@ -2101,11 +2107,33 @@ void WslCoreVm::MountRootNamespaceFolder(_In_ LPCWSTR HostPath, _In_ LPCWSTR Gue
     auto lock = m_lock.lock_exclusive();
 
     const auto flags = (ReadOnly ? hcs::Plan9ShareFlags::ReadOnly : hcs::Plan9ShareFlags::None) | hcs::Plan9ShareFlags::AllowOptions;
-    wsl::windows::common::hcs::AddPlan9Share(m_system.get(), Name, Name, HostPath, LX_INIT_UTILITY_VM_PLAN9_PORT, flags);
+
+    if (m_pluginPlan9Server && m_pluginPlan9Server->IsRunning() != S_OK)
+    {
+        m_pluginPlan9Server.reset();
+    }
+
+    {
+        if (!m_pluginPlan9Server)
+        {
+            wsl::windows::common::security::EnableTokenPrivilege(m_userToken.get(), SE_CREATE_SYMBOLIC_LINK_NAME);
+
+            auto runAsUser = wil::impersonate_token(m_userToken.get());
+            auto server =
+                wsl::windows::common::wslutil::CreateComServerAsUser<p9fs::Plan9FileSystem, IPlan9FileSystem>(m_userToken.get());
+            THROW_IF_FAILED(server->Init(&m_runtimeId, LX_INIT_UTILITY_VM_PLAN9_PLUGIN_PORT));
+            THROW_IF_FAILED(server->Resume());
+            m_pluginPlan9Server = std::move(server);
+        }
+
+        auto runAsUser = wil::impersonate_token(m_userToken.get());
+        THROW_IF_FAILED(m_pluginPlan9Server->AddSharePath(Name, HostPath, static_cast<UINT32>(flags)));
+    }
 
     wsl::shared::MessageWriter<LX_MINI_INIT_MOUNT_FOLDER_MESSAGE> message(LxMiniInitMountFolder);
     message.WriteString(message->PathIndex, GuestPath);
     message.WriteString(message->NameIndex, Name);
+    message->HostPort = LX_INIT_UTILITY_VM_PLAN9_PLUGIN_PORT;
     message->ReadOnly = ReadOnly;
 
     const auto& ResultMessage = m_miniInitChannel.Transaction<LX_MINI_INIT_MOUNT_FOLDER_MESSAGE>(message.Span());

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2107,18 +2107,12 @@ void WslCoreVm::MountRootNamespaceFolder(_In_ LPCWSTR HostPath, _In_ LPCWSTR Gue
     auto lock = m_lock.lock_exclusive();
 
     const auto flags = (ReadOnly ? hcs::Plan9ShareFlags::ReadOnly : hcs::Plan9ShareFlags::None) | hcs::Plan9ShareFlags::AllowOptions;
-
-    if (m_pluginPlan9Server && m_pluginPlan9Server->IsRunning() != S_OK)
-    {
-        m_pluginPlan9Server.reset();
-    }
+    wsl::windows::common::security::EnableTokenPrivilege(m_userToken.get(), SE_CREATE_SYMBOLIC_LINK_NAME);
 
     {
+        auto runAsUser = wil::impersonate_token(m_userToken.get());
         if (!m_pluginPlan9Server)
         {
-            wsl::windows::common::security::EnableTokenPrivilege(m_userToken.get(), SE_CREATE_SYMBOLIC_LINK_NAME);
-
-            auto runAsUser = wil::impersonate_token(m_userToken.get());
             auto server =
                 wsl::windows::common::wslutil::CreateComServerAsUser<p9fs::Plan9FileSystem, IPlan9FileSystem>(m_userToken.get());
             THROW_IF_FAILED(server->Init(&m_runtimeId, LX_INIT_UTILITY_VM_PLAN9_PLUGIN_PORT));
@@ -2126,14 +2120,12 @@ void WslCoreVm::MountRootNamespaceFolder(_In_ LPCWSTR HostPath, _In_ LPCWSTR Gue
             m_pluginPlan9Server = std::move(server);
         }
 
-        auto runAsUser = wil::impersonate_token(m_userToken.get());
         THROW_IF_FAILED(m_pluginPlan9Server->AddSharePath(Name, HostPath, static_cast<UINT32>(flags)));
     }
 
     wsl::shared::MessageWriter<LX_MINI_INIT_MOUNT_FOLDER_MESSAGE> message(LxMiniInitMountFolder);
     message.WriteString(message->PathIndex, GuestPath);
     message.WriteString(message->NameIndex, Name);
-    message->HostPort = LX_INIT_UTILITY_VM_PLAN9_PLUGIN_PORT;
     message->ReadOnly = ReadOnly;
 
     const auto& ResultMessage = m_miniInitChannel.Transaction<LX_MINI_INIT_MOUNT_FOLDER_MESSAGE>(message.Span());

--- a/src/windows/service/exe/WslCoreVm.h
+++ b/src/windows/service/exe/WslCoreVm.h
@@ -274,6 +274,7 @@ private:
     _Guarded_by_(m_guestDeviceLock) std::optional<GUID> m_adminVirtioFsDevice;
     _Guarded_by_(m_guestDeviceLock) std::map<UINT32, wil::com_ptr<IPlan9FileSystem>> m_plan9Servers;
     wil::srwlock m_lock;
+    _Guarded_by_(m_lock) wil::com_ptr<IPlan9FileSystem> m_pluginPlan9Server;
     _Guarded_by_(m_lock) wil::unique_event m_terminatingEvent { wil::EventOptions::ManualReset };
     _Guarded_by_(m_lock) wil::unique_event m_vmExitEvent { wil::EventOptions::ManualReset };
     wil::unique_event m_vmCrashEvent{wil::EventOptions::ManualReset};

--- a/test/windows/PluginTests.cpp
+++ b/test/windows/PluginTests.cpp
@@ -89,7 +89,7 @@ class PluginTests
         return true;
     }
 
-    void ConfigurePlugin(PluginTestType testCase) const
+    void ConfigurePlugin(PluginTestType testCase, LPCWSTR mountFolder = L"") const
     {
         StopWslService();
         if (!DeleteFile(logFile.c_str()))
@@ -100,6 +100,7 @@ class PluginTests
         const auto testKey = OpenTestRegistryKey(KEY_SET_VALUE);
         WriteDword(testKey.get(), nullptr, c_testType, static_cast<DWORD>(testCase));
         WriteString(testKey.get(), nullptr, c_logFile, logFile.c_str());
+        WriteString(testKey.get(), nullptr, c_mountFolder, mountFolder);
 
         const auto lxssKey =
             CreateKey(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Lxss\\Plugins", KEY_SET_VALUE, nullptr, 0);
@@ -169,6 +170,59 @@ class PluginTests
 
         ConfigurePlugin(PluginTestType::Success);
         StartWsl(0);
+        ValidateLogFile(ExpectedOutput);
+    }
+
+    WSL2_TEST_METHOD(MountFolderAccess)
+    {
+        const auto testFolder = std::filesystem::current_path() / "deny-write";
+        std::filesystem::remove_all(testFolder);
+        VERIFY_IS_TRUE(std::filesystem::create_directory(testFolder));
+        VERIFY_IS_TRUE(std::filesystem::create_directory(testFolder / "allowed"));
+
+        auto cleanup = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() { std::filesystem::remove_all(testFolder); });
+
+        const auto user = wil::get_token_information<TOKEN_USER>();
+        EXPLICIT_ACCESSW access{};
+        access.grfAccessPermissions = FILE_ADD_FILE;
+        access.grfAccessMode = DENY_ACCESS;
+        access.grfInheritance = NO_INHERITANCE;
+        access.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+        access.Trustee.ptstrName = static_cast<LPWSTR>(user->User.Sid);
+
+        PACL originalAcl = nullptr;
+        wil::unique_hlocal originalDescriptor;
+        THROW_IF_WIN32_ERROR(GetNamedSecurityInfoW(
+            testFolder.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &originalAcl, nullptr, &originalDescriptor));
+
+        auto restoreAcl = wil::scope_exit_log(WI_DIAGNOSTICS_INFO, [&]() {
+            THROW_IF_WIN32_ERROR(SetNamedSecurityInfoW(
+                const_cast<LPWSTR>(testFolder.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, originalAcl, nullptr));
+        });
+
+        wsl::windows::common::security::unique_acl deniedAcl;
+        THROW_IF_WIN32_ERROR(SetEntriesInAclW(1, &access, originalAcl, &deniedAcl));
+        THROW_IF_WIN32_ERROR(SetNamedSecurityInfoW(
+            const_cast<LPWSTR>(testFolder.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, deniedAcl.get(), nullptr));
+
+        const auto testFile = testFolder / L"plugin-test.txt";
+        wil::unique_hfile deniedFile{CreateFileW(testFile.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr)};
+        VERIFY_IS_TRUE(!deniedFile);
+        VERIFY_ARE_EQUAL(ERROR_ACCESS_DENIED, GetLastError());
+
+        ConfigurePlugin(PluginTestType::MountFolderAccess, testFolder.c_str());
+
+        constexpr auto ExpectedOutput =
+            LR"(Plugin loaded. TestMode=25
+                VM created (settings->CustomConfigurationFlags=0)
+                *Permission denied
+                Distribution started, name=test_distro, package=, PidNs=*, InitPid=*, Flavor=debian, Version=13
+                Distribution Stopping, name=test_distro, package=, PidNs=*, Flavor=debian, Version=13
+                VM Stopping)";
+
+        StartWsl(0);
+        VERIFY_IS_TRUE(std::filesystem::exists(testFolder / "allowed" / "plugin-allowed.txt"));
+        VERIFY_IS_FALSE(std::filesystem::exists(testFile));
         ValidateLogFile(ExpectedOutput);
     }
 

--- a/test/windows/PluginTests.h
+++ b/test/windows/PluginTests.h
@@ -44,11 +44,13 @@ enum class PluginTestType
     WslcImagePull,
     WslcVmRestart,
     WslcVmStopCommitted,
-    WslcVmNeverStarted
+    WslcVmNeverStarted,
+    MountFolderAccess
 };
 
 constexpr auto c_testType = L"TestType";
 constexpr auto c_logFile = L"LogFile";
+constexpr auto c_mountFolder = L"MountFolder";
 
 inline wil::unique_hkey OpenTestRegistryKey(REGSAM AccessMask)
 {

--- a/test/windows/testplugin/Plugin.cpp
+++ b/test/windows/testplugin/Plugin.cpp
@@ -123,6 +123,26 @@ HRESULT OnVmStarted(const WSLSessionInformation* Session, const WSLVmCreationSet
             return E_ABORT;
         }
     }
+    else if (g_testType == PluginTestType::MountFolderAccess)
+    {
+        const auto key = OpenTestRegistryKey(KEY_READ);
+        const auto mountSource = ReadString(key.get(), nullptr, c_mountFolder);
+
+        RETURN_IF_FAILED(
+            g_api->MountFolder(Session->SessionId, mountSource.c_str(), L"/test-plugin-access", false, L"test-plugin-access"));
+
+        std::vector<const char*> arguments = {
+            "/bin/sh",
+            "-c",
+            "{ echo allowed > /test-plugin-access/allowed/plugin-allowed.txt; echo denied > /test-plugin-access/plugin-test.txt; "
+            "} 2>&1",
+            nullptr};
+        wil::unique_socket socket;
+        RETURN_IF_FAILED(g_api->ExecuteBinary(Session->SessionId, arguments[0], arguments.data(), &socket));
+
+        const auto output = ReadFromSocket(socket.get());
+        g_logfile.write(output.data(), output.size());
+    }
     else if (g_testType == PluginTestType::ApiErrors)
     {
         auto result = g_api->MountFolder(Session->SessionId, L"C:\\DoesNotExit", L"/dummy", true, L"test-plugin-mount");
@@ -832,7 +852,7 @@ EXTERN_C __declspec(dllexport) HRESULT WSLPLUGINAPI_ENTRYPOINTV1(const WSLPlugin
         THROW_HR_IF(E_UNEXPECTED, !g_logfile);
 
         g_testType = static_cast<PluginTestType>(ReadDword(key.get(), nullptr, c_testType, static_cast<DWORD>(PluginTestType::Invalid)));
-        THROW_HR_IF(E_INVALIDARG, static_cast<DWORD>(g_testType) <= 0 || static_cast<DWORD>(g_testType) > static_cast<DWORD>(PluginTestType::WslcVmNeverStarted));
+        THROW_HR_IF(E_INVALIDARG, static_cast<DWORD>(g_testType) <= 0 || static_cast<DWORD>(g_testType) > static_cast<DWORD>(PluginTestType::MountFolderAccess));
 
         g_logfile << "Plugin loaded. TestMode=" << static_cast<DWORD>(g_testType) << std::endl;
         g_api = Api;


### PR DESCRIPTION
## Summary

Plugin folder mounts currently use the HCS-managed Plan9 server, which accesses host paths with the service identity. Using the session token with that path is not reliable.

Host plugin shares in a dedicated per-user Plan9 server on a separate port, and pass that port to mini_init when mounting. This preserves the session user's Windows file permissions without changing the existing GPU shares.

Restore the folder-access regression test with both allowed and denied writes.

## Testing

- Full x64 Debug build
- `PluginTests::MountFolderAccess`
- `PluginTests::ApiErrors`
- `PluginTests::Success`