### PR TITLE
Document WSL security model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,3 +39,12 @@ We prefer all communications to be in English.
 Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/opensource/security/cvd).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->
+
+## WSL security model
+
+WSL is an integrated development environment, not a security sandbox for running untrusted code. Configuration options that disable
+integration features do not establish a security boundary unless they are explicitly documented as security controls.
+
+Before reporting an issue, review the [WSL security model](./doc/docs/security.md). Reports should describe the unexpected security
+impact and any security boundary or documented security feature believed to be affected. MSRC determines whether an issue meets
+Microsoft's security servicing criteria.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,7 @@ Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https:
 
 ## WSL security model
 
-WSL is an integrated development environment, not a security sandbox for running untrusted code. Configuration options that disable
+WSL provides a Linux environment that is deeply integrated with Windows; it is not a security sandbox for running untrusted code. Configuration options that disable
 integration features do not establish a security boundary unless they are explicitly documented as security controls.
 
 Before reporting an issue, review the [WSL security model](./doc/docs/security.md). Reports should describe the unexpected security

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -4,6 +4,7 @@ This site contains the developer documentation for the Windows Subsystem for Lin
 
 For user documentation, including installation and configuration, see [https://learn.microsoft.com/windows/wsl/](https://learn.microsoft.com/windows/wsl/).
 
+For the trust boundaries and security guarantees provided by WSL, see the [WSL security model](security.md).
 
 To get started developing (building, testing and deploying), see [Getting started](dev-loop.md).
 

--- a/doc/docs/security.md
+++ b/doc/docs/security.md
@@ -11,6 +11,11 @@ Windows host or from other distributions running for the same user.
 The Linux `root` user has full control of its distribution and can change its configuration. Linux `root` is not the same as a
 Windows administrator, but the distribution is not a security boundary from the associated Windows user.
 
+WSL 2 distributions and sessions for the same Windows user can share a utility virtual machine. Launching WSL from elevated and
+non-elevated Windows processes does not create separate guest security boundaries. Resources made available to the utility virtual
+machine by an elevated session can remain available for the lifetime of that virtual machine. Workloads that require separation
+between elevated and non-elevated activity should use separate Windows security contexts or separately managed virtual machines.
+
 Documented Windows security boundaries and security features continue to apply. Suspected violations of those boundaries or
 features should be reported to MSRC for assessment.
 

--- a/doc/docs/security.md
+++ b/doc/docs/security.md
@@ -4,9 +4,9 @@ WSL provides a Linux environment that is deeply integrated with Windows. It is n
 
 ## Trust boundaries
 
-Code running in WSL should be treated as having the same trust level as code running under the Windows account that launched it. A
-WSL distribution does not isolate malicious or untrusted workloads from the Windows host or from other distributions running for
-the same user.
+Code running in WSL should be treated as having the same trust level as code running under the Windows account that launched it.
+WSL distributions provide functional process and file system separation, but a distribution is not a security boundary from the
+Windows host or from other distributions running for the same user.
 
 The Linux `root` user has full control of its distribution and can change its configuration. Linux `root` is not the same as a
 Windows administrator, but the distribution is not a security boundary from the associated Windows user.
@@ -30,8 +30,8 @@ Windows resources available to the user.
 
 ## Untrusted workloads and containers
 
-To isolate untrusted code from the Windows host, use a security boundary designed for that purpose, such as a dedicated virtual
-machine with appropriately restricted access.
+To isolate untrusted code from the Windows host, use a security boundary designed for that purpose, such as a separately managed
+virtual machine outside WSL with appropriately restricted access.
 
 Containers running inside WSL inherit the security properties of their container runtime configuration and WSL. Running a workload
 in a container does not make WSL a security boundary from the Windows host.

--- a/doc/docs/security.md
+++ b/doc/docs/security.md
@@ -1,0 +1,40 @@
+# WSL security model
+
+WSL provides a Linux environment that is deeply integrated with Windows. It is not a security sandbox for running untrusted code.
+
+## Trust boundaries
+
+Code running in WSL should be treated as having the same trust level as code running under the Windows account that launched it. A
+WSL distribution does not isolate malicious or untrusted workloads from the Windows host or from other distributions running for
+the same user.
+
+The Linux `root` user has full control of its distribution and can change its configuration. Linux `root` is not the same as a
+Windows administrator, but the distribution is not a security boundary from the associated Windows user.
+
+Documented Windows security boundaries and security features continue to apply. Suspected violations of those boundaries or
+features should be reported to MSRC for assessment.
+
+## Configuration settings
+
+WSL configuration settings control product behavior. Unless a setting is explicitly documented as a security control, do not use
+it as a containment boundary.
+
+For example:
+
+- `[interop] enabled=false` in `/etc/wsl.conf` disables the normal workflow for launching Windows processes from that distribution.
+- `[automount] enabled=false` in `/etc/wsl.conf` disables automatic mounting of Windows drives.
+- `.wslconfig` settings configure the WSL 2 virtual machine and its features.
+
+These settings change the available integration features, but they do not turn a distribution into a sandbox or isolate it from
+Windows resources available to the user.
+
+## Untrusted workloads and containers
+
+To isolate untrusted code from the Windows host, use a security boundary designed for that purpose, such as a dedicated virtual
+machine with appropriately restricted access.
+
+Containers running inside WSL inherit the security properties of their container runtime configuration and WSL. Running a workload
+in a container does not make WSL a security boundary from the Windows host.
+
+For the criteria used to evaluate Windows security reports, see the
+[Microsoft Security Servicing Criteria for Windows](https://www.microsoft.com/msrc/windows-security-servicing-criteria).

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: Windows Subsystem for Linux developer and architecture documen
 
 nav:
     - 'Home': 'index.md'
+    - 'Security model': 'security.md'
     - 'Getting started':
        - 'Building and testing WSL': 'dev-loop.md'
        - 'Debugging WSL': 'debugging.md'


### PR DESCRIPTION
WSL's documentation does not clearly describe its security model, which can cause integration settings to be mistaken for isolation controls.

This adds a security model page clarifying WSL trust boundaries, configuration semantics, and guidance for untrusted workloads and containers. It also links the guidance from the docs navigation and SECURITY.md.