### PR TITLE
Bump GitPython to 3.1.59

### DIFF
--- a/distributions/requirements.txt
+++ b/distributions/requirements.txt
@@ -1,5 +1,5 @@
 python-magic==0.4.27
 click==8.1.3
-GitPython==3.1.58
+GitPython==3.1.59
 PyGithub==2.5.0
 json-cfg==0.4.2

--- a/tools/devops/requirements.txt
+++ b/tools/devops/requirements.txt
@@ -1,4 +1,4 @@
 azure-devops==7.1.0b4
 click==8.1.3
-gitpython==3.1.58
+gitpython==3.1.59
 backoff==2.2.1


### PR DESCRIPTION
Resolves the 10 open Dependabot alerts (2 critical, 4 high, 4 moderate), all from GitPython <= 3.1.58.

Bumps GitPython to 3.1.59 in `distributions/requirements.txt` and `tools/devops/requirements.txt`.