### PR TITLE
Use a locally imported version of docker/dockerfile instead of downloading it from the default registry

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -19,6 +19,8 @@
     <packageSources>
         <clear />
         <add key="WSL" value="https://pkgs.dev.azure.com/shine-oss/wsl/_packaging/WslDependencies/nuget/v3/index.json" />
+        <add key="local" value="tools/test" />
+
     </packageSources>
     <disabledPackageSources>
         <!-- Override any User and Computer NuGet package settings to guarantee

--- a/nuget.config
+++ b/nuget.config
@@ -19,8 +19,6 @@
     <packageSources>
         <clear />
         <add key="WSL" value="https://pkgs.dev.azure.com/shine-oss/wsl/_packaging/WslDependencies/nuget/v3/index.json" />
-        <add key="local" value="tools/test" />
-
     </packageSources>
     <disabledPackageSources>
         <!-- Override any User and Computer NuGet package settings to guarantee

--- a/packages.config
+++ b/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.WSL.DeviceHost" version="1.2.62-0" />
   <package id="Microsoft.WSL.Kernel" version="6.18.40.1-1" targetFramework="native" />
   <package id="Microsoft.WSL.LinuxSdk" version="1.23.0" targetFramework="native" />
-  <package id="Microsoft.WSL.TestData" version="0.5.0" />
+  <package id="Microsoft.WSL.TestData" version="0.6.0" />
   <package id="Microsoft.WSL.TestDistro" version="2.7.1-1" />
   <package id="Microsoft.WSLg" version="1.0.79" />
   <package id="Microsoft.Xaml.Behaviors.WinUI.Managed" version="3.0.0" />

--- a/test/windows/Common.cpp
+++ b/test/windows/Common.cpp
@@ -2986,6 +2986,10 @@ std::filesystem::path GetTestImagePath(std::string_view imageName)
     {
         result /= L"wslc-registry.tar";
     }
+    else if (imageName == "docker/dockerfile:1")
+    {
+        result /= L"dockerfile-frontend.tar";
+    }
     else
     {
         THROW_HR_MSG(E_INVALIDARG, "Unknown test image: %hs", imageName.data());

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.cpp
@@ -119,6 +119,12 @@ const TestImage& DebianTestImage()
     return image;
 }
 
+const TestImage& DockerfileFrontendTestImage()
+{
+    static const TestImage image{L"docker/dockerfile", L"1", std::filesystem::path{g_testDataPath} / L"dockerfile-frontend.tar"};
+    return image;
+}
+
 const TestImage& HelloWorldTestImage()
 {
     static const TestImage image{L"hello-world", L"latest", std::filesystem::path{g_testDataPath} / L"HelloWorldSaved.tar"};

--- a/test/windows/wslc/e2e/WSLCE2EHelpers.h
+++ b/test/windows/wslc/e2e/WSLCE2EHelpers.h
@@ -104,6 +104,7 @@ struct TestImage
 
 const TestImage& AlpineTestImage();
 const TestImage& DebianTestImage();
+const TestImage& DockerfileFrontendTestImage();
 const TestImage& HelloWorldTestImage();
 const TestImage& PythonTestImage();
 const TestImage& InvalidTestImage();

--- a/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
+++ b/test/windows/wslc/e2e/WSLCE2EImageBuildTests.cpp
@@ -28,12 +28,22 @@ class WSLCE2EImageBuildTests
     {
         DeleteImagesWithRepositoryPrefix(c_builtImagePrefix);
         TestImageRegistry::Instance().EnsureLoaded(DebianTestImage());
+        TestImageRegistry::Instance().EnsureLoaded(DockerfileFrontendTestImage());
+
+        auto session = OpenDefaultElevatedSession();
+        auto [registryContainer, registryAddress] = StartLocalRegistry(*session, "", "", c_registryPort);
+        s_registryAddress = string::MultiByteToWide(registryAddress);
+        s_dockerfileFrontend = TagImageForRegistry(DockerfileFrontendTestImage().NameAndTag(), s_registryAddress);
+        RunWslcAndVerify(std::format(L"push {}", s_dockerfileFrontend), {.Stderr = L"", .ExitCode = 0});
+        s_registryContainer.emplace(std::move(registryContainer));
         return true;
     }
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         DeleteImagesWithRepositoryPrefix(c_builtImagePrefix);
+        RunWslc(std::format(L"image delete --force {}", s_dockerfileFrontend));
+        s_registryContainer.reset();
         return true;
     }
 
@@ -44,6 +54,14 @@ class WSLCE2EImageBuildTests
 
     // Port for the local registry backing the --pull test; distinct from the other test classes.
     static constexpr USHORT c_registryPort = 15005;
+    static inline std::optional<wsl::windows::common::RunningWSLCContainer> s_registryContainer;
+    static inline std::wstring s_registryAddress;
+    static inline std::wstring s_dockerfileFrontend;
+
+    static std::string SecretDockerfile(std::string_view dockerfile)
+    {
+        return std::format("# syntax={}\n{}", string::WideToMultiByte(s_dockerfileFrontend), dockerfile);
+    }
 
     // Returns an RAII guard that best-effort deletes the given image when it goes out of scope. It is
     // deliberately non-throwing (no VERIFY) because it may run while the stack unwinds after a test
@@ -189,10 +207,7 @@ class WSLCE2EImageBuildTests
         // A local registry acts as the private image source that --pull re-resolves the base image from.
         TestImageRegistry::Instance().EnsureLoaded(AlpineTestImage());
 
-        auto session = OpenDefaultElevatedSession();
-        auto [registryContainer, registryAddress] = StartLocalRegistry(*session, "", "", c_registryPort);
-
-        auto registryImage = TagImageForRegistry(AlpineTestImage().NameAndTag(), string::MultiByteToWide(registryAddress));
+        auto registryImage = TagImageForRegistry(AlpineTestImage().NameAndTag(), s_registryAddress);
         auto registryImageCleanup = DeleteImageOnExit(registryImage);
 
         RunWslcAndVerify(std::format(L"push {}", registryImage), {.Stderr = L"", .ExitCode = 0});
@@ -339,11 +354,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(cat /run/secrets/mysecret)\" = \"expected-secret-content-12345\" ]\n"
-            "CMD [\"echo\", \"secret-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(cat /run/secrets/mysecret)\" = \"expected-secret-content-12345\" ]\n"
+                             "CMD [\"echo\", \"secret-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_VALUE",
@@ -373,11 +387,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=WSLC_E2E_BARE_SECRET "
-            "[ \"$(cat /run/secrets/WSLC_E2E_BARE_SECRET)\" = \"bare-id-secret-content-67890\" ]\n"
-            "CMD [\"echo\", \"secret-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=WSLC_E2E_BARE_SECRET "
+                             "[ \"$(cat /run/secrets/WSLC_E2E_BARE_SECRET)\" = \"bare-id-secret-content-67890\" ]\n"
+                             "CMD [\"echo\", \"secret-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=WSLC_E2E_BARE_SECRET",
@@ -430,10 +443,9 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret [ -z \"$(cat /run/secrets/mysecret)\" ]\n"
-            "CMD [\"echo\", \"secret-empty-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret [ -z \"$(cat /run/secrets/mysecret)\" ]\n"
+                             "CMD [\"echo\", \"secret-empty-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_SECRET_UNSET_VAR",
@@ -466,11 +478,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(cat /run/secrets/mysecret)\" = \"file-secret-content-67890\" ]\n"
-            "CMD [\"echo\", \"secret-src-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(cat /run/secrets/mysecret)\" = \"file-secret-content-67890\" ]\n"
+                             "CMD [\"echo\", \"secret-src-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
@@ -511,11 +522,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(cat /run/secrets/mysecret)\" = \"symlinked-secret-content-44444\" ]\n"
-            "CMD [\"echo\", \"secret-symlink-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(cat /run/secrets/mysecret)\" = \"symlinked-secret-content-44444\" ]\n"
+                             "CMD [\"echo\", \"secret-symlink-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
@@ -572,11 +582,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(cat /run/secrets/mysecret)\" = \"env-wins-content-55555\" ]\n"
-            "CMD [\"echo\", \"secret-env-wins-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(cat /run/secrets/mysecret)\" = \"env-wins-content-55555\" ]\n"
+                             "CMD [\"echo\", \"secret-env-wins-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,env=WSLC_E2E_ENV_WINS_VALUE,src=\"{}\"",
@@ -605,11 +614,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-content-11111\" ]\n"
-            "CMD [\"echo\", \"secret-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-content-11111\" ]\n"
+                             "CMD [\"echo\", \"secret-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,env=WSLC_E2E_TYPE_ENV_VALUE",
@@ -638,11 +646,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-src-content-22222\" ]\n"
-            "CMD [\"echo\", \"secret-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(cat /run/secrets/mysecret)\" = \"type-env-src-content-22222\" ]\n"
+                             "CMD [\"echo\", \"secret-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret type=env,id=mysecret,src=WSLC_E2E_TYPE_ENV_SRC_VALUE",
@@ -669,11 +676,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(cat /run/secrets/mysecret)\" = \"type-file-content-33333\" ]\n"
-            "CMD [\"echo\", \"secret-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(cat /run/secrets/mysecret)\" = \"type-file-content-33333\" ]\n"
+                             "CMD [\"echo\", \"secret-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
@@ -705,12 +711,11 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ \"$(wc -c < /run/secrets/mysecret)\" = \"13\" ] && "
-            "[ \"$(tr -d '\\000' < /run/secrets/mysecret | tr -d '\\377')\" = \"beforeafter\" ]\n"
-            "CMD [\"echo\", \"secret-binary-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ \"$(wc -c < /run/secrets/mysecret)\" = \"13\" ] && "
+                             "[ \"$(tr -d '\\000' < /run/secrets/mysecret | tr -d '\\377')\" = \"beforeafter\" ]\n"
+                             "CMD [\"echo\", \"secret-binary-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret type=file,id=mysecret,src=\"{}\"",
@@ -741,14 +746,13 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            std::format(
-                "# syntax=docker/dockerfile:1\n"
+            SecretDockerfile(std::format(
                 "FROM debian:latest\n"
                 "RUN --mount=type=secret,id=mysecret "
                 "[ \"$(wc -c < /run/secrets/mysecret)\" = \"{}\" ] && "
                 "[ -z \"$(tr -d 'A' < /run/secrets/mysecret)\" ]\n"
                 "CMD [\"echo\", \"secret-size-ok\"]\n",
-                size));
+                size)));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
@@ -777,11 +781,10 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret "
-            "[ -f /run/secrets/mysecret ] && [ \"$(wc -c < /run/secrets/mysecret)\" = \"0\" ]\n"
-            "CMD [\"echo\", \"secret-empty-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret "
+                             "[ -f /run/secrets/mysecret ] && [ \"$(wc -c < /run/secrets/mysecret)\" = \"0\" ]\n"
+                             "CMD [\"echo\", \"secret-empty-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=mysecret,src=\"{}\"",
@@ -822,10 +825,9 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret > /dev/null\n"
-            "CMD [\"echo\", \"secret-oversize\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret > /dev/null\n"
+                             "CMD [\"echo\", \"secret-oversize\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" --secret id=mysecret,src=\"{}\"", contextDir.wstring(), dockerfilePath.wstring(), secretFile.wstring()));
@@ -862,13 +864,12 @@ class WSLCE2EImageBuildTests
         auto dockerfilePath = testRoot / L"Dockerfile";
         WriteTestFileContent(
             dockerfilePath,
-            "# syntax=docker/dockerfile:1\n"
-            "FROM debian:latest\n"
-            "RUN --mount=type=secret,id=s1 --mount=type=secret,id=s2 --mount=type=secret,id=s3 "
-            "[ \"$(cat /run/secrets/s1)\" = \"multi-secret-one-11111\" ] && "
-            "[ \"$(cat /run/secrets/s2)\" = \"multi-secret-two-22222\" ] && "
-            "[ \"$(cat /run/secrets/s3)\" = \"multi-secret-three-33333\" ]\n"
-            "CMD [\"echo\", \"secret-multi-ok\"]\n");
+            SecretDockerfile("FROM debian:latest\n"
+                             "RUN --mount=type=secret,id=s1 --mount=type=secret,id=s2 --mount=type=secret,id=s3 "
+                             "[ \"$(cat /run/secrets/s1)\" = \"multi-secret-one-11111\" ] && "
+                             "[ \"$(cat /run/secrets/s2)\" = \"multi-secret-two-22222\" ] && "
+                             "[ \"$(cat /run/secrets/s3)\" = \"multi-secret-three-33333\" ]\n"
+                             "CMD [\"echo\", \"secret-multi-ok\"]\n"));
 
         auto buildResult = RunWslc(std::format(
             L"build \"{}\" -f \"{}\" -t {} --secret id=s1,src=\"{}\" --secret id=s2,src=\"{}\" --secret id=s3,src=\"{}\"",

--- a/tools/test/generate-test-data.ps1
+++ b/tools/test/generate-test-data.ps1
@@ -168,6 +168,13 @@ function Export-TestImages {
             -Source "docker://docker.io/library/$($entry.Key)"
     }
 
+    Write-Host "[$NugetArchitecture] Downloading docker/dockerfile:1"
+    Export-DockerImage `
+        -Image "docker/dockerfile:1" `
+        -DockerArchitecture $DockerArchitecture `
+        -OutputPath (Join-Path $architectureDirectory "dockerfile-frontend.tar") `
+        -Source "docker://docker.io/docker/dockerfile:1"
+
     Invoke-WslCommand -Command @("docker", "image", "pull", "--platform", "linux/$DockerArchitecture", "hello-world:latest")
 
     $containerId = $null


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Using `# syntax=docker/dockerfile:1` in a Dockerfile actually causes the `docker/dockerfile` image to be downloaded from the default registry, which can cause test failures if the CI hits the rate limit. 

This change updates the tests to use a local image instead

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
