### PR TITLE
Tear down the stale plugin Plan9 server before recreating it

### DIFF
--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2113,6 +2113,13 @@ void WslCoreVm::MountRootNamespaceFolder(_In_ LPCWSTR HostPath, _In_ LPCWSTR Gue
         auto runAsUser = wil::impersonate_token(m_userToken.get());
         if (!m_pluginPlan9Server || m_pluginPlan9Server->IsRunning() != S_OK)
         {
+            // Tear down the previous server so it releases the port before the replacement binds it.
+            if (m_pluginPlan9Server)
+            {
+                LOG_IF_FAILED(m_pluginPlan9Server->Teardown());
+                m_pluginPlan9Server.reset();
+            }
+
             auto server =
                 wsl::windows::common::wslutil::CreateComServerAsUser<p9fs::Plan9FileSystem, IPlan9FileSystem>(m_userToken.get());
             THROW_IF_FAILED(server->Init(&m_runtimeId, LX_INIT_UTILITY_VM_PLAN9_PLUGIN_PORT));


### PR DESCRIPTION
Follow-up to #41548.

When the per-user plugin Plan9 server is no longer running, `MountRootNamespaceFolder` dropped the previous instance without calling `Teardown`, so it could still hold the Plan9 port when the replacement tries to bind it.

## Testing

- Full x64 Debug build