### PR TITLE
Validate variable-length message strings

### DIFF
--- a/src/shared/inc/lxinitshared.h
+++ b/src/shared/inc/lxinitshared.h
@@ -1607,7 +1607,7 @@ struct WSLC_GET_DISK_RESULT
     unsigned int Result{};
     char Buffer[];
 
-    PRETTY_PRINT(FIELD(Header), FIELD(Result), FIELD(Buffer));
+    PRETTY_PRINT(FIELD(Header), FIELD(Result), BUFFER_FIELD(Buffer));
 };
 
 struct WSLC_GET_DISK

--- a/src/windows/service/exe/WslCoreVm.cpp
+++ b/src/windows/service/exe/WslCoreVm.cpp
@@ -2360,14 +2360,15 @@ void WslCoreVm::OnExit(_In_opt_ PCWSTR ExitDetails)
 
 void WslCoreVm::ReadGuestCapabilities()
 {
-    const auto& info = m_miniInitChannel.ReceiveMessage<LX_INIT_GUEST_CAPABILITIES>();
+    gsl::span<gsl::byte> span;
+    const auto& info = m_miniInitChannel.ReceiveMessage<LX_INIT_GUEST_CAPABILITIES>(&span);
+    const std::string input{wsl::shared::string::FromMessageBuffer<LX_INIT_GUEST_CAPABILITIES>(span)};
 
-    m_kernelVersionString = wsl::shared::string::MultiByteToWide(info.Buffer);
+    m_kernelVersionString = wsl::shared::string::MultiByteToWide(input);
 
     // Parse the version string.
     const std::regex pattern("(\\d+)\\.(\\d+)\\.(\\d+).*");
     std::smatch match;
-    const std::string input = info.Buffer;
     if (!std::regex_match(input, match, pattern) || match.size() != 4)
     {
         THROW_HR_MSG(E_UNEXPECTED, "Failed to parse kernel version: '%hs'", input.c_str());
@@ -2381,7 +2382,7 @@ void WslCoreVm::ReadGuestCapabilities()
     }
     catch (const std::exception& e)
     {
-        THROW_HR_MSG(E_UNEXPECTED, "Failed to parse kernel version: '%hs', %hs", info.Buffer, e.what());
+        THROW_HR_MSG(E_UNEXPECTED, "Failed to parse kernel version: '%hs', %hs", input.c_str(), e.what());
     }
 
     m_seccompAvailable = info.SeccompAvailable;

--- a/src/windows/wslcsession/WSLCVirtualMachine.cpp
+++ b/src/windows/wslcsession/WSLCVirtualMachine.cpp
@@ -782,10 +782,11 @@ std::string WSLCVirtualMachine::GetVhdDevicePath(ULONG Lun)
     message.Header.MessageSize = sizeof(message);
     message.Header.MessageType = WSLC_GET_DISK::Type;
     message.ScsiLun = Lun;
-    const auto& response = m_initChannel.Transaction(message, nullptr, m_initChannelTimeout);
+    gsl::span<gsl::byte> responseSpan;
+    const auto& response = m_initChannel.Transaction(message, &responseSpan, m_initChannelTimeout);
     THROW_HR_IF_MSG(E_FAIL, response.Result != 0, "Failed to get disk path, init returned: %lu", response.Result);
 
-    return response.Buffer;
+    return std::string{wsl::shared::string::FromMessageBuffer<WSLC_GET_DISK_RESULT>(responseSpan)};
 }
 
 Microsoft::WRL::ComPtr<WSLCProcess> WSLCVirtualMachine::CreateLinuxProcess(

--- a/test/windows/UnitTests.cpp
+++ b/test/windows/UnitTests.cpp
@@ -7847,6 +7847,42 @@ Distribution successfully installed. It can be launched via 'wsl.exe -d ubuntu-d
             const auto hr = wil::ResultFromException([&]() { channel.ReceiveMessage<RESULT_MESSAGE<int32_t>>(nullptr, 100); });
             VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_TIMEOUT));
         }
+
+        // Scenario 9: Variable-length string fields must be terminated within the received message.
+        {
+            auto [a, b] = MakeSocketPair();
+            wsl::shared::SocketChannel sender{std::move(a), "sender"};
+            wsl::shared::SocketChannel receiver{std::move(b), "receiver"};
+
+            wsl::shared::MessageWriter<LX_INIT_GUEST_CAPABILITIES> message;
+            std::array<gsl::byte, 4> unterminated{
+                static_cast<gsl::byte>('1'), static_cast<gsl::byte>('.'), static_cast<gsl::byte>('2'), static_cast<gsl::byte>('3')};
+            message.WriteSpan(gsl::make_span(unterminated));
+            sender.SendMessage<LX_INIT_GUEST_CAPABILITIES>(message.Span());
+
+            gsl::span<gsl::byte> span;
+            receiver.ReceiveMessage<LX_INIT_GUEST_CAPABILITIES>(&span);
+            const auto hr =
+                wil::ResultFromException([&]() { wsl::shared::string::FromMessageBuffer<LX_INIT_GUEST_CAPABILITIES>(span); });
+            VERIFY_ARE_EQUAL(hr, E_INVALIDARG);
+        }
+
+        {
+            auto [a, b] = MakeSocketPair();
+            wsl::shared::SocketChannel sender{std::move(a), "sender"};
+            wsl::shared::SocketChannel receiver{std::move(b), "receiver"};
+
+            wsl::shared::MessageWriter<WSLC_GET_DISK_RESULT> message;
+            std::array<gsl::byte, 4> unterminated{
+                static_cast<gsl::byte>('/'), static_cast<gsl::byte>('d'), static_cast<gsl::byte>('e'), static_cast<gsl::byte>('v')};
+            message.WriteSpan(gsl::make_span(unterminated));
+            sender.SendMessage<WSLC_GET_DISK_RESULT>(message.Span());
+
+            gsl::span<gsl::byte> span;
+            receiver.ReceiveMessage<WSLC_GET_DISK_RESULT>(&span);
+            const auto hr = wil::ResultFromException([&]() { wsl::shared::string::FromMessageBuffer<WSLC_GET_DISK_RESULT>(span); });
+            VERIFY_ARE_EQUAL(hr, E_INVALIDARG);
+        }
     }
 
     TEST_METHOD(DownloadToHiddenSystemTempFolder)


### PR DESCRIPTION
## Summary
- validate variable-length guest capability strings within the received message span
- validate WSLC disk path responses before constructing strings
- use bounded formatting for WSLC disk path response buffers
- add regression coverage for unterminated message strings

## Testing
- full x64 Debug build
- UnitTests::UnitTests::SocketChannel