### PR TITLE
Use canonical path in VolumeMount_Parse_ReturnExpectedResult

### DIFF
--- a/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
+++ b/test/windows/wslc/WSLCVolumeMountUnitTests.cpp
@@ -26,7 +26,7 @@ class WSLCVolumeMountUnitTests
 
     TEST_METHOD(VolumeMount_Parse_ReturnExpectedResult)
     {
-        const auto cwd = std::filesystem::current_path();
+        const auto cwd = std::filesystem::canonical(std::filesystem::current_path());
 
         // Volume value => host, container, readonly
         std::vector<std::tuple<std::wstring, std::wstring, std::string, bool>> validVolumeArgs = {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change switches VolumeMount_Parse_ReturnExpectedResult to use canonical paths in test asserts, which solves a test failures if the tests are ran from a symlink 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Link to issue #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated if needed and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated if needed
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/wsl/) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
